### PR TITLE
fix(dashboard,relay): 로그인 캐시 버그 및 auth 상태 오류 수정

### DIFF
--- a/packages/dashboard/hooks/useAuth.ts
+++ b/packages/dashboard/hooks/useAuth.ts
@@ -19,13 +19,17 @@ export function useAuth(): AuthState {
   const navigate = useNavigate()
 
   useEffect(() => {
+    let cancelled = false
     api.get<AuthUser>('/api/v1/auth/me').then(({ data, status }) => {
+      if (cancelled) return
       if (status === 401 || !data) {
+        setState({ user: null, loading: false })
         navigate('/login', { replace: true })
       } else {
         setState({ user: data, loading: false })
       }
     })
+    return () => { cancelled = true }
   }, [navigate])
 
   return state

--- a/packages/dashboard/src/pages/Login.tsx
+++ b/packages/dashboard/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -17,12 +18,8 @@ export function Login() {
     setError('')
     setLoading(true)
     try {
-      const res = await fetch('/api/v1/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      })
-      if (!res.ok) { setError('Invalid email or password'); return }
+      const { status } = await api.post('/api/v1/auth/login', { email, password })
+      if (status !== 200) { setError('Invalid email or password'); return }
       navigate('/app-center', { replace: true })
     } catch {
       setError('Network error. Please try again.')

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -385,6 +385,10 @@ export class RelayServer {
 
     // uploads — serve uploaded files
     const url = req.url ?? '/'
+
+    if (url.startsWith('/api/')) {
+      res.setHeader('Cache-Control', 'no-store')
+    }
     if (url.startsWith('/uploads/')) {
       this.serveUpload(req, res)
       return


### PR DESCRIPTION
## Summary

- **Chrome 캐시로 인한 로그인 실패 수정**: relay의 모든 `/api/` 응답에 `Cache-Control: no-store` 추가. Chrome이 `/api/v1/auth/me`의 이전 세션 응답을 캐싱해, 재로그인 후에도 캐시된 결과를 반환하던 문제가 근본 원인
- **`useAuth` 로딩 상태 버그 수정**: 401 수신 시 `loading`이 `true`로 남던 문제 수정 + `cancelled` 플래그로 unmount 후 `setState` 방지
- **`Login.tsx` fetch 일관성**: raw `fetch` → `api.post`로 교체 (`credentials: include` 자동 적용)

## Root Cause

Chrome 계정 프로필 A에서만 로그인이 안 되던 이유: 해당 프로필의 HTTP 캐시에 `/api/v1/auth/me`의 이전 응답(만료된 세션의 401 또는 200)이 남아 있어, 재로그인 후 새 쿠키로 요청해도 캐시된 응답을 반환했기 때문. 프라이빗 모드와 다른 프로필은 캐시가 없어 정상 동작.

## Test plan

- [x] 크롬 일반 모드에서 로그인 → `/app-center` 정상 진입 확인
- [x] 크롬 개발자도구 Network 탭에서 `/api/v1/auth/me` 응답 헤더에 `Cache-Control: no-store` 확인
- [x] 로그아웃 후 재로그인 시 캐시 삭제 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)