### PR TITLE
ci(release): add NPM_TOKEN for initial @tapflowio/* publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
 
       - run: pnpm changeset publish --no-git-tag --tag latest
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
 <div align="center">
-  <a href="https://tapflow-docs.vercel.app/guide/introduction.html#introduction">▶ Watch demo</a>
+  <a href="https://www.tapflow.dev/guide/introduction.html#introduction">▶ Watch demo</a>
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
 <div align="center">
-  <a href="https://jo-duchan.github.io/tapflow/guide/introduction">▶ Watch demo</a>
+  <a href="https://tapflow-docs.vercel.app/guide/introduction.html#introduction">▶ Watch demo</a>
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
-<a href="https://www.tapflow.dev/guide/introduction.html#introduction">▶ Watch demo</a>
+[▶ Watch demo](https://www.tapflow.dev/guide/introduction.html#introduction)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@
 
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
-<div align="center">
-  <a href="https://www.tapflow.dev/guide/introduction.html#introduction">▶ Watch demo</a>
-</div>
+<a href="https://www.tapflow.dev/guide/introduction.html#introduction">▶ Watch demo</a>
 
 ---
 


### PR DESCRIPTION
## Summary

npm Trusted Publishing은 이미 존재하는 패키지에만 설정 가능합니다.
`@tapflowio/*` 패키지들은 아직 npm에 없어서 최초 publish 시 OIDC 인증이 실패합니다.
`NPM_TOKEN`을 추가해 최초 publish를 통과시킵니다.

## Test plan

- [ ] release 워크플로우에서 `@tapflowio/*` publish 성공 확인
- [ ] `npm install -g tapflow` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)