### PR TITLE
feat: rename default dataDir .tapflow → .tapflow-data

### DIFF
--- a/.changeset/rename-data-dir.md
+++ b/.changeset/rename-data-dir.md
@@ -1,0 +1,8 @@
+---
+"tapflow": patch
+"@tapflowio/relay": patch
+---
+
+**Breaking change**: default `dataDir` renamed from `.tapflow` to `.tapflow-data`.
+
+If you have an existing `.tapflow/` directory, either rename it to `.tapflow-data/` or set `dataDir: ".tapflow"` in `tapflow.config.json` to keep using the old path.

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ tapflow.config.json
 *.db-wal
 
 # playground runtime data (recordings, uploads, db)
-playground/.tapflow/
+playground/.tapflow-data/
 
 # playground test builds
 playground/test-builds/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN npm install --omit=dev
 
 COPY tapflow.config.example.json ./tapflow.config.example.json
 
-VOLUME ["/app/.tapflow"]
+VOLUME ["/app/.tapflow-data"]
 EXPOSE 4000
 
 CMD ["node", "dist/server.js"]

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -8,8 +8,7 @@
 {
   "server": {
     "port": 4000,
-    "dataDir": ".tapflow",
-    "jwtSecret": "CHANGE_THIS_TO_A_LONG_RANDOM_SECRET"
+    "dataDir": ".tapflow-data"
   },
   "smtp": {
     "host": "smtp.example.com",
@@ -31,8 +30,8 @@
 | 환경변수 | Config 키 | 기본값 | 설명 |
 |---------|-----------|--------|------|
 | `TAPFLOW_PORT` | `server.port` | `4000` | 서버 포트 |
-| `JWT_SECRET` | `server.jwtSecret` | *(개발용 기본값)* | JWT 서명 키 |
-| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow` | DB·업로드 디렉토리 (상대 경로 지원) |
+| `JWT_SECRET` | — | *(개발용 기본값)* | JWT 서명 키 (환경변수 전용) |
+| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow-data` | DB·업로드 디렉토리 (상대 경로 지원) |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP 호스트 |
 | `SMTP_PORT` | `smtp.port` | `587` | SMTP 포트 |
 | `SMTP_SECURE` | `smtp.secure` | `false` | TLS 사용 여부 (`true` 문자열로 설정) |
@@ -52,10 +51,10 @@ openssl rand -hex 32
 
 ## 데이터 디렉토리
 
-릴레이는 모든 데이터를 `.tapflow/`에 저장합니다 (기본값):
+릴레이는 모든 데이터를 `.tapflow-data/`에 저장합니다 (기본값):
 
 ```
-.tapflow/
+.tapflow-data/
   tapflow.db        ← SQLite 데이터베이스
   uploads/
     builds/         ← .app.zip 및 .apk 파일

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,8 +8,7 @@ The relay reads `tapflow.config.json` from the directory where it is started.
 {
   "server": {
     "port": 4000,
-    "dataDir": ".tapflow",
-    "jwtSecret": "CHANGE_THIS_TO_A_LONG_RANDOM_SECRET"
+    "dataDir": ".tapflow-data"
   },
   "smtp": {
     "host": "smtp.example.com",
@@ -31,8 +30,8 @@ Environment variables always take precedence over the config file — useful for
 | Variable | Config key | Default | Description |
 |----------|------------|---------|-------------|
 | `TAPFLOW_PORT` | `server.port` | `4000` | Server port |
-| `JWT_SECRET` | `server.jwtSecret` | *(dev default)* | JWT signing key |
-| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow` | DB and uploads directory (supports relative paths) |
+| `JWT_SECRET` | — | *(dev default)* | JWT signing key (env only) |
+| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow-data` | DB and uploads directory (supports relative paths) |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP host |
 | `SMTP_PORT` | `smtp.port` | `587` | SMTP port |
 | `SMTP_SECURE` | `smtp.secure` | `false` | Enable TLS (set to string `"true"`) |
@@ -52,10 +51,10 @@ openssl rand -hex 32
 
 ## Data directory
 
-The relay stores all data in `.tapflow/` by default:
+The relay stores all data in `.tapflow-data/` by default:
 
 ```
-.tapflow/
+.tapflow-data/
   tapflow.db        ← SQLite database
   uploads/
     builds/         ← .app.zip and .apk files

--- a/packages/cli/src/lib/init-config.ts
+++ b/packages/cli/src/lib/init-config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 const DEFAULT_CONFIG = {
   server: {
     port: 4000,
-    dataDir: '.tapflow',
+    dataDir: '.tapflow-data',
   },
   smtp: {
     host: '',

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -29,7 +29,7 @@ type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]>
 const DEFAULTS = {
   server: {
     port: 4000,
-    dataDir: '.tapflow',
+    dataDir: '.tapflow-data',
   },
   smtp: {
     host: '',

--- a/playground/relay.ts
+++ b/playground/relay.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { RelayServer, initDb } from '@tapflowio/relay'
 
 const PORT = Number(process.env.PORT ?? 4000)
-const dataDir = path.join(import.meta.dirname, '.tapflow')
+const dataDir = path.join(import.meta.dirname, '.tapflow-data')
 
 initDb(path.join(dataDir, 'tapflow.db'))
 

--- a/playground/seed.ts
+++ b/playground/seed.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import crypto from 'crypto'
 import { initDb, getDb } from '@tapflowio/relay'
 
-const dataDir = path.join(import.meta.dirname, '.tapflow')
+const dataDir = path.join(import.meta.dirname, '.tapflow-data')
 initDb(path.join(dataDir, 'tapflow.db'))
 
 function makePasswordHash(password: string): string {

--- a/tapflow.config.example.json
+++ b/tapflow.config.example.json
@@ -1,7 +1,7 @@
 {
   "server": {
     "port": 4000,
-    "dataDir": ".tapflow"
+    "dataDir": ".tapflow-data"
   },
   "smtp": {
     "host": "",


### PR DESCRIPTION
## Summary

- 기본 `dataDir` 값을 `.tapflow` → `.tapflow-data`로 변경
- `tapflow.config.json`(설정 파일)과 런타임 데이터 디렉토리를 시각적으로 구분
- alpha 단계라 breaking change 비용이 낮은 지금 처리

## Changes

| File | Change |
|------|--------|
| `packages/relay/src/lib/config.ts` | `DEFAULTS.server.dataDir` 변경 |
| `packages/cli/src/lib/init-config.ts` | `DEFAULT_CONFIG.server.dataDir` 변경 |
| `tapflow.config.example.json` | `dataDir` 기본값 변경 |
| `Dockerfile` | `VOLUME` 경로 변경 |
| `playground/relay.ts`, `seed.ts` | 로컬 dataDir 경로 변경 |
| `.gitignore` | playground runtime data 경로 변경 |
| `docs/reference/configuration.md` (en/ko) | dataDir 기본값, 디렉토리 구조 예시 업데이트 + `server.jwtSecret` 레퍼런스 제거 (alpha.6 이후 env 전용) |
| `.changeset/rename-data-dir.md` | breaking change 릴리스 노트 |

## Breaking Change

기존 `.tapflow/` 디렉토리가 있는 경우:
- 디렉토리명을 `.tapflow-data/`로 변경하거나
- `tapflow.config.json`에 `"dataDir": ".tapflow"`를 명시하면 계속 사용 가능

자동 마이그레이션은 제공하지 않음 (alpha 단계).

## Test plan

- [x] `packages/relay` 테스트 121개 통과
- [x] lint, typecheck 통과
- [ ] `tapflow relay start` 첫 실행 시 `.tapflow-data/` 생성 확인
- [ ] 기존 `.tapflow/` 존재 시 새로 `.tapflow-data/` 생성 (기존 디렉토리 그대로 유지) 확인
- [ ] `dataDir` 명시 config 사용 시 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Default data directory location changed from `.tapflow` to `.tapflow-data`. Users with existing installations should rename their `.tapflow/` directory to `.tapflow-data/` or set `dataDir: ".tapflow"` in `tapflow.config.json` to maintain the previous location.

* **Documentation**
  * Updated configuration reference guides to reflect the new default data directory path and environment variable mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->