### PR TITLE
feat(ios-agent): IOSurface 정적 프레임 스킵 + FPS 인디케이터 Active/Idle 개선

### DIFF
--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -28,7 +28,12 @@ function getStatusText(props: SimulatorInfoCardProps): string | null {
 export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
   const { joined, fps, keyboardActive } = props;
   const statusText = getStatusText(props);
-  const fpsColor = fps >= 30 ? '#10b981' : fps >= 15 ? '#f59e0b' : fps > 0 ? '#ef4444' : '#6b7280';
+  // fps is intentionally low when screen is static (idle keep-alive ~10fps).
+  // Use "active/idle" framing instead of red/green to avoid false alarm.
+  const isActive = fps > 15;
+  const isIdle = fps > 0 && fps <= 15;
+  const dotColor = isActive ? '#10b981' : isIdle ? '#94a3b8' : 'transparent';
+  const stateLabel = isActive ? 'Active' : isIdle ? 'Idle' : null;
 
   return (
     <div className="w-[300px] shrink-0 mt-3 rounded-xl border bg-background px-4 py-4 flex flex-col gap-3">
@@ -37,11 +42,16 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
         <span className="text-[12px] font-medium">Focus</span>
       </div>
 
-      {joined && (
+      {joined && fps > 0 && (
         <div className="flex items-center" style={{ gap: 6 }}>
-          <span className="h-2 w-2 rounded-full shrink-0" style={{ background: fpsColor }} />
+          <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
           <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
           <span className="text-[12px] text-muted-foreground">fps</span>
+          {stateLabel && (
+            <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
+              · {stateLabel}
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -236,7 +236,7 @@ export function QASession() {
                           setActiveSessionId(d.sessionId)
                         }}
                         className={cn(
-                          'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors',
+                          'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px]',
                           'hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50',
                         )}
                       >

--- a/packages/ios-agent/src/screencapture-helper.swift
+++ b/packages/ios-agent/src/screencapture-helper.swift
@@ -278,11 +278,24 @@ DispatchQueue.global().asyncAfter(deadline: .now() + 8) {
     exit(1)
 }
 
-// Timer-driven emission: fires at the target FPS and encodes the latest surface
+// Timer-driven emission: fires at the target FPS and encodes the latest surface.
+// Skips encoding when the IOSurface seed is unchanged (screen static) unless
+// 100ms have passed since the last sent frame — matching Android scrcpy's
+// KEY_REPEAT_PREVIOUS_FRAME_AFTER keep-alive behaviour.
+var lastSeed: UInt32 = 0
+var lastSentNs: UInt64 = 0
+
 let timer = DispatchSource.makeTimerSource(queue: captureQueue)
 timer.schedule(deadline: .now(), repeating: 1.0 / fps)
 timer.setEventHandler {
-    guard let surf = latestSurface, let jpeg = encodeJPEG(surf) else { return }
+    guard let surf = latestSurface else { return }
+    let seed = IOSurfaceGetSeed(surf)
+    let nowNs = DispatchTime.now().uptimeNanoseconds
+    let elapsedMs = Double(nowNs - lastSentNs) / 1_000_000
+    if seed == lastSeed && elapsedMs < 100 { return }
+    guard let jpeg = encodeJPEG(surf) else { return }
+    lastSeed = seed
+    lastSentNs = nowNs
     firstFrameSent = true
     writeFrame(jpeg)
 }


### PR DESCRIPTION
## Summary

- **iOS 정적 프레임 스킵**: `screencapture-helper.swift`에 `IOSurfaceGetSeed()` 기반 중복 프레임 스킵 추가. 화면이 정적일 때 JPEG 인코딩을 건너뛰고 100ms마다 keep-alive 프레임만 전송 — Android scrcpy의 `KEY_REPEAT_PREVIOUS_FRAME_AFTER` 동작과 동일
- **FPS 인디케이터 UX 개선**: Idle 상태(≤15fps)에서 빨간색 대신 중립 회색 + "Idle" 레이블로 표시. 의도된 저FPS가 오류처럼 보이던 문제 해결
- **dev 스크립트**: `npm run dev`에 android-agent 추가

## Test plan

- [x] iOS 시뮬레이터 스트리밍 시작 후 화면을 정적으로 두면 CPU 사용량이 감소하는지 확인
- [x] 화면 조작 시 즉시 프레임 전송 재개 확인 (100ms 이내)
- [x] FPS 인디케이터: 정적 화면 → 회색 점 + "Idle", 활성 화면 → 초록 점 + "Active" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)