### PR TITLE
feat: add Lefthook pre-commit hooks (lint + typecheck)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: lint
+      run: pnpm lint
+
+    - name: typecheck
+      run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build": "pnpm --filter @tapflow/agent-core build && pnpm --filter @tapflow/dashboard build && pnpm --filter @tapflow/relay build && pnpm --filter @tapflow/ios-agent build && pnpm --filter @tapflow/android-agent build && pnpm --filter @tapflow/cli build",
     "test": "pnpm -r test --if-present",
     "lint": "pnpm -r --if-present lint",
+    "typecheck": "pnpm -r --if-present typecheck",
+    "prepare": "lefthook install",
     "dev": "concurrently -n relay,dashboard,ios,android -c cyan,magenta,green,yellow \"pnpm dev:relay\" \"pnpm --filter @tapflow/dashboard dev\" \"pnpm dev:ios-agent\" \"pnpm dev:android-agent\"",
     "dev:relay": "pnpm --filter @tapflow/playground relay",
     "dev:ios-agent": "pnpm --filter @tapflow/playground ios-agent",
@@ -29,6 +31,7 @@
     "concurrently": "^9.0.0",
     "eslint": "^10.4.0",
     "globals": "^17.6.0",
+    "lefthook": "^2.1.7",
     "typescript-eslint": "^8.59.3"
   }
 }

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint src"
   },

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint src",
     "download-scrcpy-server": "node scripts/download-scrcpy-server.mjs"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "lint": "eslint src"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite --port 3001",
     "build": "tsc --noEmit && vite build && rm -rf ../relay/public && mkdir -p ../relay/public && cp -r dist/. ../relay/public/",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "lint": "eslint src",
     "test": "vitest run",

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint src"
   },

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "tsc && rm -rf dist/migrations && cp -r src/migrations dist/migrations",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/server.js",
     "test": "vitest run",
     "lint": "eslint src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      lefthook:
+        specifier: ^2.1.7
+        version: 2.1.7
       typescript-eslint:
         specifier: ^8.59.3
         version: 8.59.3(eslint@10.4.0(jiti@1.21.7))(typescript@5.9.3)
@@ -3280,6 +3283,60 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lefthook-darwin-arm64@2.1.7:
+    resolution: {integrity: sha512-+mbfiGMTE562tQYLNrK2xgINwqDGkq2NYVBPp4Ked+o0VG87yfgkhAmbgEo/mfK7IImksg2/ywFkEKb++yyx8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.7:
+    resolution: {integrity: sha512-2YhpbuzGrI9aoK4r+5lsiSHe2qUjS4tNzH0moZy8stu4o1F0QwqgNdiQmSkj+HX/R25Y9ikDj/8JljttjwPF0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.7:
+    resolution: {integrity: sha512-kLe1Tbslo01JTI8GeJ+DvyytC4VJbALk1NS3q4yHvvSQ9bq3XstE5gfvBmt43+vhDnOOvlDaI+mvvW6RSUe7JA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.7:
+    resolution: {integrity: sha512-YXHWnErHfGrvjz8dbl6Y/HHBM7KDEc+3mFY/iKJ2yXlusECOpMvIqgWsUWy8uNOGkncNPibJhUSTJCCB2vEwDA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.7:
+    resolution: {integrity: sha512-O7f3vAadDJt4rIOBmwQ08/5CXraysenL+hTdI6KFamGQzoCb35cY31PP+CZ2MG3gnDYOo/jNPaDcYLLLAQ+rfQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.7:
+    resolution: {integrity: sha512-hC6IwcvgRTpvGhooga2kMFDb0wxASX5xEfwMwYfvhw6nCqVlqmSg+amu2Y+vRX7GG6F4Km1WtJz/O/jrclEHCw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.7:
+    resolution: {integrity: sha512-iXvYfXwfePfXE2qmgmTHgjUv/nYm4HlW706s2wvm8TM39kvrb2bi7ZkJtXZnBwNhLdtr+biglC0QNCFwqcS3AA==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.7:
+    resolution: {integrity: sha512-5n7yunOGxOUINT2bauNro1ANlWV4mr5ESGUYLLPvhZvgMNZ/eWLxhtoOj2ku751xj19y6Snnttb9a2bcoYio0A==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.7:
+    resolution: {integrity: sha512-gWKReP7gWlfDkMj4ijgcQTm5nsosh2SV5c9h/HE7ASWdGCp5KqSHGS0qeDTeQ03ewMLTsTK386lx/1w/gBHNdQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.7:
+    resolution: {integrity: sha512-kL1RmE5hywOSa2L2ZgBW3rTtjn3MJZqPdb22eiH7efT//4uc4iz9v9+tAe2t52hQLOw6TT70uEX6oJ2QlL3Ntg==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.7:
+    resolution: {integrity: sha512-G0+vlYjyIuZAQkQqtXof7C+smA06a1i+Z8HCWIrqHtaeEWEUq60pkGpARTuUs+s4XQwnRdop5AwfCUCrKY/RhQ==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -7463,6 +7520,49 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lefthook-darwin-arm64@2.1.7:
+    optional: true
+
+  lefthook-darwin-x64@2.1.7:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.7:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.7:
+    optional: true
+
+  lefthook-linux-arm64@2.1.7:
+    optional: true
+
+  lefthook-linux-x64@2.1.7:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.7:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.7:
+    optional: true
+
+  lefthook-windows-arm64@2.1.7:
+    optional: true
+
+  lefthook-windows-x64@2.1.7:
+    optional: true
+
+  lefthook@2.1.7:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.7
+      lefthook-darwin-x64: 2.1.7
+      lefthook-freebsd-arm64: 2.1.7
+      lefthook-freebsd-x64: 2.1.7
+      lefthook-linux-arm64: 2.1.7
+      lefthook-linux-x64: 2.1.7
+      lefthook-openbsd-arm64: 2.1.7
+      lefthook-openbsd-x64: 2.1.7
+      lefthook-windows-arm64: 2.1.7
+      lefthook-windows-x64: 2.1.7
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- `lefthook` 설치 (root devDependency)
- `lefthook.yml` 추가 — pre-commit 시 `lint` + `typecheck` 병렬 실행
- 각 패키지에 `typecheck: tsc --noEmit` 스크립트 추가 (agent-core, relay, ios-agent, android-agent, cli, dashboard)
- root `package.json`에 `typecheck: pnpm -r --if-present typecheck` 및 `prepare: lefthook install` 추가

## Test plan

- [x] `pnpm typecheck` — 전 패키지 타입 오류 없음 확인
- [x] `git commit` 시 pre-commit 훅 실행 — lint + typecheck 모두 통과 확인 (6.42s)
- [ ] 타입 오류 코드 staged 후 commit 시도 → 훅이 차단하는지 확인

## Related

Phase 2 Quality plan — 첫 번째 항목

🤖 Generated with [Claude Code](https://claude.com/claude-code)