### PR TITLE
chore: release v0.1.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter @tapflowio/cli build",
+    "build": "pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter tapflow build",
     "test": "pnpm -r test --if-present",
     "lint": "pnpm -r --if-present lint",
     "typecheck": "pnpm -r --if-present typecheck",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @tapflowio/agent-core
+
+## 0.1.0-alpha.2

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
-  "keywords": ["tapflow", "ios", "android", "simulator", "emulator", "device-agent"],
+  "keywords": [
+    "tapflow",
+    "ios",
+    "android",
+    "simulator",
+    "emulator",
+    "device-agent"
+  ],
   "homepage": "https://github.com/jo-duchan/tapflow",
   "bugs": "https://github.com/jo-duchan/tapflow/issues",
   "repository": {

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tapflowio/android-agent
+
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.2

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
-  "keywords": ["tapflow", "android", "emulator", "adb", "scrcpy", "streaming", "qa"],
+  "keywords": [
+    "tapflow",
+    "android",
+    "emulator",
+    "adb",
+    "scrcpy",
+    "streaming",
+    "qa"
+  ],
   "homepage": "https://github.com/jo-duchan/tapflow",
   "bugs": "https://github.com/jo-duchan/tapflow/issues",
   "repository": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,11 @@
+# tapflow
+
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- fix(release): correct build filter name for CLI package and add npm README thumbnail
+  - @tapflowio/agent-core@0.1.0-alpha.2
+  - @tapflowio/ios-agent@0.1.0-alpha.2
+  - @tapflowio/android-agent@0.1.0-alpha.2
+  - @tapflowio/relay@0.1.0-alpha.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tapflowio/ios-agent
+
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.2

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
-  "keywords": ["tapflow", "ios", "simulator", "xcrun", "simctl", "streaming", "qa"],
+  "keywords": [
+    "tapflow",
+    "ios",
+    "simulator",
+    "xcrun",
+    "simctl",
+    "streaming",
+    "qa"
+  ],
   "homepage": "https://github.com/jo-duchan/tapflow",
   "bugs": "https://github.com/jo-duchan/tapflow/issues",
   "repository": {
@@ -12,7 +20,9 @@
   },
   "license": "MIT",
   "author": "tapflow contributors",
-  "os": ["darwin"],
+  "os": [
+    "darwin"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tapflowio/relay
+
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.2

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

- Fix root `build` script: `--filter @tapflowio/cli` → `--filter tapflow` (package name mismatch caused CLI to be skipped during CI build, preventing npm publish)
- Bump all packages to `0.1.0-alpha.2`

## Test plan

- [x] Merge → tag `v0.1.0-alpha.2` → confirm release workflow publishes `tapflow@0.1.0-alpha.2` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)