### PR TITLE
docs(claude): add PR merge prohibition and branch workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Get user confirmation before any hard-to-reverse operation.
 
 - `git push --force`, `git reset --hard`, sending messages to external systems, DB drops, etc.
 - Only create commits or PRs when the user explicitly requests it.
+- **Do not merge PRs.** Always leave merging to the user — even with `--admin`. Create the PR and stop.
 - **Avoid breaking changes.** If unavoidable, report to the user and get approval before proceeding. Breaking change scope: public API / interface signature changes, DB schema changes, WebSocket message protocol changes, CLI command / flag changes.
 
 ---
@@ -65,6 +66,10 @@ Get user confirmation before any hard-to-reverse operation.
 
 ### Branches, Commits & Releases
 → [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+Before starting any task that requires code changes:
+1. `git checkout main && git pull origin main` — always start from the latest main.
+2. `git checkout -b <branch-name>` — work on a new branch, never directly on main.
 
 ### Workflow (Plan → Work → Review → Compound)
 


### PR DESCRIPTION
## Summary

- `HOW NOT`에 PR 머지 금지 규칙 추가 — `--admin` 포함, 머지는 항상 유저가 직접
- `Branches, Commits & Releases` 섹션에 작업 전 워크플로우 추가 — main pull → 새 브랜치 생성 후 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution workflow guidelines with new requirements: developers must sync with the latest main branch before creating feature branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->