### PR TITLE
Add typed errors for agent core and key runtime paths

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -24,12 +24,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./utils": {
+      "types": "./src/utils/index.ts",
       "source": "./src/utils/index.ts",
       "tsx": "./src/utils/index.ts",
       "import": "./dist/utils/index.js",

--- a/packages/agent-core/src/AgentRegistry.ts
+++ b/packages/agent-core/src/AgentRegistry.ts
@@ -1,4 +1,5 @@
 import type { DeviceAgent, DeviceAgentConstructor } from './DeviceAgent.js'
+import { PlatformError } from './errors.js'
 
 const constructors = new Map<string, DeviceAgentConstructor>()
 const instances = new Map<string, DeviceAgent>()
@@ -11,7 +12,7 @@ export const AgentRegistry = {
 
   get(platform: string): DeviceAgent {
     if (!constructors.has(platform)) {
-      throw new Error(`No agent registered for platform: ${platform}`)
+      throw new PlatformError(`No agent registered for platform: ${platform}`)
     }
     if (!instances.has(platform)) {
       const AgentClass = constructors.get(platform)!

--- a/packages/agent-core/src/__tests__/AgentRegistry.test.ts
+++ b/packages/agent-core/src/__tests__/AgentRegistry.test.ts
@@ -36,8 +36,16 @@ describe('AgentRegistry', () => {
   })
 
   it('throws when platform is not registered', () => {
-    expect(() => AgentRegistry.get('unknown')).toThrow(PlatformError)
-    expect(() => AgentRegistry.get('unknown')).toThrow('No agent registered for platform: unknown')
+    let thrown: unknown
+
+    try {
+      AgentRegistry.get('unknown')
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(PlatformError)
+    expect((thrown as Error).message).toBe('No agent registered for platform: unknown')
   })
 
 

--- a/packages/agent-core/src/__tests__/AgentRegistry.test.ts
+++ b/packages/agent-core/src/__tests__/AgentRegistry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { PlatformError } from '../index'
 import { AgentRegistry } from '../AgentRegistry'
 import type { DeviceAgent } from '../DeviceAgent'
 import type { Device } from '../types'
@@ -35,10 +36,10 @@ describe('AgentRegistry', () => {
   })
 
   it('throws when platform is not registered', () => {
-    expect(() => AgentRegistry.get('unknown')).toThrow(
-      'No agent registered for platform: unknown'
-    )
+    expect(() => AgentRegistry.get('unknown')).toThrow(PlatformError)
+    expect(() => AgentRegistry.get('unknown')).toThrow('No agent registered for platform: unknown')
   })
+
 
   it('resets cached instance when re-registering', () => {
     AgentRegistry.register('mock', MockAgent)

--- a/packages/agent-core/src/errors.ts
+++ b/packages/agent-core/src/errors.ts
@@ -1,0 +1,11 @@
+class TapflowError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = new.target.name
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+export class ValidationError extends TapflowError {}
+
+export class PlatformError extends TapflowError {}

--- a/packages/agent-core/src/errors.ts
+++ b/packages/agent-core/src/errors.ts
@@ -9,3 +9,5 @@ class TapflowError extends Error {
 export class ValidationError extends TapflowError {}
 
 export class PlatformError extends TapflowError {}
+
+export class AuthError extends TapflowError {}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,5 +1,6 @@
 export type { Platform, DeviceStatus, Device, Point, AndroidButton, AgentResources } from './types.js'
 export type { DeviceAgent, DeviceAgentConstructor } from './DeviceAgent.js'
 export { AgentRegistry } from './AgentRegistry.js'
+export { ValidationError, PlatformError } from './errors.js'
 export type { Logger, LogLevel } from './logger.js'
 export { createLogger } from './logger.js'

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,6 +1,6 @@
 export type { Platform, DeviceStatus, Device, Point, AndroidButton, AgentResources } from './types.js'
 export type { DeviceAgent, DeviceAgentConstructor } from './DeviceAgent.js'
 export { AgentRegistry } from './AgentRegistry.js'
-export { ValidationError, PlatformError } from './errors.js'
+export { ValidationError, PlatformError, AuthError } from './errors.js'
 export type { Logger, LogLevel } from './logger.js'
 export { createLogger } from './logger.js'

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -25,6 +25,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",

--- a/packages/android-agent/src/AdbWrapper.ts
+++ b/packages/android-agent/src/AdbWrapper.ts
@@ -1,4 +1,5 @@
 import type { Device } from '@tapflowio/agent-core'
+import { PlatformError, ValidationError } from '@tapflowio/agent-core'
 import { defaultRunner, type AdbRunner } from './adb.js'
 
 export class AdbWrapper {
@@ -94,7 +95,7 @@ export class AdbWrapper {
     const output = await this.runner.exec('-s', serial, 'shell', 'wm', 'size')
     // "Physical size: 1080x2400"
     const m = output.match(/(\d+)x(\d+)/)
-    if (!m) throw new Error(`Cannot parse screen size from: ${output}`)
+    if (!m) throw new PlatformError(`Cannot parse screen size from: ${output}`)
     return { width: parseInt(m[1], 10), height: parseInt(m[2], 10) }
   }
 
@@ -110,15 +111,15 @@ export class AdbWrapper {
       if (stderr) {
         // "Failure [INSTALL_FAILED_...]" → show just the code
         const failureMatch = stderr.match(/Failure\s*\[(.+?)\]/)
-        if (failureMatch) throw new Error(failureMatch[1])
+        if (failureMatch) throw new ValidationError(failureMatch[1])
         // Strip "adb: failed to install <path>:" prefix and stack trace
         const stripped = stderr
           .replace(/^adb: failed to install [^:]+:\s*/, '')
           .replace(/\s+at\s+[\w$.]+\([\w.]+:\d+\)[\s\S]*$/, '')
           .trim()
-        throw new Error(stripped || stderr)
+        throw new ValidationError(stripped || stderr)
       }
-      throw new Error((e as Error).message)
+      throw new ValidationError((e as Error).message, { cause: e })
     }
   }
 

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -391,7 +391,7 @@ export class AndroidAgent implements DeviceAgent {
       if (seq !== state.bootSeq) return
 
       const target = devices.find((d) => d.id === avdId)
-      if (!target) throw new ValidationError(`Device not found: ${avdId}`)
+      if (!target) throw new PlatformError(`Device not found: ${avdId}`)
 
       if (target.status !== 'booted') {
         this.launcher.launch(avdName)

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -1,7 +1,7 @@
 import os from 'os'
 import { WebSocket } from 'ws'
 import type { AndroidButton, Device, DeviceAgent } from '@tapflowio/agent-core'
-import { createLogger } from '@tapflowio/agent-core'
+import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 import { createResourceSampler, registerStreamWs } from '@tapflowio/agent-core/utils'
 import { AdbWrapper } from './AdbWrapper.js'
 import { EmulatorLauncher } from './EmulatorLauncher.js'
@@ -180,7 +180,7 @@ export class AndroidAgent implements DeviceAgent {
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
           resolve()
         } else {
-          reject(new Error(`Unexpected message during handshake: ${msg.type}`))
+          reject(new PlatformError(`Unexpected message during handshake: ${msg.type}`))
         }
       })
 
@@ -391,7 +391,7 @@ export class AndroidAgent implements DeviceAgent {
       if (seq !== state.bootSeq) return
 
       const target = devices.find((d) => d.id === avdId)
-      if (!target) throw new Error(`Device not found: ${avdId}`)
+      if (!target) throw new ValidationError(`Device not found: ${avdId}`)
 
       if (target.status !== 'booted') {
         this.launcher.launch(avdName)
@@ -667,27 +667,27 @@ export class AndroidAgent implements DeviceAgent {
   async installApp(apkPath: string): Promise<void> {
     const first = this.deviceStates.values().next().value
     const serial = first ? this.adb.getSerial(first.deviceId) : undefined
-    if (!serial) throw new Error('no booted device — call connect() first')
+    if (!serial) throw new ValidationError('no booted device — call connect() first')
     await this.adb.installApp(serial, apkPath)
   }
 
   async launchApp(packageName: string): Promise<void> {
     const first = this.deviceStates.values().next().value
     const serial = first ? this.adb.getSerial(first.deviceId) : undefined
-    if (!serial) throw new Error('no booted device — call connect() first')
+    if (!serial) throw new ValidationError('no booted device — call connect() first')
     await this.adb.launchApp(serial, packageName)
   }
 
   async screenshot(): Promise<Buffer> {
     const first = this.deviceStates.values().next().value
     const serial = first ? this.adb.getSerial(first.deviceId) : undefined
-    if (!serial) throw new Error('no booted device — call connect() first')
+    if (!serial) throw new ValidationError('no booted device — call connect() first')
     return this.adb.screenshot(serial)
   }
 
   stream(): ReadableStream<Buffer> {
     const state = this.deviceStates.values().next().value
-    if (!state?.scrcpySession) throw new Error('no active scrcpy session — call connect() first')
+    if (!state?.scrcpySession) throw new ValidationError('no active scrcpy session — call connect() first')
     return state.scrcpySession.video.start()
   }
 

--- a/packages/android-agent/src/EmulatorLauncher.ts
+++ b/packages/android-agent/src/EmulatorLauncher.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
-import { createLogger } from '@tapflowio/agent-core'
+import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 
 const execFileAsync = promisify(execFile)
 const logger = createLogger('android-agent:emulator')
@@ -8,14 +8,14 @@ const logger = createLogger('android-agent:emulator')
 function getAdbPath(): string {
   if (process.env['ADB_PATH']) return process.env['ADB_PATH']
   const androidHome = process.env['ANDROID_HOME']
-  if (!androidHome) throw new Error('ANDROID_HOME not set')
+  if (!androidHome) throw new ValidationError('ANDROID_HOME not set')
   return `${androidHome}/platform-tools/adb`
 }
 
 function getEmulatorPath(): string {
   const androidHome = process.env['ANDROID_HOME']
   if (!androidHome) {
-    throw new Error(
+    throw new ValidationError(
       'ANDROID_HOME not set. Install Android SDK and set the environment variable.\n' +
       'Example: export ANDROID_HOME=$HOME/Library/Android/sdk',
     )
@@ -58,7 +58,7 @@ export class EmulatorLauncher {
       await new Promise((r) => setTimeout(r, 2_000))
     }
 
-    throw new Error(`Could not find emulator serial for AVD "${avdName}" within ${timeoutMs / 1000}s`)
+    throw new PlatformError(`Could not find emulator serial for AVD "${avdName}" within ${timeoutMs / 1000}s`)
   }
 
   async waitForBoot(serial: string, timeoutMs = 120_000): Promise<void> {
@@ -78,6 +78,6 @@ export class EmulatorLauncher {
       await new Promise((r) => setTimeout(r, 3_000))
     }
 
-    throw new Error(`Emulator ${serial} did not finish booting within ${timeoutMs / 1000}s`)
+    throw new PlatformError(`Emulator ${serial} did not finish booting within ${timeoutMs / 1000}s`)
   }
 }

--- a/packages/android-agent/src/__tests__/AdbWrapper.test.ts
+++ b/packages/android-agent/src/__tests__/AdbWrapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PlatformError, ValidationError } from '@tapflowio/agent-core'
 import { AdbWrapper } from '../AdbWrapper'
 import type { AdbRunner } from '../adb'
 
@@ -113,6 +114,15 @@ describe('AdbWrapper', () => {
       await wrapper.installApp('emulator-5554', '/tmp/app.apk')
       expect(runner.exec).toHaveBeenCalledWith('-s', 'emulator-5554', 'install', '-r', '/tmp/app.apk')
     })
+
+    it('throws ValidationError when adb returns INSTALL_FAILED code', async () => {
+      const runner = mockRunner()
+      ;(runner.exec as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
+        stderr: 'Failure [INSTALL_FAILED_VERSION_DOWNGRADE]',
+      })
+      const wrapper = new AdbWrapper(runner)
+      await expect(wrapper.installApp('emulator-5554', '/tmp/app.apk')).rejects.toBeInstanceOf(ValidationError)
+    })
   })
 
   describe('launchApp', () => {
@@ -132,6 +142,11 @@ describe('AdbWrapper', () => {
       const wrapper = new AdbWrapper(mockRunner({ screenSize: '1080x2400' }))
       const size = await wrapper.getScreenSize('emulator-5554')
       expect(size).toEqual({ width: 1080, height: 2400 })
+    })
+
+    it('throws PlatformError when wm size output is malformed', async () => {
+      const wrapper = new AdbWrapper(mockRunner({ screenSize: 'unknown' }))
+      await expect(wrapper.getScreenSize('emulator-5554')).rejects.toBeInstanceOf(PlatformError)
     })
   })
 

--- a/packages/android-agent/src/adb.ts
+++ b/packages/android-agent/src/adb.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { ValidationError } from '@tapflowio/agent-core'
 
 const execFileAsync = promisify(execFile)
 
@@ -7,7 +8,7 @@ function getAdbPath(): string {
   if (process.env['ADB_PATH']) return process.env['ADB_PATH']
   const androidHome = process.env['ANDROID_HOME']
   if (!androidHome) {
-    throw new Error(
+    throw new ValidationError(
       'ADB not found. Set ANDROID_HOME or ADB_PATH environment variable.\n' +
       'Example: export ANDROID_HOME=$HOME/Library/Android/sdk',
     )
@@ -18,7 +19,7 @@ function getAdbPath(): string {
 function getEmulatorPath(): string {
   const androidHome = process.env['ANDROID_HOME']
   if (!androidHome) {
-    throw new Error(
+    throw new ValidationError(
       'ANDROID_HOME not set. Install Android SDK and set the environment variable.\n' +
       'Example: export ANDROID_HOME=$HOME/Library/Android/sdk',
     )

--- a/packages/android-agent/src/scrcpy/ScrcpySession.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpySession.ts
@@ -8,7 +8,7 @@ import { promisify } from 'util'
 import { ScrcpyVideo } from './ScrcpyVideo.js'
 import { ScrcpyControl } from './ScrcpyControl.js'
 import type { ScrcpyDeviceInfo } from './ScrcpyVideo.js'
-import { createLogger } from '@tapflowio/agent-core'
+import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 
 const logger = createLogger('android-agent:scrcpy')
 
@@ -20,7 +20,7 @@ const DEVICE_PATH = '/data/local/tmp/scrcpy-server.jar'
 function getAdbPath(): string {
   if (process.env['ADB_PATH']) return process.env['ADB_PATH']
   const androidHome = process.env['ANDROID_HOME']
-  if (!androidHome) throw new Error('ANDROID_HOME not set')
+  if (!androidHome) throw new ValidationError('ANDROID_HOME not set')
   return `${androidHome}/platform-tools/adb`
 }
 
@@ -54,12 +54,12 @@ export class ScrcpySession {
   }
 
   get video(): ScrcpyVideo {
-    if (!this._video) throw new Error('ScrcpySession not started')
+    if (!this._video) throw new PlatformError('ScrcpySession not started')
     return this._video
   }
 
   get control(): ScrcpyControl {
-    if (!this._control) throw new Error('ScrcpySession not started')
+    if (!this._control) throw new PlatformError('ScrcpySession not started')
     return this._control
   }
 
@@ -138,7 +138,7 @@ export class ScrcpySession {
   private connectTcp(port: number): Promise<net.Socket> {
     return new Promise((resolve, reject) => {
       const socket: net.Socket = net.connect(port, '127.0.0.1', () => resolve(socket))
-      socket.once('error', reject)
+      socket.once('error', (error) => reject(new PlatformError(`Failed to connect to scrcpy on port ${port}`, { cause: error })))
     })
   }
 }

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -28,6 +28,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -237,7 +237,7 @@ export class IOSAgent implements DeviceAgent {
       if (seq !== state.bootSeq) return
 
       const target = devices.find((d) => d.id === deviceId)
-      if (!target) throw new ValidationError(`Device not found: ${deviceId}`)
+      if (!target) throw new PlatformError(`Device not found: ${deviceId}`)
 
       if (fullErase) {
         await this.simctl.erase(deviceId)

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { spawnSync } from 'child_process'
 import { WebSocket } from 'ws'
 import type { Device, DeviceAgent } from '@tapflowio/agent-core'
-import { createLogger } from '@tapflowio/agent-core'
+import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 
 const logger = createLogger('ios-agent')
 import { createResourceSampler, registerStreamWs } from '@tapflowio/agent-core/utils'
@@ -96,7 +96,7 @@ export class IOSAgent implements DeviceAgent {
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
           resolve()
         } else {
-          reject(new Error(`Unexpected message during handshake: ${msg.type}`))
+          reject(new PlatformError(`Unexpected message during handshake: ${msg.type}`))
         }
       })
 
@@ -237,7 +237,7 @@ export class IOSAgent implements DeviceAgent {
       if (seq !== state.bootSeq) return
 
       const target = devices.find((d) => d.id === deviceId)
-      if (!target) throw new Error(`Device not found: ${deviceId}`)
+      if (!target) throw new ValidationError(`Device not found: ${deviceId}`)
 
       if (fullErase) {
         await this.simctl.erase(deviceId)
@@ -464,13 +464,13 @@ export class IOSAgent implements DeviceAgent {
     try {
       const result = spawnSync('unzip', ['-o', filePath, '-d', tmpDir])
       if (result.status !== 0) {
-        throw new Error(`zip 압축 해제 실패 — 시뮬레이터용 .app.zip 파일인지 확인하세요.`)
+        throw new ValidationError(`zip 압축 해제 실패 — 시뮬레이터용 .app.zip 파일인지 확인하세요.`)
       }
 
       const entries = fs.readdirSync(tmpDir)
       const appDir = entries.find(e => e.endsWith('.app') && fs.statSync(path.join(tmpDir, e)).isDirectory())
       if (!appDir) {
-        throw new Error('.app 디렉토리를 찾을 수 없습니다. xcodebuild -sdk iphonesimulator 로 빌드한 .app 을 zip 압축해 업로드하세요.')
+        throw new ValidationError('.app 디렉토리를 찾을 수 없습니다. xcodebuild -sdk iphonesimulator 로 빌드한 .app 을 zip 압축해 업로드하세요.')
       }
 
       await this.simctl.installApp(path.join(tmpDir, appDir))
@@ -488,7 +488,7 @@ export class IOSAgent implements DeviceAgent {
   screenshot(): Promise<Buffer> { return this.simctl.screenshot() }
   stream(): ReadableStream<Buffer> {
     const first = this.deviceStates.values().next().value
-    if (!first) throw new Error('no booted device — call connect() first')
+    if (!first) throw new ValidationError('no booted device — call connect() first')
     return new ScreenCaptureStreamer(this.fps, first.deviceId).start()
   }
 

--- a/packages/ios-agent/src/ScreenCaptureStreamer.ts
+++ b/packages/ios-agent/src/ScreenCaptureStreamer.ts
@@ -1,7 +1,7 @@
 import { spawn, execFileSync } from 'child_process'
 import { existsSync, statSync, unlinkSync } from 'fs'
 import { join } from 'path'
-import { createLogger } from '@tapflowio/agent-core'
+import { createLogger, PlatformError } from '@tapflowio/agent-core'
 
 const logger = createLogger('ios-agent:screencapture')
 
@@ -10,7 +10,7 @@ const BINARY = join(import.meta.dirname, '..', 'bin', 'screencapture-helper')
 
 function ensureCompiled(): void {
   if (existsSync(BINARY)) {
-    // Swift source is not included in the published package — skip recompilation check
+    // Swift source is not included in the published package - skip recompilation check
     if (!existsSync(SWIFT_SRC)) return
     const srcMtime = statSync(SWIFT_SRC).mtimeMs
     const binMtime = statSync(BINARY).mtimeMs
@@ -19,7 +19,7 @@ function ensureCompiled(): void {
     unlinkSync(BINARY)
   }
   if (!existsSync(SWIFT_SRC)) {
-    throw new Error('screencapture-helper binary missing and Swift source not found — reinstall @tapflowio/ios-agent')
+    throw new PlatformError('screencapture-helper binary missing and Swift source not found - reinstall @tapflowio/ios-agent')
   }
   logger.info('compiling screencapture-helper...')
   execFileSync('swiftc', [
@@ -78,10 +78,11 @@ export class ScreenCaptureStreamer {
         proc.stdout.on('end', close)
         proc.on('error', error)
         proc.on('exit', (code) => {
-          if (code !== null && code !== 0)
-            error(new Error(`[ScreenCaptureStreamer] exited with code ${code}`))
-          else
+          if (code !== null && code !== 0) {
+            error(new PlatformError(`[ScreenCaptureStreamer] exited with code ${code}`))
+          } else {
             close()
+          }
         })
       },
       cancel() {

--- a/packages/ios-agent/src/ScreenCaptureStreamer.ts
+++ b/packages/ios-agent/src/ScreenCaptureStreamer.ts
@@ -10,7 +10,7 @@ const BINARY = join(import.meta.dirname, '..', 'bin', 'screencapture-helper')
 
 function ensureCompiled(): void {
   if (existsSync(BINARY)) {
-    // Swift source is not included in the published package - skip recompilation check
+    // Swift source is not included in the published package — skip recompilation check
     if (!existsSync(SWIFT_SRC)) return
     const srcMtime = statSync(SWIFT_SRC).mtimeMs
     const binMtime = statSync(BINARY).mtimeMs
@@ -19,7 +19,7 @@ function ensureCompiled(): void {
     unlinkSync(BINARY)
   }
   if (!existsSync(SWIFT_SRC)) {
-    throw new PlatformError('screencapture-helper binary missing and Swift source not found - reinstall @tapflowio/ios-agent')
+    throw new PlatformError('screencapture-helper binary missing and Swift source not found — reinstall @tapflowio/ios-agent')
   }
   logger.info('compiling screencapture-helper...')
   execFileSync('swiftc', [

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } 
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { ValidationError } from '@tapflowio/agent-core'
 
 vi.mock('../TouchHelper', () => ({
   TouchHelper: vi.fn(() => ({
@@ -128,6 +129,11 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({}, simctl)
       await agent.launchApp('com.example.app')
       expect(simctl.launchApp).toHaveBeenCalledWith('com.example.app')
+    })
+
+    it('stream throws ValidationError before any device session is available', () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      expect(() => agent.stream()).toThrow(ValidationError)
     })
   })
 

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -25,6 +25,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { WebSocket } from 'ws'
 import type { DeviceStatus } from '@tapflowio/agent-core'
+import { ValidationError } from '@tapflowio/agent-core'
 import type { AgentResources, SessionInfo } from './types.js'
 
 export interface Session {
@@ -80,9 +81,9 @@ export class SessionManager {
 
   join(sessionId: string, browserSocket: WebSocket): void {
     const session = this.sessions.get(sessionId)
-    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    if (!session) throw new ValidationError(`Session not found: ${sessionId}`)
     if (session.browserSocket?.readyState === WebSocket.OPEN) {
-      throw new Error(`Session busy: ${sessionId}`)
+      throw new ValidationError(`Session busy: ${sessionId}`)
     }
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }
     if (session.browserSocket) this.browserSocketIndex.delete(session.browserSocket)

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ValidationError } from '@tapflowio/agent-core'
 import { SessionManager } from '../SessionManager'
 import type { WebSocket } from 'ws'
 
@@ -128,6 +129,7 @@ describe('SessionManager', () => {
 
     it('throws when session is not found', () => {
       const sm = new SessionManager()
+      expect(() => sm.join('bad-id', mockSocket())).toThrow(ValidationError)
       expect(() => sm.join('bad-id', mockSocket())).toThrow('Session not found: bad-id')
     })
 
@@ -136,6 +138,7 @@ describe('SessionManager', () => {
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const busyWs = { readyState: OPEN } as WebSocket
       sm.join(id, busyWs)
+      expect(() => sm.join(id, mockSocket())).toThrow(ValidationError)
       expect(() => sm.join(id, mockSocket())).toThrow('Session busy')
     })
   })

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -129,8 +129,14 @@ describe('SessionManager', () => {
 
     it('throws when session is not found', () => {
       const sm = new SessionManager()
-      expect(() => sm.join('bad-id', mockSocket())).toThrow(ValidationError)
-      expect(() => sm.join('bad-id', mockSocket())).toThrow('Session not found: bad-id')
+      let thrown: unknown
+      try {
+        sm.join('bad-id', mockSocket())
+      } catch (error) {
+        thrown = error
+      }
+      expect(thrown).toBeInstanceOf(ValidationError)
+      expect((thrown as Error).message).toBe('Session not found: bad-id')
     })
 
     it('throws when session is busy (browserSocket is OPEN)', () => {
@@ -138,8 +144,14 @@ describe('SessionManager', () => {
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const busyWs = { readyState: OPEN } as WebSocket
       sm.join(id, busyWs)
-      expect(() => sm.join(id, mockSocket())).toThrow(ValidationError)
-      expect(() => sm.join(id, mockSocket())).toThrow('Session busy')
+      let thrown: unknown
+      try {
+        sm.join(id, mockSocket())
+      } catch (error) {
+        thrown = error
+      }
+      expect(thrown).toBeInstanceOf(ValidationError)
+      expect((thrown as Error).message).toContain('Session busy')
     })
   })
 

--- a/packages/relay/src/__tests__/auth.test.ts
+++ b/packages/relay/src/__tests__/auth.test.ts
@@ -9,6 +9,7 @@ vi.mock('../db.js', () => ({ getDb: mockGet }))
 import {
   signJwt,
   verifyJwt,
+  verifyJwtOrThrow,
   getAuth,
   requireAuth,
   requireRole,
@@ -16,6 +17,7 @@ import {
   verifyPat,
 } from '../middleware/auth.js'
 import type { AuthContext } from '../middleware/auth.js'
+import { AuthError } from '@tapflowio/agent-core'
 
 // --- 헬퍼 ---
 
@@ -60,6 +62,10 @@ describe('signJwt / verifyJwt', () => {
   it('임의 문자열은 null 반환', () => {
     expect(verifyJwt('not.a.jwt')).toBeNull()
     expect(verifyJwt('')).toBeNull()
+  })
+
+  it('invalid JWT throws AuthError via verifyJwtOrThrow', () => {
+    expect(() => verifyJwtOrThrow('not.a.jwt')).toThrow(AuthError)
   })
 
   it('페이로드에 userId·email·role이 담긴다', () => {

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -1,11 +1,12 @@
 import Database from 'better-sqlite3'
 import fs from 'fs'
 import path from 'path'
+import { PlatformError } from '@tapflowio/agent-core'
 
 let db: Database.Database | null = null
 
 export function getDb(): Database.Database {
-  if (!db) throw new Error('DB not initialized — call initDb() first')
+  if (!db) throw new PlatformError('DB not initialized — call initDb() first')
   return db
 }
 

--- a/packages/relay/src/middleware/auth.ts
+++ b/packages/relay/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import http from 'http'
 import crypto from 'crypto'
 import jwt from 'jsonwebtoken'
+import { AuthError } from '@tapflowio/agent-core'
 import { getDb } from '../db.js'
 import { jwtSecret } from '../lib/config.js'
 
@@ -16,9 +17,17 @@ export function signJwt(payload: AuthContext): string {
   return jwt.sign(payload, jwtSecret, { expiresIn: JWT_EXPIRES })
 }
 
-export function verifyJwt(token: string): AuthContext | null {
+export function verifyJwtOrThrow(token: string): AuthContext {
   try {
     return jwt.verify(token, jwtSecret) as AuthContext
+  } catch (cause) {
+    throw new AuthError('Invalid or expired auth token', { cause })
+  }
+}
+
+export function verifyJwt(token: string): AuthContext | null {
+  try {
+    return verifyJwtOrThrow(token)
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

Adds shared typed errors to `@tapflow/agent-core` and replaces key generic `Error` throw sites with `ValidationError` and `PlatformError` so consumers can handle failures with `instanceof`.

## Changes

- Added `ValidationError`, `PlatformError`, and `AuthError`
- Exported them from `@tapflow/agent-core`
- Updated key throw sites in `agent-core`, `android-agent`, `ios-agent`, and `relay`
- Added focused test coverage for typed error handling
- Fixed workspace TypeScript package resolution for local typecheck by adding `types` entries to package export maps

## Verification

- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added base TapflowError and new error classes (ValidationError, PlatformError, AuthError); errors are re-exported. Added a throwing JWT verifier (verifyJwtOrThrow).
  * Package manifests now include explicit TypeScript type entrypoints for improved type resolution.

* **Bug Fixes**
  * Replaced many generic throws with specific error types to improve error clarity across agents, session handling, DB access, and streams.

* **Tests**
  * Updated and added tests to assert the new error types and messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->