### PR TITLE
chore: release v0.1.0-alpha.7

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,17 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@tapflowio/docs": "0.0.0",
+    "@tapflowio/agent-core": "0.1.0-alpha.6",
+    "@tapflowio/android-agent": "0.1.0-alpha.6",
+    "tapflow": "0.1.0-alpha.6",
+    "@tapflowio/dashboard": "0.1.0",
+    "@tapflowio/ios-agent": "0.1.0-alpha.6",
+    "@tapflowio/relay": "0.1.0-alpha.6",
+    "@tapflowio/playground": "0.0.0"
+  },
+  "changesets": [
+    "rename-data-dir"
+  ]
+}

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,3 +1,5 @@
 # @tapflowio/agent-core
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.2

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.2
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # tapflow
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- f13bd85: **Breaking change**: default `dataDir` renamed from `.tapflow` to `.tapflow-data`.
+
+  If you have an existing `.tapflow/` directory, either rename it to `.tapflow-data/` or set `dataDir: ".tapflow"` in `tapflow.config.json` to keep using the old path.
+
+- Updated dependencies [f13bd85]
+  - @tapflowio/relay@0.1.0-alpha.7
+  - @tapflowio/android-agent@0.1.0-alpha.7
+  - @tapflowio/ios-agent@0.1.0-alpha.7
+  - @tapflowio/agent-core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.2
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tapflowio/relay
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- f13bd85: **Breaking change**: default `dataDir` renamed from `.tapflow` to `.tapflow-data`.
+
+  If you have an existing `.tapflow/` directory, either rename it to `.tapflow-data/` or set `dataDir: ".tapflow"` in `tapflow.config.json` to keep using the old path.
+
+  - @tapflowio/agent-core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.2
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.1.0-alpha.7

### Breaking Changes
- **default `dataDir` renamed** `.tapflow` → `.tapflow-data` — existing directories must be renamed manually (or set `dataDir: ".tapflow"` in config to keep the old path)

### Features & Fixes
- `smtp.from` auto-derived from `smtp.user` when not explicitly set — prevents 553 relay errors
- Invite email send status shown as Sonner toast (success / warning)
- docs: config restart note, directory diagram with `tapflow.config.json`, `tapflow.config.example.json` removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Default data directory renamed from `.tapflow` to `.tapflow-data`. Existing users must rename their directory or update their configuration file accordingly.

* **Updates**
  * Version 0.1.0-alpha.7 released across all packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->