### PR TITLE
fix: graceful shutdown, release automation, and alpha docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,6 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm --filter @tapflow/agent-core build && pnpm --filter @tapflow/relay build
+
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
       - run: pnpm lint
 
-      - run: pnpm --filter @tapflow/agent-core build && pnpm --filter @tapflow/relay build
+      - run: pnpm --filter @tapflow/agent-core build
+      - run: pnpm --filter @tapflow/relay --filter @tapflow/ios-agent --filter @tapflow/android-agent build
 
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - run: pnpm changeset publish --no-git-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ pnpm dev
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
 - Always create new branches from `origin/main` (`git fetch origin && git checkout -b feature/{topic} origin/main`). Your local `main` may be behind.
-- Releases are triggered by a git tag (Semver) → GitHub Release + npm publish. Merging to main does not auto-publish.
+- Releases are driven by [changesets](https://github.com/changesets/changesets). A tag push triggers GitHub Actions → npm publish + GitHub Release. Merging to main does not auto-publish.
 
 ### Versioning (Semver)
 
@@ -46,12 +46,21 @@ v0.3.0-rc.1      # release candidate, no new features
 #### Cutting a release
 
 ```sh
-# confirm you are on an up-to-date main
+# 1. confirm you are on an up-to-date main
 git checkout main && git pull origin main
 
-# tag and push (CI publishes to npm automatically)
-git tag v0.3.0
-git push origin v0.3.0
+# 2. record what changed
+pnpm changeset add
+
+# 3. bump all package versions (edits package.json files and CHANGELOG.md)
+pnpm changeset version
+
+# 4. commit the version bump
+git add -A && git commit -m "chore: release v<new-version>"
+
+# 5. tag and push — GitHub Actions publishes to npm and creates a GitHub Release
+git tag v<new-version>
+git push origin main v<new-version>
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   </p>
 </div>
 
+> **alpha**: tapflow is in active development (v0.x). Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for known gaps.
+
 ---
 
 ## Demo

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,7 @@ Critical bug fixes before the first public release.
 
 Developer experience and reliability improvements.
 
+- [ ] Pre-commit hooks — add Lefthook with lint + typecheck on staged files to catch errors before push
 - [ ] `logger.ts` abstraction — replace 66 direct `console.log/error` calls with a leveled logger (`debug` / `info` / `warn` / `error`)
 - [ ] Custom error classes — `ValidationError`, `PlatformError`, `AuthError`
 - [ ] CLI smoke tests — `doctor`, `version`, `devices` commands

--- a/packages/android-agent/src/__tests__/ScrcpySession.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpySession.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { execFile, spawn } from 'child_process'
+
+vi.mock('child_process', () => ({ execFile: vi.fn(), spawn: vi.fn() }))
+
+function makeFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
+  }
+  proc.stdout = new EventEmitter()
+  proc.kill = vi.fn()
+  proc.unref = vi.fn()
+  return proc
+}
+
+// execFile callback arrives as the last argument regardless of options
+function cbSuccess(_f: unknown, _a: unknown, cb: (e: null, out: string, err: string) => void) {
+  cb(null, '', '')
+  return {} as ReturnType<typeof execFile>
+}
+
+function cbFail(error: Error) {
+  return (_f: unknown, _a: unknown, cb: (e: Error) => void) => {
+    cb(error)
+    return {} as ReturnType<typeof execFile>
+  }
+}
+
+describe('ScrcpySession', () => {
+  beforeEach(() => {
+    process.env['ADB_PATH'] = '/usr/bin/adb'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetAllMocks()
+    delete process.env['ADB_PATH']
+  })
+
+  it('kills serverProc when an error is thrown after spawn', async () => {
+    vi.useFakeTimers()
+
+    const proc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(proc as never)
+    vi.mocked(execFile)
+      .mockImplementationOnce(cbSuccess as never)                              // push: success
+      .mockImplementationOnce(cbFail(new Error('forward failed')) as never)   // forward: fail
+
+    const { ScrcpySession } = await import('../scrcpy/ScrcpySession.js')
+    const session = new ScrcpySession()
+
+    // Attach catch immediately to prevent PromiseRejectionHandledWarning
+    let caughtError: Error | undefined
+    const startPromise = session.start('emulator-5554').catch(e => { caughtError = e })
+    await vi.advanceTimersByTimeAsync(1500)
+    await startPromise
+
+    expect(caughtError?.message).toBe('forward failed')
+    expect(proc.kill).toHaveBeenCalled()
+  })
+
+  it('does not kill serverProc on the error path before spawn', async () => {
+    vi.useFakeTimers()
+
+    const proc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(proc as never)
+    vi.mocked(execFile)
+      .mockImplementationOnce(cbFail(new Error('push failed')) as never)  // push: fail (before spawn)
+
+    const { ScrcpySession } = await import('../scrcpy/ScrcpySession.js')
+    const session = new ScrcpySession()
+
+    await expect(session.start('emulator-5554')).rejects.toThrow('push failed')
+    expect(proc.kill).not.toHaveBeenCalled()
+  })
+})

--- a/packages/android-agent/src/scrcpy/ScrcpySession.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpySession.ts
@@ -94,22 +94,28 @@ export class ScrcpySession {
     })
     serverProc.unref()
 
-    // Wait for server to bind the abstract socket
-    await new Promise((r) => setTimeout(r, 1500))
+    try {
+      // Wait for server to bind the abstract socket
+      await new Promise((r) => setTimeout(r, 1500))
 
-    await execFileAsync(adb, ['-s', serial, 'forward', `tcp:${port}`, `localabstract:${this.socketName}`])
+      await execFileAsync(adb, ['-s', serial, 'forward', `tcp:${port}`, `localabstract:${this.socketName}`])
 
-    // scrcpy accepts connections sequentially on the same socket:
-    // 1st accept() → video stream, 2nd accept() → control stream
-    this.videoSocket = await this.connectTcp(port)
-    this.controlSocket = await this.connectTcp(port)
+      // scrcpy accepts connections sequentially on the same socket:
+      // 1st accept() → video stream, 2nd accept() → control stream
+      this.videoSocket = await this.connectTcp(port)
+      this.controlSocket = await this.connectTcp(port)
 
-    this._video = new ScrcpyVideo(this.videoSocket)
-    const info = await this._video.deviceInfo()
+      this._video = new ScrcpyVideo(this.videoSocket)
+      const info = await this._video.deviceInfo()
 
-    this._control = new ScrcpyControl(this.controlSocket, info.width, info.height, onRotation)
-    console.log(`[scrcpy] ready — ${info.deviceName} ${info.width}×${info.height}`)
-    return info
+      this._control = new ScrcpyControl(this.controlSocket, info.width, info.height, onRotation)
+      console.log(`[scrcpy] ready — ${info.deviceName} ${info.width}×${info.height}`)
+      return info
+    } catch (e) {
+      serverProc.kill()
+      this.serverProc = null
+      throw e
+    }
   }
 
   stop(serial: string): void {

--- a/packages/ios-agent/src/ScreenCaptureStreamer.ts
+++ b/packages/ios-agent/src/ScreenCaptureStreamer.ts
@@ -83,7 +83,9 @@ export class ScreenCaptureStreamer {
       },
       cancel() {
         done = true
-        proc.kill('SIGKILL')
+        proc.kill('SIGTERM')
+        const killTimer = setTimeout(() => proc.kill('SIGKILL'), 1000)
+        proc.once('exit', () => clearTimeout(killTimer))
       },
     })
   }

--- a/packages/ios-agent/src/__tests__/ScreenCaptureStreamer.test.ts
+++ b/packages/ios-agent/src/__tests__/ScreenCaptureStreamer.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { existsSync } from 'fs'
+
+vi.mock('child_process', () => ({ spawn: vi.fn(), execFileSync: vi.fn() }))
+vi.mock('fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('fs')>()),
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}))
+
+function makeFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  proc.stdout = new EventEmitter()
+  proc.stderr = new EventEmitter()
+  proc.kill = vi.fn()
+  return proc
+}
+
+async function setupProc() {
+  const { spawn } = await import('child_process')
+  const proc = makeFakeProc()
+  vi.mocked(spawn).mockReturnValue(proc as never)
+  // existsSync(BINARY)=true, existsSync(SWIFT_SRC)=false → ensureCompiled() skips recompile
+  vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false)
+  return proc
+}
+
+describe('ScreenCaptureStreamer', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('sends SIGTERM on cancel', async () => {
+    const proc = await setupProc()
+    const { ScreenCaptureStreamer } = await import('../ScreenCaptureStreamer')
+
+    const reader = new ScreenCaptureStreamer(30, 'booted').start().getReader()
+    await reader.cancel()
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('does not send SIGKILL when process exits within 1s', async () => {
+    vi.useFakeTimers()
+    const proc = await setupProc()
+    const { ScreenCaptureStreamer } = await import('../ScreenCaptureStreamer')
+
+    const reader = new ScreenCaptureStreamer(30, 'booted').start().getReader()
+    await reader.cancel()
+    proc.emit('exit', 0)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(proc.kill).not.toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('sends SIGKILL if process does not exit within 1s', async () => {
+    vi.useFakeTimers()
+    const proc = await setupProc()
+    const { ScreenCaptureStreamer } = await import('../ScreenCaptureStreamer')
+
+    const reader = new ScreenCaptureStreamer(30, 'booted').start().getReader()
+    await reader.cancel()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+})

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -118,24 +118,24 @@ describe('SimctlWrapper', () => {
   })
 
   describe('rotate', () => {
-    it('calls osascript with Cmd+Right for landscapeRight', async () => {
+    it('calls rotation-helper with landscapeRight', async () => {
       const { execFile } = await import('child_process')
       const wrapper = new SimctlWrapper()
       await wrapper.rotate('device-1', 'landscapeRight')
       expect(vi.mocked(execFile)).toHaveBeenCalledWith(
-        'osascript',
-        expect.arrayContaining([expect.stringContaining('key code 124')]),
+        expect.stringContaining('rotation-helper'),
+        ['landscapeRight', 'device-1'],
         expect.any(Function),
       )
     })
 
-    it('calls osascript with Cmd+Left for portrait', async () => {
+    it('calls rotation-helper with portrait', async () => {
       const { execFile } = await import('child_process')
       const wrapper = new SimctlWrapper()
       await wrapper.rotate('device-1', 'portrait')
       expect(vi.mocked(execFile)).toHaveBeenCalledWith(
-        'osascript',
-        expect.arrayContaining([expect.stringContaining('key code 123')]),
+        expect.stringContaining('rotation-helper'),
+        ['portrait', 'device-1'],
         expect.any(Function),
       )
     })

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -43,6 +43,9 @@ export class RelayServer {
   private router: Router
   private resourceBuffers = new Map<string, { cpu: number[]; mem: number[] }>()
   private logBuffer: string[] = []
+  private purgeRecordingsTimer: ReturnType<typeof setInterval> | null = null
+  private purgeOldResourcesTimer: ReturnType<typeof setInterval> | null = null
+  private flushResourcesTimer: ReturnType<typeof setInterval> | null = null
 
   constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number }) {
     this.sessions = new SessionManager({ idleTimeoutMs: options.idleTimeoutMs })
@@ -109,7 +112,8 @@ export class RelayServer {
     // recordings
     const recordingsDir = path.join(u, '../recordings')
     purgeExpiredRecordings(recordingsDir)
-    setInterval(() => purgeExpiredRecordings(recordingsDir), 24 * 60 * 60 * 1000).unref()
+    this.purgeRecordingsTimer = setInterval(() => purgeExpiredRecordings(recordingsDir), 24 * 60 * 60 * 1000)
+    this.purgeRecordingsTimer.unref()
     this.router.post('/api/v1/recordings/upload', (req, res) => handleUploadRecording(req, res, recordingsDir))
     this.router.get('/api/v1/recordings', (req, res) => handleListRecordings(req, res))
     this.router.get('/api/v1/recordings/:filename', (req, res) => handleDownloadRecording(req, res, recordingsDir))
@@ -127,8 +131,10 @@ export class RelayServer {
       getDb().prepare(`DELETE FROM agent_resources WHERE recorded_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')`).run()
     }
     purgeOldResources()
-    setInterval(purgeOldResources, 24 * 60 * 60 * 1000).unref()
-    setInterval(() => this.flushResourceBuffers(), 60_000).unref()
+    this.purgeOldResourcesTimer = setInterval(purgeOldResources, 24 * 60 * 60 * 1000)
+    this.purgeOldResourcesTimer.unref()
+    this.flushResourcesTimer = setInterval(() => this.flushResourceBuffers(), 60_000)
+    this.flushResourcesTimer.unref()
     this.router.get('/api/v1/agents', handleListAgents)
     this.router.get('/api/v1/agents/:name/resources', handleGetAgentResources)
   }
@@ -154,6 +160,9 @@ export class RelayServer {
   }
 
   stop(): Promise<void> {
+    if (this.purgeRecordingsTimer) { clearInterval(this.purgeRecordingsTimer); this.purgeRecordingsTimer = null }
+    if (this.purgeOldResourcesTimer) { clearInterval(this.purgeOldResourcesTimer); this.purgeOldResourcesTimer = null }
+    if (this.flushResourcesTimer) { clearInterval(this.flushResourcesTimer); this.flushResourcesTimer = null }
     return new Promise((resolve, reject) => {
       this.wss.clients.forEach((ws) => ws.terminate())
       this.wss.close(() => {

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -718,4 +718,20 @@ describe('RelayServer', () => {
     agent.close()
     browser2.close()
   })
+
+  describe('stop', () => {
+    let stopServer: RelayServer
+
+    beforeEach(async () => {
+      stopServer = new RelayServer({ port: 0 })
+      await stopServer.start()
+    })
+
+    it('clears all interval timers', async () => {
+      const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+      await stopServer.stop()
+      expect(clearSpy).toHaveBeenCalledTimes(3)
+      clearSpy.mockRestore()
+    })
+  })
 })

--- a/playground/android-agent.ts
+++ b/playground/android-agent.ts
@@ -4,6 +4,10 @@ const RELAY = process.env['RELAY_URL'] ?? 'ws://localhost:4000'
 
 const agent = new AndroidAgent()
 
+const shutdown = () => { agent.disconnect(); process.exit(0) }
+process.once('SIGINT', shutdown)
+process.once('SIGTERM', shutdown)
+
 const devices = await agent.listDevices()
 console.log(`Found ${devices.length} emulators`)
 devices.forEach((d) => console.log(` · [${d.status}] ${d.name} (${d.id})`))

--- a/playground/ios-agent.ts
+++ b/playground/ios-agent.ts
@@ -7,6 +7,10 @@ const deviceArg = deviceArgIdx >= 0 ? process.argv[deviceArgIdx + 1] : undefined
 
 const agent = new IOSAgent()
 
+const shutdown = () => { agent.disconnect(); process.exit(0) }
+process.once('SIGINT', shutdown)
+process.once('SIGTERM', shutdown)
+
 const devices = await agent.listDevices()
 console.log(`Found ${devices.length} simulators`)
 devices.forEach((d) => console.log(` · [${d.status}] ${d.name} (${d.id})`))


### PR DESCRIPTION
## Summary

- **Phase 1 버그 수정** (closes #29 #30 #31 #32): iOS/Android agent 종료 시 자식 프로세스 정리, RelayServer 인터벌 누수 제거
- **릴리즈 자동화**: `ci.yml` (PR 게이트: lint + test), `release.yml` (태그 트리거 → npm publish + GitHub Release)
- **문서**: README 알파 배너 추가, CONTRIBUTING.md 릴리즈 절차를 changeset 플로우로 재작성

## Test plan

- [x] CI 워크플로우가 PR에서 정상 실행되는지 확인
- [ ] 머지 후 D단계: `changeset add` → `changeset version` → `git tag v0.1.0-alpha.1` → push → release 워크플로우 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)