### PR TITLE
feat(cli+ios-agent): WDA auto-setup and CLI bootstrap commands

### DIFF
--- a/packages/ios-agent/src/WdaLauncher.ts
+++ b/packages/ios-agent/src/WdaLauncher.ts
@@ -15,10 +15,10 @@ export class WdaNotInstalledError extends Error {
 }
 
 const XCODEBUILD_ERROR_MAP: Array<[RegExp, string]> = [
-  [/Code signing is required/, 'code signing 오류: 시뮬레이터는 서명이 필요 없습니다. CODE_SIGN_IDENTITY="" 확인.'],
-  [/No such scheme/, 'scheme을 찾을 수 없습니다. WebDriverAgentRunner scheme이 존재하는지 확인하세요.'],
-  [/No provisioning profile/, '프로비저닝 프로파일 오류: 시뮬레이터 빌드에서는 불필요합니다.'],
-  [/xcode-select/, 'Xcode 커맨드라인 도구 미설치. `xcode-select --install`을 실행하세요.'],
+  [/Code signing is required/, 'Code signing error: not required for simulator builds. Check CODE_SIGN_IDENTITY="".'],
+  [/No such scheme/, 'Scheme not found. Make sure the WebDriverAgentRunner scheme exists in your project.'],
+  [/No provisioning profile/, 'Provisioning profile error: not required for simulator builds.'],
+  [/xcode-select/, 'Xcode command-line tools not installed. Run `xcode-select --install`.'],
 ]
 
 export interface WdaLaunchOptions {


### PR DESCRIPTION
## Summary

- **WDA auto-setup** (`ios-agent`): `WdaLauncher.ensureRunning()` added — health-checks WDA, auto-starts via cached `.xctestrun` or `WDA_PATH` env, manages PID lifecycle, and maps `xcodebuild` stderr to friendly English error messages
- **CLI commands** (`cli`): `tapflow doctor`, `devices`, `boot`, `wda install/start/stop/status`, `start` (relay + WDA + agent in one command), `reset` — all built with `cac`
- **Playground conveniences**: `dev:doctor`, `dev:reset`, `dev:up`, `--device` arg support for `dev:ios-agent`
- **Shared doctor logic**: `packages/cli/src/lib/doctor.ts` shared between CLI and playground
- **WebRTC streaming** (merged from `feature/webrtc-streaming`): MJPEG fallback, `@roamhq/wrtc` type declarations

## Out of scope (tracked in `.work/2026-05-09-backlog-todo.md`)

- WDA strategy 3: auto-detect source dir (`WDA_SOURCE_PATH`) and trigger `build-for-testing` from within `WdaLauncher` — deferred to multi-simulator phase

## Test plan

- [x] `tapflow doctor` — all checks pass on a healthy macOS + Xcode environment
- [x] `tapflow wda install` — clones WDA, builds, caches `.xctestrun`
- [x] `tapflow start` — relay + WDA + agent connect in one command
- [x] `tapflow start --relay ws://remote:3000` — skips local relay spawn
- [x] `tapflow reset` — prompt N aborts, prompt Y cleans up processes and pid file
- [x] `WdaLauncher` unit tests pass (`npm test --workspace=@tapflow/ios-agent`)
- [x] `RelayServer` unit tests pass (`npm test --workspace=@tapflow/relay`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)