### PR TITLE
fix(dashboard): prevent spinner hang when stopping recording

### DIFF
--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -186,7 +186,11 @@ export function AndroidViewer({
   const stopClientRecording = useCallback(async () => {
     setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
     const mr = mediaRecorderRef.current; if (!mr) return
-    await new Promise<void>((resolve) => { mr.onstop = () => resolve(); mr.stop() })
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 5000)
+      mr.onstop = () => { clearTimeout(timeout); resolve() }
+      try { mr.stop() } catch { clearTimeout(timeout); resolve() }
+    })
     mediaRecorderRef.current = null
     const mime = recordMimeRef.current; const ext = mime.includes('mp4') ? '.mp4' : '.webm'
     const blob = new Blob(recordChunksRef.current, { type: mime }); recordChunksRef.current = []

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -185,7 +185,7 @@ export function AndroidViewer({
 
   const stopClientRecording = useCallback(async () => {
     setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
-    const mr = mediaRecorderRef.current; if (!mr) return
+    const mr = mediaRecorderRef.current; if (!mr) { setRecordState('idle'); return }
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, 5000)
       mr.onstop = () => { clearTimeout(timeout); resolve() }

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -210,7 +210,7 @@ export function IOSViewer({
 
   const stopClientRecording = useCallback(async () => {
     setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
-    const mr = mediaRecorderRef.current; if (!mr) return
+    const mr = mediaRecorderRef.current; if (!mr) { setRecordState('idle'); return }
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, 5000)
       mr.onstop = () => { clearTimeout(timeout); resolve() }

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -211,7 +211,11 @@ export function IOSViewer({
   const stopClientRecording = useCallback(async () => {
     setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
     const mr = mediaRecorderRef.current; if (!mr) return
-    await new Promise<void>((resolve) => { mr.onstop = () => resolve(); mr.stop() })
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 5000)
+      mr.onstop = () => { clearTimeout(timeout); resolve() }
+      try { mr.stop() } catch { clearTimeout(timeout); resolve() }
+    })
     mediaRecorderRef.current = null
     const mime = recordMimeRef.current; const ext = mime.includes('mp4') ? '.mp4' : '.webm'
     const blob = new Blob(recordChunksRef.current, { type: mime }); recordChunksRef.current = []

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -111,6 +111,8 @@ export function QASession() {
   }, [activeSessionId, deviceId, send]);
 
   // 디바이스 선택 → Mac 선택
+  const handleRecordingUploaded = useCallback(() => setRecordingsKey((k) => k + 1), []);
+
   const handleBackToMacs = useCallback(() => {
     if (activeSessionId && deviceId) {
       send({ type: 'device:shutdown', sessionId: activeSessionId, payload: { deviceId } });
@@ -208,7 +210,7 @@ export function QASession() {
                 deviceId={deviceId}
                 buildId={build?.id}
                 resetMode={resetMode}
-                onRecordingUploaded={() => setRecordingsKey((k) => k + 1)}
+                onRecordingUploaded={handleRecordingUploaded}
               />
             </div>
           ) : selectedAgent ? (


### PR DESCRIPTION
## Summary

- `mr.stop()` was called outside the try-catch in `stopClientRecording` — if it threw `InvalidStateError` (MediaRecorder already inactive), or if `onstop` never fired (codec/browser edge case), the async function rejected silently and `recordState` stayed stuck at `'uploading'` indefinitely
- Fix applies to both `IOSViewer` and `AndroidViewer`

## Changes

- Wrap `mr.stop()` in try-catch so an `InvalidStateError` resolves immediately instead of rejecting the outer Promise
- Add a 5-second safety timeout so the upload phase always proceeds even if `onstop` is never dispatched

## Test plan

- [x] Start a recording session on iOS simulator → click stop → verify spinner clears and file downloads
- [x] Start a recording session on Android emulator → click stop → verify spinner clears and file downloads
- [x] Verify that stopping and immediately re-starting recording does not cause a hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)