### PR TITLE
feat(cli): CLI smoke tests 추가

### DIFF
--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const pkgRoot = path.resolve(__dirname, '../..')
+const entry = path.resolve(__dirname, '../index.ts')
+const tsx = path.resolve(pkgRoot, 'node_modules/.bin/tsx')
+
+function run(...args: string[]) {
+  return spawnSync(tsx, [entry, ...args], { encoding: 'utf-8', cwd: pkgRoot })
+}
+
+describe('CLI smoke tests', () => {
+  it('tapflow --version → semver 출력, exit 0', () => {
+    const { stdout, status } = run('--version')
+    expect(status).toBe(0)
+    expect(stdout).toMatch(/\d+\.\d+\.\d+/)
+  })
+
+  it('tapflow --help → 사용법 출력, exit 0', () => {
+    const { stdout, status } = run('--help')
+    expect(status).toBe(0)
+    expect(stdout).toContain('tapflow')
+    expect(stdout).toContain('--help')
+  })
+})


### PR DESCRIPTION
## Summary

`--version`, `--help`는 `cac` built-in 처리라 기존 unit test로는 커버할 수 없는 영역입니다. `spawnSync` + `tsx`로 실제 프로세스를 실행해 exit code와 출력 포맷을 검증하는 smoke test를 추가했습니다.

## Changes

| 파일 | 내용 |
|------|------|
| `packages/cli/src/__tests__/smoke.test.ts` | 신규 — `--version`, `--help` subprocess smoke test |

## Test plan

- [x] `pnpm --filter tapflow test` → 83개 모두 통과
- [x] `tapflow --version` 출력에 semver 포함 확인
- [x] `tapflow --help` 출력에 커맨드 목록 포함 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)