### PR TITLE
chore: bump packages to 0.1.0-alpha.3

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": [
     "ios",

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

- 5개 패키지 버전 `0.1.0-alpha.2` → `0.1.0-alpha.3`
- PR #68 (post-release bug fixes) 반영 버전

## Packages

- `tapflow`
- `@tapflowio/relay`
- `@tapflowio/agent-core`
- `@tapflowio/ios-agent`
- `@tapflowio/android-agent`

머지 후 `v0.1.0-alpha.3` 태그를 붙여 npm 배포를 트리거합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)