### PR TITLE
fix(ios-agent): restore bin/ execute permissions via postinstall

### DIFF
--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "scripts": {
+    "postinstall": "node -e \"require('fs').readdirSync('bin').forEach(f => require('fs').chmodSync('bin/' + f, 0o755))\"",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- npm does not always preserve execute permissions on binary files after install
- `touch-helper`, `screencapture-helper`, `keyboard-helper`, `rotation-helper` were installed without the execute bit, causing `EACCES` on spawn
- Added a `postinstall` script that runs automatically after install to restore `chmod 755` on all files in `bin/`

## Test plan

- [ ] `npm install -g tapflow` completes without error
- [ ] `tapflow agent start` spawns iOS binaries without `EACCES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)