### PR TITLE
feat(dashboard): integrate react-hook-form + Zod across all forms (closes #52)

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/dashboard/src/pages/Invite.tsx
+++ b/packages/dashboard/src/pages/Invite.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -8,52 +11,54 @@ import { Separator } from '@/components/ui/separator'
 import { Pencil } from 'lucide-react'
 import { avatarColors } from '@/components/user-avatar'
 
+const schema = z.object({
+  displayName: z.string().optional(),
+  avatar: z.instanceof(File).nullable().optional(),
+  password: z.string().min(8),
+  confirm: z.string(),
+}).refine((d) => d.password === d.confirm, {
+  message: 'Passwords do not match',
+  path: ['confirm'],
+})
+type FormData = z.infer<typeof schema>
+
 export function Invite() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const token = searchParams.get('token') ?? ''
-
   const [status, setStatus] = useState<'loading' | 'valid' | 'invalid'>('loading')
   const [inviteRole, setInviteRole] = useState('')
-  const [displayName, setDisplayName] = useState('')
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
-  const [password, setPassword] = useState('')
-  const [confirm, setConfirm] = useState('')
-  const [error, setError] = useState('')
-  const [submitting, setSubmitting] = useState(false)
   const avatarRef = useRef<HTMLInputElement>(null)
+
+  const { register, handleSubmit, control, watch, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+    defaultValues: { displayName: '', avatar: null },
+  })
+  const displayName = watch('displayName') ?? ''
 
   useEffect(() => {
     if (!token) { setStatus('invalid'); return }
     fetch(`/api/v1/invitations/verify?token=${token}`)
       .then((r) => r.ok ? r.json() : Promise.reject())
-      .then((data) => { setInviteRole(data.role); setStatus('valid') })
+      .then((data: { role: string }) => { setInviteRole(data.role); setStatus('valid') })
       .catch(() => setStatus('invalid'))
   }, [token])
 
-  async function handleSubmit(e: { preventDefault(): void }) {
-    e.preventDefault()
-    if (password !== confirm) { setError('Passwords do not match'); return }
-    setError('')
-    setSubmitting(true)
+  async function onSubmit(data: FormData) {
     try {
       const form = new FormData()
       form.append('token', token)
-      form.append('password', password)
-      if (displayName.trim()) form.append('display_name', displayName.trim())
-      if (avatarFile) form.append('avatar', avatarFile)
+      form.append('password', data.password)
+      if (data.displayName?.trim()) form.append('display_name', data.displayName.trim())
+      if (data.avatar) form.append('avatar', data.avatar)
 
-      const res = await fetch('/api/v1/invitations/accept', {
-        method: 'POST',
-        body: form,
-      })
-      if (!res.ok) { setError('Failed to accept invitation'); return }
+      const res = await fetch('/api/v1/invitations/accept', { method: 'POST', body: form })
+      if (!res.ok) { setError('root', { message: 'Failed to accept invitation' }); return }
       navigate('/app-center', { replace: true })
     } catch {
-      setError('Network error. Please try again.')
-    } finally {
-      setSubmitting(false)
+      setError('root', { message: 'Network error. Please try again.' })
     }
   }
 
@@ -80,68 +85,71 @@ export function Invite() {
           <CardDescription>You&apos;re joining as <strong>{inviteRole}</strong></CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="display-name">Nickname <span className="text-muted-foreground text-xs">(optional)</span></Label>
-              <Input
-                id="display-name"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="Your name"
-              />
+              <Input id="display-name" placeholder="Your name" {...register('displayName')} />
             </div>
 
             <div className="grid gap-2">
               <Label>Avatar <span className="text-muted-foreground text-xs">(optional, png · jpg, max 2MB)</span></Label>
-              <div className="relative w-14 h-14">
-                {avatarPreview ? (
-                  <img src={avatarPreview} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
-                ) : (
-                  <div
-                    className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
-                    style={(() => { const c = avatarColors(displayName); return { backgroundColor: c.bg, color: c.fg } })()}
-                  >
-                    {displayName?.[0]?.toUpperCase() ?? '?'}
+              <Controller
+                name="avatar"
+                control={control}
+                render={({ field }) => (
+                  <div className="relative w-14 h-14">
+                    {avatarPreview ? (
+                      <img src={avatarPreview} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
+                    ) : (
+                      <div
+                        className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
+                        style={(() => { const c = avatarColors(displayName); return { backgroundColor: c.bg, color: c.fg } })()}
+                      >
+                        {displayName?.[0]?.toUpperCase() ?? '?'}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => avatarRef.current?.click()}
+                      className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
+                    >
+                      <Pencil className="w-3 h-3" />
+                    </button>
+                    <input
+                      ref={avatarRef}
+                      type="file"
+                      accept="image/png,image/jpeg"
+                      className="hidden"
+                      onChange={(e) => {
+                        const f = e.target.files?.[0]
+                        if (!f) return
+                        if (f.size > 2 * 1024 * 1024) { setError('avatar', { message: 'Max 2MB for avatar' }); return }
+                        field.onChange(f)
+                        setAvatarPreview(URL.createObjectURL(f))
+                      }}
+                    />
                   </div>
                 )}
-                <button
-                  type="button"
-                  onClick={() => avatarRef.current?.click()}
-                  className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
-                >
-                  <Pencil className="w-3 h-3" />
-                </button>
-                <input
-                  ref={avatarRef}
-                  type="file"
-                  accept="image/png,image/jpeg"
-                  className="hidden"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0]
-                    if (!f) return
-                    if (f.size > 2 * 1024 * 1024) { setError('Max 2MB for avatar'); return }
-                    setAvatarFile(f)
-                    setAvatarPreview(URL.createObjectURL(f))
-                    setError('')
-                  }}
-                />
-              </div>
+              />
+              {errors.avatar && <p className="text-sm text-destructive">{errors.avatar.message}</p>}
             </div>
 
             <Separator />
 
             <div className="grid gap-2">
               <Label htmlFor="password">Password</Label>
-              <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={8} />
+              <Input id="password" type="password" {...register('password')} />
+              {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="confirm">Confirm password</Label>
-              <Input id="confirm" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required minLength={8} />
+              <Input id="confirm" type="password" {...register('confirm')} />
+              {errors.confirm && <p className="text-sm text-destructive">{errors.confirm.message}</p>}
             </div>
 
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" disabled={submitting} className="w-full">
-              {submitting ? 'Creating account…' : 'Create account'}
+            {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+              {isSubmitting ? 'Creating account…' : 'Create account'}
             </Button>
           </form>
         </CardContent>

--- a/packages/dashboard/src/pages/Invite.tsx
+++ b/packages/dashboard/src/pages/Invite.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { useForm, Controller } from 'react-hook-form'
+import { useForm, useWatch, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button } from '@/components/ui/button'
@@ -31,12 +31,12 @@ export function Invite() {
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
   const avatarRef = useRef<HTMLInputElement>(null)
 
-  const { register, handleSubmit, control, watch, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
+  const { register, handleSubmit, control, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
     resolver: zodResolver(schema),
     mode: 'onBlur',
     defaultValues: { displayName: '', avatar: null },
   })
-  const displayName = watch('displayName') ?? ''
+  const displayName = useWatch({ control, name: 'displayName' }) ?? ''
 
   useEffect(() => {
     if (!token) { setStatus('invalid'); return }

--- a/packages/dashboard/src/pages/Login.tsx
+++ b/packages/dashboard/src/pages/Login.tsx
@@ -1,33 +1,37 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from 'next-themes'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+})
+type FormData = z.infer<typeof schema>
+
 export function Login() {
   const navigate = useNavigate()
   const { resolvedTheme } = useTheme()
   const defaultLogo = resolvedTheme === 'dark' ? '/logo-dark.svg' : '/logo.svg'
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
 
-  async function handleSubmit(e: { preventDefault(): void }) {
-    e.preventDefault()
-    setError('')
-    setLoading(true)
+  const { register, handleSubmit, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+  })
+
+  async function onSubmit(data: FormData) {
     try {
-      const { status } = await api.post('/api/v1/auth/login', { email, password })
-      if (status !== 200) { setError('Invalid email or password'); return }
+      const { status } = await api.post('/api/v1/auth/login', { email: data.email, password: data.password })
+      if (status !== 200) { setError('root', { message: 'Invalid email or password' }); return }
       navigate('/app-center', { replace: true })
     } catch {
-      setError('Network error. Please try again.')
-    } finally {
-      setLoading(false)
+      setError('root', { message: 'Network error. Please try again.' })
     }
   }
 
@@ -44,33 +48,31 @@ export function Login() {
           <CardDescription>Sign in to your team workspace</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
               <Input
                 id="email"
                 type="email"
                 placeholder="you@company.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
                 autoComplete="email"
+                {...register('email')}
               />
+              {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="password">Password</Label>
               <Input
                 id="password"
                 type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
                 autoComplete="current-password"
+                {...register('password')}
               />
+              {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" size="pill" disabled={loading} className="w-full mt-1">
-              {loading ? 'Signing in…' : 'Sign in'}
+            {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
+            <Button type="submit" size="pill" disabled={isSubmitting} className="w-full mt-1">
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               First time here?{' '}

--- a/packages/dashboard/src/pages/ResetPassword.tsx
+++ b/packages/dashboard/src/pages/ResetPassword.tsx
@@ -1,20 +1,32 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 
+const schema = z.object({
+  password: z.string().min(8),
+  confirm: z.string(),
+}).refine((d) => d.password === d.confirm, {
+  message: 'Passwords do not match',
+  path: ['confirm'],
+})
+type FormData = z.infer<typeof schema>
+
 export function ResetPassword() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const token = searchParams.get('token') ?? ''
-
   const [status, setStatus] = useState<'loading' | 'valid' | 'invalid'>('loading')
-  const [password, setPassword] = useState('')
-  const [confirm, setConfirm] = useState('')
-  const [error, setError] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+
+  const { register, handleSubmit, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+  })
 
   useEffect(() => {
     if (!token) { setStatus('invalid'); return }
@@ -23,27 +35,21 @@ export function ResetPassword() {
       .catch(() => setStatus('invalid'))
   }, [token])
 
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    if (password !== confirm) { setError('Passwords do not match'); return }
-    setError('')
-    setSubmitting(true)
+  async function onSubmit(data: FormData) {
     try {
       const res = await fetch('/api/v1/auth/reset-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, password }),
+        body: JSON.stringify({ token, password: data.password }),
       })
       if (!res.ok) {
-        const d = await res.json()
-        setError(d.error ?? 'Failed to reset password')
+        const d = await res.json() as { error?: string }
+        setError('root', { message: d.error ?? 'Failed to reset password' })
         return
       }
       navigate('/login', { replace: true })
     } catch {
-      setError('Network error. Please try again.')
-    } finally {
-      setSubmitting(false)
+      setError('root', { message: 'Network error. Please try again.' })
     }
   }
 
@@ -70,18 +76,20 @@ export function ResetPassword() {
           <CardDescription>Enter your new password below.</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="password">New password</Label>
-              <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={8} />
+              <Input id="password" type="password" {...register('password')} />
+              {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="confirm">Confirm password</Label>
-              <Input id="confirm" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required minLength={8} />
+              <Input id="confirm" type="password" {...register('confirm')} />
+              {errors.confirm && <p className="text-sm text-destructive">{errors.confirm.message}</p>}
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" disabled={submitting} className="w-full">
-              {submitting ? 'Saving…' : 'Set new password'}
+            {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+              {isSubmitting ? 'Saving…' : 'Set new password'}
             </Button>
           </form>
         </CardContent>

--- a/packages/dashboard/src/pages/settings/Default.tsx
+++ b/packages/dashboard/src/pages/settings/Default.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTheme } from 'next-themes'
-import { useForm, Controller } from 'react-hook-form'
+import { useForm, useWatch, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -176,7 +176,7 @@ export function DefaultSettings() {
     setTimeout(() => setAppsSaved((p) => ({ ...p, [appId]: false })), 2000)
   }
 
-  const profileDisplayName = profileForm.watch('displayName')
+  const profileDisplayName = useWatch({ control: profileForm.control, name: 'displayName' })
 
   return (
     <div className="flex flex-col gap-6 max-w-[900px] mx-auto w-full p-6">

--- a/packages/dashboard/src/pages/settings/Default.tsx
+++ b/packages/dashboard/src/pages/settings/Default.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTheme } from 'next-themes'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
@@ -24,6 +27,28 @@ import { useAuth } from '@/hooks/useAuth'
 
 type App = { id: number; name: string; bundle_id_key: string; platform: string }
 
+const workspaceSchema = z.object({
+  teamName: z.string().min(1),
+  logo: z.instanceof(File).nullable().optional(),
+})
+type WorkspaceData = z.infer<typeof workspaceSchema>
+
+const profileSchema = z.object({
+  displayName: z.string().min(1),
+  avatar: z.instanceof(File).nullable().optional(),
+})
+type ProfileData = z.infer<typeof profileSchema>
+
+const passwordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine((d) => d.newPassword === d.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+type PasswordData = z.infer<typeof passwordSchema>
+
 export function DefaultSettings() {
   const { resolvedTheme } = useTheme()
   const defaultLogo = resolvedTheme === 'dark' ? '/logo-dark.svg' : '/logo.svg'
@@ -32,91 +57,83 @@ export function DefaultSettings() {
   const canEditApps = user?.role === 'Admin' || user?.role === 'Developer'
 
   // ── Workspace (Admin only) ────────────────────────────────────────────────
-  const [teamName, setTeamName] = useState('')
   const [logoUrl, setLogoUrl] = useState<string | null>(null)
-  const [logoFile, setLogoFile] = useState<File | null>(null)
-  const logoRef = useRef<HTMLInputElement>(null)
-  const [workspaceSaving, setWorkspaceSaving] = useState(false)
   const [workspaceSaved, setWorkspaceSaved] = useState(false)
+  const logoRef = useRef<HTMLInputElement>(null)
+
+  const workspaceForm = useForm<WorkspaceData>({
+    resolver: zodResolver(workspaceSchema),
+    mode: 'onBlur',
+    defaultValues: { teamName: '', logo: null },
+  })
 
   useEffect(() => {
     if (!isAdmin) return
     fetch('/api/v1/settings', { credentials: 'include' })
       .then((r) => r.ok ? r.json() : null)
-      .then((d) => { if (d) { setTeamName(d.team_name); setLogoUrl(d.logo_url) } })
-  }, [isAdmin])
+      .then((d: { team_name: string; logo_url: string | null } | null) => {
+        if (d) { workspaceForm.reset({ teamName: d.team_name, logo: null }); setLogoUrl(d.logo_url) }
+      })
+  }, [isAdmin]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function handleWorkspaceSave(e: { preventDefault(): void }) {
-    e.preventDefault()
-    setWorkspaceSaving(true)
+  async function onWorkspaceSave(data: WorkspaceData) {
     const form = new FormData()
-    form.append('team_name', teamName)
-    if (logoFile) form.append('logo', logoFile)
+    form.append('team_name', data.teamName)
+    if (data.logo) form.append('logo', data.logo)
     await fetch('/api/v1/settings', { method: 'PATCH', credentials: 'include', body: form })
-    setWorkspaceSaving(false)
     setWorkspaceSaved(true)
     setTimeout(() => setWorkspaceSaved(false), 2000)
   }
 
   // ── Profile (everyone) ────────────────────────────────────────────────────
-  const [displayName, setDisplayName] = useState('')
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const avatarRef = useRef<HTMLInputElement>(null)
-  const [profileSaving, setProfileSaving] = useState(false)
   const [profileSaved, setProfileSaved] = useState(false)
+  const avatarRef = useRef<HTMLInputElement>(null)
+
+  const profileForm = useForm<ProfileData>({
+    resolver: zodResolver(profileSchema),
+    mode: 'onBlur',
+    defaultValues: { displayName: '', avatar: null },
+  })
 
   useEffect(() => {
     if (!user) return
-    setDisplayName(user.displayName ?? '')
+    profileForm.reset({ displayName: user.displayName ?? '', avatar: null })
     setAvatarUrl(user.avatarUrl ?? null)
-  }, [user])
+  }, [user]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function handleProfileSave(e: { preventDefault(): void }) {
-    e.preventDefault()
-    setProfileSaving(true)
+  async function onProfileSave(data: ProfileData) {
     const form = new FormData()
-    form.append('display_name', displayName)
-    if (avatarFile) form.append('avatar', avatarFile)
+    form.append('display_name', data.displayName)
+    if (data.avatar) form.append('avatar', data.avatar)
     await fetch('/api/v1/profile', { method: 'PATCH', credentials: 'include', body: form })
-    setProfileSaving(false)
     setProfileSaved(true)
     setTimeout(() => setProfileSaved(false), 2000)
   }
 
-  // ── Password (everyone) ──────────────────────────────────────────────────
-  const [currentPassword, setCurrentPassword] = useState('')
-  const [newPassword, setNewPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [passwordError, setPasswordError] = useState('')
-  const [passwordSaving, setPasswordSaving] = useState(false)
+  // ── Password (everyone) ───────────────────────────────────────────────────
   const [passwordSaved, setPasswordSaved] = useState(false)
 
-  async function handlePasswordChange(e: { preventDefault(): void }) {
-    e.preventDefault()
-    if (newPassword !== confirmPassword) { setPasswordError('Passwords do not match'); return }
-    setPasswordError('')
-    setPasswordSaving(true)
-    try {
-      const res = await fetch('/api/v1/auth/change-password', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ currentPassword, newPassword }),
-      })
-      if (!res.ok) {
-        const d = await res.json()
-        setPasswordError(d.error ?? 'Failed to change password')
-        return
-      }
-      setCurrentPassword('')
-      setNewPassword('')
-      setConfirmPassword('')
-      setPasswordSaved(true)
-      setTimeout(() => setPasswordSaved(false), 2000)
-    } finally {
-      setPasswordSaving(false)
+  const passwordForm = useForm<PasswordData>({
+    resolver: zodResolver(passwordSchema),
+    mode: 'onBlur',
+  })
+
+  async function onPasswordSave(data: PasswordData) {
+    const res = await fetch('/api/v1/auth/change-password', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentPassword: data.currentPassword, newPassword: data.newPassword }),
+    })
+    if (!res.ok) {
+      const d = await res.json() as { error?: string }
+      passwordForm.setError('root', { message: d.error ?? 'Failed to change password' })
+      return
     }
+    passwordForm.reset()
+    setPasswordSaved(true)
+    setTimeout(() => setPasswordSaved(false), 2000)
   }
 
   // ── Apps (Admin + Developer) ──────────────────────────────────────────────
@@ -130,11 +147,11 @@ export function DefaultSettings() {
     if (!canEditApps) return
     fetch('/api/v1/apps', { credentials: 'include' })
       .then((r) => r.ok ? r.json() : null)
-      .then((d) => {
+      .then((d: { items: App[] } | null) => {
         if (!d) return
         setApps(d.items)
         const names: Record<number, string> = {}
-        d.items.forEach((a: App) => { names[a.id] = a.name })
+        d.items.forEach((a) => { names[a.id] = a.name })
         setAppNames(names)
       })
   }, [canEditApps])
@@ -159,6 +176,8 @@ export function DefaultSettings() {
     setTimeout(() => setAppsSaved((p) => ({ ...p, [appId]: false })), 2000)
   }
 
+  const profileDisplayName = profileForm.watch('displayName')
+
   return (
     <div className="flex flex-col gap-6 max-w-[900px] mx-auto w-full p-6">
       <h1 className="text-xl font-semibold tracking-display-sm">Settings</h1>
@@ -168,35 +187,44 @@ export function DefaultSettings() {
         <Card>
           <CardHeader><CardTitle>Workspace</CardTitle></CardHeader>
           <CardContent>
-            <form onSubmit={handleWorkspaceSave} className="flex flex-col gap-4">
+            <form onSubmit={workspaceForm.handleSubmit(onWorkspaceSave)} className="flex flex-col gap-4">
               <div className="grid gap-2">
                 <Label htmlFor="team-name">Team name</Label>
-                <Input id="team-name" value={teamName} onChange={(e) => setTeamName(e.target.value)} placeholder="My QA Team" />
+                <Input id="team-name" placeholder="My QA Team" {...workspaceForm.register('teamName')} />
+                {workspaceForm.formState.errors.teamName && (
+                  <p className="text-sm text-destructive">{workspaceForm.formState.errors.teamName.message}</p>
+                )}
               </div>
               <Separator />
               <div className="grid gap-2">
                 <Label>Logo <span className="text-muted-foreground text-xs">(png · jpg, max 2MB)</span></Label>
-                <div className="relative w-16 h-16">
-                  <img src={logoUrl ?? defaultLogo} alt="logo" className="w-16 h-16 rounded-lg object-contain" />
-                  <button
-                    type="button"
-                    onClick={() => logoRef.current?.click()}
-                    className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
-                  >
-                    <Pencil className="w-3 h-3" />
-                  </button>
-                  <input ref={logoRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
-                    onChange={(e) => {
-                      const f = e.target.files?.[0]
-                      if (f && f.size > 2 * 1024 * 1024) { alert('Max 2MB'); return }
-                      if (f) { setLogoFile(f); setLogoUrl(URL.createObjectURL(f)) }
-                    }}
-                  />
-                </div>
+                <Controller
+                  name="logo"
+                  control={workspaceForm.control}
+                  render={({ field }) => (
+                    <div className="relative w-16 h-16">
+                      <img src={logoUrl ?? defaultLogo} alt="logo" className="w-16 h-16 rounded-lg object-contain" />
+                      <button
+                        type="button"
+                        onClick={() => logoRef.current?.click()}
+                        className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
+                      >
+                        <Pencil className="w-3 h-3" />
+                      </button>
+                      <input ref={logoRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
+                        onChange={(e) => {
+                          const f = e.target.files?.[0]
+                          if (f && f.size > 2 * 1024 * 1024) { alert('Max 2MB'); return }
+                          if (f) { field.onChange(f); setLogoUrl(URL.createObjectURL(f)) }
+                        }}
+                      />
+                    </div>
+                  )}
+                />
               </div>
               <div className="flex justify-end">
-                <Button type="submit" size="sm" disabled={workspaceSaving}>
-                  {workspaceSaved ? 'Saved!' : workspaceSaving ? 'Saving…' : 'Save changes'}
+                <Button type="submit" size="sm" disabled={workspaceForm.formState.isSubmitting}>
+                  {workspaceSaved ? 'Saved!' : workspaceForm.formState.isSubmitting ? 'Saving…' : 'Save changes'}
                 </Button>
               </div>
             </form>
@@ -208,44 +236,53 @@ export function DefaultSettings() {
       <Card>
         <CardHeader><CardTitle>Profile</CardTitle></CardHeader>
         <CardContent>
-          <form onSubmit={handleProfileSave} className="flex flex-col gap-4">
+          <form onSubmit={profileForm.handleSubmit(onProfileSave)} className="flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="display-name">Nickname</Label>
-              <Input id="display-name" value={displayName} onChange={(e) => setDisplayName(e.target.value)} placeholder="Your name" />
+              <Input id="display-name" placeholder="Your name" {...profileForm.register('displayName')} />
+              {profileForm.formState.errors.displayName && (
+                <p className="text-sm text-destructive">{profileForm.formState.errors.displayName.message}</p>
+              )}
             </div>
             <Separator />
             <div className="grid gap-2">
               <Label>Avatar <span className="text-muted-foreground text-xs">(png · jpg, max 2MB)</span></Label>
-              <div className="relative w-14 h-14">
-                {avatarUrl ? (
-                  <img src={avatarUrl} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
-                ) : (
-                  <div
-                    className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
-                    style={(() => { const c = avatarColors(displayName || user?.email || ''); return { backgroundColor: c.bg, color: c.fg } })()}
-                  >
-                    {displayName?.[0]?.toUpperCase() ?? '?'}
+              <Controller
+                name="avatar"
+                control={profileForm.control}
+                render={({ field }) => (
+                  <div className="relative w-14 h-14">
+                    {avatarUrl ? (
+                      <img src={avatarUrl} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
+                    ) : (
+                      <div
+                        className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
+                        style={(() => { const c = avatarColors(profileDisplayName || user?.email || ''); return { backgroundColor: c.bg, color: c.fg } })()}
+                      >
+                        {profileDisplayName?.[0]?.toUpperCase() ?? '?'}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => avatarRef.current?.click()}
+                      className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
+                    >
+                      <Pencil className="w-3 h-3" />
+                    </button>
+                    <input ref={avatarRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
+                      onChange={(e) => {
+                        const f = e.target.files?.[0]
+                        if (f && f.size > 2 * 1024 * 1024) { alert('Max 2MB'); return }
+                        if (f) { field.onChange(f); setAvatarUrl(URL.createObjectURL(f)) }
+                      }}
+                    />
                   </div>
                 )}
-                <button
-                  type="button"
-                  onClick={() => avatarRef.current?.click()}
-                  className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
-                >
-                  <Pencil className="w-3 h-3" />
-                </button>
-                <input ref={avatarRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0]
-                    if (f && f.size > 2 * 1024 * 1024) { alert('Max 2MB'); return }
-                    if (f) { setAvatarFile(f); setAvatarUrl(URL.createObjectURL(f)) }
-                  }}
-                />
-              </div>
+              />
             </div>
             <div className="flex justify-end">
-              <Button type="submit" size="sm" disabled={profileSaving}>
-                {profileSaved ? 'Saved!' : profileSaving ? 'Saving…' : 'Save changes'}
+              <Button type="submit" size="sm" disabled={profileForm.formState.isSubmitting}>
+                {profileSaved ? 'Saved!' : profileForm.formState.isSubmitting ? 'Saving…' : 'Save changes'}
               </Button>
             </div>
           </form>
@@ -256,23 +293,34 @@ export function DefaultSettings() {
       <Card>
         <CardHeader><CardTitle>Password</CardTitle></CardHeader>
         <CardContent>
-          <form onSubmit={handlePasswordChange} className="flex flex-col gap-4">
+          <form onSubmit={passwordForm.handleSubmit(onPasswordSave)} className="flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="current-password">Current password</Label>
-              <Input id="current-password" type="password" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} required />
+              <Input id="current-password" type="password" {...passwordForm.register('currentPassword')} />
+              {passwordForm.formState.errors.currentPassword && (
+                <p className="text-sm text-destructive">{passwordForm.formState.errors.currentPassword.message}</p>
+              )}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="new-password">New password</Label>
-              <Input id="new-password" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required minLength={8} />
+              <Input id="new-password" type="password" {...passwordForm.register('newPassword')} />
+              {passwordForm.formState.errors.newPassword && (
+                <p className="text-sm text-destructive">{passwordForm.formState.errors.newPassword.message}</p>
+              )}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="confirm-password">Confirm new password</Label>
-              <Input id="confirm-password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required minLength={8} />
+              <Input id="confirm-password" type="password" {...passwordForm.register('confirmPassword')} />
+              {passwordForm.formState.errors.confirmPassword && (
+                <p className="text-sm text-destructive">{passwordForm.formState.errors.confirmPassword.message}</p>
+              )}
             </div>
-            {passwordError && <p className="text-sm text-destructive">{passwordError}</p>}
+            {passwordForm.formState.errors.root && (
+              <p className="text-sm text-destructive">{passwordForm.formState.errors.root.message}</p>
+            )}
             <div className="flex justify-end">
-              <Button type="submit" size="sm" disabled={passwordSaving}>
-                {passwordSaved ? 'Saved!' : passwordSaving ? 'Saving…' : 'Change password'}
+              <Button type="submit" size="sm" disabled={passwordForm.formState.isSubmitting}>
+                {passwordSaved ? 'Saved!' : passwordForm.formState.isSubmitting ? 'Saving…' : 'Change password'}
               </Button>
             </div>
           </form>

--- a/packages/dashboard/src/pages/settings/Team.tsx
+++ b/packages/dashboard/src/pages/settings/Team.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -16,14 +19,23 @@ import { UserPlus } from 'lucide-react'
 
 type Member = { id: number; email: string; display_name: string; role: string; joined_at: string }
 
+const inviteSchema = z.object({
+  email: z.string().email(),
+  role: z.string().min(1),
+})
+type InviteData = z.infer<typeof inviteSchema>
+
 export function TeamSettings() {
   const [members, setMembers] = useState<Member[]>([])
   const [resetSent, setResetSent] = useState<Record<number, string>>({})
-  const [inviteEmail, setInviteEmail] = useState('')
-  const [inviteRole, setInviteRole] = useState('QA')
   const [inviteLink, setInviteLink] = useState('')
   const [inviteOpen, setInviteOpen] = useState(false)
-  const [inviting, setInviting] = useState(false)
+
+  const { register, handleSubmit, control, reset, formState: { errors, isSubmitting } } = useForm<InviteData>({
+    resolver: zodResolver(inviteSchema),
+    mode: 'onBlur',
+    defaultValues: { email: '', role: 'QA' },
+  })
 
   function load() {
     fetch('/api/v1/team/members', { credentials: 'include' }).then((r) => r.json()).then(setMembers)
@@ -31,20 +43,22 @@ export function TeamSettings() {
 
   useEffect(() => { load() }, [])
 
-  async function handleInvite(e: FormEvent) {
-    e.preventDefault()
-    setInviting(true)
+  async function onInvite(data: InviteData) {
     const res = await fetch('/api/v1/team/invite', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+      body: JSON.stringify({ email: data.email, role: data.role }),
     })
-    const data = await res.json()
-    const link = `${location.origin}/invite?token=${data.token}`
+    const json = await res.json() as { token: string }
+    const link = `${location.origin}/invite?token=${json.token}`
     setInviteLink(link)
     navigator.clipboard.writeText(link).catch(() => {})
-    setInviting(false)
+  }
+
+  function handleDialogClose(open: boolean) {
+    setInviteOpen(open)
+    if (!open) { setInviteLink(''); reset() }
   }
 
   async function handleRoleChange(id: number, role: string) {
@@ -59,7 +73,7 @@ export function TeamSettings() {
 
   async function handleSendReset(id: number) {
     const res = await fetch(`/api/v1/team/members/${id}/send-reset`, { method: 'POST', credentials: 'include' })
-    const data = await res.json()
+    const data = await res.json() as { emailSent: boolean }
     const msg = data.emailSent ? 'Sent' : 'No SMTP'
     setResetSent((p) => ({ ...p, [id]: msg }))
     setTimeout(() => setResetSent((p) => { const n = { ...p }; delete n[id]; return n }), 3000)
@@ -75,7 +89,7 @@ export function TeamSettings() {
     <div className="flex flex-col gap-6 max-w-[900px] mx-auto w-full p-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Team</h1>
-        <Dialog open={inviteOpen} onOpenChange={(o) => { setInviteOpen(o); if (!o) { setInviteEmail(''); setInviteLink('') } }}>
+        <Dialog open={inviteOpen} onOpenChange={handleDialogClose}>
           <DialogTrigger asChild>
             <Button size="sm"><UserPlus className="mr-2 h-4 w-4" />Invite member</Button>
           </DialogTrigger>
@@ -88,24 +102,31 @@ export function TeamSettings() {
                 <Button onClick={() => setInviteOpen(false)}>Done</Button>
               </div>
             ) : (
-              <form onSubmit={handleInvite} className="flex flex-col gap-4 pt-2">
+              <form onSubmit={handleSubmit(onInvite)} className="flex flex-col gap-4 pt-2">
                 <div className="grid gap-2">
                   <Label htmlFor="invite-email">Email</Label>
-                  <Input id="invite-email" type="email" value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)} required />
+                  <Input id="invite-email" type="email" {...register('email')} />
+                  {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
                 </div>
                 <div className="grid gap-2">
                   <Label>Role</Label>
-                  <Select value={inviteRole} onValueChange={setInviteRole}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="Admin">Admin</SelectItem>
-                      <SelectItem value="Developer">Developer</SelectItem>
-                      <SelectItem value="QA">QA</SelectItem>
-                      <SelectItem value="Viewer">Viewer</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <Controller
+                    name="role"
+                    control={control}
+                    render={({ field }) => (
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="Admin">Admin</SelectItem>
+                          <SelectItem value="Developer">Developer</SelectItem>
+                          <SelectItem value="QA">QA</SelectItem>
+                          <SelectItem value="Viewer">Viewer</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
                 </div>
-                <Button type="submit" disabled={inviting}>{inviting ? 'Creating link…' : 'Generate invite link'}</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Creating link…' : 'Generate invite link'}</Button>
               </form>
             )}
           </DialogContent>
@@ -146,11 +167,7 @@ export function TeamSettings() {
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
-                      <Button
-                        variant="secondary"
-                        size="nav"
-                        onClick={() => handleSendReset(m.id)}
-                      >
+                      <Button variant="secondary" size="nav" onClick={() => handleSendReset(m.id)}>
                         {resetSent[m.id] ?? 'Reset pwd'}
                       </Button>
                       <Button variant="destructive" size="nav" onClick={() => handleDelete(m.id)}>

--- a/packages/dashboard/src/pages/settings/Tokens.tsx
+++ b/packages/dashboard/src/pages/settings/Tokens.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -14,13 +17,25 @@ import { Plus, Trash2 } from 'lucide-react'
 
 type Token = { id: number; name: string; scope: string; last_used_at: string | null; expires_at: string | null; created_at: string }
 
+const schema = z.object({
+  name: z.string().min(1),
+  expiresDays: z.string().refine(
+    (v) => { const n = parseInt(v, 10); return !isNaN(n) && n >= 1 && n <= 365 },
+    { message: 'Must be between 1 and 365' },
+  ),
+})
+type FormData = z.infer<typeof schema>
+
 export function TokenSettings() {
   const [tokens, setTokens] = useState<Token[]>([])
   const [open, setOpen] = useState(false)
-  const [name, setName] = useState('')
-  const [expiresDays, setExpiresDays] = useState('30')
   const [newToken, setNewToken] = useState('')
-  const [creating, setCreating] = useState(false)
+
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+    defaultValues: { name: '', expiresDays: '30' },
+  })
 
   function load() {
     fetch('/api/v1/tokens', { credentials: 'include' }).then((r) => r.json()).then(setTokens)
@@ -28,19 +43,21 @@ export function TokenSettings() {
 
   useEffect(() => { load() }, [])
 
-  async function handleCreate(e: FormEvent) {
-    e.preventDefault()
-    setCreating(true)
+  async function onCreate(data: FormData) {
     const res = await fetch('/api/v1/tokens', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, expires_in_days: Number(expiresDays) }),
+      body: JSON.stringify({ name: data.name, expires_in_days: parseInt(data.expiresDays, 10) }),
     })
-    const data = await res.json()
-    setNewToken(data.token)
-    setCreating(false)
+    const json = await res.json() as { token: string }
+    setNewToken(json.token)
     load()
+  }
+
+  function handleDialogClose(o: boolean) {
+    setOpen(o)
+    if (!o) { setNewToken(''); reset() }
   }
 
   async function handleRevoke(id: number) {
@@ -57,7 +74,7 @@ export function TokenSettings() {
     <div className="flex flex-col gap-6 max-w-[900px] mx-auto w-full p-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Personal Access Tokens</h1>
-        <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) { setName(''); setNewToken('') } }}>
+        <Dialog open={open} onOpenChange={handleDialogClose}>
           <DialogTrigger asChild>
             <Button size="sm"><Plus className="mr-2 h-4 w-4" />New token</Button>
           </DialogTrigger>
@@ -72,17 +89,19 @@ export function TokenSettings() {
                 </Button>
               </div>
             ) : (
-              <form onSubmit={handleCreate} className="flex flex-col gap-4 pt-2">
+              <form onSubmit={handleSubmit(onCreate)} className="flex flex-col gap-4 pt-2">
                 <div className="grid gap-2">
                   <Label htmlFor="token-name">Name</Label>
-                  <Input id="token-name" placeholder="e.g. ci-deploy" value={name} onChange={(e) => setName(e.target.value)} required />
+                  <Input id="token-name" placeholder="e.g. ci-deploy" {...register('name')} />
+                  {errors.name && <p className="text-sm text-destructive">{errors.name.message}</p>}
                 </div>
                 <div className="grid gap-2">
                   <Label htmlFor="expires">Expires in (days)</Label>
-                  <Input id="expires" type="number" min="1" max="365" value={expiresDays} onChange={(e) => setExpiresDays(e.target.value)} />
+                  <Input id="expires" type="number" {...register('expiresDays')} />
+                  {errors.expiresDays && <p className="text-sm text-destructive">{errors.expiresDays.message}</p>}
                 </div>
                 <p className="text-xs text-muted-foreground">Scope: <Badge variant="secondary">builds:write</Badge></p>
-                <Button type="submit" disabled={creating}>{creating ? 'Creating…' : 'Create token'}</Button>
+                <Button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Creating…' : 'Create token'}</Button>
               </form>
             )}
           </DialogContent>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.75.0(react@19.2.6))
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1189,6 +1192,11 @@ packages:
   '@fontsource/jetbrains-mono@5.2.8':
     resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1882,6 +1890,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5264,6 +5275,11 @@ snapshots:
 
   '@fontsource/jetbrains-mono@5.2.8': {}
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.6))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.75.0(react@19.2.6)
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5929,6 +5945,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `@hookform/resolvers` dependency
- Migrates all 6 dashboard forms from manual `useState` + `setError` to `useForm` + `zodResolver`
- All forms use `mode: 'onBlur'` and Zod default error messages

## Forms migrated

| File | Validation |
|------|-----------|
| `Login.tsx` | email format + password min-length |
| `ResetPassword.tsx` | password min-length + confirm match (`.refine()`) |
| `Invite.tsx` | displayName, password, confirm, avatar File (`Controller`) |
| `settings/Team.tsx` | invite email format, role Select (`Controller`) |
| `settings/Tokens.tsx` | name non-empty, expiresDays 1–365 |
| `settings/Default.tsx` | three separate forms: `workspaceForm` / `profileForm` / `passwordForm`; logo/avatar via `Controller` |

## Notes

- Server-side errors use `setError('root', ...)` — kept separate from field errors
- `useWatch` used instead of `watch()` to satisfy React Compiler memoization rules
- Apps section in Default.tsx left as-is (row-level save, not a single form)

## Test plan

- [ ] Login: invalid email / short password → inline errors; valid credentials → navigate
- [ ] ResetPassword: mismatched passwords → confirm error before API call
- [ ] Invite: empty displayName / password mismatch → inline errors; valid → account created
- [ ] Team: invalid email format → inline error; valid → invite link generated
- [ ] Tokens: empty name or out-of-range days → inline errors; valid → token created
- [ ] Default: empty teamName / displayName → inline errors; password mismatch → confirm error

🤖 Generated with [Claude Code](https://claude.com/claude-code)