### PR TITLE
chore(docs): Vercel output directory .vitepress/dist 명시

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": ".vitepress/dist"
+}


### PR DESCRIPTION
## Summary

- `docs/vercel.json` 추가: Vercel output directory를 `.vitepress/dist`로 명시
- VitePress 빌드 결과물 경로가 기본값(`dist`)과 달라 발생하는 배포 에러 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)