### PR TITLE
feat: 디바이스 단위 세션 분리 — 다중 사용자 동시 사용 지원

### DIFF
--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -61,14 +61,14 @@ export function SessionList({ onSelect }: Props) {
     if (connected) send({ type: 'agents:list' })
   }, [connected, send])
 
-  const handleBoot = (session: SessionInfo, deviceId: string) => {
-    onSelect(session.sessionId, deviceId)
+  const handleBoot = (_session: SessionInfo, deviceId: string, sessionId: string) => {
+    onSelect(sessionId, deviceId)
   }
 
-  const handleShutdown = (session: SessionInfo, deviceId: string) => {
+  const handleShutdown = (deviceId: string, sessionId: string) => {
     setShutting((prev) => ({ ...prev, [deviceId]: true }))
-    send({ type: 'session:start', sessionId: session.sessionId })
-    send({ type: 'device:shutdown', sessionId: session.sessionId, payload: { deviceId } })
+    send({ type: 'session:start', sessionId })
+    send({ type: 'device:shutdown', sessionId, payload: { deviceId } })
   }
 
   if (!connected) {
@@ -99,11 +99,11 @@ export function SessionList({ onSelect }: Props) {
           const isBooting = booting[d.id] === 'booting'
           const isError = booting[d.id] === 'error'
           const isShutting = shutting[d.id] === true
-          const isBusy = s.busy
+          const isBusy = d.busy
           const isBooted = d.status === 'booted'
 
           return (
-            <li key={`${s.sessionId}-${d.id}`}>
+            <li key={`${d.sessionId}-${d.id}`}>
               <Card>
                 <CardContent className="flex items-center gap-4 p-5">
                   <div className="flex-1">
@@ -122,7 +122,7 @@ export function SessionList({ onSelect }: Props) {
                   )}
 
                   {isBooted && !isBusy && !isShutting && (
-                    <Button size="sm" onClick={() => onSelect(s.sessionId, d.id)}>
+                    <Button size="sm" onClick={() => onSelect(d.sessionId, d.id)}>
                       Connect
                     </Button>
                   )}
@@ -130,18 +130,18 @@ export function SessionList({ onSelect }: Props) {
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => handleShutdown(s, d.id)}
+                      onClick={() => handleShutdown(d.id, d.sessionId)}
                     >
                       Shutdown
                     </Button>
                   )}
                   {!isBooted && !isBooting && !isError && !isShutting && (
-                    <Button size="sm" variant="outline" onClick={() => handleBoot(s, d.id)}>
+                    <Button size="sm" variant="outline" onClick={() => handleBoot(s, d.id, d.sessionId)}>
                       Boot
                     </Button>
                   )}
                   {isError && (
-                    <Button size="sm" variant="outline" onClick={() => handleBoot(s, d.id)}>
+                    <Button size="sm" variant="outline" onClick={() => handleBoot(s, d.id, d.sessionId)}>
                       Retry
                     </Button>
                   )}

--- a/packages/dashboard/components/comment-panel.tsx
+++ b/packages/dashboard/components/comment-panel.tsx
@@ -6,6 +6,13 @@ import { Separator } from '@/components/ui/separator'
 import { Link2, ImagePlus } from 'lucide-react'
 import type { Comment } from '@/lib/types'
 
+// SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" (UTC, no timezone marker).
+// Normalize to unambiguous ISO 8601 UTC so all browsers parse it correctly.
+function parseUTCDate(ts: string): Date {
+  if (/[Zz]|[+-]\d{2}/.test(ts)) return new Date(ts)
+  return new Date(ts.replace(' ', 'T') + 'Z')
+}
+
 const MAX_SIZE_BYTES = 5 * 1024 * 1024
 const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp']
 
@@ -84,7 +91,7 @@ export function CommentPanel({ buildId }: Props) {
                   <span className="text-xs font-medium">{c.author}</span>
                   <div className="flex items-center gap-1">
                     <span className="text-xs text-muted-foreground">
-                      {new Date(c.created_at).toLocaleString()}
+                      {parseUTCDate(c.created_at).toLocaleString()}
                     </span>
                     <Button variant="ghost" size="icon" className="h-5 w-5" onClick={() => copyLink(c.id)}>
                       <Link2 className="h-3 w-3" />

--- a/packages/dashboard/components/comment-panel.tsx
+++ b/packages/dashboard/components/comment-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -58,7 +58,7 @@ export function CommentPanel({ buildId }: Props) {
     setFile(f)
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     if (!body.trim() && !file) return
     setSubmitting(true)

--- a/packages/dashboard/components/upload-build-dialog.tsx
+++ b/packages/dashboard/components/upload-build-dialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -29,7 +29,7 @@ export function UploadBuildDialog({ onSuccess }: Props) {
   const [uploading, setUploading] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  async function handleUpload(e: React.FormEvent) {
+  async function handleUpload(e: FormEvent) {
     e.preventDefault()
     if (!file) return
     setError('')

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -4,6 +4,8 @@ export interface AgentDevice {
   platform: string
   status: string
   osVersion?: string
+  sessionId: string
+  busy: boolean
 }
 
 export interface Comment {
@@ -21,9 +23,7 @@ export interface CommentAttachment {
 }
 
 export interface SessionInfo {
-  sessionId: string
   agentName?: string
-  busy: boolean
   devices: AgentDevice[]
 }
 

--- a/packages/dashboard/src/pages/Invite.tsx
+++ b/packages/dashboard/src/pages/Invite.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -25,7 +25,7 @@ export function Invite() {
       .catch(() => setStatus('invalid'))
   }, [token])
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     if (password !== confirm) { setError('Passwords do not match'); return }
     setError('')

--- a/packages/dashboard/src/pages/Login.tsx
+++ b/packages/dashboard/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -12,7 +12,7 @@ export function Login() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setError('')
     setLoading(true)

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -92,7 +92,6 @@ export function QASession() {
     if (!selectedDevice || !deviceId) return;
     setBooting(true);
     setStatus('Booting…');
-    send({ type: 'session:start', sessionId: selectedDevice.sessionId, deviceId });
     setActiveSessionId(selectedDevice.sessionId);
   }
 
@@ -101,6 +100,8 @@ export function QASession() {
       send({ type: 'device:shutdown', sessionId: activeSessionId, payload: { deviceId } });
     }
     setActiveSessionId(null);
+    setBooting(false);
+    setStatus('');
   }
 
   return (

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -86,15 +86,14 @@ export function QASession() {
     ? filteredDevices.filter((d) => d.osVersion === osVersion)
     : filteredDevices;
 
-  const selectedSession = sessions.find((s) => s.devices.some((d) => d.id === deviceId));
   const selectedDevice = allDevices.find((d) => d.id === deviceId);
 
   function handleBoot() {
-    if (!selectedSession || !deviceId) return;
+    if (!selectedDevice || !deviceId) return;
     setBooting(true);
     setStatus('Booting…');
-    send({ type: 'session:start', sessionId: selectedSession.sessionId, deviceId });
-    setActiveSessionId(selectedSession.sessionId);
+    send({ type: 'session:start', sessionId: selectedDevice.sessionId, deviceId });
+    setActiveSessionId(selectedDevice.sessionId);
   }
 
   function handleBack() {

--- a/packages/dashboard/src/pages/settings/Default.tsx
+++ b/packages/dashboard/src/pages/settings/Default.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -19,7 +19,7 @@ export function DefaultSettings() {
       .then((d) => { if (d) { setTeamName(d.team_name); setLogoUrl(d.logo_url) } })
   }, [])
 
-  async function handleSave(e: React.FormEvent) {
+  async function handleSave(e: FormEvent) {
     e.preventDefault()
     setSaving(true)
     const form = new FormData()

--- a/packages/dashboard/src/pages/settings/Team.tsx
+++ b/packages/dashboard/src/pages/settings/Team.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -30,7 +30,7 @@ export function TeamSettings() {
 
   useEffect(() => { load() }, [])
 
-  async function handleInvite(e: React.FormEvent) {
+  async function handleInvite(e: FormEvent) {
     e.preventDefault()
     setInviting(true)
     const res = await fetch('/api/v1/team/invite', {

--- a/packages/dashboard/src/pages/settings/Tokens.tsx
+++ b/packages/dashboard/src/pages/settings/Tokens.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -28,7 +28,7 @@ export function TokenSettings() {
 
   useEffect(() => { load() }, [])
 
-  async function handleCreate(e: React.FormEvent) {
+  async function handleCreate(e: FormEvent) {
     e.preventDefault()
     setCreating(true)
     const res = await fetch('/api/v1/tokens', {

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -12,7 +12,7 @@ import { DeviceChromeLoader, type ChromeData } from './DeviceChromeLoader'
 export interface WdaOptions {
   /** Auto-launch WDA if not running. Defaults to false. */
   autoStart?: boolean
-  /** WDA HTTP port. Defaults to 8100. */
+  /** WDA HTTP port for the first device. Defaults to 8100. Additional devices increment from here. */
   port?: number
   /** Path to a pre-built .xctestrun file. Takes priority over WDA_PATH env and cache. */
   xctestrunPath?: string
@@ -25,49 +25,64 @@ export interface IOSAgentOptions {
   wda?: WdaOptions
 }
 
+interface DeviceState {
+  sessionId: string
+  deviceId: string
+  touchHelper: TouchHelper | null
+  wdaLauncher: WdaLauncher | null
+  wdaClient: WdaClient
+  wdaPort: number
+  streamWs: WebSocket | null
+  streamReader: ReadableStreamDefaultReader<Buffer> | null
+  bootSeq: number
+  orientation: 'portrait' | 'landscapeRight'
+  loadedChrome: ChromeData | null
+}
+
 export class IOSAgent implements DeviceAgent {
   private readonly simctl: SimctlWrapper
-  private readonly wda: WdaClient
   private readonly fps: number
   private readonly intervalMs: number | undefined
   private readonly wdaOptions: WdaOptions
   private readonly chromeLoader: DeviceChromeLoader
-  private wdaLauncher: WdaLauncher | null = null
-  private touchHelper: TouchHelper | null = null
-  private loadedChrome: ChromeData | null = null
-  private bootedDeviceId: string | null = null
-  private bootSeq = 0
-  private orientation: 'portrait' | 'landscapeRight' = 'portrait'
   private ws: WebSocket | null = null
-  private _sessionId: string | null = null
-  private streamReader: ReadableStreamDefaultReader<Buffer> | null = null
+  // keyed by sessionId
+  private deviceStates = new Map<string, DeviceState>()
+  private relayUrl: string | null = null
 
   constructor(options: IOSAgentOptions = {}, simctl?: SimctlWrapper, wdaClient?: WdaClient) {
     this.simctl = simctl ?? new SimctlWrapper()
     this.fps = options.fps ?? 60
     this.intervalMs = options.intervalMs
     this.wdaOptions = options.wda ?? {}
-    const wdaPort = options.wda?.port ?? 8100
-    const wdaBase = options.wdaUrl ?? `http://localhost:${wdaPort}`
-    this.wda = wdaClient ?? new WdaClient(wdaBase)
     this.chromeLoader = new DeviceChromeLoader()
+    // wdaClient injection is kept for single-device backward compat in unit tests
+    if (wdaClient) {
+      // will be overridden per-device after connect()
+      this._injectedWdaClient = wdaClient
+    }
   }
 
+  private _injectedWdaClient: WdaClient | null = null
+
+  /** Returns the sessionId of the first registered device. Useful in single-device scenarios. */
   get sessionId(): string | null {
-    return this._sessionId
+    const first = this.deviceStates.values().next().value
+    return first?.sessionId ?? null
   }
 
   async connect(relayUrl: string): Promise<void> {
+    this.relayUrl = relayUrl
     const devices = await this.simctl.listDevices()
     const booted = devices.find((d) => d.status === 'booted')
 
     if (booted && this.wdaOptions.autoStart) {
-      this.wdaLauncher = new WdaLauncher({
+      const launcher = new WdaLauncher({
         udid: booted.id,
         port: this.wdaOptions.port ?? 8100,
         xctestrunPath: this.wdaOptions.xctestrunPath,
       })
-      await this.wdaLauncher.ensureRunning()
+      await launcher.ensureRunning()
     }
 
     return new Promise((resolve, reject) => {
@@ -91,7 +106,10 @@ export class IOSAgent implements DeviceAgent {
         const msg = JSON.parse(data.toString())
         if (msg.type === 'agent:registered') {
           this.ws = ws
-          this._sessionId = msg.sessionId
+          this.initDeviceStates(
+            msg.registeredSessions as Array<{ deviceId: string; sessionId: string }>,
+            devices,
+          )
           ws.on('message', (d) => {
             try { this.handleRelayMessage(JSON.parse(d.toString())) } catch { /* ignore malformed */ }
           })
@@ -105,79 +123,146 @@ export class IOSAgent implements DeviceAgent {
     })
   }
 
+  private initDeviceStates(
+    registeredSessions: Array<{ deviceId: string; sessionId: string }>,
+    devices: Device[],
+  ): void {
+    const basePort = this.wdaOptions.port ?? 8100
+    registeredSessions.forEach(({ deviceId, sessionId }, index) => {
+      const wdaPort = basePort + index
+      const wdaClient = this._injectedWdaClient ?? new WdaClient(`http://localhost:${wdaPort}`)
+      const device = devices.find((d) => d.id === deviceId)
+      this.deviceStates.set(sessionId, {
+        sessionId,
+        deviceId,
+        touchHelper: null,
+        wdaLauncher: null,
+        wdaClient,
+        wdaPort,
+        streamWs: null,
+        streamReader: null,
+        bootSeq: 0,
+        orientation: 'portrait',
+        loadedChrome: null,
+      })
+      // If this device was already booted at connect time and autoStart is set, WDA is running
+      if (device?.status === 'booted' && this.wdaOptions.autoStart) {
+        // wdaLauncher already started above in connect(); store state reference if needed
+      }
+    })
+  }
+
   disconnect(): void {
-    this.streamReader?.cancel()
-    this.streamReader = null
-    this.touchHelper?.stop()
-    this.touchHelper = null
-    this.wdaLauncher?.stop()
-    this.wdaLauncher = null
+    for (const state of this.deviceStates.values()) {
+      this.cleanupDeviceState(state)
+    }
+    this.deviceStates.clear()
     this.ws?.close()
     this.ws = null
-    this._sessionId = null
+    this.relayUrl = null
   }
 
-  private sendChromeData(devices: Device[]): void {
-    const booted = devices.find((d) => d.status === 'booted')
-    if (!booted || !this.ws) return
-    this.bootedDeviceId = booted.id
-    this.touchHelper = new TouchHelper(booted.id)
-    this.touchHelper.start()
+  private cleanupDeviceState(state: DeviceState): void {
+    state.streamReader?.cancel()
+    state.streamReader = null
+    state.touchHelper?.stop()
+    state.touchHelper = null
+    state.wdaLauncher?.stop()
+    state.wdaLauncher = null
+    state.streamWs?.close()
+    state.streamWs = null
+  }
+
+  private sendChromeData(state: DeviceState, device: Device): void {
+    if (!this.ws) return
+    state.touchHelper = new TouchHelper(device.id)
+    state.touchHelper.start()
     this.ws.send(JSON.stringify({
       type: 'session:deviceInfo',
+      sessionId: state.sessionId,
       payload: {
-        deviceName: booted.name,
-        osVersion: booted.osVersion ?? '',
+        deviceName: device.name,
+        osVersion: device.osVersion ?? '',
       },
     }))
-    this.loadedChrome = this.chromeLoader.load(booted.typeId ?? booted.name)
-    if (!this.loadedChrome) return
-    this.ws.send(JSON.stringify({ type: 'session:chrome', payload: this.loadedChrome }))
+    state.loadedChrome = this.chromeLoader.load(device.typeId ?? device.name)
+    if (!state.loadedChrome) return
+    this.ws.send(JSON.stringify({
+      type: 'session:chrome',
+      sessionId: state.sessionId,
+      payload: state.loadedChrome,
+    }))
   }
 
-  private startBinaryStream(): void {
+  private startBinaryStream(state: DeviceState, streamWs: WebSocket): void {
     const stream = this.intervalMs !== undefined
       ? new MjpegStreamer(this.simctl, this.intervalMs).start()
-      : new ScreenCaptureStreamer(this.fps, this.bootedDeviceId ?? 'booted').start()
+      : new ScreenCaptureStreamer(this.fps, state.deviceId).start()
 
     const reader = stream.getReader()
-    this.streamReader = reader
+    state.streamReader = reader
 
     const pump = async () => {
       try {
         while (true) {
           const { value, done } = await reader.read()
           if (done) break
-          if (this.ws?.readyState === WebSocket.OPEN) {
-            this.ws.send(value)
+          if (streamWs.readyState === WebSocket.OPEN) {
+            streamWs.send(value)
           }
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect
       }
-      // auto-restart if still connected (e.g. screencapture-helper exited unexpectedly)
-      if (this.streamReader === reader && this.ws?.readyState === WebSocket.OPEN) {
-        this.startBinaryStream()
+      // auto-restart if still connected
+      if (state.streamReader === reader && streamWs.readyState === WebSocket.OPEN) {
+        this.startBinaryStream(state, streamWs)
       }
     }
 
     pump()
   }
 
-  private async handleDeviceBoot(deviceId: string): Promise<void> {
-    const seq = ++this.bootSeq
+  private async openStreamWs(state: DeviceState): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const streamWs = new WebSocket(this.relayUrl!)
+      state.streamWs = streamWs
 
-    this.streamReader?.cancel()
-    this.streamReader = null
-    this.touchHelper?.stop()
-    this.touchHelper = null
+      streamWs.once('open', () => {
+        streamWs.send(JSON.stringify({ type: 'stream:register', sessionId: state.sessionId }))
+      })
 
-    if (!this.ws) return
-    this.ws.send(JSON.stringify({ type: 'device:booting' }))
+      const onMsg = (data: Buffer) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'stream:registered') {
+          streamWs.off('message', onMsg)
+          resolve(streamWs)
+        }
+      }
+      streamWs.on('message', onMsg)
+      streamWs.once('error', reject)
+    })
+  }
+
+  private async handleDeviceBoot(sessionId: string, deviceId: string): Promise<void> {
+    const state = this.deviceStates.get(sessionId)
+    if (!state || !this.ws) return
+
+    const seq = ++state.bootSeq
+
+    // Tear down previous stream for this device if re-booting
+    state.streamReader?.cancel()
+    state.streamReader = null
+    state.touchHelper?.stop()
+    state.touchHelper = null
+    state.streamWs?.close()
+    state.streamWs = null
+
+    this.ws.send(JSON.stringify({ type: 'device:booting', sessionId }))
 
     try {
       const devices = await this.simctl.listDevices()
-      if (seq !== this.bootSeq) return
+      if (seq !== state.bootSeq) return
 
       const target = devices.find((d) => d.id === deviceId)
       if (!target) throw new Error(`Device not found: ${deviceId}`)
@@ -186,133 +271,169 @@ export class IOSAgent implements DeviceAgent {
         await this.simctl.boot(deviceId)
       }
 
-      if (seq !== this.bootSeq) return
+      if (seq !== state.bootSeq) return
 
       const refreshed = await this.simctl.listDevices()
-      this.sendChromeData(refreshed.map((d) => ({
-        ...d,
-        status: (d.id === deviceId ? 'booted' : 'shutdown') as Device['status'],
-      })))
-      this.startBinaryStream()
-      this.ws?.send(JSON.stringify({ type: 'device:ready', payload: { deviceId } }))
+      const refreshedDevice = refreshed.find((d) => d.id === deviceId) ?? target
+      this.sendChromeData(state, {
+        ...refreshedDevice,
+        status: 'booted',
+      } as Device)
+
+      // Open dedicated stream WS and wait for relay to confirm before sending device:ready
+      const streamWs = await this.openStreamWs(state)
+      if (seq !== state.bootSeq) {
+        streamWs.close()
+        return
+      }
+
+      this.startBinaryStream(state, streamWs)
+      this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId } }))
     } catch (e) {
-      if (seq !== this.bootSeq) return
+      if (seq !== state.bootSeq) return
       const message = e instanceof Error ? e.message : String(e)
-      this.ws?.send(JSON.stringify({ type: 'device:boot-error', message }))
+      this.ws?.send(JSON.stringify({ type: 'device:boot-error', sessionId, message }))
     }
   }
 
-  private async handleDeviceShutdown(deviceId: string): Promise<void> {
-    this.bootSeq++
-    this.streamReader?.cancel()
-    this.streamReader = null
-    this.touchHelper?.stop()
-    this.touchHelper = null
-    this.bootedDeviceId = null
+  private async handleDeviceShutdown(sessionId: string, deviceId: string): Promise<void> {
+    const state = this.deviceStates.get(sessionId)
+    if (!state) return
+
+    state.bootSeq++
+    state.streamReader?.cancel()
+    state.streamReader = null
+    state.touchHelper?.stop()
+    state.touchHelper = null
+    state.streamWs?.close()
+    state.streamWs = null
 
     try {
       await this.simctl.shutdown(deviceId)
-      this.ws?.send(JSON.stringify({ type: 'device:shutdown-done', payload: { deviceId } }))
+      this.ws?.send(JSON.stringify({
+        type: 'device:shutdown-done',
+        sessionId,
+        payload: { deviceId },
+      }))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       console.error('[agent] shutdown failed:', message)
     }
   }
 
-  private handleRelayMessage(msg: { type: string; payload?: unknown }): void {
+  private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
     switch (msg.type) {
       case 'device:boot': {
         const { deviceId } = msg.payload as { deviceId: string }
-        this.handleDeviceBoot(deviceId).catch((e) => console.error('[agent] handleDeviceBoot failed:', e))
+        const sessionId = msg.sessionId!
+        this.handleDeviceBoot(sessionId, deviceId)
+          .catch((e) => console.error('[agent] handleDeviceBoot failed:', e))
         break
       }
       case 'device:shutdown': {
         const { deviceId } = msg.payload as { deviceId: string }
-        this.handleDeviceShutdown(deviceId).catch((e) => console.error('[agent] handleDeviceShutdown failed:', e))
+        const sessionId = msg.sessionId!
+        this.handleDeviceShutdown(sessionId, deviceId)
+          .catch((e) => console.error('[agent] handleDeviceShutdown failed:', e))
         break
       }
       case 'app:install': {
         const { filePath } = msg.payload as { filePath: string }
+        const sessionId = msg.sessionId
         this.simctl.installApp(filePath)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:install-done' })))
+          .then(() => this.ws?.send(JSON.stringify({ type: 'app:install-done', sessionId })))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:install-error', message }))
+            this.ws?.send(JSON.stringify({ type: 'app:install-error', sessionId, message }))
           })
         break
       }
       case 'app:launch': {
         const { bundleId } = msg.payload as { bundleId: string }
+        const sessionId = msg.sessionId
         this.simctl.launchApp(bundleId)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:launch-done' })))
+          .then(() => this.ws?.send(JSON.stringify({ type: 'app:launch-done', sessionId })))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:launch-error', message }))
+            this.ws?.send(JSON.stringify({ type: 'app:launch-error', sessionId, message }))
           })
         break
       }
       case 'input:touch:start': {
-        if (!this.touchHelper) { console.error('[agent] touch:start — touchHelper not ready'); break }
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) { console.error('[agent] touch:start — touchHelper not ready'); break }
         const { x, y } = msg.payload as { x: number; y: number }
-        this.touchStart(x, y)
+        this.touchStartForState(state, x, y)
         break
       }
       case 'input:touch:move': {
-        if (!this.touchHelper) break
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) break
         const { x, y } = msg.payload as { x: number; y: number }
-        this.touchMove(x, y)
+        state.touchHelper.touchMove(x, y)
         break
       }
       case 'input:touch:end': {
-        this.touchEnd().catch(() => {})
+        const state = this.deviceStates.get(msg.sessionId!)
+        state?.touchHelper?.touchEnd()
         break
       }
       case 'input:pinch:start': {
-        if (!this.touchHelper) break
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) break
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
-        this.touchHelper.pinchStart(f0.x, f0.y, f1.x, f1.y)
+        state.touchHelper.pinchStart(f0.x, f0.y, f1.x, f1.y)
         break
       }
       case 'input:pinch:move': {
-        if (!this.touchHelper) break
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) break
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
-        this.touchHelper.pinchMove(f0.x, f0.y, f1.x, f1.y)
+        state.touchHelper.pinchMove(f0.x, f0.y, f1.x, f1.y)
         break
       }
       case 'input:pinch:end': {
-        if (!this.touchHelper) break
-        this.touchHelper.pinchEnd()
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) break
+        state.touchHelper.pinchEnd()
         break
       }
       case 'input:rotate': {
-        if (!this.bootedDeviceId) break
-        this.orientation = this.orientation === 'portrait' ? 'landscapeRight' : 'portrait'
-        this.simctl.rotate(this.bootedDeviceId, this.orientation)
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state) break
+        state.orientation = state.orientation === 'portrait' ? 'landscapeRight' : 'portrait'
+        this.simctl.rotate(state.deviceId, state.orientation)
           .catch((e) => console.error('[agent] rotate failed:', e))
         break
       }
       case 'input:type': {
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state) break
         const { text } = msg.payload as { text: string }
-        this.wda.type(text).catch((e) => console.error('[agent] type failed:', e))
+        state.wdaClient.type(text).catch((e) => console.error('[agent] type failed:', e))
         break
       }
       case 'input:button': {
+        const state = this.deviceStates.get(msg.sessionId!)
+        if (!state?.touchHelper) break
         const { name } = msg.payload as { name: string }
-        if (this.touchHelper) {
-          if (name === 'home') {
-            this.touchHelper.pressLegacyButton(0)
+        if (name === 'home') {
+          state.touchHelper.pressLegacyButton(0)
+        } else {
+          const btn = state.loadedChrome?.buttons.find((b) => b.name === name)
+          if (btn && btn.usagePage > 0 && btn.usage > 0) {
+            state.touchHelper.pressButton(btn.usagePage, btn.usage)
           } else {
-            const btn = this.loadedChrome?.buttons.find((b) => b.name === name)
-            if (btn && btn.usagePage > 0 && btn.usage > 0) {
-              this.touchHelper.pressButton(btn.usagePage, btn.usage)
-            } else {
-              this.wda.pressButton(name).catch((e) => console.error('[agent] button wda fallback failed:', e))
-            }
+            state.wdaClient.pressButton(name).catch((e) => console.error('[agent] button wda fallback failed:', e))
           }
         }
         break
       }
     }
+  }
+
+  private touchStartForState(state: DeviceState, x: number, y: number): void {
+    state.touchHelper?.touchStart(x, y)
   }
 
   // DeviceAgent interface — delegate to SimctlWrapper
@@ -323,18 +444,27 @@ export class IOSAgent implements DeviceAgent {
   launchApp(bundleId: string): Promise<void> { return this.simctl.launchApp(bundleId) }
   screenshot(): Promise<Buffer> { return this.simctl.screenshot() }
   stream(): ReadableStream<Buffer> {
-    if (!this.bootedDeviceId) throw new Error('no booted device — call connect() first')
-    return new ScreenCaptureStreamer(this.fps, this.bootedDeviceId).start()
+    const first = this.deviceStates.values().next().value
+    if (!first) throw new Error('no booted device — call connect() first')
+    return new ScreenCaptureStreamer(this.fps, first.deviceId).start()
   }
 
-  touchStart(x: number, y: number): void { this.touchHelper?.touchStart(x, y) }
+  touchStart(x: number, y: number): void {
+    const first = this.deviceStates.values().next().value
+    first?.touchHelper?.touchStart(x, y)
+  }
   touchMove(x: number, y: number): Promise<void> {
-    this.touchHelper?.touchMove(x, y)
+    const first = this.deviceStates.values().next().value
+    first?.touchHelper?.touchMove(x, y)
     return Promise.resolve()
   }
   touchEnd(): Promise<void> {
-    this.touchHelper?.touchEnd()
+    const first = this.deviceStates.values().next().value
+    first?.touchHelper?.touchEnd()
     return Promise.resolve()
   }
-  type(text: string): Promise<void> { return this.wda.type(text) }
+  type(text: string): Promise<void> {
+    const first = this.deviceStates.values().next().value
+    return first?.wdaClient.type(text) ?? Promise.resolve()
+  }
 }

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -162,7 +162,7 @@ describe('IOSAgent', () => {
 
   describe('device:boot handler', () => {
     it('sends device:booting then device:ready for a shutdown device', async () => {
-      const simctl = mockSimctl(false) // device is shutdown
+      const simctl = mockSimctl(false)
       const agent = new IOSAgent({ intervalMs: 50 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
 
@@ -185,7 +185,7 @@ describe('IOSAgent', () => {
     })
 
     it('skips boot call for already-booted device', async () => {
-      const simctl = mockSimctl(true) // already booted
+      const simctl = mockSimctl(true)
       const agent = new IOSAgent({ intervalMs: 50 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
 
@@ -222,6 +222,23 @@ describe('IOSAgent', () => {
       agent.disconnect()
       browser.close()
     })
+
+    it('agents:listed includes sessionId per device', async () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'agents:list' }))
+      const listed = await waitForType(browser, 'agents:listed')
+
+      const sessions = listed.sessions as Array<{ devices: Array<{ sessionId?: string }> }>
+      expect(typeof sessions[0]?.devices[0]?.sessionId).toBe('string')
+      expect(sessions[0].devices[0].sessionId).toBe(agent.sessionId)
+
+      agent.disconnect()
+      browser.close()
+    })
   })
 
   describe('relay connection', () => {
@@ -232,7 +249,7 @@ describe('IOSAgent', () => {
       agent.disconnect()
     })
 
-    it('forwards binary frame to browser after connecting', async () => {
+    it('forwards binary frame to browser via stream WS after connecting', async () => {
       const browser = new WebSocket(`ws://localhost:${port}`)
       browser.binaryType = 'nodebuffer'
       await waitForOpen(browser)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -117,7 +117,8 @@ export class RelayServer {
   private handleConnection(ws: WebSocket): void {
     ws.on('message', (data, isBinary) => {
       if (isBinary) {
-        const session = this.sessions.getBySocket(ws)
+        // Binary frames arrive on the dedicated stream WS, route to the session's browser
+        const session = this.sessions.getByStreamSocket(ws)
         if (session?.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(data, { binary: true })
         }
@@ -132,12 +133,24 @@ export class RelayServer {
     })
 
     ws.on('close', () => {
-      const session = this.sessions.getBySocket(ws)
-      if (!session) return
-      if (session.agentSocket === ws) {
-        this.sessions.remove(session.id)
-      } else {
-        this.sessions.clearBrowser(session.id)
+      // Agent main socket disconnected → remove all device sessions for this agent
+      const agentSessions = this.sessions.getAllByAgentSocket(ws)
+      if (agentSessions.length > 0) {
+        for (const s of agentSessions) this.sessions.remove(s.id)
+        return
+      }
+
+      // Stream socket disconnected → clear the streamSocket reference
+      const streamSession = this.sessions.getByStreamSocket(ws)
+      if (streamSession) {
+        streamSession.streamSocket = null
+        return
+      }
+
+      // Browser socket disconnected → clear browserSocket so session becomes available again
+      const browserSession = this.sessions.getByBrowserSocket(ws)
+      if (browserSession) {
+        this.sessions.clearBrowser(browserSession.id)
       }
     })
   }
@@ -145,8 +158,12 @@ export class RelayServer {
   private route(ws: WebSocket, msg: RelayMessage): void {
     switch (msg.type) {
       case 'agent:register': {
-        const sessionId = this.sessions.create(ws, msg.devices ?? [], msg.agentName)
-        ws.send(JSON.stringify({ type: 'agent:registered', sessionId }))
+        const sessionIds = this.sessions.create(ws, msg.devices ?? [], msg.agentName)
+        const registeredSessions = (msg.devices ?? []).map((d, i) => ({
+          deviceId: d.id,
+          sessionId: sessionIds[i],
+        }))
+        ws.send(JSON.stringify({ type: 'agent:registered', registeredSessions }))
         break
       }
 
@@ -162,7 +179,12 @@ export class RelayServer {
           ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }))
           return
         }
-        this.sessions.join(msg.sessionId!, ws)
+        try {
+          this.sessions.join(msg.sessionId!, ws)
+        } catch {
+          ws.send(JSON.stringify({ type: 'error', message: 'Session busy' }))
+          return
+        }
         ws.send(JSON.stringify({ type: 'session:joined', sessionId: msg.sessionId }))
         if (session.chromeData) {
           ws.send(JSON.stringify({ type: 'session:chrome', payload: session.chromeData }))
@@ -170,17 +192,15 @@ export class RelayServer {
         if (session.deviceInfo) {
           ws.send(JSON.stringify({ type: 'session:deviceInfo', payload: session.deviceInfo }))
         }
-        // If a device is already booted (e.g. browser reconnected after a brief WS blip),
-        // replay device:ready so deviceReadyRef is set and frames start drawing immediately.
-        const bootedDevice = session.devices.find((d) => d.status === 'booted')
-        if (bootedDevice) {
-          ws.send(JSON.stringify({ type: 'device:ready', payload: { deviceId: bootedDevice.id } }))
+        // Replay device:ready if the device is already booted (browser WS blip reconnect)
+        if (session.deviceStatus === 'booted') {
+          ws.send(JSON.stringify({ type: 'device:ready', payload: { deviceId: session.deviceId } }))
         }
         break
       }
 
       case 'session:chrome': {
-        const session = this.sessions.getBySocket(ws)
+        const session = this.sessions.get(msg.sessionId!)
         if (!session) break
         this.sessions.setChromeData(session.id, msg.payload)
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
@@ -190,7 +210,7 @@ export class RelayServer {
       }
 
       case 'session:deviceInfo': {
-        const session = this.sessions.getBySocket(ws)
+        const session = this.sessions.get(msg.sessionId!)
         if (!session) break
         this.sessions.setDeviceInfo(session.id, msg.payload as { deviceName: string; osVersion: string })
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
@@ -200,8 +220,17 @@ export class RelayServer {
       }
 
       case 'session:end': {
-        const session = this.sessions.getBySocket(ws)
-        if (session) this.sessions.remove(session.id)
+        if (msg.sessionId) this.sessions.remove(msg.sessionId)
+        break
+      }
+
+      case 'stream:register': {
+        // Dedicated stream WS from agent: register it and ack so agent knows it's safe to send frames
+        const session = this.sessions.get(msg.sessionId!)
+        if (session) {
+          this.sessions.setStreamSocket(session.id, ws)
+          ws.send(JSON.stringify({ type: 'stream:registered' }))
+        }
         break
       }
 
@@ -216,9 +245,8 @@ export class RelayServer {
       }
 
       case 'device:booting': {
-        // agent → browser; clear cached device data so the next session:start
-        // doesn't replay stale chrome/deviceInfo/device:ready from the old device.
-        const session = this.sessions.getBySocket(ws)
+        // agent → browser; clear cached device data so reconnecting browser doesn't get stale chrome
+        const session = this.sessions.get(msg.sessionId!)
         if (!session) break
         this.sessions.clearDeviceCache(session.id)
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
@@ -229,7 +257,7 @@ export class RelayServer {
 
       case 'device:boot-error': {
         // agent → browser
-        const session = this.sessions.getBySocket(ws)
+        const session = this.sessions.get(msg.sessionId!)
         if (session?.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -237,11 +265,10 @@ export class RelayServer {
       }
 
       case 'device:shutdown-done': {
-        // agent → browser + persist status so agents:list reflects shutdown state
-        const session = this.sessions.getBySocket(ws)
+        // agent → browser + persist shutdown status
+        const session = this.sessions.get(msg.sessionId!)
         if (!session) break
-        const { deviceId } = (msg as { type: string; payload: { deviceId: string } }).payload
-        this.sessions.updateDeviceStatus(session.id, deviceId, 'shutdown')
+        this.sessions.updateDeviceStatus(session.id, 'shutdown')
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -249,11 +276,10 @@ export class RelayServer {
       }
 
       case 'device:ready': {
-        // agent → browser + persist status so agents:list reflects booted state
-        const session = this.sessions.getBySocket(ws)
+        // agent → browser + persist booted status
+        const session = this.sessions.get(msg.sessionId!)
         if (!session) break
-        const { deviceId } = (msg as { type: string; payload: { deviceId: string } }).payload
-        this.sessions.updateDeviceStatus(session.id, deviceId, 'booted')
+        this.sessions.updateDeviceStatus(session.id, 'booted')
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -261,7 +287,7 @@ export class RelayServer {
       }
 
       case 'app:install': {
-        // browser → agent: relay looks up file_path from DB and enriches
+        // browser → agent: relay looks up file_path from DB and enriches; includes sessionId for response routing
         const session = this.sessions.get(msg.sessionId!)
         if (!session) {
           ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }))
@@ -275,7 +301,11 @@ export class RelayServer {
           break
         }
         if (session.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify({ type: 'app:install', payload: { filePath: build.file_path } }))
+          session.agentSocket.send(JSON.stringify({
+            type: 'app:install',
+            sessionId: msg.sessionId,
+            payload: { filePath: build.file_path },
+          }))
         }
         break
       }
@@ -283,7 +313,7 @@ export class RelayServer {
       case 'app:install-done':
       case 'app:install-error': {
         // agent → browser
-        const session = this.sessions.getBySocket(ws)
+        const session = this.sessions.get(msg.sessionId!)
         if (session?.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -291,7 +321,7 @@ export class RelayServer {
       }
 
       case 'app:launch': {
-        // browser → agent: relay looks up bundle_id from DB
+        // browser → agent: relay looks up bundle_id from DB; includes sessionId for response routing
         const session = this.sessions.get(msg.sessionId!)
         if (!session) {
           ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }))
@@ -305,7 +335,11 @@ export class RelayServer {
           break
         }
         if (session.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify({ type: 'app:launch', payload: { bundleId: build.bundle_id } }))
+          session.agentSocket.send(JSON.stringify({
+            type: 'app:launch',
+            sessionId: msg.sessionId,
+            payload: { bundleId: build.bundle_id },
+          }))
         }
         break
       }
@@ -313,7 +347,7 @@ export class RelayServer {
       case 'app:launch-done':
       case 'app:launch-error': {
         // agent → browser
-        const session = this.sessions.getBySocket(ws)
+        const session = this.sessions.get(msg.sessionId!)
         if (session?.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -336,7 +370,6 @@ export class RelayServer {
         }
         break
       }
-
     }
   }
 

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -1,33 +1,74 @@
 import { randomUUID } from 'crypto'
 import type { WebSocket } from 'ws'
-import type { DeviceInfo, SessionInfo } from './types'
+import type { SessionInfo } from './types'
 
 export interface Session {
   id: string
   agentName?: string
   agentSocket: WebSocket
   browserSocket: WebSocket | null
-  devices: DeviceInfo[]
+  streamSocket: WebSocket | null
+  deviceId: string
+  deviceName: string
+  devicePlatform: string
+  deviceStatus: string
+  deviceOsVersion?: string
   chromeData?: unknown
   deviceInfo?: { deviceName: string; osVersion: string }
 }
 
+type RawDevice = { id: string; name: string; platform: string; status: string; osVersion?: string }
+
 export class SessionManager {
   private sessions = new Map<string, Session>()
 
-  create(agentSocket: WebSocket, devices: DeviceInfo[] = [], agentName?: string): string {
-    const id = randomUUID()
-    this.sessions.set(id, { id, agentName, agentSocket, browserSocket: null, devices })
-    return id
+  create(agentSocket: WebSocket, devices: RawDevice[] = [], agentName?: string): string[] {
+    return devices.map((d) => {
+      const id = randomUUID()
+      this.sessions.set(id, {
+        id,
+        agentName,
+        agentSocket,
+        browserSocket: null,
+        streamSocket: null,
+        deviceId: d.id,
+        deviceName: d.name,
+        devicePlatform: d.platform,
+        deviceStatus: d.status,
+        deviceOsVersion: d.osVersion,
+      })
+      return id
+    })
   }
 
   get(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId)
   }
 
+  getAllByAgentSocket(ws: WebSocket): Session[] {
+    return Array.from(this.sessions.values()).filter((s) => s.agentSocket === ws)
+  }
+
+  getByStreamSocket(ws: WebSocket): Session | undefined {
+    for (const session of this.sessions.values()) {
+      if (session.streamSocket === ws) return session
+    }
+    return undefined
+  }
+
+  getByBrowserSocket(ws: WebSocket): Session | undefined {
+    for (const session of this.sessions.values()) {
+      if (session.browserSocket === ws) return session
+    }
+    return undefined
+  }
+
   join(sessionId: string, browserSocket: WebSocket): void {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error(`Session not found: ${sessionId}`)
+    if (session.browserSocket?.readyState === 1 /* OPEN */) {
+      throw new Error(`Session busy: ${sessionId}`)
+    }
     session.browserSocket = browserSocket
   }
 
@@ -39,9 +80,6 @@ export class SessionManager {
     const session = this.sessions.get(sessionId)
     if (!session) return
     session.browserSocket = null
-    // Keep chromeData / deviceInfo / device status — cleared in clearDeviceCache (device:booting).
-    // Preserving them lets a reconnecting browser (e.g. React StrictMode WS blip) pick up
-    // the cached state from session:start without waiting for a new device:boot cycle.
   }
 
   clearDeviceCache(sessionId: string): void {
@@ -49,7 +87,12 @@ export class SessionManager {
     if (!session) return
     session.chromeData = undefined
     session.deviceInfo = undefined
-    session.devices = session.devices.map((d) => ({ ...d, status: 'shutdown' as const }))
+    session.deviceStatus = 'shutdown'
+  }
+
+  setStreamSocket(sessionId: string, ws: WebSocket): void {
+    const session = this.sessions.get(sessionId)
+    if (session) session.streamSocket = ws
   }
 
   setChromeData(sessionId: string, data: unknown): void {
@@ -62,29 +105,31 @@ export class SessionManager {
     if (session) session.deviceInfo = info
   }
 
-  getBySocket(socket: WebSocket): Session | undefined {
-    for (const session of this.sessions.values()) {
-      if (session.agentSocket === socket || session.browserSocket === socket) {
-        return session
-      }
-    }
-    return undefined
-  }
-
-  updateDeviceStatus(sessionId: string, deviceId: string, status: string): void {
+  updateDeviceStatus(sessionId: string, status: string): void {
     const session = this.sessions.get(sessionId)
-    if (!session) return
-    session.devices = session.devices.map((d) =>
-      d.id === deviceId ? { ...d, status: status as DeviceInfo['status'] } : d
-    )
+    if (session) session.deviceStatus = status
   }
 
   list(): SessionInfo[] {
-    return Array.from(this.sessions.values()).map((s) => ({
-      sessionId: s.id,
-      agentName: s.agentName,
-      busy: s.browserSocket !== null,
-      devices: s.devices,
+    // Group sessions by agentSocket
+    const agentMap = new Map<WebSocket, Session[]>()
+    for (const session of this.sessions.values()) {
+      const group = agentMap.get(session.agentSocket) ?? []
+      group.push(session)
+      agentMap.set(session.agentSocket, group)
+    }
+
+    return Array.from(agentMap.values()).map((group) => ({
+      agentName: group[0].agentName,
+      devices: group.map((s) => ({
+        id: s.deviceId,
+        name: s.deviceName,
+        platform: s.devicePlatform,
+        status: s.deviceStatus,
+        osVersion: s.deviceOsVersion,
+        sessionId: s.id,
+        busy: s.browserSocket !== null,
+      })),
     }))
   }
 }

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -11,6 +11,18 @@ const waitForMessage = (ws: WebSocket) =>
     ws.once('message', (data) => resolve(JSON.parse(data.toString())))
   )
 
+const waitForType = (ws: WebSocket, type: string) =>
+  new Promise<RelayMessage>((resolve) => {
+    const listener = (data: Buffer) => {
+      const msg = JSON.parse(data.toString())
+      if (msg.type === type) {
+        ws.off('message', listener)
+        resolve(msg)
+      }
+    }
+    ws.on('message', listener)
+  })
+
 describe('RelayServer', () => {
   let server: RelayServer
   let port: number
@@ -32,21 +44,41 @@ describe('RelayServer', () => {
     ws.close()
   })
 
-  it('registers an agent and returns a sessionId', async () => {
+  it('registers an agent with devices and returns registeredSessions', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const ws = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(ws)
-    ws.send(JSON.stringify({ type: 'agent:register' }))
+    ws.send(JSON.stringify({ type: 'agent:register', devices }))
     const msg = await waitForMessage(ws)
     expect(msg.type).toBe('agent:registered')
-    expect(typeof msg.sessionId).toBe('string')
+    expect(msg.registeredSessions).toHaveLength(1)
+    expect(msg.registeredSessions![0].deviceId).toBe('devA')
+    expect(typeof msg.registeredSessions![0].sessionId).toBe('string')
     ws.close()
   })
 
-  it('allows a browser to join an agent session', async () => {
+  it('registers an agent with multiple devices — one sessionId per device', async () => {
+    const devices = [
+      { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+    ]
+    const ws = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(ws)
+    ws.send(JSON.stringify({ type: 'agent:register', devices }))
+    const msg = await waitForMessage(ws)
+    expect(msg.registeredSessions).toHaveLength(2)
+    const ids = msg.registeredSessions!.map((s) => s.sessionId)
+    expect(ids[0]).not.toBe(ids[1])
+    ws.close()
+  })
+
+  it('allows a browser to join a device session', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
@@ -58,11 +90,77 @@ describe('RelayServer', () => {
     browser.close()
   })
 
-  it('routes input:touch:start from browser to agent', async () => {
+  it('returns error when joining a non-existent session', async () => {
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId: 'bad-id' }))
+    const msg = await waitForMessage(browser)
+    expect(msg.type).toBe('error')
+    expect(msg.message).toBe('Session not found')
+    browser.close()
+  })
+
+  it('returns error when a second browser tries to join a busy session', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const browser1 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser1)
+    browser1.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForMessage(browser1) // session:joined
+
+    const browser2 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser2)
+    browser2.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const msg = await waitForMessage(browser2)
+    expect(msg.type).toBe('error')
+    expect(msg.message).toBe('Session busy')
+
+    agent.close()
+    browser1.close()
+    browser2.close()
+  })
+
+  it('two browsers can use different device sessions concurrently', async () => {
+    const devices = [
+      { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+    ]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionA = registeredSessions!.find((s) => s.deviceId === 'devA')!.sessionId
+    const sessionB = registeredSessions!.find((s) => s.deviceId === 'devB')!.sessionId
+
+    const browserA = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browserA)
+    browserA.send(JSON.stringify({ type: 'session:start', sessionId: sessionA }))
+    const msgA = await waitForMessage(browserA)
+    expect(msgA.type).toBe('session:joined')
+
+    const browserB = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browserB)
+    browserB.send(JSON.stringify({ type: 'session:start', sessionId: sessionB }))
+    const msgB = await waitForMessage(browserB)
+    expect(msgB.type).toBe('session:joined')
+
+    agent.close()
+    browserA.close()
+    browserB.close()
+  })
+
+  it('routes input:touch:start from browser to agent', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
@@ -79,133 +177,188 @@ describe('RelayServer', () => {
     browser.close()
   })
 
-  it('routes input:button from browser to agent', async () => {
+  it('input from browserA does not reach browserB session agent', async () => {
+    const devices = [
+      { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+    ]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionA = registeredSessions!.find((s) => s.deviceId === 'devA')!.sessionId
+    const sessionB = registeredSessions!.find((s) => s.deviceId === 'devB')!.sessionId
+
+    const browserA = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browserA)
+    browserA.send(JSON.stringify({ type: 'session:start', sessionId: sessionA }))
+    await waitForMessage(browserA)
+
+    // Agent receives browserA's touch for sessionA
+    const touchPromise = waitForType(agent, 'input:touch:start')
+    browserA.send(JSON.stringify({ type: 'input:touch:start', sessionId: sessionA, payload: { x: 0.1, y: 0.2 } }))
+    const touch = await touchPromise
+    expect(touch.sessionId).toBe(sessionA)  // carries sessionA, not sessionB
+
+    // A touch for sessionB should also route correctly when browser B joins
+    const browserB = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browserB)
+    browserB.send(JSON.stringify({ type: 'session:start', sessionId: sessionB }))
+    await waitForMessage(browserB)
+
+    const touch2Promise = waitForType(agent, 'input:touch:start')
+    browserB.send(JSON.stringify({ type: 'input:touch:start', sessionId: sessionB, payload: { x: 0.9, y: 0.8 } }))
+    const touch2 = await touch2Promise
+    expect(touch2.sessionId).toBe(sessionB)
+
+    agent.close()
+    browserA.close()
+    browserB.close()
+  })
+
+  it('routes device:boot from browser to agent', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForMessage(browser)
 
-    const buttonPromise = waitForMessage(agent)
-    browser.send(JSON.stringify({ type: 'input:button', sessionId, payload: { name: 'leftButtonSideVolumeUp' } }))
-    const btn = await buttonPromise
-    expect(btn.type).toBe('input:button')
-    expect(btn.payload).toEqual({ name: 'leftButtonSideVolumeUp' })
+    const bootPromise = waitForMessage(agent)
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
+    const boot = await bootPromise
+    expect(boot.type).toBe('device:boot')
+    expect((boot.payload as { deviceId: string }).deviceId).toBe('devA')
 
     agent.close()
     browser.close()
   })
 
-  it('routes stream:frame from agent to browser', async () => {
+  it('routes device:booting and device:ready from agent to browser', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForMessage(browser)
 
-    const framePromise = waitForMessage(browser)
-    agent.send(JSON.stringify({ type: 'stream:frame', payload: 'base64abc' }))
-    const frame = await framePromise
-    expect(frame.type).toBe('stream:frame')
-    expect(frame.payload).toBe('base64abc')
+    const bootingPromise = waitForMessage(browser)
+    agent.send(JSON.stringify({ type: 'device:booting', sessionId }))
+    const booting = await bootingPromise
+    expect(booting.type).toBe('device:booting')
+
+    const readyPromise = waitForMessage(browser)
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    const ready = await readyPromise
+    expect(ready.type).toBe('device:ready')
+    expect((ready.payload as { deviceId: string }).deviceId).toBe('devA')
 
     agent.close()
     browser.close()
   })
 
-  it('returns error when joining a non-existent session', async () => {
-    const browser = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'session:start', sessionId: 'bad-id' }))
-    const msg = await waitForMessage(browser)
-    expect(msg.type).toBe('error')
-    browser.close()
-  })
-
-  it('routes webrtc:offer from agent to browser', async () => {
+  it('registers a stream socket and forwards binary frames to browser', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
+    browser.binaryType = 'nodebuffer'
     await waitForOpen(browser)
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForMessage(browser) // session:joined
 
-    const offerPromise = waitForMessage(browser)
-    agent.send(JSON.stringify({ type: 'webrtc:offer', payload: { sdp: 'offer-sdp', type: 'offer' } }))
-    const offer = await offerPromise
-    expect(offer.type).toBe('webrtc:offer')
-    expect((offer.payload as { sdp: string }).sdp).toBe('offer-sdp')
+    // Stream WS connects and registers
+    const streamWs = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(streamWs)
+    streamWs.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    const ack = await waitForMessage(streamWs)
+    expect(ack.type).toBe('stream:registered')
+
+    // Binary frames sent via stream WS are forwarded to browser
+    const framePromise = new Promise<Buffer>((r) =>
+      browser.once('message', (d, isBinary) => { if (isBinary) r(d as Buffer) })
+    )
+    const frame = Buffer.from([0xff, 0xd8, 0xff]) // fake JPEG header
+    streamWs.send(frame)
+    const received = await framePromise
+    expect(received).toEqual(frame)
 
     agent.close()
     browser.close()
+    streamWs.close()
   })
 
-  it('routes webrtc:answer from browser to agent', async () => {
-    const agent = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
-
-    const browser = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
-    await waitForMessage(browser)
-
-    const answerPromise = waitForMessage(agent)
-    browser.send(JSON.stringify({ type: 'webrtc:answer', sessionId, payload: { sdp: 'answer-sdp', type: 'answer' } }))
-    const answer = await answerPromise
-    expect(answer.type).toBe('webrtc:answer')
-    expect((answer.payload as { sdp: string }).sdp).toBe('answer-sdp')
-
-    agent.close()
-    browser.close()
-  })
-
-  it('routes webrtc:ice bidirectionally', async () => {
-    const agent = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
-
-    const browser = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
-    await waitForMessage(browser)
-
-    // agent → browser
-    const iceFromAgentPromise = waitForMessage(browser)
-    agent.send(JSON.stringify({ type: 'webrtc:ice', payload: { candidate: 'agent-ice' } }))
-    const iceFromAgent = await iceFromAgentPromise
-    expect(iceFromAgent.type).toBe('webrtc:ice')
-    expect((iceFromAgent.payload as { candidate: string }).candidate).toBe('agent-ice')
-
-    // browser → agent
-    const iceFromBrowserPromise = waitForMessage(agent)
-    browser.send(JSON.stringify({ type: 'webrtc:ice', payload: { candidate: 'browser-ice' } }))
-    const iceFromBrowser = await iceFromBrowserPromise
-    expect(iceFromBrowser.type).toBe('webrtc:ice')
-    expect((iceFromBrowser.payload as { candidate: string }).candidate).toBe('browser-ice')
-
-    agent.close()
-    browser.close()
-  })
-
-  it('returns agents list with devices', async () => {
-    const devices = [{ id: 'd1', name: 'iPhone 15', platform: 'ios', status: 'shutdown' }]
+  it('stream from devA does not reach browser of devB', async () => {
+    const devices = [
+      { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+    ]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
     agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionA = registeredSessions!.find((s) => s.deviceId === 'devA')!.sessionId
+    const sessionB = registeredSessions!.find((s) => s.deviceId === 'devB')!.sessionId
+
+    const browserA = new WebSocket(`ws://localhost:${port}`)
+    browserA.binaryType = 'nodebuffer'
+    await waitForOpen(browserA)
+    browserA.send(JSON.stringify({ type: 'session:start', sessionId: sessionA }))
+    await waitForMessage(browserA)
+
+    const browserB = new WebSocket(`ws://localhost:${port}`)
+    browserB.binaryType = 'nodebuffer'
+    await waitForOpen(browserB)
+    browserB.send(JSON.stringify({ type: 'session:start', sessionId: sessionB }))
+    await waitForMessage(browserB)
+
+    // Stream WS for devA
+    const streamA = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(streamA)
+    streamA.send(JSON.stringify({ type: 'stream:register', sessionId: sessionA }))
+    await waitForMessage(streamA) // stream:registered
+
+    // browserB should NOT receive frames from streamA
+    let browserBGotBinary = false
+    browserB.on('message', (_d, isBinary) => { if (isBinary) browserBGotBinary = true })
+
+    const framePromise = new Promise<Buffer>((r) =>
+      browserA.once('message', (d, isBinary) => { if (isBinary) r(d as Buffer) })
+    )
+    streamA.send(Buffer.from([0xaa, 0xbb]))
+    const received = await framePromise
+    expect(received).toEqual(Buffer.from([0xaa, 0xbb]))
+    await new Promise((r) => setTimeout(r, 20))
+    expect(browserBGotBinary).toBe(false)
+
+    agent.close()
+    browserA.close()
+    browserB.close()
+    streamA.close()
+  })
+
+  it('agents:listed groups devices by agent and includes sessionId per device', async () => {
+    const devices = [
+      { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+    ]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', agentName: 'MyMac', devices }))
     await waitForMessage(agent)
 
     const browser = new WebSocket(`ws://localhost:${port}`)
@@ -215,86 +368,102 @@ describe('RelayServer', () => {
 
     expect(msg.type).toBe('agents:listed')
     expect(msg.sessions).toHaveLength(1)
-    expect(msg.sessions![0].devices).toEqual(devices)
+    expect(msg.sessions![0].agentName).toBe('MyMac')
+    expect(msg.sessions![0].devices).toHaveLength(2)
+    expect(msg.sessions![0].devices[0].sessionId).toBeTruthy()
+    expect(msg.sessions![0].devices[1].sessionId).toBeTruthy()
+    expect(msg.sessions![0].devices[0].busy).toBe(false)
 
     agent.close()
     browser.close()
   })
 
-  it('includes agentName and busy in agents:listed', async () => {
-    const devices = [{ id: 'd1', name: 'iPhone 15', platform: 'ios', status: 'shutdown' }]
+  it('agents:listed shows busy=true after browser joins a device session', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register', agentName: 'MyMac', devices }))
-    const { sessionId } = await waitForMessage(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
 
-    // not busy yet
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'agents:list' }))
-    const listed = await waitForMessage(browser)
-    expect(listed.sessions![0].agentName).toBe('MyMac')
-    expect(listed.sessions![0].busy).toBe(false)
-
-    // join → becomes busy
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForMessage(browser) // session:joined
 
+    const observer = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(observer)
+    observer.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForMessage(observer)
+    expect(listed.sessions![0].devices[0].busy).toBe(true)
+
+    agent.close()
+    browser.close()
+    observer.close()
+  })
+
+  it('removes all device sessions when agent disconnects', async () => {
+    const devices = [
+      { id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' },
+      { id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' },
+    ]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    await waitForMessage(agent)
+    agent.close()
+
+    // Wait for close to propagate
+    await new Promise((r) => setTimeout(r, 50))
+
+    const observer = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(observer)
+    observer.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForMessage(observer)
+    expect(listed.sessions).toHaveLength(0)
+
+    observer.close()
+  })
+
+  it('replays device:ready on reconnect when device is already booted', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForMessage(browser) // session:joined
+
+    // Agent reports device is ready
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await waitForType(browser, 'device:ready')
+
+    browser.close()
+    await new Promise((r) => setTimeout(r, 30))
+
+    // Browser reconnects
     const browser2 = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser2)
-    browser2.send(JSON.stringify({ type: 'agents:list' }))
-    const listed2 = await waitForMessage(browser2)
-    expect(listed2.sessions![0].busy).toBe(true)
+    browser2.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const msgs: string[] = []
+    await new Promise<void>((resolve) => {
+      let received = 0
+      browser2.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        msgs.push(msg.type)
+        received++
+        if (received >= 2) resolve()
+      })
+      setTimeout(resolve, 200)
+    })
+    expect(msgs).toContain('session:joined')
+    expect(msgs).toContain('device:ready')
 
     agent.close()
-    browser.close()
     browser2.close()
-  })
-
-  it('routes device:boot from browser to agent', async () => {
-    const agent = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
-
-    const browser = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
-    await waitForMessage(browser)
-
-    const bootPromise = waitForMessage(agent)
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'dev-1' } }))
-    const boot = await bootPromise
-    expect(boot.type).toBe('device:boot')
-    expect((boot.payload as { deviceId: string }).deviceId).toBe('dev-1')
-
-    agent.close()
-    browser.close()
-  })
-
-  it('routes device:booting and device:ready from agent to browser', async () => {
-    const agent = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(agent)
-    agent.send(JSON.stringify({ type: 'agent:register' }))
-    const { sessionId } = await waitForMessage(agent)
-
-    const browser = new WebSocket(`ws://localhost:${port}`)
-    await waitForOpen(browser)
-    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
-    await waitForMessage(browser)
-
-    const bootingPromise = waitForMessage(browser)
-    agent.send(JSON.stringify({ type: 'device:booting' }))
-    const booting = await bootingPromise
-    expect(booting.type).toBe('device:booting')
-
-    const readyPromise = waitForMessage(browser)
-    agent.send(JSON.stringify({ type: 'device:ready', payload: { deviceId: 'dev-1' } }))
-    const ready = await readyPromise
-    expect(ready.type).toBe('device:ready')
-    expect((ready.payload as { deviceId: string }).deviceId).toBe('dev-1')
-
-    agent.close()
-    browser.close()
   })
 })

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -3,89 +3,217 @@ import { SessionManager } from '../SessionManager'
 import type { WebSocket } from 'ws'
 
 const mockSocket = () => ({} as WebSocket)
+const OPEN = 1
 
 describe('SessionManager', () => {
-  it('creates a session and returns a string id', () => {
-    const sm = new SessionManager()
-    const id = sm.create(mockSocket())
-    expect(typeof id).toBe('string')
-    expect(id.length).toBeGreaterThan(0)
+  describe('create()', () => {
+    it('returns an empty array when no devices given', () => {
+      const sm = new SessionManager()
+      const ids = sm.create(mockSocket(), [])
+      expect(ids).toEqual([])
+    })
+
+    it('creates one session per device and returns sessionIds', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const devices = [
+        { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+        { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+      ]
+      const ids = sm.create(ws, devices)
+      expect(ids).toHaveLength(2)
+      expect(typeof ids[0]).toBe('string')
+      expect(typeof ids[1]).toBe('string')
+      expect(ids[0]).not.toBe(ids[1])
+    })
+
+    it('each session stores the correct deviceId', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const devices = [
+        { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+        { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+      ]
+      const [idA, idB] = sm.create(ws, devices)
+      expect(sm.get(idA)?.deviceId).toBe('devA')
+      expect(sm.get(idB)?.deviceId).toBe('devB')
+    })
+
+    it('sessions share the same agentSocket', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const [idA, idB] = sm.create(ws, [
+        { id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' },
+        { id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' },
+      ])
+      expect(sm.get(idA)?.agentSocket).toBe(ws)
+      expect(sm.get(idB)?.agentSocket).toBe(ws)
+    })
+
+    it('new sessions start with null browserSocket and streamSocket', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      const s = sm.get(id)!
+      expect(s.browserSocket).toBeNull()
+      expect(s.streamSocket).toBeNull()
+    })
   })
 
-  it('retrieves a created session', () => {
-    const sm = new SessionManager()
-    const ws = mockSocket()
-    const id = sm.create(ws)
-    const session = sm.get(id)
-    expect(session?.agentSocket).toBe(ws)
-    expect(session?.browserSocket).toBeNull()
+  describe('get()', () => {
+    it('returns undefined for unknown sessionId', () => {
+      const sm = new SessionManager()
+      expect(sm.get('unknown')).toBeUndefined()
+    })
+
+    it('retrieves a created session', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const [id] = sm.create(ws, [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      expect(sm.get(id)?.agentSocket).toBe(ws)
+    })
   })
 
-  it('returns undefined for unknown session id', () => {
-    const sm = new SessionManager()
-    expect(sm.get('unknown')).toBeUndefined()
+  describe('getAllByAgentSocket()', () => {
+    it('returns all sessions for a given agent socket', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const ids = sm.create(ws, [
+        { id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' },
+        { id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' },
+      ])
+      const found = sm.getAllByAgentSocket(ws)
+      expect(found).toHaveLength(2)
+      expect(found.map((s) => s.id).sort()).toEqual(ids.sort())
+    })
+
+    it('returns empty array for an unknown socket', () => {
+      const sm = new SessionManager()
+      expect(sm.getAllByAgentSocket(mockSocket())).toEqual([])
+    })
+
+    it('does not return sessions from other agents', () => {
+      const sm = new SessionManager()
+      const wsA = mockSocket()
+      const wsB = mockSocket()
+      sm.create(wsA, [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }])
+      sm.create(wsB, [{ id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' }])
+      expect(sm.getAllByAgentSocket(wsA)).toHaveLength(1)
+      expect(sm.getAllByAgentSocket(wsB)).toHaveLength(1)
+    })
   })
 
-  it('joins a browser socket to a session', () => {
-    const sm = new SessionManager()
-    const browserWs = mockSocket()
-    const id = sm.create(mockSocket())
-    sm.join(id, browserWs)
-    expect(sm.get(id)?.browserSocket).toBe(browserWs)
+  describe('getByStreamSocket()', () => {
+    it('returns undefined when no stream socket registered', () => {
+      const sm = new SessionManager()
+      expect(sm.getByStreamSocket(mockSocket())).toBeUndefined()
+    })
+
+    it('returns the session after setStreamSocket()', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      const streamWs = mockSocket()
+      sm.setStreamSocket(id, streamWs)
+      expect(sm.getByStreamSocket(streamWs)?.id).toBe(id)
+    })
   })
 
-  it('throws when joining a non-existent session', () => {
-    const sm = new SessionManager()
-    expect(() => sm.join('bad-id', mockSocket())).toThrow('Session not found: bad-id')
+  describe('join()', () => {
+    it('sets browserSocket on the session', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      const browserWs = mockSocket()
+      sm.join(id, browserWs)
+      expect(sm.get(id)?.browserSocket).toBe(browserWs)
+    })
+
+    it('throws when session is not found', () => {
+      const sm = new SessionManager()
+      expect(() => sm.join('bad-id', mockSocket())).toThrow('Session not found: bad-id')
+    })
+
+    it('throws when session is busy (browserSocket is OPEN)', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      const busyWs = { readyState: OPEN } as WebSocket
+      sm.join(id, busyWs)
+      expect(() => sm.join(id, mockSocket())).toThrow('Session busy')
+    })
   })
 
-  it('removes a session', () => {
-    const sm = new SessionManager()
-    const id = sm.create(mockSocket())
-    sm.remove(id)
-    expect(sm.get(id)).toBeUndefined()
+  describe('remove()', () => {
+    it('removes a session', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      sm.remove(id)
+      expect(sm.get(id)).toBeUndefined()
+    })
   })
 
-  it('finds a session by agent socket', () => {
-    const sm = new SessionManager()
-    const ws = mockSocket()
-    const id = sm.create(ws)
-    expect(sm.getBySocket(ws)?.id).toBe(id)
+  describe('clearBrowser()', () => {
+    it('sets browserSocket to null', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      sm.join(id, mockSocket())
+      sm.clearBrowser(id)
+      expect(sm.get(id)?.browserSocket).toBeNull()
+    })
   })
 
-  it('finds a session by browser socket', () => {
-    const sm = new SessionManager()
-    const agentWs = mockSocket()
-    const browserWs = mockSocket()
-    const id = sm.create(agentWs)
-    sm.join(id, browserWs)
-    expect(sm.getBySocket(browserWs)?.id).toBe(id)
+  describe('updateDeviceStatus()', () => {
+    it('updates deviceStatus on the session', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      sm.updateDeviceStatus(id, 'booted')
+      expect(sm.get(id)?.deviceStatus).toBe('booted')
+    })
   })
 
-  it('returns undefined when socket is not in any session', () => {
-    const sm = new SessionManager()
-    expect(sm.getBySocket(mockSocket())).toBeUndefined()
-  })
+  describe('list()', () => {
+    it('returns empty array when no sessions', () => {
+      const sm = new SessionManager()
+      expect(sm.list()).toEqual([])
+    })
 
-  it('stores devices when creating a session', () => {
-    const sm = new SessionManager()
-    const devices = [{ id: 'd1', name: 'iPhone 15', platform: 'ios', status: 'shutdown' }]
-    const id = sm.create(mockSocket(), devices)
-    expect(sm.get(id)?.devices).toEqual(devices)
-  })
+    it('groups devices by agent into one SessionInfo', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      sm.create(ws, [
+        { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
+        { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
+      ], 'MyMac')
+      const listed = sm.list()
+      expect(listed).toHaveLength(1)
+      expect(listed[0].agentName).toBe('MyMac')
+      expect(listed[0].devices).toHaveLength(2)
+    })
 
-  it('list() returns all sessions with their devices', () => {
-    const sm = new SessionManager()
-    const devices = [{ id: 'd1', name: 'iPhone 15', platform: 'ios', status: 'booted' }]
-    const id = sm.create(mockSocket(), devices)
-    const listed = sm.list()
-    expect(listed).toHaveLength(1)
-    expect(listed[0].sessionId).toBe(id)
-    expect(listed[0].devices).toEqual(devices)
-  })
+    it('includes sessionId on each device', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      const [idA] = sm.create(ws, [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }])
+      const listed = sm.list()
+      expect(listed[0].devices[0].sessionId).toBe(idA)
+    })
 
-  it('list() returns empty array when no sessions', () => {
-    const sm = new SessionManager()
-    expect(sm.list()).toEqual([])
+    it('reflects busy=true when browserSocket is set', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      sm.join(id, mockSocket())
+      expect(sm.list()[0].devices[0].busy).toBe(true)
+    })
+
+    it('reflects busy=false when browserSocket is null', () => {
+      const sm = new SessionManager()
+      sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      expect(sm.list()[0].devices[0].busy).toBe(false)
+    })
+
+    it('separates sessions from different agents', () => {
+      const sm = new SessionManager()
+      sm.create(mockSocket(), [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }], 'Mac1')
+      sm.create(mockSocket(), [{ id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' }], 'Mac2')
+      const listed = sm.list()
+      expect(listed).toHaveLength(2)
+    })
   })
 })

--- a/packages/relay/src/api/comments.ts
+++ b/packages/relay/src/api/comments.ts
@@ -91,7 +91,7 @@ export function handleCreateComment(
 
     const db = getDb()
     const commentResult = db.prepare(
-      'INSERT INTO comments (build_id, author_id, body) VALUES (?, ?, ?)'
+      "INSERT INTO comments (build_id, author_id, body, created_at) VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"
     ).run(fields.build_id, auth.userId, fields.body.trim())
 
     const commentId = commentResult.lastInsertRowid as number

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -8,6 +8,8 @@ export type MessageType =
   | 'session:chrome'
   | 'session:deviceInfo'
   | 'session:end'
+  | 'stream:register'
+  | 'stream:registered'
   | 'device:boot'
   | 'device:booting'
   | 'device:ready'
@@ -37,12 +39,13 @@ export interface DeviceInfo {
   platform: string
   status: string
   osVersion?: string
+  sessionId: string
+  busy: boolean
 }
 
+// agents:listed response groups devices by agent machine
 export interface SessionInfo {
-  sessionId: string
   agentName?: string
-  busy: boolean
   devices: DeviceInfo[]
 }
 
@@ -52,7 +55,11 @@ export interface RelayMessage {
   payload?: unknown
   message?: string
   agentName?: string
-  devices?: DeviceInfo[]
+  // agent:register: raw device list (without sessionId/busy — added by relay)
+  devices?: Array<{ id: string; name: string; platform: string; status: string; osVersion?: string }>
+  // agents:listed: grouped by agent
   sessions?: SessionInfo[]
+  // agent:registered: per-device sessionId assignments
+  registeredSessions?: Array<{ deviceId: string; sessionId: string }>
   buildId?: number
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "echo 'No tests for playground'",
     "relay": "tsx relay.ts",
     "seed": "tsx seed.ts",
     "ios-agent": "tsx ios-agent.ts",


### PR DESCRIPTION
## Summary

- **디바이스 단위 세션 분리**: relay 세션 모델을 agent 1:1에서 deviceId 1:1로 재설계해 여러 사용자가 서로 다른 시뮬레이터를 동시에 독립적으로 사용할 수 있도록 구현
- **Session busy 체크**: 이미 점유된 sessionId에 두 번째 브라우저가 join 시도 시 `error: Session busy` 반환
- **스트림 WS 분리**: 디바이스별 전용 stream WebSocket으로 JPEG 프레임을 분리 전달, `stream:register` / `stream:registered` handshake로 ordering 보장
- **WDA 포트 순차 할당**: 디바이스마다 8100, 8101... 포트에 WDA를 독립 실행해 type/pressButton이 올바른 디바이스에만 전달

## Changes

| 패키지 | 변경 내용 |
|--------|----------|
| `relay` | SessionManager 전면 재작성 (per-device session), RelayServer 메시지 라우팅 업데이트, `stream:register` 신규 메시지 타입 |
| `ios-agent` | DeviceState Map 도입, openStreamWs() 구현, WDA 포트 순차 할당 |
| `dashboard` | AgentDevice 타입에 sessionId/busy 추가, QASession double session:start 제거 |
| `relay` (api) | 코멘트 타임스탬프 UTC 명시화 (`strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`) |
| `dashboard` | 코멘트 타임스탬프 로컬라이징 (`parseUTCDate` + `toLocaleString`) |
| `dashboard` | `React.FormEvent` → named `FormEvent` import (TS6133/6385 진단 해소) |
| `playground` | 누락된 test 스크립트 추가 |

## Test plan

- [x] 단일 agent + 단일 브라우저 — 기존 흐름 회귀 없음 확인
- [x] 두 브라우저가 서로 다른 디바이스 boot → 각자 화면/입력 독립 확인
- [x] 이미 점유된 session join 시도 → `Session busy` 에러 반환 확인
- [x] agent disconnect → 모든 연결 session 정리 확인
- [x] 코멘트 타임스탬프 — 브라우저 로컬 시간대로 표시 확인
- [x] `npm run test --workspaces` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)