### PR TITLE
fix(ci): add --provenance flag for npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm changeset publish --no-git-tag --tag latest
+      - run: pnpm changeset publish --no-git-tag --tag latest --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

`pnpm changeset publish`이 `--provenance` 없이는 OIDC 토큰 교환을 트리거하지 않아서 `id-token: write` 권한이 있어도 E404 인증 오류가 발생했음.

`--provenance` 플래그 추가 → npm이 GitHub Actions OIDC 토큰을 직접 사용해 인증.

## Root Cause

`setup-node`의 `registry-url`은 `.npmrc`에 `NODE_AUTH_TOKEN` 참조를 설정함. `--provenance` 없이는 changeset이 OIDC 교환을 하지 않아 `NODE_AUTH_TOKEN`이 비어 있어 E404 반환.

## Test plan

- [ ] 머지 후 `v0.1.0-alpha.3` 태그 재push → CI 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)