### PR TITLE
feat: WDA auto-setup, CLI commands, and playground improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1837,6 +1837,32 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1989,7 +2015,6 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2040,6 +2065,36 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -2108,6 +2163,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2117,6 +2187,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2125,6 +2215,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/cssesc": {
@@ -2205,6 +2320,13 @@
       "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -2384,6 +2506,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -2408,6 +2540,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -2460,6 +2602,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3010,6 +3162,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -3129,6 +3291,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3193,6 +3365,19 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3222,6 +3407,34 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -3267,6 +3480,22 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3456,6 +3685,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -4149,6 +4388,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -4168,6 +4425,45 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/agent-core": {
@@ -4193,10 +4489,21 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@tapflow/agent-core": "*"
+        "@tapflow/agent-core": "*",
+        "@tapflow/ios-agent": "*",
+        "@tapflow/relay": "*",
+        "cac": "^6.7.14",
+        "ws": "^8.0.0"
       },
       "bin": {
         "tapflow": "bin/tapflow.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/ws": "^8.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
       }
     },
     "packages/dashboard": {
@@ -4263,10 +4570,12 @@
       "dependencies": {
         "@tapflow/agent-core": "*",
         "@tapflow/android-agent": "*",
+        "@tapflow/cli": "*",
         "@tapflow/ios-agent": "*",
         "@tapflow/relay": "*"
       },
       "devDependencies": {
+        "concurrently": "^9.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0"
       }

--- a/packages/cli/bin/tapflow.js
+++ b/packages/cli/bin/tapflow.js
@@ -1,1 +1,2 @@
-console.log('Tapflow is coming soon.');
+#!/usr/bin/env node
+require('../dist/index.js')

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tapflow/cli",
   "version": "0.1.0",
-  "description": "tapflow CLI — deploy relay, manage agents and teams",
+  "description": "tapflow CLI — setup, agent management, and playground utilities",
   "bin": {
     "tapflow": "./bin/tapflow.js"
   },
@@ -10,10 +10,22 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
+    "dev": "tsx src/index.ts",
     "test": "vitest run",
     "lint": "eslint src"
   },
   "dependencies": {
-    "@tapflow/agent-core": "*"
+    "@tapflow/agent-core": "*",
+    "@tapflow/ios-agent": "*",
+    "@tapflow/relay": "*",
+    "cac": "^6.7.14",
+    "ws": "^8.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/ws": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/cli/src/commands/boot.ts
+++ b/packages/cli/src/commands/boot.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'node:child_process'
+
+export async function cmdBoot(nameOrUdid: string): Promise<void> {
+  const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+  const data = JSON.parse(raw) as {
+    devices: Record<string, Array<{ udid: string; name: string; state: string }>>
+  }
+  const all = Object.values(data.devices).flat()
+  const target = all.find(
+    (d) => d.udid === nameOrUdid || d.name === nameOrUdid,
+  )
+
+  if (!target) {
+    console.error(`Device not found: ${nameOrUdid}`)
+    console.error('Run `tapflow devices` to see available simulators.')
+    process.exit(1)
+  }
+
+  if (target.state === 'Booted') {
+    console.log(`${target.name} is already booted.`)
+    return
+  }
+
+  console.log(`Booting ${target.name}…`)
+  execSync(`xcrun simctl boot ${target.udid}`, { stdio: 'inherit' })
+  console.log(`${target.name} booted.`)
+}

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -1,0 +1,47 @@
+import { execSync } from 'node:child_process'
+
+interface SimDevice {
+  udid: string
+  name: string
+  state: string
+  deviceTypeIdentifier?: string
+}
+
+export function cmdDevices(): void {
+  let raw: string
+  try {
+    raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+  } catch {
+    console.error('Failed to list simulators. Is Xcode installed?')
+    process.exit(1)
+  }
+
+  const data = JSON.parse(raw) as { devices: Record<string, SimDevice[]> }
+  const all = Object.entries(data.devices)
+    .flatMap(([runtime, devices]) => devices.map((d) => ({ ...d, runtime })))
+    .filter((d) => d.udid)
+
+  if (all.length === 0) {
+    console.log('No simulators found.')
+    return
+  }
+
+  const booted = all.filter((d) => d.state === 'Booted')
+  const available = all.filter((d) => d.state === 'Shutdown')
+
+  if (booted.length > 0) {
+    console.log('Booted:')
+    for (const d of booted) {
+      console.log(`  ● ${d.name}  ${d.udid}`)
+    }
+    console.log()
+  }
+
+  console.log('Available:')
+  for (const d of available.slice(0, 20)) {
+    console.log(`  ○ ${d.name}  ${d.udid}`)
+  }
+  if (available.length > 20) {
+    console.log(`  … and ${available.length - 20} more`)
+  }
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,24 @@
+import { runDoctorChecks } from '../lib/doctor'
+
+export async function cmdDoctor(): Promise<void> {
+  console.log('tapflow doctor\n')
+  const checks = await runDoctorChecks()
+  let hasFailure = false
+
+  for (const check of checks) {
+    const icon = check.ok ? '✓' : '✗'
+    console.log(`  ${icon} ${check.label}`)
+    if (!check.ok && check.detail) {
+      console.log(`    → ${check.detail}`)
+      hasFailure = true
+    }
+  }
+
+  console.log()
+  if (hasFailure) {
+    console.log('Some checks failed. Fix the issues above before running `tapflow start`.')
+    process.exit(1)
+  } else {
+    console.log('All checks passed.')
+  }
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,24 +1,31 @@
 import { runDoctorChecks } from '../lib/doctor'
 
+const GREEN = '\x1b[32m'
+const RED = '\x1b[31m'
+const DIM = '\x1b[2m'
+const R = '\x1b[0m'
+
 export async function cmdDoctor(): Promise<void> {
-  console.log('tapflow doctor\n')
+  console.log('\ntapflow doctor\n')
   const checks = await runDoctorChecks()
   let hasFailure = false
 
   for (const check of checks) {
-    const icon = check.ok ? '✓' : '✗'
-    console.log(`  ${icon} ${check.label}`)
-    if (!check.ok && check.detail) {
-      console.log(`    → ${check.detail}`)
+    if (check.ok) {
+      console.log(`  ${GREEN}✓${R}  ${check.label}`)
+    } else {
+      console.log(`  ${RED}✗${R}  ${check.label}`)
+      if (check.detail) console.log(`${DIM}       → ${check.detail}${R}`)
       hasFailure = true
     }
   }
 
   console.log()
   if (hasFailure) {
-    console.log('Some checks failed. Fix the issues above before running `tapflow start`.')
+    console.log(`  ${RED}Some checks failed.${R} Fix the issues above before running \`tapflow start\`.`)
     process.exit(1)
   } else {
-    console.log('All checks passed.')
+    console.log(`  ${GREEN}All checks passed.${R}`)
   }
+  console.log()
 }

--- a/packages/cli/src/commands/reset.ts
+++ b/packages/cli/src/commands/reset.ts
@@ -1,0 +1,42 @@
+import { execSync } from 'node:child_process'
+import { existsSync, rmSync } from 'node:fs'
+import * as readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+import { WDA_PID_FILE } from '../lib/tapflow-dir'
+import { checkWdaProcess } from '../lib/doctor'
+
+export async function cmdReset(): Promise<void> {
+  const rl = readline.createInterface({ input, output })
+  const answer = await rl.question(
+    'This will stop WDA and shut down all simulators. Continue? [y/N] ',
+  )
+  rl.close()
+
+  if (!answer.trim().toLowerCase().startsWith('y')) {
+    console.log('Aborted.')
+    return
+  }
+
+  const { running, pid } = checkWdaProcess()
+  if (running && pid) {
+    try {
+      process.kill(pid, 'SIGTERM')
+      console.log('WDA stopped.')
+    } catch {
+      console.warn('Could not stop WDA process.')
+    }
+  }
+
+  if (existsSync(WDA_PID_FILE)) {
+    rmSync(WDA_PID_FILE)
+  }
+
+  try {
+    execSync('xcrun simctl shutdown all', { stdio: 'pipe' })
+    console.log('All simulators shut down.')
+  } catch {
+    console.warn('Could not shut down simulators.')
+  }
+
+  console.log('Reset complete.')
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,0 +1,60 @@
+import { execSync } from 'node:child_process'
+import { RelayServer } from '@tapflow/relay'
+import { IOSAgent } from '@tapflow/ios-agent'
+
+export interface StartOptions {
+  device?: string
+  relay?: string
+}
+
+export async function cmdStart(opts: StartOptions): Promise<void> {
+  const relayUrl = opts.relay ?? 'ws://localhost:3000'
+
+  if (!opts.relay) {
+    const server = new RelayServer({ port: 3000 })
+    await server.start()
+    console.log('Relay started on ws://localhost:3000')
+  }
+
+  const agent = new IOSAgent({ wda: { autoStart: true } })
+
+  const devices = await agent.listDevices()
+  let targetId: string | undefined
+
+  if (opts.device) {
+    const target = devices.find((d) => d.name === opts.device || d.id === opts.device)
+    if (!target) {
+      console.error(`Device not found: ${opts.device}`)
+      console.error('Run `tapflow devices` to see available simulators.')
+      process.exit(1)
+    }
+    if (target.status !== 'booted') {
+      console.log(`Booting ${target.name}…`)
+      execSync(`xcrun simctl boot ${target.id}`, { stdio: 'pipe' })
+    }
+    targetId = target.id
+  } else {
+    const booted = devices.find((d) => d.status === 'booted')
+    if (!booted) {
+      const first = devices[0]
+      if (!first) {
+        console.error('No simulators found. Create one in Xcode.')
+        process.exit(1)
+      }
+      console.log(`No booted simulator found. Booting ${first.name}…`)
+      execSync(`xcrun simctl boot ${first.id}`, { stdio: 'pipe' })
+      targetId = first.id
+    } else {
+      targetId = booted.id
+    }
+  }
+
+  console.log(`Connecting agent to relay: ${relayUrl}`)
+  await agent.connect(relayUrl)
+  console.log('Agent connected. Press Ctrl+C to stop.\n')
+
+  process.on('SIGINT', () => {
+    agent.disconnect()
+    process.exit(0)
+  })
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,9 @@
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { RelayServer } from '@tapflow/relay'
-import { IOSAgent } from '@tapflow/ios-agent'
+import { IOSAgent, WdaLauncher, WdaNotInstalledError } from '@tapflow/ios-agent'
+import { WDA_XCTESTRUN_CACHE } from '../lib/tapflow-dir'
+import { banner, createSpinner, step } from '../lib/print'
 
 export interface StartOptions {
   device?: string
@@ -10,51 +13,107 @@ export interface StartOptions {
 export async function cmdStart(opts: StartOptions): Promise<void> {
   const relayUrl = opts.relay ?? 'ws://localhost:3000'
 
+  // ── 1. Relay ──────────────────────────────────────────────────────────────
   if (!opts.relay) {
     const server = new RelayServer({ port: 3000 })
     await server.start()
-    console.log('Relay started on ws://localhost:3000')
+    step('Relay started on ws://localhost:3000')
   }
 
-  const agent = new IOSAgent({ wda: { autoStart: true } })
-
+  // ── 2. Device ─────────────────────────────────────────────────────────────
+  const agent = new IOSAgent()
   const devices = await agent.listDevices()
-  let targetId: string | undefined
+
+  let targetId: string
+  let targetName: string
 
   if (opts.device) {
-    const target = devices.find((d) => d.name === opts.device || d.id === opts.device)
-    if (!target) {
-      console.error(`Device not found: ${opts.device}`)
-      console.error('Run `tapflow devices` to see available simulators.')
+    const match = devices.find((d) => d.name === opts.device || d.id === opts.device)
+    if (!match) {
+      banner('error', 'DEVICE NOT FOUND', [
+        `"${opts.device}" does not match any simulator.`,
+        'Run `tapflow devices` to see available simulators.',
+      ])
       process.exit(1)
     }
-    if (target.status !== 'booted') {
-      console.log(`Booting ${target.name}…`)
-      execSync(`xcrun simctl boot ${target.id}`, { stdio: 'pipe' })
+    if (match.status !== 'booted') {
+      const spinner = createSpinner(`Booting ${match.name}…`)
+      spinner.start()
+      execSync(`xcrun simctl boot ${match.id}`, { stdio: 'pipe' })
+      spinner.stop(true)
     }
-    targetId = target.id
+    targetId = match.id
+    targetName = match.name
   } else {
     const booted = devices.find((d) => d.status === 'booted')
-    if (!booted) {
+    if (booted) {
+      targetId = booted.id
+      targetName = booted.name
+    } else {
       const first = devices[0]
       if (!first) {
-        console.error('No simulators found. Create one in Xcode.')
+        banner('error', 'NO SIMULATOR FOUND', ['Create one in Xcode → Window → Devices and Simulators.'])
         process.exit(1)
       }
-      console.log(`No booted simulator found. Booting ${first.name}…`)
+      const spinner = createSpinner(`Booting ${first.name}…`)
+      spinner.start()
       execSync(`xcrun simctl boot ${first.id}`, { stdio: 'pipe' })
+      spinner.stop(true)
       targetId = first.id
-    } else {
-      targetId = booted.id
+      targetName = first.name
     }
   }
 
-  console.log(`Connecting agent to relay: ${relayUrl}`)
-  await agent.connect(relayUrl)
-  console.log('Agent connected. Press Ctrl+C to stop.\n')
+  step(`Simulator: ${targetName}`)
+
+  // ── 3. WDA ────────────────────────────────────────────────────────────────
+  let launcher: WdaLauncher | null = null
+  if (existsSync(WDA_XCTESTRUN_CACHE)) {
+    launcher = new WdaLauncher({ udid: targetId, xctestrunPath: WDA_XCTESTRUN_CACHE })
+    const spinner = createSpinner('Starting WebDriverAgent…')
+    spinner.start()
+    try {
+      await launcher.ensureRunning()
+      spinner.stop(true)
+    } catch (e) {
+      spinner.stop(false)
+      if (e instanceof WdaNotInstalledError) {
+        console.log('\n  WDA not found — touch input disabled. Run `tapflow wda install` to enable.\n')
+        launcher = null
+      } else {
+        banner('error', 'WDA FAILED TO START', [(e as Error).message])
+        console.log('  Continuing without WDA — touch input will not work.\n')
+        launcher = null
+      }
+    }
+  } else {
+    console.log('\n  WebDriverAgent not installed — touch input disabled.')
+    console.log('  Run `tapflow wda install` to enable it.\n')
+  }
+
+  // ── 4. Connect agent ──────────────────────────────────────────────────────
+  const connectSpinner = createSpinner('Connecting agent to relay…')
+  connectSpinner.start()
+  try {
+    // autoStart is false — WDA is already handled above
+    await agent.connect(relayUrl)
+    connectSpinner.stop(true)
+  } catch (e) {
+    connectSpinner.stop(false)
+    banner('error', 'CONNECTION FAILED', [(e as Error).message])
+    launcher?.stop()
+    process.exit(1)
+  }
+
+  banner('success', 'AGENT CONNECTED', [
+    `Relay  : ${relayUrl}`,
+    'Open http://localhost:3000 in your browser.',
+    'Press Ctrl+C to stop.',
+  ])
 
   process.on('SIGINT', () => {
     agent.disconnect()
+    launcher?.stop()
     process.exit(0)
   })
 }

--- a/packages/cli/src/commands/wda.ts
+++ b/packages/cli/src/commands/wda.ts
@@ -1,0 +1,153 @@
+import { execSync, spawn } from 'node:child_process'
+import { existsSync, copyFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import * as readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+import {
+  ensureTapflowDir,
+  WDA_SOURCE_DIR,
+  WDA_BUILD_DIR,
+  WDA_XCTESTRUN_CACHE,
+  WDA_PID_FILE,
+} from '../lib/tapflow-dir'
+import { checkWdaProcess } from '../lib/doctor'
+
+const WDA_REPO = 'https://github.com/appium/WebDriverAgent.git'
+
+export async function cmdWda(action: string | undefined): Promise<void> {
+  switch (action) {
+    case 'install': return wdaInstall()
+    case 'start':   return wdaStart()
+    case 'stop':    return wdaStop()
+    case 'status':  return wdaStatus()
+    default:
+      console.error('Usage: tapflow wda <install|start|stop|status>')
+      process.exit(1)
+  }
+}
+
+async function wdaInstall(): Promise<void> {
+  ensureTapflowDir()
+
+  if (existsSync(WDA_XCTESTRUN_CACHE)) {
+    const rl = readline.createInterface({ input, output })
+    const answer = await rl.question('WebDriverAgent is already installed. Reinstall? [y/N] ')
+    rl.close()
+    if (!answer.trim().toLowerCase().startsWith('y')) return
+  }
+
+  let sourcePath: string
+  try {
+    sourcePath = await cloneWda()
+  } catch (e) {
+    console.error(`Auto-clone failed: ${(e as Error).message}`)
+    const rl = readline.createInterface({ input, output })
+    const manual = await rl.question('Enter path to your WebDriverAgent source directory: ')
+    rl.close()
+    sourcePath = manual.trim()
+    if (!sourcePath || !existsSync(sourcePath)) {
+      console.error('Path not found.')
+      process.exit(1)
+    }
+  }
+
+  await buildWda(sourcePath)
+}
+
+async function cloneWda(): Promise<string> {
+  if (existsSync(join(WDA_SOURCE_DIR, 'WebDriverAgent.xcodeproj'))) {
+    console.log('WebDriverAgent source already cloned. Updating…')
+    execSync('git pull --ff-only', { cwd: WDA_SOURCE_DIR, stdio: 'inherit' })
+  } else {
+    console.log(`Cloning WebDriverAgent from ${WDA_REPO}…`)
+    execSync(`git clone --depth 1 ${WDA_REPO} ${WDA_SOURCE_DIR}`, { stdio: 'inherit' })
+  }
+  return WDA_SOURCE_DIR
+}
+
+async function buildWda(sourcePath: string): Promise<void> {
+  const xcodeproj = join(sourcePath, 'WebDriverAgent.xcodeproj')
+  if (!existsSync(xcodeproj)) {
+    console.error(`WebDriverAgent.xcodeproj not found in ${sourcePath}`)
+    process.exit(1)
+  }
+
+  console.log('Building WebDriverAgent (this may take a few minutes)…')
+  execSync(
+    [
+      'xcodebuild build-for-testing',
+      `-project ${xcodeproj}`,
+      '-scheme WebDriverAgentRunner',
+      '-destination "platform=iOS Simulator,name=iPhone 16"',
+      `-derivedDataPath ${WDA_BUILD_DIR}`,
+      'CODE_SIGN_IDENTITY=""',
+      'CODE_SIGNING_REQUIRED=NO',
+      'GCC_TREAT_WARNINGS_AS_ERRORS=0',
+    ].join(' '),
+    { stdio: 'inherit' },
+  )
+
+  const productsDir = join(WDA_BUILD_DIR, 'Build', 'Products')
+  const xctestrunFiles = readdirSync(productsDir).filter((f) => f.endsWith('.xctestrun'))
+  if (xctestrunFiles.length === 0) {
+    console.error('Build succeeded but no .xctestrun file found.')
+    process.exit(1)
+  }
+
+  const src = join(productsDir, xctestrunFiles[0]!)
+  copyFileSync(src, WDA_XCTESTRUN_CACHE)
+  console.log(`\nWebDriverAgent installed → ${WDA_XCTESTRUN_CACHE}`)
+  console.log('Run `tapflow wda start` or `tapflow start` to use it.')
+}
+
+async function wdaStart(): Promise<void> {
+  const { running } = checkWdaProcess()
+  if (running) {
+    console.log('WDA is already running.')
+    return
+  }
+
+  if (!existsSync(WDA_XCTESTRUN_CACHE)) {
+    console.error('WebDriverAgent not installed. Run `tapflow wda install` first.')
+    process.exit(1)
+  }
+
+  const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+  const data = JSON.parse(raw) as {
+    devices: Record<string, Array<{ udid: string; name: string; state: string }>>
+  }
+  const booted = Object.values(data.devices).flat().find((d) => d.state === 'Booted')
+  if (!booted) {
+    console.error('No booted simulator. Run `tapflow boot <name>` first.')
+    process.exit(1)
+  }
+
+  const { WdaLauncher } = require('@tapflow/ios-agent') as typeof import('@tapflow/ios-agent')
+  const launcher = new WdaLauncher({ udid: booted.udid, xctestrunPath: WDA_XCTESTRUN_CACHE })
+  console.log(`Starting WDA for ${booted.name}…`)
+  await launcher.ensureRunning()
+  console.log('WDA running on :8100')
+}
+
+function wdaStop(): void {
+  const { running, pid } = checkWdaProcess()
+  if (!running) {
+    console.log('WDA is not running.')
+    return
+  }
+  try {
+    process.kill(pid!, 'SIGTERM')
+    console.log('WDA stopped.')
+  } catch {
+    console.error('Failed to stop WDA.')
+  }
+}
+
+function wdaStatus(): void {
+  const { running, pid } = checkWdaProcess()
+  const installed = existsSync(WDA_XCTESTRUN_CACHE)
+  console.log(`Installed : ${installed ? '✓' : '✗'}`)
+  console.log(`Running   : ${running ? `✓ (PID ${pid})` : '✗'}`)
+  if (running && pid) process.exit(0)
+  if (!running) process.exit(1)
+}

--- a/packages/cli/src/commands/wda.ts
+++ b/packages/cli/src/commands/wda.ts
@@ -1,10 +1,11 @@
 import { execSync, spawn } from 'node:child_process'
-import { existsSync, copyFileSync, readdirSync } from 'node:fs'
+import { existsSync, copyFileSync, readdirSync, cpSync } from 'node:fs'
 import { join } from 'node:path'
 import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import {
   ensureTapflowDir,
+  WDA_DIR,
   WDA_SOURCE_DIR,
   WDA_BUILD_DIR,
   WDA_XCTESTRUN_CACHE,
@@ -125,7 +126,15 @@ async function buildWda(sourcePath: string): Promise<void> {
     process.exit(1)
   }
 
+  // xctestrun uses __TESTROOT__ (its own directory) to resolve test bundle paths.
+  // Copy xctestrun + all sibling directories (Debug-iphonesimulator/ etc.) so they
+  // land next to each other in WDA_DIR and the paths resolve correctly.
   copyFileSync(join(productsDir, xctestrunFiles[0]!), WDA_XCTESTRUN_CACHE)
+  for (const entry of readdirSync(productsDir)) {
+    if (entry.endsWith('.xctestrun')) continue
+    cpSync(join(productsDir, entry), join(WDA_DIR, entry), { recursive: true, force: true })
+  }
+
   banner('success', 'BUILD SUCCEEDED', [
     `Installed: ${WDA_XCTESTRUN_CACHE}`,
     'Run `tapflow start` to connect.',

--- a/packages/cli/src/commands/wda.ts
+++ b/packages/cli/src/commands/wda.ts
@@ -8,9 +8,9 @@ import {
   WDA_SOURCE_DIR,
   WDA_BUILD_DIR,
   WDA_XCTESTRUN_CACHE,
-  WDA_PID_FILE,
 } from '../lib/tapflow-dir'
 import { checkWdaProcess } from '../lib/doctor'
+import { banner, createSpinner, step } from '../lib/print'
 
 const WDA_REPO = 'https://github.com/appium/WebDriverAgent.git'
 
@@ -40,13 +40,13 @@ async function wdaInstall(): Promise<void> {
   try {
     sourcePath = await cloneWda()
   } catch (e) {
-    console.error(`Auto-clone failed: ${(e as Error).message}`)
+    banner('error', 'CLONE FAILED', [(e as Error).message])
     const rl = readline.createInterface({ input, output })
-    const manual = await rl.question('Enter path to your WebDriverAgent source directory: ')
+    const manual = await rl.question('\nEnter path to your WebDriverAgent source directory: ')
     rl.close()
     sourcePath = manual.trim()
     if (!sourcePath || !existsSync(sourcePath)) {
-      console.error('Path not found.')
+      banner('error', 'PATH NOT FOUND', [sourcePath])
       process.exit(1)
     }
   }
@@ -55,49 +55,90 @@ async function wdaInstall(): Promise<void> {
 }
 
 async function cloneWda(): Promise<string> {
-  if (existsSync(join(WDA_SOURCE_DIR, 'WebDriverAgent.xcodeproj'))) {
-    console.log('WebDriverAgent source already cloned. Updating…')
-    execSync('git pull --ff-only', { cwd: WDA_SOURCE_DIR, stdio: 'inherit' })
-  } else {
-    console.log(`Cloning WebDriverAgent from ${WDA_REPO}…`)
-    execSync(`git clone --depth 1 ${WDA_REPO} ${WDA_SOURCE_DIR}`, { stdio: 'inherit' })
+  const alreadyCloned = existsSync(join(WDA_SOURCE_DIR, 'WebDriverAgent.xcodeproj'))
+  const msg = alreadyCloned ? 'Updating WebDriverAgent source…' : 'Cloning WebDriverAgent…'
+  const spinner = createSpinner(msg)
+  spinner.start()
+
+  try {
+    if (alreadyCloned) {
+      execSync('git pull --ff-only', { cwd: WDA_SOURCE_DIR, stdio: 'pipe' })
+    } else {
+      execSync(`git clone --depth 1 ${WDA_REPO} ${WDA_SOURCE_DIR}`, { stdio: 'pipe' })
+    }
+    spinner.stop(true)
+    step(`Source ready: ${WDA_SOURCE_DIR}`)
+    return WDA_SOURCE_DIR
+  } catch (e) {
+    spinner.stop(false)
+    throw e
   }
-  return WDA_SOURCE_DIR
 }
 
 async function buildWda(sourcePath: string): Promise<void> {
   const xcodeproj = join(sourcePath, 'WebDriverAgent.xcodeproj')
   if (!existsSync(xcodeproj)) {
-    console.error(`WebDriverAgent.xcodeproj not found in ${sourcePath}`)
+    banner('error', 'BUILD FAILED', [`WebDriverAgent.xcodeproj not found in ${sourcePath}`])
     process.exit(1)
   }
 
-  console.log('Building WebDriverAgent (this may take a few minutes)…')
-  execSync(
-    [
-      'xcodebuild build-for-testing',
-      `-project ${xcodeproj}`,
-      '-scheme WebDriverAgentRunner',
-      '-destination "platform=iOS Simulator,name=iPhone 16"',
-      `-derivedDataPath ${WDA_BUILD_DIR}`,
-      'CODE_SIGN_IDENTITY=""',
-      'CODE_SIGNING_REQUIRED=NO',
-      'GCC_TREAT_WARNINGS_AS_ERRORS=0',
-    ].join(' '),
-    { stdio: 'inherit' },
-  )
+  const spinner = createSpinner('Building WebDriverAgent (this may take a few minutes)…')
+  spinner.start()
+
+  let stdout = ''
+  let stderr = ''
+
+  const exitCode = await new Promise<number>((resolve) => {
+    const proc = spawn(
+      'xcodebuild',
+      [
+        'build-for-testing',
+        '-project', xcodeproj,
+        '-scheme', 'WebDriverAgentRunner',
+        '-destination', 'platform=iOS Simulator,name=iPhone 16',
+        '-derivedDataPath', WDA_BUILD_DIR,
+        'CODE_SIGN_IDENTITY=',
+        'CODE_SIGNING_REQUIRED=NO',
+        'GCC_TREAT_WARNINGS_AS_ERRORS=0',
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    proc.stdout?.on('data', (d: Buffer) => { stdout += d.toString() })
+    proc.stderr?.on('data', (d: Buffer) => { stderr += d.toString() })
+    proc.on('exit', (code) => resolve(code ?? 1))
+    proc.on('error', () => resolve(1))
+  })
+
+  const succeeded = stdout.includes('** TEST BUILD SUCCEEDED **') || exitCode === 0
+  spinner.stop(succeeded)
+
+  if (!succeeded) {
+    const errorLines = extractKeyErrors(stdout + stderr)
+    banner('error', 'BUILD FAILED', errorLines)
+    process.exit(1)
+  }
 
   const productsDir = join(WDA_BUILD_DIR, 'Build', 'Products')
   const xctestrunFiles = readdirSync(productsDir).filter((f) => f.endsWith('.xctestrun'))
   if (xctestrunFiles.length === 0) {
-    console.error('Build succeeded but no .xctestrun file found.')
+    banner('error', 'BUILD FAILED', ['Build reported success but no .xctestrun file was found.'])
     process.exit(1)
   }
 
-  const src = join(productsDir, xctestrunFiles[0]!)
-  copyFileSync(src, WDA_XCTESTRUN_CACHE)
-  console.log(`\nWebDriverAgent installed → ${WDA_XCTESTRUN_CACHE}`)
-  console.log('Run `tapflow wda start` or `tapflow start` to use it.')
+  copyFileSync(join(productsDir, xctestrunFiles[0]!), WDA_XCTESTRUN_CACHE)
+  banner('success', 'BUILD SUCCEEDED', [
+    `Installed: ${WDA_XCTESTRUN_CACHE}`,
+    'Run `tapflow start` to connect.',
+  ])
+}
+
+function extractKeyErrors(output: string): string[] {
+  return output
+    .split('\n')
+    .filter((l) => /error:|Code signing|No such scheme|BUILD FAILED/.test(l))
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(0, 5)
 }
 
 async function wdaStart(): Promise<void> {
@@ -124,9 +165,17 @@ async function wdaStart(): Promise<void> {
 
   const { WdaLauncher } = require('@tapflow/ios-agent') as typeof import('@tapflow/ios-agent')
   const launcher = new WdaLauncher({ udid: booted.udid, xctestrunPath: WDA_XCTESTRUN_CACHE })
-  console.log(`Starting WDA for ${booted.name}…`)
-  await launcher.ensureRunning()
-  console.log('WDA running on :8100')
+  const spinner = createSpinner(`Starting WDA for ${booted.name}…`)
+  spinner.start()
+  try {
+    await launcher.ensureRunning()
+    spinner.stop(true)
+    banner('success', 'WDA STARTED', [`Running on http://localhost:${launcher.port}`])
+  } catch (e) {
+    spinner.stop(false)
+    banner('error', 'WDA FAILED TO START', [(e as Error).message])
+    process.exit(1)
+  }
 }
 
 function wdaStop(): void {
@@ -137,17 +186,16 @@ function wdaStop(): void {
   }
   try {
     process.kill(pid!, 'SIGTERM')
-    console.log('WDA stopped.')
+    banner('success', 'WDA STOPPED', [])
   } catch {
-    console.error('Failed to stop WDA.')
+    banner('error', 'FAILED TO STOP WDA', [`PID ${pid} could not be terminated.`])
   }
 }
 
 function wdaStatus(): void {
   const { running, pid } = checkWdaProcess()
   const installed = existsSync(WDA_XCTESTRUN_CACHE)
-  console.log(`Installed : ${installed ? '✓' : '✗'}`)
-  console.log(`Running   : ${running ? `✓ (PID ${pid})` : '✗'}`)
-  if (running && pid) process.exit(0)
+  console.log(`  Installed : ${installed ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m'}`)
+  console.log(`  Running   : ${running ? `\x1b[32m✓\x1b[0m  (PID ${pid})` : '\x1b[31m✗\x1b[0m'}`)
   if (!running) process.exit(1)
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,39 @@
+import cac from 'cac'
+import { cmdDoctor } from './commands/doctor'
+import { cmdDevices } from './commands/devices'
+import { cmdBoot } from './commands/boot'
+import { cmdWda } from './commands/wda'
+import { cmdStart } from './commands/start'
+import { cmdReset } from './commands/reset'
+
+const cli = cac('tapflow')
+
+cli
+  .command('doctor', 'Check system prerequisites')
+  .action(() => cmdDoctor())
+
+cli
+  .command('devices', 'List available simulators')
+  .action(() => cmdDevices())
+
+cli
+  .command('boot <name>', 'Boot a simulator by name or UDID')
+  .action((name: string) => cmdBoot(name))
+
+cli
+  .command('wda [action]', 'Manage WebDriverAgent (install|start|stop|status)')
+  .action((action?: string) => cmdWda(action))
+
+cli
+  .command('start', 'Start relay + iOS agent (one-command setup)')
+  .option('--device <name>', 'Simulator name or UDID to use')
+  .option('--relay <url>', 'Relay WebSocket URL (skips local relay spawn)')
+  .action((opts: { device?: string; relay?: string }) => cmdStart(opts))
+
+cli
+  .command('reset', 'Stop WDA and shut down all simulators')
+  .action(() => cmdReset())
+
+cli.help()
+cli.version('0.1.0')
+cli.parse()

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -1,0 +1,115 @@
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { WDA_XCTESTRUN_CACHE, WDA_PID_FILE } from './tapflow-dir'
+
+export interface DoctorCheck {
+  label: string
+  ok: boolean
+  detail?: string
+}
+
+export async function runDoctorChecks(): Promise<DoctorCheck[]> {
+  return Promise.all([
+    checkMacOS(),
+    checkXcode(),
+    checkSimctl(),
+    checkBootedSimulator(),
+    checkWda(),
+    checkNodeVersion(),
+  ])
+}
+
+function checkMacOS(): DoctorCheck {
+  const ok = process.platform === 'darwin'
+  return {
+    label: 'macOS',
+    ok,
+    detail: ok ? undefined : 'tapflow is macOS-only',
+  }
+}
+
+function checkXcode(): DoctorCheck {
+  try {
+    const out = execSync('xcodebuild -version', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+    const version = out.split('\n')[0]?.replace('Xcode ', '') ?? ''
+    return { label: `Xcode ${version}`, ok: true }
+  } catch {
+    return {
+      label: 'Xcode',
+      ok: false,
+      detail: 'Not installed. Install Xcode from the App Store.',
+    }
+  }
+}
+
+function checkSimctl(): DoctorCheck {
+  try {
+    execSync('xcrun simctl list --json', { stdio: 'pipe' })
+    return { label: 'xcrun simctl', ok: true }
+  } catch {
+    return {
+      label: 'xcrun simctl',
+      ok: false,
+      detail: 'Run `xcode-select --install` to install command-line tools.',
+    }
+  }
+}
+
+function checkBootedSimulator(): DoctorCheck {
+  try {
+    const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+    const data = JSON.parse(raw) as { devices: Record<string, Array<{ name: string; state: string }>> }
+    const booted = Object.values(data.devices)
+      .flat()
+      .find((d) => d.state === 'Booted')
+    if (booted) {
+      return { label: `Simulator booted: ${booted.name}`, ok: true }
+    }
+    return {
+      label: 'Simulator',
+      ok: false,
+      detail: 'No booted simulator. Run `tapflow boot <name>` or open Simulator.app.',
+    }
+  } catch {
+    return { label: 'Simulator', ok: false, detail: 'Could not query simulators.' }
+  }
+}
+
+async function checkWda(): Promise<DoctorCheck> {
+  try {
+    const res = await fetch('http://localhost:8100/status', { signal: AbortSignal.timeout(1_000) })
+    if (res.ok) return { label: 'WebDriverAgent (running on :8100)', ok: true }
+  } catch { /* not running */ }
+
+  if (existsSync(WDA_XCTESTRUN_CACHE)) {
+    return { label: 'WebDriverAgent (installed, not running)', ok: true }
+  }
+
+  return {
+    label: 'WebDriverAgent',
+    ok: false,
+    detail: 'Run `tapflow wda install` to set it up.',
+  }
+}
+
+function checkNodeVersion(): DoctorCheck {
+  const version = process.version
+  const [, major] = version.match(/^v(\d+)/) ?? []
+  const ok = Number(major) >= 20
+  return {
+    label: `Node ${version}`,
+    ok,
+    detail: ok ? undefined : 'Node ≥ 20 required.',
+  }
+}
+
+export function checkWdaProcess(): { running: boolean; pid?: number } {
+  if (!existsSync(WDA_PID_FILE)) return { running: false }
+  try {
+    const pid = Number(readFileSync(WDA_PID_FILE, 'utf8').trim())
+    process.kill(pid, 0) // throws if process does not exist
+    return { running: true, pid }
+  } catch {
+    return { running: false }
+  }
+}

--- a/packages/cli/src/lib/print.ts
+++ b/packages/cli/src/lib/print.ts
@@ -1,0 +1,47 @@
+const R = '\x1b[0m'
+const BOLD = '\x1b[1m'
+const DIM = '\x1b[2m'
+const GREEN = '\x1b[32m'
+const RED = '\x1b[31m'
+
+export function banner(type: 'success' | 'error', title: string, lines: string[] = []): void {
+  const color = type === 'success' ? GREEN : RED
+  const icon = type === 'success' ? '✓' : '✗'
+  const contentWidth = Math.max(title.length + 5, ...lines.map((l) => l.length + 2), 40)
+  const bar = '─'.repeat(contentWidth)
+
+  console.log()
+  console.log(`${color}${BOLD}  ┌${bar}┐${R}`)
+  console.log(`${color}${BOLD}  │  ${icon}  ${title.padEnd(contentWidth - 5)}│${R}`)
+  console.log(`${color}${BOLD}  └${bar}┘${R}`)
+  for (const line of lines) {
+    console.log(`${DIM}     ${line}${R}`)
+  }
+  console.log()
+}
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+export function createSpinner(msg: string) {
+  let frame = 0
+  let id: ReturnType<typeof setInterval> | null = null
+
+  return {
+    start() {
+      process.stdout.write(`\n  ${SPINNER_FRAMES[0]}  ${msg}`)
+      id = setInterval(() => {
+        frame = (frame + 1) % SPINNER_FRAMES.length
+        process.stdout.write(`\r  ${SPINNER_FRAMES[frame]}  ${msg}`)
+      }, 80)
+    },
+    stop(ok: boolean) {
+      if (id) clearInterval(id)
+      const icon = ok ? `${GREEN}✓${R}` : `${RED}✗${R}`
+      process.stdout.write(`\r  ${icon}  ${msg}\n`)
+    },
+  }
+}
+
+export function step(msg: string): void {
+  console.log(`  ${DIM}→${R}  ${msg}`)
+}

--- a/packages/cli/src/lib/print.ts
+++ b/packages/cli/src/lib/print.ts
@@ -4,17 +4,32 @@ const DIM = '\x1b[2m'
 const GREEN = '\x1b[32m'
 const RED = '\x1b[31m'
 
+const MAX_WIDTH = 72
+
+function wrap(line: string, maxWidth: number): string[] {
+  if (line.length <= maxWidth) return [line]
+  const chunks: string[] = []
+  for (let i = 0; i < line.length; i += maxWidth) {
+    chunks.push(line.slice(i, i + maxWidth))
+  }
+  return chunks
+}
+
 export function banner(type: 'success' | 'error', title: string, lines: string[] = []): void {
   const color = type === 'success' ? GREEN : RED
   const icon = type === 'success' ? '✓' : '✗'
-  const contentWidth = Math.max(title.length + 5, ...lines.map((l) => l.length + 2), 40)
+  const wrappedLines = lines.flatMap((l) => wrap(l, MAX_WIDTH))
+  const contentWidth = Math.min(
+    MAX_WIDTH,
+    Math.max(title.length + 5, ...wrappedLines.map((l) => l.length + 2), 40),
+  )
   const bar = '─'.repeat(contentWidth)
 
   console.log()
   console.log(`${color}${BOLD}  ┌${bar}┐${R}`)
   console.log(`${color}${BOLD}  │  ${icon}  ${title.padEnd(contentWidth - 5)}│${R}`)
   console.log(`${color}${BOLD}  └${bar}┘${R}`)
-  for (const line of lines) {
+  for (const line of wrappedLines) {
     console.log(`${DIM}     ${line}${R}`)
   }
   console.log()

--- a/packages/cli/src/lib/tapflow-dir.ts
+++ b/packages/cli/src/lib/tapflow-dir.ts
@@ -1,0 +1,14 @@
+import { mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export const TAPFLOW_DIR = join(homedir(), '.tapflow')
+export const WDA_DIR = join(TAPFLOW_DIR, 'wda')
+export const WDA_SOURCE_DIR = join(WDA_DIR, 'source')
+export const WDA_BUILD_DIR = join(WDA_DIR, 'build')
+export const WDA_XCTESTRUN_CACHE = join(WDA_DIR, 'WebDriverAgent.xctestrun')
+export const WDA_PID_FILE = join(TAPFLOW_DIR, 'wda.pid')
+
+export function ensureTapflowDir(): void {
+  mkdirSync(WDA_DIR, { recursive: true })
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__", "dist", "node_modules"]
+}

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -4,12 +4,23 @@ import { SimctlWrapper } from './SimctlWrapper'
 import { ScreenCaptureStreamer } from './ScreenCaptureStreamer'
 import { MjpegStreamer } from './MjpegStreamer'
 import { WdaClient } from './WdaClient'
+import { WdaLauncher } from './WdaLauncher'
 import { DeviceChromeLoader, type ChromeData } from './DeviceChromeLoader'
+
+export interface WdaOptions {
+  /** Auto-launch WDA if not running. Defaults to false. */
+  autoStart?: boolean
+  /** WDA HTTP port. Defaults to 8100. */
+  port?: number
+  /** Path to a pre-built .xctestrun file. Takes priority over WDA_PATH env and cache. */
+  xctestrunPath?: string
+}
 
 export interface IOSAgentOptions {
   fps?: number
   intervalMs?: number  // when set, uses MjpegStreamer (simctl screenshot polling) instead of ScreenCaptureStreamer
   wdaUrl?: string
+  wda?: WdaOptions
 }
 
 export class IOSAgent implements DeviceAgent {
@@ -17,7 +28,9 @@ export class IOSAgent implements DeviceAgent {
   private readonly wda: WdaClient
   private readonly fps: number
   private readonly intervalMs: number | undefined
+  private readonly wdaOptions: WdaOptions
   private readonly chromeLoader: DeviceChromeLoader
+  private wdaLauncher: WdaLauncher | null = null
   private loadedChrome: ChromeData | null = null
   private bootedDeviceId: string | null = null
   private ws: WebSocket | null = null
@@ -25,11 +38,14 @@ export class IOSAgent implements DeviceAgent {
   private streamReader: ReadableStreamDefaultReader<Buffer> | null = null
   private streamMimeType: string = 'image/jpeg'
 
-  constructor(options: IOSAgentOptions = {}, simctl?: SimctlWrapper, wda?: WdaClient) {
+  constructor(options: IOSAgentOptions = {}, simctl?: SimctlWrapper, wdaClient?: WdaClient) {
     this.simctl = simctl ?? new SimctlWrapper()
     this.fps = options.fps ?? 30
     this.intervalMs = options.intervalMs
-    this.wda = wda ?? new WdaClient(options.wdaUrl)
+    this.wdaOptions = options.wda ?? {}
+    const wdaPort = options.wda?.port ?? 8100
+    const wdaBase = options.wdaUrl ?? `http://localhost:${wdaPort}`
+    this.wda = wdaClient ?? new WdaClient(wdaBase)
     this.chromeLoader = new DeviceChromeLoader()
   }
 
@@ -39,6 +55,17 @@ export class IOSAgent implements DeviceAgent {
 
   async connect(relayUrl: string): Promise<void> {
     const devices = await this.simctl.listDevices()
+    const booted = devices.find((d) => d.status === 'booted')
+
+    if (booted && this.wdaOptions.autoStart) {
+      this.wdaLauncher = new WdaLauncher({
+        udid: booted.id,
+        port: this.wdaOptions.port ?? 8100,
+        xctestrunPath: this.wdaOptions.xctestrunPath,
+      })
+      await this.wdaLauncher.ensureRunning()
+    }
+
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(relayUrl)
 
@@ -75,6 +102,8 @@ export class IOSAgent implements DeviceAgent {
   disconnect(): void {
     this.streamReader?.cancel()
     this.streamReader = null
+    this.wdaLauncher?.stop()
+    this.wdaLauncher = null
     this.ws?.close()
     this.ws = null
     this._sessionId = null

--- a/packages/ios-agent/src/ScreenCaptureStreamer.ts
+++ b/packages/ios-agent/src/ScreenCaptureStreamer.ts
@@ -39,11 +39,26 @@ export class ScreenCaptureStreamer {
 
     proc.stderr.on('data', (d: Buffer) => process.stderr.write(d))
 
+    // done is hoisted so both start() and cancel() share the same flag
+    let done = false
+
     return new ReadableStream<Buffer>({
       start(controller) {
         let buf = Buffer.alloc(0)
 
+        const close = () => {
+          if (done) return
+          done = true
+          controller.close()
+        }
+        const error = (e: Error) => {
+          if (done) return
+          done = true
+          controller.error(e)
+        }
+
         proc.stdout.on('data', (chunk: Buffer) => {
+          if (done) return
           buf = Buffer.concat([buf, chunk])
           while (buf.length >= 4) {
             const frameLen = buf.readUInt32BE(0)
@@ -53,14 +68,17 @@ export class ScreenCaptureStreamer {
           }
         })
 
-        proc.stdout.on('end', () => controller.close())
-        proc.on('error', (e) => controller.error(e))
+        proc.stdout.on('end', close)
+        proc.on('error', error)
         proc.on('exit', (code) => {
           if (code !== null && code !== 0)
-            controller.error(new Error(`[ScreenCaptureStreamer] exited with code ${code}`))
+            error(new Error(`[ScreenCaptureStreamer] exited with code ${code}`))
+          else
+            close()
         })
       },
       cancel() {
+        done = true
         proc.kill()
       },
     })

--- a/packages/ios-agent/src/WdaLauncher.ts
+++ b/packages/ios-agent/src/WdaLauncher.ts
@@ -78,7 +78,10 @@ export class WdaLauncher {
     return candidates.find((p): p is string => !!p && existsSync(p)) ?? null
   }
 
+  private stderrLines: string[] = []
+
   private spawnXcodebuild(xctestrunPath: string): void {
+    this.stderrLines = []
     this.process = spawn(
       'xcodebuild',
       [
@@ -91,6 +94,7 @@ export class WdaLauncher {
 
     this.process.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString()
+      this.stderrLines.push(...text.split('\n').filter(Boolean))
       for (const [pattern, msg] of XCODEBUILD_ERROR_MAP) {
         if (pattern.test(text)) {
           console.error(`[wda] ${msg}`)
@@ -107,7 +111,22 @@ export class WdaLauncher {
       await new Promise((r) => setTimeout(r, 500))
     }
     this.stop()
-    throw new Error(`WDA did not respond within ${timeoutMs / 1000}s`)
+
+    const hint = this.extractHint()
+    const msg = hint
+      ? `WDA did not respond within ${timeoutMs / 1000}s\n  Hint: ${hint}`
+      : `WDA did not respond within ${timeoutMs / 1000}s\n  Run \`tapflow wda install\` to rebuild, or check \`xcodebuild\` output manually.`
+    throw new Error(msg)
+  }
+
+  private extractHint(): string | null {
+    // Check known patterns first
+    for (const [pattern, msg] of XCODEBUILD_ERROR_MAP) {
+      if (this.stderrLines.some((l) => pattern.test(l))) return msg
+    }
+    // Surface the first error-looking line from stderr
+    const errorLine = this.stderrLines.find((l) => /error:|failed|cannot/.test(l.toLowerCase()))
+    return errorLine?.trim() ?? null
   }
 
   private writePid(): void {

--- a/packages/ios-agent/src/WdaLauncher.ts
+++ b/packages/ios-agent/src/WdaLauncher.ts
@@ -1,0 +1,118 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export const TAPFLOW_DIR = join(homedir(), '.tapflow')
+export const WDA_DIR = join(TAPFLOW_DIR, 'wda')
+export const WDA_PID_FILE = join(TAPFLOW_DIR, 'wda.pid')
+export const WDA_XCTESTRUN_CACHE = join(WDA_DIR, 'WebDriverAgent.xctestrun')
+
+export class WdaNotInstalledError extends Error {
+  constructor() {
+    super('WebDriverAgent not found. Run `tapflow wda install` to set it up.')
+  }
+}
+
+const XCODEBUILD_ERROR_MAP: Array<[RegExp, string]> = [
+  [/Code signing is required/, 'code signing 오류: 시뮬레이터는 서명이 필요 없습니다. CODE_SIGN_IDENTITY="" 확인.'],
+  [/No such scheme/, 'scheme을 찾을 수 없습니다. WebDriverAgentRunner scheme이 존재하는지 확인하세요.'],
+  [/No provisioning profile/, '프로비저닝 프로파일 오류: 시뮬레이터 빌드에서는 불필요합니다.'],
+  [/xcode-select/, 'Xcode 커맨드라인 도구 미설치. `xcode-select --install`을 실행하세요.'],
+]
+
+export interface WdaLaunchOptions {
+  udid: string
+  port?: number
+  xctestrunPath?: string
+}
+
+export class WdaLauncher {
+  readonly port: number
+  private readonly udid: string
+  private readonly xctestrunPath: string | undefined
+  private process: ChildProcess | null = null
+
+  constructor(opts: WdaLaunchOptions) {
+    this.udid = opts.udid
+    this.port = opts.port ?? 8100
+    this.xctestrunPath = opts.xctestrunPath
+  }
+
+  async ensureRunning(): Promise<void> {
+    if (await this.isHealthy()) return
+
+    mkdirSync(WDA_DIR, { recursive: true })
+
+    const xctestrun = this.resolveXctestrun()
+    if (!xctestrun) throw new WdaNotInstalledError()
+
+    this.spawnXcodebuild(xctestrun)
+    await this.pollHealth(30_000)
+    this.writePid()
+  }
+
+  stop(): void {
+    this.process?.kill()
+    this.process = null
+    try { rmSync(WDA_PID_FILE) } catch { /* already gone */ }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const res = await fetch(`http://localhost:${this.port}/status`, {
+        signal: AbortSignal.timeout(1_000),
+      })
+      return res.ok
+    } catch {
+      return false
+    }
+  }
+
+  private resolveXctestrun(): string | null {
+    const candidates = [
+      this.xctestrunPath,
+      process.env['WDA_PATH'],
+      WDA_XCTESTRUN_CACHE,
+    ]
+    return candidates.find((p): p is string => !!p && existsSync(p)) ?? null
+  }
+
+  private spawnXcodebuild(xctestrunPath: string): void {
+    this.process = spawn(
+      'xcodebuild',
+      [
+        'test-without-building',
+        '-xctestrun', xctestrunPath,
+        '-destination', `platform=iOS Simulator,id=${this.udid}`,
+      ],
+      { stdio: ['ignore', 'ignore', 'pipe'] },
+    )
+
+    this.process.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString()
+      for (const [pattern, msg] of XCODEBUILD_ERROR_MAP) {
+        if (pattern.test(text)) {
+          console.error(`[wda] ${msg}`)
+          return
+        }
+      }
+    })
+  }
+
+  private async pollHealth(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (await this.isHealthy()) return
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    this.stop()
+    throw new Error(`WDA did not respond within ${timeoutMs / 1000}s`)
+  }
+
+  private writePid(): void {
+    if (this.process?.pid) {
+      writeFileSync(WDA_PID_FILE, String(this.process.pid))
+    }
+  }
+}

--- a/packages/ios-agent/src/__tests__/WdaLauncher.test.ts
+++ b/packages/ios-agent/src/__tests__/WdaLauncher.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  rmSync: vi.fn(),
+}))
+
+import { spawn } from 'node:child_process'
+import { existsSync, writeFileSync, rmSync } from 'node:fs'
+
+const mockSpawn = vi.mocked(spawn)
+const mockExistsSync = vi.mocked(existsSync)
+const mockWriteFileSync = vi.mocked(writeFileSync)
+const mockRmSync = vi.mocked(rmSync)
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeProcess(pid = 1234): ChildProcess {
+  const proc = new EventEmitter() as unknown as ChildProcess
+  ;(proc as Record<string, unknown>).pid = pid
+  ;(proc as Record<string, unknown>).stderr = new EventEmitter()
+  ;(proc as Record<string, unknown>).kill = vi.fn()
+  return proc
+}
+
+// Dynamic import after mocks are set up
+const { WdaLauncher, WdaNotInstalledError, WDA_XCTESTRUN_CACHE } = await import('../WdaLauncher')
+
+const UDID = 'test-udid-1234'
+
+function healthOk() {
+  return Promise.resolve(new Response('{}', { status: 200 }))
+}
+function healthFail() {
+  return Promise.reject(new Error('ECONNREFUSED'))
+}
+
+describe('WdaLauncher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env['WDA_PATH']
+  })
+
+  afterEach(() => {
+    delete process.env['WDA_PATH']
+  })
+
+  describe('ensureRunning — already healthy', () => {
+    it('returns without spawning when WDA is already responding', async () => {
+      mockFetch.mockResolvedValueOnce(healthOk())
+      const launcher = new WdaLauncher({ udid: UDID })
+      await launcher.ensureRunning()
+      expect(mockSpawn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ensureRunning — WDA_PATH env priority', () => {
+    it('uses WDA_PATH env over cache when both exist', async () => {
+      process.env['WDA_PATH'] = '/env/path/WDA.xctestrun'
+      mockFetch.mockRejectedValueOnce(new Error('fail'))
+      mockExistsSync.mockImplementation((p) =>
+        p === '/env/path/WDA.xctestrun' || p === WDA_XCTESTRUN_CACHE
+      )
+      const proc = makeProcess()
+      mockSpawn.mockReturnValueOnce(proc)
+      mockFetch.mockResolvedValue(healthOk())
+
+      const launcher = new WdaLauncher({ udid: UDID })
+      await launcher.ensureRunning()
+
+      const [, args] = mockSpawn.mock.calls[0]
+      expect(args).toContain('/env/path/WDA.xctestrun')
+    })
+  })
+
+  describe('ensureRunning — explicit xctestrunPath', () => {
+    it('uses constructor xctestrunPath over env and cache', async () => {
+      process.env['WDA_PATH'] = '/env/path/WDA.xctestrun'
+      mockFetch.mockRejectedValueOnce(new Error('fail'))
+      mockExistsSync.mockImplementation((p) => p === '/explicit/WDA.xctestrun')
+      const proc = makeProcess()
+      mockSpawn.mockReturnValueOnce(proc)
+      mockFetch.mockResolvedValue(healthOk())
+
+      const launcher = new WdaLauncher({ udid: UDID, xctestrunPath: '/explicit/WDA.xctestrun' })
+      await launcher.ensureRunning()
+
+      const [, args] = mockSpawn.mock.calls[0]
+      expect(args).toContain('/explicit/WDA.xctestrun')
+    })
+  })
+
+  describe('ensureRunning — cache fallback', () => {
+    it('spawns xcodebuild with cached xctestrun', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('fail'))
+      mockExistsSync.mockImplementation((p) => p === WDA_XCTESTRUN_CACHE)
+      const proc = makeProcess()
+      mockSpawn.mockReturnValueOnce(proc)
+      mockFetch.mockResolvedValue(healthOk())
+
+      const launcher = new WdaLauncher({ udid: UDID })
+      await launcher.ensureRunning()
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'xcodebuild',
+        expect.arrayContaining([
+          'test-without-building',
+          '-xctestrun', WDA_XCTESTRUN_CACHE,
+          '-destination', `platform=iOS Simulator,id=${UDID}`,
+        ]),
+        expect.any(Object),
+      )
+      expect(mockWriteFileSync).toHaveBeenCalled()
+    })
+  })
+
+  describe('ensureRunning — nothing found', () => {
+    it('throws WdaNotInstalledError when no xctestrun exists', async () => {
+      mockFetch.mockRejectedValue(new Error('fail'))
+      mockExistsSync.mockReturnValue(false)
+
+      const launcher = new WdaLauncher({ udid: UDID })
+      await expect(launcher.ensureRunning()).rejects.toThrow(WdaNotInstalledError)
+      expect(mockSpawn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ensureRunning — custom port', () => {
+    it('health-checks on the configured port', async () => {
+      mockFetch.mockResolvedValueOnce(healthOk())
+      const launcher = new WdaLauncher({ udid: UDID, port: 8200 })
+      await launcher.ensureRunning()
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8200/status',
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('stop', () => {
+    it('kills the spawned process and removes PID file', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('fail'))
+      mockExistsSync.mockImplementation((p) => p === WDA_XCTESTRUN_CACHE)
+      const proc = makeProcess()
+      mockSpawn.mockReturnValueOnce(proc)
+      mockFetch.mockResolvedValue(healthOk())
+
+      const launcher = new WdaLauncher({ udid: UDID })
+      await launcher.ensureRunning()
+
+      launcher.stop()
+      expect(proc.kill).toHaveBeenCalled()
+      expect(mockRmSync).toHaveBeenCalled()
+    })
+
+    it('does not throw when called without a running process', () => {
+      const launcher = new WdaLauncher({ udid: UDID })
+      expect(() => launcher.stop()).not.toThrow()
+    })
+  })
+})

--- a/packages/ios-agent/src/index.ts
+++ b/packages/ios-agent/src/index.ts
@@ -1,5 +1,7 @@
 export { IOSAgent } from './IOSAgent'
-export type { IOSAgentOptions } from './IOSAgent'
+export type { IOSAgentOptions, WdaOptions } from './IOSAgent'
 export { SimctlWrapper } from './SimctlWrapper'
 export { MjpegStreamer } from './MjpegStreamer'
 export { WdaClient } from './WdaClient'
+export { WdaLauncher, WdaNotInstalledError } from './WdaLauncher'
+export type { WdaLaunchOptions } from './WdaLauncher'

--- a/packages/ios-agent/src/types/roamhq-wrtc.d.ts
+++ b/packages/ios-agent/src/types/roamhq-wrtc.d.ts
@@ -1,0 +1,26 @@
+declare module '@roamhq/wrtc' {
+  export class RTCPeerConnection {
+    onicecandidate: ((event: { candidate: RTCIceCandidate | null }) => void) | null
+    addTrack(track: MediaStreamTrack): RTCRtpSender
+    createOffer(): Promise<RTCSessionDescriptionInit>
+    setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>
+    setRemoteDescription(description: RTCSessionDescription): Promise<void>
+    addIceCandidate(candidate: RTCIceCandidateInit): Promise<void>
+    close(): void
+  }
+
+  export class RTCSessionDescription {
+    constructor(init: { type: RTCSdpType; sdp: string })
+  }
+
+  export const nonstandard: {
+    RTCVideoSource: new () => {
+      createTrack(): MediaStreamTrack
+      onFrame(frame: { width: number; height: number; data: Buffer }): void
+    }
+    rgbaToI420(
+      rgba: { width: number; height: number; data: Buffer },
+      i420: { width: number; height: number; data: Buffer },
+    ): void
+  }
+}

--- a/playground/ios-agent.ts
+++ b/playground/ios-agent.ts
@@ -1,6 +1,10 @@
 import { IOSAgent } from '@tapflow/ios-agent'
 
-const RELAY = process.env.RELAY_URL ?? 'ws://localhost:3000'
+const RELAY = process.env['RELAY_URL'] ?? 'ws://localhost:3000'
+
+// Accept --device <name|udid> argument
+const deviceArgIdx = process.argv.indexOf('--device')
+const deviceArg = deviceArgIdx >= 0 ? process.argv[deviceArgIdx + 1] : undefined
 
 const agent = new IOSAgent()
 
@@ -8,13 +12,27 @@ const devices = await agent.listDevices()
 console.log('Available simulators:')
 devices.forEach((d) => console.log(` · [${d.status}] ${d.name} (${d.id})`))
 
-const booted = devices.find((d) => d.status === 'booted')
-if (!booted) {
+let target = deviceArg
+  ? devices.find((d) => d.name === deviceArg || d.id === deviceArg)
+  : devices.find((d) => d.status === 'booted')
+
+if (deviceArg && !target) {
+  console.error(`\nDevice not found: ${deviceArg}`)
+  process.exit(1)
+}
+
+if (!target) {
   console.log('\nNo booted simulator found. Boot one first:')
   console.log('  xcrun simctl boot <device-id>')
+  console.log('  or: npm run dev:ios-agent -- --device "iPhone 16"')
   process.exit(1)
+}
+
+if (target.status !== 'booted') {
+  console.log(`\nBooting ${target.name}…`)
+  await agent.boot(target.id)
 }
 
 console.log(`\nConnecting to relay: ${RELAY}`)
 await agent.connect(RELAY)
-console.log(`iOS Agent connected — streaming ${booted.name}`)
+console.log(`iOS Agent connected — streaming ${target.name}`)

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,15 +6,20 @@
   "scripts": {
     "relay": "tsx relay.ts",
     "ios-agent": "tsx ios-agent.ts",
-    "android-agent": "tsx android-agent.ts"
+    "android-agent": "tsx android-agent.ts",
+    "dev:doctor": "tsx ../packages/cli/src/index.ts doctor",
+    "dev:reset": "tsx ../packages/cli/src/index.ts reset",
+    "dev:up": "concurrently -n relay,agent -c cyan,green \"npm run relay\" \"npm run ios-agent\""
   },
   "dependencies": {
     "@tapflow/agent-core": "*",
     "@tapflow/ios-agent": "*",
     "@tapflow/android-agent": "*",
-    "@tapflow/relay": "*"
+    "@tapflow/relay": "*",
+    "@tapflow/cli": "*"
   },
   "devDependencies": {
+    "concurrently": "^9.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
## Summary

- **WDA 자동 셋업** (`WdaLauncher`) — `WDA_PATH` env → `~/.tapflow/wda/` 캐시 순으로 xctestrun 탐색, `ensureRunning()`으로 헬스체크 후 자동 기동. 타임아웃 시 xcodebuild stderr 힌트 포함. xctestrun과 함께 `Debug-iphonesimulator/` 번들도 복사해 `__TESTROOT__` 경로 해소.
- **IOSAgent 확장** — `WdaOptions(autoStart, port, xctestrunPath)` 추가. `connect()`/`disconnect()`에서 launcher lifecycle 연동. 기본값 `autoStart: false`로 기존 테스트 영향 없음.
- **CLI** (`cac`) — `doctor` / `devices` / `boot` / `wda install|start|stop|status` / `start` / `reset` 전 커맨드 구현. spinner + ANSI 배너로 시각적 피드백 통일. `tapflow start`는 relay 자동 spawn + WDA 자동 기동 포함.
- **`tapflow wda install`** — git clone 후 `xcodebuild build-for-testing`, 실패 시 수동 경로 입력 폴백.
- **playground** — `--device` 인자, `dev:doctor` / `dev:reset` / `dev:up`(concurrently) 스크립트 추가.
- **버그 수정** — `ScreenCaptureStreamer` cancel 후 이중 `controller.close()` → `ERR_INVALID_STATE` 해소.

## Test plan

- [x] `tapflow doctor` — 각 체크 항목 ✓/✗ 정상 출력
- [x] `tapflow wda install` — clone → build → banner 확인
- [x] `tapflow start` — relay + WDA 자동 기동, `AGENT CONNECTED` 배너 확인
- [x] `tapflow wda start` — 타임아웃 시 stderr 힌트 노출 확인
- [x] `tapflow reset` — 확인 프롬프트 후 cleanup 확인
- [x] `npm run dev:up` — relay + agent 동시 기동 확인
- [x] `npm run test --workspaces` — 전체 62개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)