### PR TITLE
fix(simulator): Installing app… 메시지 설치 완료 후 잔류 버그 수정

### DIFF
--- a/packages/dashboard/components/SimulatorViewer.tsx
+++ b/packages/dashboard/components/SimulatorViewer.tsx
@@ -717,9 +717,7 @@ export function SimulatorViewer({ sessionId, deviceId, buildId, onRecordingUploa
           : installError
             ? `Install failed: ${installError.length > 22 ? installError.slice(0, 22) + '…' : installError}`
             : null;
-  // TODO: remove dummy
-  const _statusText = statusText;
-  const statusTextDisplay = _statusText ?? 'Installing app…';
+  const statusTextDisplay = statusText;
 
   return (
     <div className="flex items-start justify-center gap-16">


### PR DESCRIPTION
## Summary

- 앱이 정상 설치·실행된 이후에도 "Installing app…" 메시지가 계속 표시되는 버그 수정
- 원인: `statusText`가 `null`(정상 완료 상태)일 때 `?? 'Installing app…'` fallback이 항상 적용되던 TODO 코드
- `statusTextDisplay = statusText` 로 단순화하여 완료 시 메시지 자동 소거

## Test plan

- [x] QA 세션에서 빌드 선택 → 앱 설치 완료 후 "Installing app…" 메시지가 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)