### PR TITLE
chore: exit changeset pre mode for stable release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@tapflowio/docs": "0.0.0",


### PR DESCRIPTION
## Summary
- Exits changeset pre mode (`alpha`) in preparation for stable 0.1.0 release
- After merge, run `changeset version` to bump all packages to 0.1.0

## Test plan
- [ ] Merge this PR
- [ ] Run `pnpm changeset version` on next branch to confirm versions resolve to 0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->