### PR TITLE
fix(readme): use user-attachments URL for demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Demo
 
-<video src="https://github.com/jo-duchan/tapflow/releases/download/demo-assets/tapflow-demo-final-compressed.mp4" controls width="100%"></video>
+<video src="https://github.com/user-attachments/assets/f8dfb969-3670-41f3-b810-86179d23915e" controls width="100%"></video>
 
 ---
 


### PR DESCRIPTION
## Summary

- Release asset URL (`releases/download/...`) causes 302 redirect that GitHub README's video renderer doesn't follow
- Replaced with direct `user-attachments/assets` URL uploaded via GitHub

## Test plan

- [x] Demo video renders in README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)