### PR TITLE
fix(ci): remove --tag flag from changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm changeset publish --no-git-tag --tag alpha
+      - run: pnpm changeset publish --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `--tag` 옵션을 제거 (`--no-git-tag`만 유지)

pre mode에서는 `--tag` 옵션 자체가 허용되지 않음. `latest`든 `alpha`든 동일하게 막힘. pre.json의 tag(`alpha`)가 자동 적용됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to ensure packages are published with appropriate version tags, removing forced alpha tag designation during the publish step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->