### PR TITLE
feat(cli): auto-generate tapflow.config.json on relay start + move JWT to env-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ packages/relay/public/
 .env.local
 .env.*.local
 
+# tapflow runtime config (auto-generated, may contain local paths)
+tapflow.config.json
+
 # os
 .DS_Store
 

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -33,16 +33,9 @@ tapflow relay start
 tapflow agent start --relay wss://your-relay-url
 ```
 
-## Node.js
+## Deployment configuration
 
-```sh
-npm install -g tapflow
-tapflow relay start
-```
-
-The relay reads `tapflow.config.json` from the working directory. See [Configuration](/reference/configuration).
-
-## JWT_SECRET
+### JWT_SECRET
 
 ::: warning Replace before deploying to a server
 The default value (`tapflow-dev-secret-change-in-production`) is public in the source code. Leaving it unchanged lets anyone forge valid tokens.
@@ -54,48 +47,32 @@ Generate a secure random secret:
 openssl rand -hex 32
 ```
 
-Inject the generated value as an environment variable:
+Inject the generated value as an environment variable when starting the relay:
 
 ```sh
-# Node.js
 JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
-
-# PM2
-JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
 ```
 
 Once set, keep this value stable — changing it invalidates all active sessions immediately. Only rotate if the secret is compromised or you want to force everyone to log out.
 
-## PM2 (recommended for servers)
+### tapflow.config.json
 
-Handles automatic restart on crash, restart on server reboot, and log management.
+The relay reads `tapflow.config.json` from the working directory. See [Configuration](/reference/configuration).
 
-```sh
-npm install -g pm2 tapflow
-```
+## Internal access
 
-Inject the JWT_SECRET you generated above, then start:
+The simplest way for teammates on the same network to reach the dashboard.
 
 ```sh
-JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
-pm2 save
-pm2 startup
+npm install -g tapflow
+JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
 ```
 
-To update tapflow:
-
-```sh
-npm update -g tapflow
-pm2 restart relay
-```
-
-::: tip Next step
-Once the relay is running, create the first admin account with `tapflow init`. For team invitations and your first build upload, see [First-time Setup](/dashboard/setup).
-:::
+Teammates connect to `http://<machine-local-ip>:4000` in their browser.
 
 ## External access
 
-Regardless of how you run the relay, you need an external URL when teammates access the dashboard from outside your local machine, or when agents connect from a different network.
+You need an external URL when teammates access the dashboard from outside your local network, or when agents connect from a different network.
 
 ### ngrok (quick start)
 
@@ -161,3 +138,30 @@ tapflow.myteam.example.com {
 ```
 
 Caddy handles TLS and WebSocket upgrades automatically.
+
+## PM2 (recommended for servers)
+
+Handles automatic restart on crash, restart on server reboot, and log management.
+
+```sh
+npm install -g pm2 tapflow
+```
+
+Inject the JWT_SECRET you generated above, then start:
+
+```sh
+JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
+pm2 save
+pm2 startup
+```
+
+To update tapflow:
+
+```sh
+npm update -g tapflow
+pm2 restart relay
+```
+
+::: tip Next step
+Once the relay is running, create the first admin account with `tapflow init`. For team invitations and your first build upload, see [First-time Setup](/dashboard/setup).
+:::

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -68,7 +68,7 @@ npm install -g tapflow
 JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
 ```
 
-Teammates connect to `http://<machine-local-ip>:4000` in their browser.
+Teammates connect to `http://MACHINE_LOCAL_IP:4000` in their browser.
 
 ## External access
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -68,7 +68,7 @@ npm install -g tapflow
 JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
 ```
 
-팀원은 `http://<mac-local-ip>:4000`으로 대시보드에 접속합니다.
+팀원은 `http://MAC_LOCAL_IP:4000`으로 대시보드에 접속합니다.
 
 ## 외부 공유
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -33,16 +33,9 @@ tapflow relay start
 tapflow agent start --relay wss://your-relay-url
 ```
 
-## 로컬 설치 (Node.js)
+## 배포 설정
 
-```sh
-npm install -g tapflow
-tapflow relay start
-```
-
-릴레이는 현재 디렉토리에서 `tapflow.config.json`을 읽습니다. [설정 파일](/ko/reference/configuration)을 참고하세요.
-
-## JWT_SECRET 설정
+### JWT_SECRET
 
 ::: warning 서버 배포 시 반드시 교체하세요
 기본값(`tapflow-dev-secret-change-in-production`)이 소스코드에 공개되어 있습니다. 이 값을 그대로 사용하면 누구나 유효한 토큰을 위조할 수 있습니다.
@@ -54,48 +47,32 @@ tapflow relay start
 openssl rand -hex 32
 ```
 
-생성된 값을 환경변수로 주입합니다:
+생성된 값을 환경변수로 주입해 릴레이를 시작합니다:
 
 ```sh
-# Node.js
 JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
-
-# PM2
-JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
 ```
 
 한 번 설정한 후에는 값을 유지하세요. 변경하면 기존 세션이 즉시 모두 만료됩니다. 시크릿이 유출됐거나 의도적으로 전체 세션을 초기화할 때만 교체하면 됩니다.
 
-## PM2 (서버 운영 권장)
+### tapflow.config.json
 
-서버에서 릴레이를 안정적으로 운영할 때 권장합니다. 크래시 시 자동 재시작, 서버 재부팅 후 자동 시작, 로그 관리를 처리합니다.
+릴레이는 현재 디렉토리에서 `tapflow.config.json`을 읽습니다. [설정 파일](/ko/reference/configuration)을 참고하세요.
 
-```sh
-npm install -g pm2 tapflow
-```
+## 내부 공유
 
-위에서 생성한 `JWT_SECRET`을 환경변수로 주입해 시작합니다:
+같은 네트워크의 팀원이 대시보드에 접근하는 가장 간단한 방법입니다.
 
 ```sh
-JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
-pm2 save
-pm2 startup
+npm install -g tapflow
+JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
 ```
 
-tapflow를 업데이트할 때는:
-
-```sh
-npm update -g tapflow
-pm2 restart relay
-```
-
-::: tip 다음 단계
-릴레이가 실행되면 `tapflow init`으로 최초 관리자 계정을 생성합니다. 이후 팀원 초대와 첫 빌드 업로드는 [대시보드 최초 설정](/ko/dashboard/setup)을 참고하세요.
-:::
+팀원은 `http://<mac-local-ip>:4000`으로 대시보드에 접속합니다.
 
 ## 외부 공유
 
-위 방식 중 어느 것으로 릴레이를 실행하든, 로컬호스트 밖에서 팀원이 접근하거나 에이전트가 다른 네트워크에서 연결하려면 외부 URL이 필요합니다.
+로컬 네트워크 밖에서 팀원이 대시보드에 접근하거나 에이전트가 다른 네트워크에서 연결하려면 외부 URL이 필요합니다.
 
 ### ngrok (빠른 시작)
 
@@ -162,3 +139,29 @@ tapflow.myteam.example.com {
 
 Caddy는 TLS와 WebSocket 업그레이드를 자동으로 처리합니다.
 
+## PM2 (서버 운영 권장)
+
+크래시 시 자동 재시작, 서버 재부팅 후 자동 시작, 로그 관리를 처리합니다.
+
+```sh
+npm install -g pm2 tapflow
+```
+
+위에서 생성한 `JWT_SECRET`을 환경변수로 주입해 시작합니다:
+
+```sh
+JWT_SECRET=YOUR_JWT_SECRET pm2 start tapflow --name relay -- relay start
+pm2 save
+pm2 startup
+```
+
+tapflow를 업데이트할 때는:
+
+```sh
+npm update -g tapflow
+pm2 restart relay
+```
+
+::: tip 다음 단계
+릴레이가 실행되면 `tapflow init`으로 최초 관리자 계정을 생성합니다. 이후 팀원 초대와 첫 빌드 업로드는 [대시보드 최초 설정](/ko/dashboard/setup)을 참고하세요.
+:::

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { z } from 'zod'
 import { RelayServer, initDb, config } from '@tapflowio/relay'
 import { banner, step } from '../lib/print.js'
+import { initConfigFile } from '../lib/init-config.js'
 
 export interface RelayStartOptions {
   port?: number
@@ -19,6 +20,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
     process.exit(1)
   }
   const port = portResult.data
+  initConfigFile()
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port, uploadsDir: path.join(config.server.dataDir, 'uploads') })
   await server.start()

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,6 +4,7 @@ import { AndroidAgent } from '@tapflowio/android-agent'
 import { banner, createSpinner, step } from '../lib/print.js'
 import { hasAdb } from '../lib/platform.js'
 import { resolveAndBootIOSDevice } from '../lib/ios-boot.js'
+import { initConfigFile } from '../lib/init-config.js'
 
 export interface StartOptions {
   device?: string
@@ -21,6 +22,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
   const runAndroid = explicit === 'android' || explicit === 'all' || (!explicit && hasAdb())
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
+  initConfigFile()
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.server.dataDir, 'uploads') })
   await server.start()

--- a/packages/cli/src/lib/init-config.ts
+++ b/packages/cli/src/lib/init-config.ts
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+
+const DEFAULT_CONFIG = {
+  server: {
+    port: 4000,
+    dataDir: '.tapflow',
+  },
+  smtp: {
+    host: '',
+    port: 587,
+    secure: false,
+    user: '',
+    pass: '',
+    from: 'tapflow <noreply@tapflow.local>',
+  },
+}
+
+export function initConfigFile(): void {
+  const configPath = path.join(process.cwd(), 'tapflow.config.json')
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n', 'utf-8')
+  }
+}

--- a/packages/relay/src/__tests__/config.test.ts
+++ b/packages/relay/src/__tests__/config.test.ts
@@ -23,6 +23,7 @@ describe('relay config validation', () => {
   })
 
   it('유효한 기본값 → 정상 로드', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { config } = await import('../lib/config.js')
     expect(config.server.port).toBe(4000)
     expect(exitSpy).not.toHaveBeenCalled()
@@ -45,20 +46,31 @@ describe('relay config validation', () => {
     vi.stubEnv('JWT_SECRET', 'tooshort')
     await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('server.jwtSecret'))
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('JWT_SECRET'))
   })
 
   it('JWT_SECRET 32자 이상 → 정상 로드', async () => {
     vi.stubEnv('JWT_SECRET', 'a'.repeat(32))
-    const { config } = await import('../lib/config.js')
-    expect(config.server.jwtSecret).toBe('a'.repeat(32))
+    const { jwtSecret } = await import('../lib/config.js')
+    expect(jwtSecret).toBe('a'.repeat(32))
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
   it('기본 JWT_SECRET 사용 시 경고 로그', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const { config } = await import('../lib/config.js')
-    expect(config.server.jwtSecret).toContain('tapflow-dev-secret')
+    const { jwtSecret } = await import('../lib/config.js')
+    expect(jwtSecret).toContain('tapflow-dev-secret')
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dev default'))
+  })
+
+  it('config 파일에 jwtSecret 잔존 시 deprecation 경고', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.default.existsSync).mockReturnValue(true)
+    vi.mocked(fs.default.readFileSync).mockReturnValue(
+      JSON.stringify({ server: { jwtSecret: 'old-secret-value-from-config-file' } })
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await import('../lib/config.js')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'))
   })
 })

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -5,11 +5,12 @@ import { createLogger } from '@tapflowio/agent-core'
 
 const logger = createLogger('relay:config')
 
+const DEV_DEFAULT_SECRET = 'tapflow-dev-secret-change-in-production'
+
 const configSchema = z.object({
   server: z.object({
     port: z.number().int().min(1).max(65535),
     dataDir: z.string().min(1),
-    jwtSecret: z.string().min(32, 'jwtSecret must be at least 32 characters'),
   }),
   smtp: z.object({
     host: z.string(),
@@ -29,7 +30,6 @@ const DEFAULTS = {
   server: {
     port: 4000,
     dataDir: '.tapflow',
-    jwtSecret: 'tapflow-dev-secret-change-in-production',
   },
   smtp: {
     host: '',
@@ -46,22 +46,25 @@ function resolveDataDir(raw: string): string {
 }
 
 function load(): TapflowConfig {
-  let file: DeepPartial<TapflowConfig> = {}
+  let file: DeepPartial<TapflowConfig> & { server?: { jwtSecret?: unknown } } = {}
 
   const configPath = path.join(process.cwd(), 'tapflow.config.json')
   if (fs.existsSync(configPath)) {
     try {
-      file = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as DeepPartial<TapflowConfig>
+      file = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as typeof file
     } catch {
       logger.warn('Failed to parse tapflow.config.json — using defaults')
     }
+  }
+
+  if (file.server?.jwtSecret) {
+    logger.warn('server.jwtSecret in tapflow.config.json is deprecated — use JWT_SECRET env var instead')
   }
 
   const cfg: TapflowConfig = {
     server: {
       port: file.server?.port ?? DEFAULTS.server.port,
       dataDir: resolveDataDir(file.server?.dataDir ?? DEFAULTS.server.dataDir),
-      jwtSecret: file.server?.jwtSecret ?? DEFAULTS.server.jwtSecret,
     },
     smtp: {
       host: file.smtp?.host ?? DEFAULTS.smtp.host,
@@ -73,10 +76,8 @@ function load(): TapflowConfig {
     },
   }
 
-  // env vars override config file (useful for Docker / CI)
   if (process.env.TAPFLOW_PORT) cfg.server.port = Number(process.env.TAPFLOW_PORT)
   if (process.env.TAPFLOW_DATA_DIR) cfg.server.dataDir = resolveDataDir(process.env.TAPFLOW_DATA_DIR)
-  if (process.env.JWT_SECRET) cfg.server.jwtSecret = process.env.JWT_SECRET
   if (process.env.SMTP_HOST) cfg.smtp.host = process.env.SMTP_HOST
   if (process.env.SMTP_PORT) cfg.smtp.port = Number(process.env.SMTP_PORT)
   if (process.env.SMTP_SECURE) cfg.smtp.secure = process.env.SMTP_SECURE === 'true'
@@ -92,11 +93,20 @@ function load(): TapflowConfig {
     process.exit(1)
   }
 
-  if (cfg.server.jwtSecret === DEFAULTS.server.jwtSecret) {
-    logger.warn('JWT_SECRET is using the dev default — set a strong secret in production')
-  }
-
   return result.data
 }
 
+function loadJwtSecret(): string {
+  if (process.env.JWT_SECRET) {
+    if (process.env.JWT_SECRET.length < 32) {
+      logger.error('config error: JWT_SECRET — must be at least 32 characters')
+      process.exit(1)
+    }
+    return process.env.JWT_SECRET
+  }
+  logger.warn('JWT_SECRET is using the dev default — set a strong secret in production')
+  return DEV_DEFAULT_SECRET
+}
+
 export const config = load()
+export const jwtSecret = loadJwtSecret()

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -57,7 +57,7 @@ function load(): TapflowConfig {
     }
   }
 
-  if (file.server?.jwtSecret) {
+  if (file.server != null && 'jwtSecret' in file.server) {
     logger.warn('server.jwtSecret in tapflow.config.json is deprecated — use JWT_SECRET env var instead')
   }
 
@@ -97,7 +97,7 @@ function load(): TapflowConfig {
 }
 
 function loadJwtSecret(): string {
-  if (process.env.JWT_SECRET) {
+  if (process.env.JWT_SECRET !== undefined) {
     if (process.env.JWT_SECRET.length < 32) {
       logger.error('config error: JWT_SECRET — must be at least 32 characters')
       process.exit(1)

--- a/packages/relay/src/middleware/auth.ts
+++ b/packages/relay/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import http from 'http'
 import crypto from 'crypto'
 import jwt from 'jsonwebtoken'
 import { getDb } from '../db.js'
-import { config } from '../lib/config.js'
+import { jwtSecret } from '../lib/config.js'
 
 export interface AuthContext {
   userId: number
@@ -13,12 +13,12 @@ export interface AuthContext {
 const JWT_EXPIRES = '7d'
 
 export function signJwt(payload: AuthContext): string {
-  return jwt.sign(payload, config.server.jwtSecret, { expiresIn: JWT_EXPIRES })
+  return jwt.sign(payload, jwtSecret, { expiresIn: JWT_EXPIRES })
 }
 
 export function verifyJwt(token: string): AuthContext | null {
   try {
-    return jwt.verify(token, config.server.jwtSecret) as AuthContext
+    return jwt.verify(token, jwtSecret) as AuthContext
   } catch {
     return null
   }

--- a/tapflow.config.example.json
+++ b/tapflow.config.example.json
@@ -1,8 +1,7 @@
 {
   "server": {
     "port": 4000,
-    "dataDir": ".tapflow",
-    "jwtSecret": "CHANGE_THIS_TO_A_LONG_RANDOM_SECRET"
+    "dataDir": ".tapflow"
   },
   "smtp": {
     "host": "",


### PR DESCRIPTION
Closes #72

## Summary

- `tapflow relay start` / `tapflow start` 최초 실행 시 `tapflow.config.json` 자동 생성 (DB 초기화와 같은 시점)
- `jwtSecret`을 config 파일 스키마에서 제거하고 `JWT_SECRET` 환경변수 단일 진입점으로 전환
- 구버전 config 파일에 `jwtSecret`이 남아 있는 경우 무시 + deprecation warn 출력
- self-hosting 문서 구조 개편 (배포 설정 / 내부 공유 / 외부 공유 / PM2 순서)

## Changes

- `relay/lib/config.ts` — jwtSecret 스키마 제거, `export const jwtSecret` 별도 추가 (env 전용 로딩)
- `relay/middleware/auth.ts` — `config.server.jwtSecret` → `jwtSecret` import
- `relay/tests/config.test.ts` — jwtSecret export 기준 테스트 수정, deprecation warn 케이스 추가
- `cli/lib/init-config.ts` — config 파일 생성 유틸리티 신규 추가
- `cli/commands/relay-start.ts`, `start.ts` — `initConfigFile()` 호출 추가
- `tapflow.config.example.json` — jwtSecret 필드 제거
- `docs/guide/self-hosting.md` (en/ko) — 구조 개편

## Test plan

- [ ] `tapflow relay start` 최초 실행 시 `tapflow.config.json` 생성 확인
- [ ] 재실행 시 기존 파일 덮어쓰지 않음 확인
- [ ] `JWT_SECRET` 없이 실행 시 dev default warn 로그 확인
- [ ] `JWT_SECRET=xxx tapflow relay start` 실행 시 env 값 사용 확인
- [ ] 구버전 config (`jwtSecret` 필드 존재) 사용 시 deprecation warn 확인
- [ ] `pnpm test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized self-hosting guides (EN/KO): added a "Deployment configuration" section, clearer internal/external access guidance, and moved the PM2 setup to a dedicated section.

* **New Features**
  * CLI creates a default runtime config file automatically on first run.
  * JWT must be supplied via the JWT_SECRET environment variable; minimum length is enforced.

* **Chores**
  * Updated example config and .gitignore to exclude local runtime config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->