### PR TITLE
fix(relay): bundle_id 불일치 시 업로드를 올바른 앱으로 라우팅

### DIFF
--- a/packages/relay/src/__tests__/builds.test.ts
+++ b/packages/relay/src/__tests__/builds.test.ts
@@ -132,6 +132,56 @@ describe('upsertApp: bundle_id grouping', () => {
   })
 })
 
+// ── app_id + mismatched bundle_id routing ─────────────────────────────────
+
+describe('upload: app_id provided but bundle_id differs → new app', () => {
+  let tmpDir: string
+  let upsertApp: typeof import('../api/builds').upsertApp
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-mismatch-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+    const mod = await import('../api/builds')
+    upsertApp = mod.upsertApp
+  })
+
+  afterAll(() => { fs.rmSync(tmpDir, { recursive: true }) })
+
+  it('bundle_id가 다른 앱을 app_id 지정 업로드 시 새 앱에 라우팅된다', () => {
+    const db = getDb()
+    const bankioId = upsertApp('Bankio', 'com.bankio.mobile', 'ios')
+    const bankio = db.prepare('SELECT id, bundle_id_key FROM apps WHERE id = ?')
+      .get(bankioId) as { id: number; bundle_id_key: string }
+
+    // 핸들러 분기 시뮬레이션: bundleId !== app.bundle_id_key → upsertApp으로 라우팅
+    const uploadedBundleId = 'com.theapp.bundle'
+    const appId =
+      uploadedBundleId && bankio.bundle_id_key && bankio.bundle_id_key !== uploadedBundleId
+        ? upsertApp('TheApp', uploadedBundleId, 'ios')
+        : bankioId
+
+    expect(appId).not.toBe(bankioId)
+    const newApp = db.prepare('SELECT name, bundle_id_key FROM apps WHERE id = ?')
+      .get(appId) as { name: string; bundle_id_key: string }
+    expect(newApp.bundle_id_key).toBe('com.theapp.bundle')
+  })
+
+  it('bundle_id가 같으면 기존 app_id를 그대로 사용한다', () => {
+    const db = getDb()
+    const bankioId = upsertApp('Bankio2', 'com.bankio2.mobile', 'ios')
+    const bankio = db.prepare('SELECT id, bundle_id_key FROM apps WHERE id = ?')
+      .get(bankioId) as { id: number; bundle_id_key: string }
+
+    const uploadedBundleId = 'com.bankio2.mobile'
+    const appId =
+      uploadedBundleId && bankio.bundle_id_key && bankio.bundle_id_key !== uploadedBundleId
+        ? upsertApp('Bankio2', uploadedBundleId, 'ios')
+        : bankioId
+
+    expect(appId).toBe(bankioId)
+  })
+})
+
 // ── extractAppZipInfo unit tests ──────────────────────────────────────────
 
 describe('extractAppZipInfo', () => {

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -373,11 +373,16 @@ export function handleUploadBuild(
         fs.unlinkSync(savedPath)
         return json(res, 404, { error: 'App not found' })
       }
-      if (app.platform !== 'both' && app.platform !== platform) {
-        db.prepare('UPDATE apps SET platform = ? WHERE id = ?').run('both', appId)
-      }
-      if (!app.bundle_id_key && bundleId) {
-        db.prepare('UPDATE apps SET bundle_id_key = ? WHERE id = ?').run(bundleId, appId)
+      // 추출된 bundle_id가 지정한 앱과 다르면 bundle_id 기준으로 앱을 찾거나 생성
+      if (bundleId && app.bundle_id_key && app.bundle_id_key !== bundleId) {
+        appId = upsertApp(appName, bundleIdKey, platform)
+      } else {
+        if (app.platform !== 'both' && app.platform !== platform) {
+          db.prepare('UPDATE apps SET platform = ? WHERE id = ?').run('both', appId)
+        }
+        if (!app.bundle_id_key && bundleId) {
+          db.prepare('UPDATE apps SET bundle_id_key = ? WHERE id = ?').run(bundleId, appId)
+        }
       }
     } else {
       appId = upsertApp(appName, bundleIdKey, platform)


### PR DESCRIPTION
## Summary

- `handleUploadBuild`에서 `app_id`가 전달되더라도 업로드 파일의 `bundle_id`가 해당 앱의 `bundle_id_key`와 다르면 `app_id`를 무시하고 `bundle_id` 기준으로 앱을 찾거나 새로 생성하도록 수정
- 기존 동작: Bankio 화면에서 TheApp 번들을 업로드하면 Bankio의 새 버전으로 등록됨
- 수정 후: TheApp용 앱 엔티티를 별도 생성하여 빌드를 등록

## Test plan

- [x] `pnpm --filter @tapflow/relay test` 통과 확인 (109 tests)
- [x] bundle_id 불일치 → 새 앱 라우팅 케이스 (`builds.test.ts` 신규 추가)
- [x] bundle_id 일치 → 기존 앱 유지 케이스 (`builds.test.ts` 신규 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)