### PR TITLE
feat(relay,cli): Zod 기반 런타임 config 검증 추가

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,16 @@
   "name": "tapflow",
   "version": "0.1.0-alpha.1",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
-  "keywords": ["ios", "android", "simulator", "emulator", "qa", "testing", "streaming", "self-hosted"],
+  "keywords": [
+    "ios",
+    "android",
+    "simulator",
+    "emulator",
+    "qa",
+    "testing",
+    "streaming",
+    "self-hosted"
+  ],
   "homepage": "https://github.com/jo-duchan/tapflow",
   "bugs": "https://github.com/jo-duchan/tapflow/issues",
   "repository": {
@@ -42,11 +51,12 @@
   },
   "dependencies": {
     "@tapflow/agent-core": "workspace:*",
-    "@tapflow/ios-agent": "workspace:*",
     "@tapflow/android-agent": "workspace:*",
+    "@tapflow/ios-agent": "workspace:*",
     "@tapflow/relay": "workspace:*",
     "cac": "^6.7.14",
-    "ws": "^8.0.0"
+    "ws": "^8.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cli/src/__tests__/commands/agent-start.test.ts
+++ b/packages/cli/src/__tests__/commands/agent-start.test.ts
@@ -105,6 +105,30 @@ describe('cmdAgentStart', () => {
     expect(exitSpy).toHaveBeenCalledWith(1)
   })
 
+  it('--relay http:// 스킴 → exit(1)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
+    await expect(cmdAgentStart({ platform: 'ios', relay: 'http://localhost:4000' })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('--relay ftp:// 스킴 → exit(1)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
+    await expect(cmdAgentStart({ platform: 'ios', relay: 'ftp://localhost:4000' })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('--relay wss:// 스킴 → 정상 연결', async () => {
+    const connectSpy = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(IOSAgent).mockImplementation(() => ({
+      listDevices: vi.fn().mockResolvedValue([{ id: 'AAA', name: 'iPhone 16 Pro', status: 'booted' }]),
+      connect: connectSpy,
+      disconnect: vi.fn(),
+    } as never))
+
+    await cmdAgentStart({ platform: 'ios', relay: 'wss://relay.example.com' })
+    expect(connectSpy).toHaveBeenCalledWith('wss://relay.example.com')
+  })
+
   it('SIGINT → 모든 에이전트 disconnect', async () => {
     const disconnectSpy = vi.fn()
     vi.mocked(IOSAgent).mockImplementation(() => ({

--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -55,4 +55,19 @@ describe('cmdRelayStart', () => {
     await cmdRelayStart({})
     expect(output.join('\n')).toContain('localhost:4000')
   })
+
+  it('포트 범위 초과(99999) → exit(1)', async () => {
+    await expect(cmdRelayStart({ port: 99999 })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('포트 0 → exit(1)', async () => {
+    await expect(cmdRelayStart({ port: 0 })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('NaN 포트 → exit(1)', async () => {
+    await expect(cmdRelayStart({ port: NaN })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
 })

--- a/packages/cli/src/commands/agent-start.ts
+++ b/packages/cli/src/commands/agent-start.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { AndroidAgent } from '@tapflow/android-agent'
 import { banner, createSpinner } from '../lib/print.js'
 import { hasAdb } from '../lib/platform.js'
@@ -11,9 +12,21 @@ export interface AgentStartOptions {
 
 const DEFAULT_RELAY = 'ws://localhost:4000'
 
+const relayUrlSchema = z
+  .string()
+  .refine((v) => v.startsWith('ws://') || v.startsWith('wss://'), {
+    message: '--relay must start with ws:// or wss://',
+  })
+
 export async function cmdAgentStart(opts: AgentStartOptions): Promise<void> {
   const isMac = process.platform === 'darwin'
-  const relayUrl = opts.relay ?? DEFAULT_RELAY
+  const rawRelay = opts.relay ?? DEFAULT_RELAY
+  const relayResult = relayUrlSchema.safeParse(rawRelay)
+  if (!relayResult.success) {
+    banner('error', 'INVALID CONFIG', [relayResult.error.issues[0].message])
+    process.exit(1)
+  }
+  const relayUrl = relayResult.data
 
   const explicit = opts.platform
   const runIOS = explicit === 'ios' || explicit === 'all' || (!explicit && isMac)

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { RelayServer } from '@tapflow/relay'
 import { banner, step } from '../lib/print.js'
 
@@ -7,8 +8,16 @@ export interface RelayStartOptions {
 
 const DEFAULT_PORT = 4000
 
+const portSchema = z.number().int().min(1).max(65535, 'port must be between 1 and 65535')
+
 export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
-  const port = opts.port ?? DEFAULT_PORT
+  const rawPort = opts.port ?? DEFAULT_PORT
+  const portResult = portSchema.safeParse(rawPort)
+  if (!portResult.success) {
+    banner('error', 'INVALID CONFIG', [`--port: ${portResult.error.issues[0].message}`])
+    process.exit(1)
+  }
+  const port = portResult.data
   const server = new RelayServer({ port })
   await server.start()
   step(`Relay started on ws://localhost:${port}`)

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -2,7 +2,15 @@
   "name": "@tapflow/relay",
   "version": "0.1.0-alpha.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
-  "keywords": ["tapflow", "relay", "websocket", "self-hosted", "ios", "android", "simulator"],
+  "keywords": [
+    "tapflow",
+    "relay",
+    "websocket",
+    "self-hosted",
+    "ios",
+    "android",
+    "simulator"
+  ],
   "homepage": "https://github.com/jo-duchan/tapflow",
   "bugs": "https://github.com/jo-duchan/tapflow/issues",
   "repository": {
@@ -48,7 +56,8 @@
     "busboy": "^1.6.0",
     "jsonwebtoken": "^9.0.3",
     "nodemailer": "^8.0.7",
-    "ws": "^8.0.0"
+    "ws": "^8.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/relay/src/__tests__/config.test.ts
+++ b/packages/relay/src/__tests__/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn(),
+  },
+}))
+
+describe('relay config validation', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('유효한 기본값 → 정상 로드', async () => {
+    const { config } = await import('../lib/config.js')
+    expect(config.server.port).toBe(4000)
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('TAPFLOW_PORT=abc → exit(1) + 에러 로그', async () => {
+    vi.stubEnv('TAPFLOW_PORT', 'abc')
+    await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('server.port'))
+  })
+
+  it('TAPFLOW_PORT=99999 → exit(1)', async () => {
+    vi.stubEnv('TAPFLOW_PORT', '99999')
+    await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('JWT_SECRET 32자 미만 → exit(1) + 에러 로그', async () => {
+    vi.stubEnv('JWT_SECRET', 'tooshort')
+    await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('server.jwtSecret'))
+  })
+
+  it('JWT_SECRET 32자 이상 → 정상 로드', async () => {
+    vi.stubEnv('JWT_SECRET', 'a'.repeat(32))
+    const { config } = await import('../lib/config.js')
+    expect(config.server.jwtSecret).toBe('a'.repeat(32))
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('기본 JWT_SECRET 사용 시 경고 로그', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { config } = await import('../lib/config.js')
+    expect(config.server.jwtSecret).toContain('tapflow-dev-secret')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dev default'))
+  })
+})

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -1,24 +1,27 @@
 import fs from 'fs'
 import path from 'path'
+import { z } from 'zod'
 import { createLogger } from '@tapflow/agent-core'
 
 const logger = createLogger('relay:config')
 
-export interface TapflowConfig {
-  server: {
-    port: number
-    dataDir: string
-    jwtSecret: string
-  }
-  smtp: {
-    host: string
-    port: number
-    secure: boolean
-    user: string
-    pass: string
-    from: string
-  }
-}
+const configSchema = z.object({
+  server: z.object({
+    port: z.number().int().min(1).max(65535),
+    dataDir: z.string().min(1),
+    jwtSecret: z.string().min(32, 'jwtSecret must be at least 32 characters'),
+  }),
+  smtp: z.object({
+    host: z.string(),
+    port: z.number().int().min(1).max(65535),
+    secure: z.boolean(),
+    user: z.string(),
+    pass: z.string(),
+    from: z.string(),
+  }),
+})
+
+export type TapflowConfig = z.infer<typeof configSchema>
 
 type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }
 
@@ -81,7 +84,19 @@ function load(): TapflowConfig {
   if (process.env.SMTP_PASS) cfg.smtp.pass = process.env.SMTP_PASS
   if (process.env.SMTP_FROM) cfg.smtp.from = process.env.SMTP_FROM
 
-  return cfg
+  const result = configSchema.safeParse(cfg)
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      logger.error(`config error: ${issue.path.join('.')} — ${issue.message}`)
+    }
+    process.exit(1)
+  }
+
+  if (cfg.server.jwtSecret === DEFAULTS.server.jwtSecret) {
+    logger.warn('JWT_SECRET is using the dev default — set a strong secret in production')
+  }
+
+  return result.data
 }
 
 export const config = load()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       ws:
         specifier: ^8.0.0
         version: 8.20.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -298,6 +301,9 @@ importers:
       ws:
         specifier: ^8.0.0
         version: 8.20.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13


### PR DESCRIPTION
## Summary

- **relay `config.ts`**: Zod 스키마로 시작 시점에 설정값 검증. 실패 시 오류 필드를 명시하고 즉시 `process.exit(1)`
- **relay `config.ts`**: 개발용 기본 `JWT_SECRET` 사용 시 경고 로그 출력
- **cli `relay-start`**: `--port` NaN·범위 초과(1–65535) 시 즉시 `exit(1)`
- **cli `agent-start`**: `--relay` URL이 `ws://` 또는 `wss://` 스킴 아니면 즉시 `exit(1)`

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `packages/relay/src/lib/config.ts` | Zod 스키마 추가, `TapflowConfig` → `z.infer<>` 타입으로 교체 |
| `packages/cli/src/commands/relay-start.ts` | port 인라인 검증 추가 |
| `packages/cli/src/commands/agent-start.ts` | relay URL 스킴 인라인 검증 추가 |
| `packages/relay/src/__tests__/config.test.ts` | 신규 — `TAPFLOW_PORT=abc`, `JWT_SECRET=short` 등 검증 케이스 |
| `packages/cli/src/__tests__/commands/relay-start.test.ts` | 포트 범위 초과·NaN 케이스 추가 |
| `packages/cli/src/__tests__/commands/agent-start.test.ts` | 잘못된 스킴, wss:// 정상 연결 케이스 추가 |

## Test plan

- [ ] `TAPFLOW_PORT=abc node packages/relay/dist/server.js` → `config error: server.port` 출력 후 종료
- [ ] `JWT_SECRET=short node packages/relay/dist/server.js` → `config error: server.jwtSecret` 출력 후 종료
- [ ] `tapflow agent start --relay http://localhost:4000` → 스킴 오류 메시지 출력 후 종료
- [ ] `tapflow relay start --port 99999` → 포트 오류 메시지 출력 후 종료
- [ ] `pnpm test` → relay 116개, cli 81개 모두 통과

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)