### PR TITLE
fix: post alpha.4 CLI and docs fixes

### DIFF
--- a/docs/ko/reference/cli.md
+++ b/docs/ko/reference/cli.md
@@ -18,7 +18,11 @@ pnpm add -g tapflow
 
 :::
 
----
+업데이트:
+
+```sh
+npm update -g tapflow
+```
 
 ## `tapflow init`
 
@@ -43,7 +47,6 @@ tapflow init
 
 비밀번호는 최소 8자 이상이어야 합니다.
 
----
 
 ## `tapflow start`
 
@@ -62,7 +65,6 @@ tapflow start
 릴레이를 서버에 따로 배포한다면 `tapflow relay start`와 `tapflow agent start`를 사용하세요.
 :::
 
----
 
 ## `tapflow relay start`
 
@@ -76,7 +78,6 @@ tapflow relay start
 |------|------|
 | `--port <n>` | 포트 (기본값: `4000`) |
 
----
 
 ## `tapflow agent start`
 
@@ -92,7 +93,6 @@ tapflow agent start --relay wss://relay.myteam.example.com
 | `--platform <ios\|android\|all>` | 자동 감지 | 시작할 플랫폼 |
 | `--device <name>` | 첫 번째 부팅된 시뮬레이터 | iOS 시뮬레이터 이름 또는 UDID |
 
----
 
 ## `tapflow doctor`
 
@@ -110,7 +110,6 @@ tapflow doctor
 
 문제가 하나라도 있으면 종료 코드 `1`을 반환합니다.
 
----
 
 ## `tapflow devices`
 
@@ -120,7 +119,6 @@ tapflow doctor
 tapflow devices
 ```
 
----
 
 ## `tapflow boot`
 
@@ -137,7 +135,6 @@ tapflow boot Pixel_8
 
 Android 에뮬레이터는 백그라운드에서 시작됩니다. `tapflow devices`로 상태를 확인하세요.
 
----
 
 ## `tapflow reset`
 
@@ -149,7 +146,6 @@ tapflow reset
 
 실행 전에 확인 프롬프트가 표시됩니다 (`y/N`). `y`를 입력해야 종료가 진행됩니다.
 
----
 
 ## `tapflow status`
 
@@ -177,7 +173,6 @@ tapflow status
   1 agent(s) · 2 device(s) · 1 active session(s)
 ```
 
----
 
 ## `tapflow logs`
 

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -56,7 +56,7 @@ openssl rand -hex 32
 
 ```
 .tapflow/
-  db.sqlite         ← SQLite 데이터베이스
+  tapflow.db        ← SQLite 데이터베이스
   uploads/
     builds/         ← .app.zip 및 .apk 파일
     avatars/

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,7 +18,11 @@ pnpm add -g tapflow
 
 :::
 
----
+To update:
+
+```sh
+npm update -g tapflow
+```
 
 ## `tapflow init`
 
@@ -43,7 +47,6 @@ Example:
 
 Password must be at least 8 characters.
 
----
 
 ## `tapflow start`
 
@@ -62,7 +65,6 @@ tapflow start
 If you are running the relay on a separate server, use `tapflow relay start` and `tapflow agent start` instead.
 :::
 
----
 
 ## `tapflow relay start`
 
@@ -76,7 +78,6 @@ tapflow relay start
 |--------|-------------|
 | `--port <n>` | Port (default: `4000`) |
 
----
 
 ## `tapflow agent start`
 
@@ -92,7 +93,6 @@ tapflow agent start --relay wss://relay.myteam.example.com
 | `--platform <ios\|android\|all>` | auto-detect | Platform to start |
 | `--device <name>` | first booted simulator | iOS Simulator name or UDID |
 
----
 
 ## `tapflow doctor`
 
@@ -110,7 +110,6 @@ Auto-detects available platforms and checks only what's relevant:
 
 Exits with code `1` if any check fails.
 
----
 
 ## `tapflow devices`
 
@@ -120,7 +119,6 @@ List available simulators and emulators.
 tapflow devices
 ```
 
----
 
 ## `tapflow boot`
 
@@ -137,7 +135,6 @@ tapflow boot Pixel_8
 
 Android AVDs start in the background. Run `tapflow devices` to check status.
 
----
 
 ## `tapflow reset`
 
@@ -149,7 +146,6 @@ tapflow reset
 
 A confirmation prompt is shown (`y/N`). Enter `y` to proceed.
 
----
 
 ## `tapflow status`
 
@@ -177,7 +173,6 @@ Example output:
   1 agent(s) · 2 device(s) · 1 active session(s)
 ```
 
----
 
 ## `tapflow logs`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -56,7 +56,7 @@ The relay stores all data in `.tapflow/` by default:
 
 ```
 .tapflow/
-  db.sqlite         ← SQLite database
+  tapflow.db        ← SQLite database
   uploads/
     builds/         ← .app.zip and .apk files
     avatars/

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,14 +25,16 @@ function readPassword(prompt: string): Promise<string> {
         process.stdout.write('\n')
         resolve(chars.join(''))
       } else if (ch === '') {
-        // Ctrl+C
         process.stdout.write('\n')
         process.exit(0)
       } else if (ch === '' || ch === '\b') {
-        // Backspace / DEL
-        chars.pop()
+        if (chars.length > 0) {
+          chars.pop()
+          process.stdout.write('\b \b')
+        }
       } else if (ch >= ' ') {
         chars.push(ch)
+        process.stdout.write('*')
       }
     }
     process.stdin.on('data', onData)

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -20,7 +20,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const port = portResult.data
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port })
+  const server = new RelayServer({ port, uploadsDir: path.join(config.server.dataDir, 'uploads') })
   await server.start()
   step(`Relay started on ws://localhost:${port}`)
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,7 +22,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port: RELAY_PORT })
+  const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.server.dataDir, 'uploads') })
   await server.start()
   step(`Relay started on ws://localhost:${RELAY_PORT}`)
 


### PR DESCRIPTION
## Summary

**CLI**
- `tapflow init`: password input now shows `*` instead of being completely silent
- `tapflow start` / `tapflow relay start`: fix uploads being saved to node_modules fallback path — now correctly saved to `.tapflow/uploads/`

**Docs**
- CLI reference: remove redundant `---` dividers (h2 already has border-top), add `npm update -g tapflow`
- Configuration: fix db filename `db.sqlite` → `tapflow.db`

## Test plan

- [ ] `tapflow init` — password field shows `*` per keystroke, backspace removes last `*`
- [ ] Upload a build via dashboard → `.tapflow/uploads/builds/` is created in the working directory
- [ ] Docs: CLI reference has no double dividers between sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)