### PR TITLE
fix: smtp from config, invite toast, toaster theme

### DIFF
--- a/packages/cli/src/lib/init-config.ts
+++ b/packages/cli/src/lib/init-config.ts
@@ -12,7 +12,6 @@ const DEFAULT_CONFIG = {
     secure: false,
     user: '',
     pass: '',
-    from: 'tapflow <noreply@tapflow.local>',
   },
 }
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { Toaster } from 'sonner'
+import { Toaster, type ToasterProps } from 'sonner'
 import { useTheme } from 'next-themes'
 import { DashboardLayout } from './layouts/DashboardLayout'
 import { Login } from './pages/Login'
@@ -31,7 +31,7 @@ export function App() {
           <Route path="*" element={<Navigate to="/app-center" replace />} />
         </Route>
       </Routes>
-      <Toaster position="bottom-right" richColors theme={resolvedTheme as 'light' | 'dark'} />
+      <Toaster position="bottom-right" richColors theme={resolvedTheme as ToasterProps['theme']} />
     </BrowserRouter>
   )
 }

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
+import { useTheme } from 'next-themes'
 import { DashboardLayout } from './layouts/DashboardLayout'
 import { Login } from './pages/Login'
 import { Invite } from './pages/Invite'
@@ -12,6 +13,7 @@ import { TeamSettings } from './pages/settings/Team'
 import { TokenSettings } from './pages/settings/Tokens'
 
 export function App() {
+  const { resolvedTheme } = useTheme()
   return (
     <BrowserRouter>
       <Routes>
@@ -29,7 +31,7 @@ export function App() {
           <Route path="*" element={<Navigate to="/app-center" replace />} />
         </Route>
       </Routes>
-      <Toaster position="bottom-right" richColors />
+      <Toaster position="bottom-right" richColors theme={resolvedTheme as 'light' | 'dark'} />
     </BrowserRouter>
   )
 }

--- a/packages/dashboard/src/pages/settings/Team.tsx
+++ b/packages/dashboard/src/pages/settings/Team.tsx
@@ -50,20 +50,25 @@ export function TeamSettings() {
   useEffect(() => { load() }, [])
 
   async function onInvite(data: InviteData) {
-    const res = await fetch('/api/v1/team/invite', {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: data.email, role: data.role }),
-    })
-    const json = inviteResponseSchema.parse(await res.json())
-    const link = `${location.origin}/invite?token=${json.token}`
-    setInviteLink(link)
-    navigator.clipboard.writeText(link).catch(() => {})
-    if (json.emailSent) {
-      toast.success(`Invite email sent to ${data.email}`)
-    } else {
-      toast.warning('Invite link copied — email could not be sent. Check your SMTP settings.')
+    try {
+      const res = await fetch('/api/v1/team/invite', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: data.email, role: data.role }),
+      })
+      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      const json = inviteResponseSchema.parse(await res.json())
+      const link = `${location.origin}/invite?token=${json.token}`
+      setInviteLink(link)
+      navigator.clipboard.writeText(link).catch(() => {})
+      if (json.emailSent) {
+        toast.success(`Invite email sent to ${data.email}`)
+      } else {
+        toast.warning('Invite link copied — email could not be sent. Check your SMTP settings.')
+      }
+    } catch {
+      toast.error('Failed to create invite link')
     }
   }
 


### PR DESCRIPTION
## Summary

- **cli**: `tapflow.config.json` 생성 시 `smtp.from` 제거 — SMTP user가 설정된 경우 auto-derive가 작동하지 않던 버그 수정
- **dashboard**: `onInvite`에 try-catch 추가 — API 에러 시 무음 실패 → `toast.error` 표시
- **dashboard**: `Toaster`에 `resolvedTheme` 전달 (`ToasterProps['theme']` 타입) — 라이트/다크 모드 동적 반영

## Test plan

- [ ] SMTP 설정 후 `tapflow.config.json`에 `from` 필드 없을 때 auto-derive 동작 확인
- [ ] 팀원 초대 성공 시 `toast.success`, SMTP 미설정 시 `toast.warning`, 실패 시 `toast.error` 확인
- [ ] 라이트/다크 모드 전환 시 토스트 테마 따라가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now properly reflect the currently active theme
  * Team invite functionality provides enhanced user feedback with success, warning, and error notifications
  * Improved error handling prevents silent failures in the invite workflow

* **Chores**
  * Updated default SMTP configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->