### PR TITLE
chore: release v0.1.0-alpha.8

### DIFF
--- a/.changeset/fix-ci-release-tag.md
+++ b/.changeset/fix-ci-release-tag.md
@@ -1,0 +1,5 @@
+---
+"tapflow": patch
+---
+
+fix(ci): use --tag alpha for changeset publish in pre mode

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,6 +12,7 @@
     "@tapflowio/playground": "0.0.0"
   },
   "changesets": [
+    "fix-ci-release-tag",
     "rename-data-dir"
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm changeset publish --no-git-tag --tag latest
+      - run: pnpm changeset publish --no-git-tag --tag alpha
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.2

--- a/packages/agent-core/CLAUDE.md
+++ b/packages/agent-core/CLAUDE.md
@@ -23,5 +23,5 @@ The sole contract that platform implementations (ios-agent, android-agent) depen
 
 ## Directory Structure
 
-- `src/` — `DeviceAgent` interface, `AgentRegistry`, shared types
-- `src/utils/` — shared implementation utils for ios-agent and android-agent. Currently: `createResourceSampler` (CPU & memory sampling). Not exposed through the interface.
+- `src/` — `DeviceAgent` interface, `AgentRegistry`, shared types, `createLogger` (leveled console logger)
+- `src/utils/` — shared implementation utils for ios-agent and android-agent. Currently: `createResourceSampler` (CPU & memory sampling, `resources.ts`) and `registerStreamWs` (stream:register handshake helper, `stream.ts`). Not exposed through the interface.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # tapflow
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- fix(ci): use --tag alpha for changeset publish in pre mode
+  - @tapflowio/agent-core@0.1.0-alpha.8
+  - @tapflowio/ios-agent@0.1.0-alpha.8
+  - @tapflowio/android-agent@0.1.0-alpha.8
+  - @tapflowio/relay@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": [
     "ios",

--- a/packages/dashboard/CLAUDE.md
+++ b/packages/dashboard/CLAUDE.md
@@ -60,7 +60,7 @@ socket.onmessage = (e) => {
   try { onMessageRef.current(JSON.parse(e.data)) } catch { }
 }
 
-// SimulatorViewer.tsx — frame rendering
+// IOSViewer.tsx — frame rendering
 createImageBitmap(new Blob([data], { type: 'image/jpeg' }))
   .then((bitmap) => {
     ctx.drawImage(bitmap, 0, 0)

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/ios-agent/CLAUDE.md
+++ b/packages/ios-agent/CLAUDE.md
@@ -182,7 +182,7 @@ Cache key: `tapflow-frame-v2-{chromeName}.png`
 innerRadius = max(outerRadius - bezelInset, 0)
 bezelInset  = max(leftWidth, topHeight)   // chrome.json images.sizing
 ```
-`ChromeData.screenCornerRadius` is in 2× px units. CSS conversion in `SimulatorViewer.tsx`: `÷2 × displayScale`.
+`ChromeData.screenCornerRadius` is in 2× px units. CSS conversion in `IOSViewer.tsx`: `÷2 × displayScale`.
 
 ---
 

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/relay/CLAUDE.md
+++ b/packages/relay/CLAUDE.md
@@ -17,7 +17,7 @@ A single process on a single configurable port (default: 4000) handles both WebS
 - **builds**: build artifacts. `app_id FK → apps.id`. Contains `version_name`, `build_number`, `file_path`.
 - `bundle_id_key` is used to auto-lookup/create the `apps` row → re-uploading the same app adds only a new `builds` row.
 
-Build file storage path: `uploads/builds/` (legacy `uploads/apps/` is preserved).
+Build file storage path: `uploads/builds/`.
 
 iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 - Auto-extracts `CFBundleIdentifier`, `CFBundleShortVersionString`, `CFBundleVersion`, `CFBundleDisplayName`/`CFBundleName` from `*.app/Info.plist`.
@@ -38,7 +38,9 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/v1/apps` | App list (with latest_build summary) |
+| `POST` | `/api/v1/apps` | Create an app entry |
 | `PATCH` | `/api/v1/apps/:id` | Manually rename an app (Admin/Developer) |
+| `DELETE` | `/api/v1/apps/:id` | Delete an app (and its builds) |
 | `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.apk`) |
 | `GET` | `/api/v1/builds` | Build list (filterable by `app_id`) |
 | `GET` | `/api/v1/builds/:id` | Single build |

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

- Bumps all packages to `0.1.0-alpha.8`
- Fixes CI publish failure: `--tag latest` → `--tag alpha` (blocked in changeset pre mode)
- Includes doc-sync CLAUDE.md updates from the previous session

## Test plan

- [ ] PR 머지 후 `v0.1.0-alpha.8` 태그 push → CI Release 워크플로우 통과 확인
- [ ] npm `tapflow@alpha` 버전이 `0.1.0-alpha.8`로 업데이트됐는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release process to correctly publish pre-release versions with alpha tag.

* **Chores**
  * Released version 0.1.0-alpha.8 across all packages with updated changelogs and documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->