### PR TITLE
chore: add pre-push hook + improve demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 ## Demo
 
+<video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
+
 <div align="center">
-  <a href="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395">
-    <img src="https://raw.githubusercontent.com/jo-duchan/tapflow/main/docs/public/demo-thumbnail.png" alt="tapflow demo — click to play" width="100%" />
-  </a>
+  <a href="https://jo-duchan.github.io/tapflow/guide/introduction">▶ Watch demo</a>
 </div>
 
 ---

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,3 +6,13 @@ pre-commit:
 
     - name: typecheck
       run: pnpm typecheck
+
+pre-push:
+  jobs:
+    - name: no-direct-main-push
+      run: |
+        branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+        if [ "$branch" = "main" ]; then
+          echo "Direct push to main is not allowed. Please open a PR."
+          exit 1
+        fi

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@
 ## Demo
 
 <div align="center">
-  <a href="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395">
+  <a href="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" target="_blank" rel="noopener noreferrer">
     <img src="https://raw.githubusercontent.com/jo-duchan/tapflow/main/docs/public/demo-thumbnail.png" alt="tapflow demo — click to play" width="100%" />
   </a>
   <p><em>Click to play</em></p>


### PR DESCRIPTION
## Summary

- `lefthook.yml`에 `pre-push` 훅 추가 — main 브랜치 직접 push 시 차단
- root README: 썸네일 → `<video>` 태그로 복원 (데스크탑 GitHub에서 인라인 재생) + docs 링크를 모바일 fallback으로 추가
- cli README: 데모 링크에 `target="_blank" rel="noopener noreferrer"` 추가 (npm에서 동작)

## Test plan

- [x] main 브랜치에서 `git push` 시도 → 차단 메시지 확인
- [x] 다른 브랜치에서 `git push` → 정상 통과 확인
- [x] GitHub README 데스크탑: `<video>` 인라인 재생 확인
- [x] GitHub README 모바일: `Watch demo` 링크 → docs introduction 페이지 이동 확인
- [x] npmjs.com README: 썸네일 클릭 → 새 탭에서 영상 열림 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)