### PR TITLE
chore: release v0.1.0-alpha.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm changeset publish --no-git-tag
+      - run: pnpm changeset publish --no-git-tag --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflow/agent-core",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": ["tapflow", "ios", "android", "simulator", "emulator", "device-agent"],
   "homepage": "https://github.com/jo-duchan/tapflow",

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflow/android-agent",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": ["tapflow", "android", "emulator", "adb", "scrcpy", "streaming", "qa"],
   "homepage": "https://github.com/jo-duchan/tapflow",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": ["ios", "android", "simulator", "emulator", "qa", "testing", "streaming", "self-hosted"],
   "homepage": "https://github.com/jo-duchan/tapflow",

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflow/ios-agent",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": ["tapflow", "ios", "simulator", "xcrun", "simctl", "streaming", "qa"],
   "homepage": "https://github.com/jo-duchan/tapflow",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflow/relay",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": ["tapflow", "relay", "websocket", "self-hosted", "ios", "android", "simulator"],
   "homepage": "https://github.com/jo-duchan/tapflow",


### PR DESCRIPTION
## Summary

- Bump all publish targets to `0.1.0-alpha.1`
  - `tapflow`, `@tapflow/agent-core`, `@tapflow/ios-agent`, `@tapflow/android-agent`, `@tapflow/relay`
- Tag `v0.1.0-alpha.1` has been pushed — release workflow is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)