### PR TITLE
fix(ci): use NPM_CONFIG_PROVENANCE env var for Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      - run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 
@@ -31,7 +33,6 @@ jobs:
       - run: pnpm changeset publish --no-git-tag --tag latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,10 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm changeset publish --no-git-tag --tag latest --provenance
+      - run: pnpm changeset publish --no-git-tag --tag latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

`changeset publish`은 `--provenance` 플래그를 지원하지 않음 (unknown flag 오류).
`NPM_CONFIG_PROVENANCE=true` 환경변수로 npm에 직접 전달하는 방식으로 변경.

## Test plan

- [ ] 머지 후 `v0.1.0-alpha.3` 태그 재push → CI 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)