### PR TITLE
refactor(dashboard): extract useClientRecording hook (#59)

### DIFF
--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useClientRecording } from '@/hooks/useClientRecording';
 import { ArrowLeft, Home, LayoutGrid, Loader2, Play, Power, Volume1, Volume2 } from 'lucide-react';
 import { H264Decoder } from '@/lib/H264Decoder';
 import { useWebGLRenderer } from '@/lib/WebGLVideoRenderer';
@@ -50,6 +51,7 @@ export function AndroidViewer({
   const containerRef = useRef<HTMLDivElement>(null);
   const { init: glInit, dispose: glDispose, drawFrame: glDrawFrame } = useWebGLRenderer(canvasRef);
   const { fps, frameCount } = useFps();
+  const { recordState, recordCanvasRef, startClientRecording, stopClientRecording } = useClientRecording({ sessionId, buildId, onRecordingUploaded });
 
   const [canvasReady, setCanvasReady] = useState(false);
   const [glError, setGlError] = useState(false);
@@ -99,18 +101,8 @@ export function AndroidViewer({
     }
   }, [glInit, glDispose, glDrawFrame, frameCount, binaryFrameHandlerRef])
 
-  // ── Recording ─────────────────────────────────────────────────────────────
-  const [recordState, setRecordState] = useState<'idle' | 'recording' | 'uploading' | 'done'>('idle');
-  const recordCanvasRef = useRef<HTMLCanvasElement>(null);
-  const recordingRef = useRef(false);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const recordChunksRef = useRef<Blob[]>([]);
-  const recordMimeRef = useRef('');
-  const rafIdRef = useRef(0);
-  const composeFrameRef = useRef<() => void>(() => {});
-
+  // ── Recording (composeFrame only — state/refs/lifecycle in useClientRecording) ──
   const composeFrame = useCallback(() => {
-    if (!recordingRef.current) return
     const rc = recordCanvasRef.current; const fc = canvasRef.current
     if (!rc || !fc) return
     const ctx = rc.getContext('2d')
@@ -162,64 +154,7 @@ export function AndroidViewer({
     }
 
     ctx.restore()
-    rafIdRef.current = requestAnimationFrame(composeFrameRef.current)
   }, [])
-  useLayoutEffect(() => { composeFrameRef.current = composeFrame }, [composeFrame])
-
-  const startClientRecording = useCallback(() => {
-    const rc = recordCanvasRef.current; if (!rc) return
-    const container = containerRef.current
-    const dpr = window.devicePixelRatio || 1
-    if (container && container.clientWidth > 0) { rc.width = container.clientWidth * dpr; rc.height = container.clientHeight * dpr }
-    else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
-    const ctx0 = rc.getContext('2d'); if (ctx0) { ctx0.fillStyle = '#000'; ctx0.fillRect(0, 0, rc.width, rc.height) }
-    const types = ['video/mp4;codecs=avc1', 'video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm']
-    const mime = types.find((t) => MediaRecorder.isTypeSupported(t)) ?? ''; if (!mime) { console.error('[record] no supported codec'); return }
-    recordMimeRef.current = mime; recordChunksRef.current = []
-    const mr = new MediaRecorder(rc.captureStream(30), { mimeType: mime })
-    mr.ondataavailable = (e) => { if (e.data.size > 0) recordChunksRef.current.push(e.data) }
-    mediaRecorderRef.current = mr; mr.start(1000)
-    recordingRef.current = true; rafIdRef.current = requestAnimationFrame(composeFrame)
-    setRecordState('recording')
-  }, [composeFrame])
-
-  const stopClientRecording = useCallback(async () => {
-    setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
-    const mr = mediaRecorderRef.current; if (!mr) { setRecordState('idle'); return }
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, 5000)
-      mr.onstop = () => { clearTimeout(timeout); resolve() }
-      try { mr.stop() } catch { clearTimeout(timeout); resolve() }
-    })
-    mediaRecorderRef.current = null
-    const mime = recordMimeRef.current; const ext = mime.includes('mp4') ? '.mp4' : '.webm'
-    const blob = new Blob(recordChunksRef.current, { type: mime }); recordChunksRef.current = []
-    const formData = new FormData(); formData.append('file', blob, `tapflow-${Date.now()}${ext}`)
-    try {
-      const params = new URLSearchParams({ sessionId }); if (buildId) params.set('buildId', String(buildId))
-      const res = await fetch(`/api/v1/recordings/upload?${params}`, { method: 'POST', credentials: 'include', body: formData })
-      const json = await res.json() as { url?: string }
-      if (res.ok && json.url) {
-        const a = document.createElement('a'); a.href = json.url; a.download = ''; a.click()
-        onRecordingUploaded?.(); setRecordState('done'); setTimeout(() => setRecordState('idle'), 2000)
-      } else { setRecordState('idle') }
-    } catch { setRecordState('idle') }
-  }, [sessionId, buildId, onRecordingUploaded])
-
-  useEffect(() => {
-    if (recordState !== 'recording') return
-    const onVisibility = () => { if (document.visibilityState === 'hidden') stopClientRecording() }
-    document.addEventListener('visibilitychange', onVisibility)
-    return () => {
-      document.removeEventListener('visibilitychange', onVisibility)
-      if (recordingRef.current) {
-        recordingRef.current = false
-        cancelAnimationFrame(rafIdRef.current)
-        mediaRecorderRef.current?.stop()
-        mediaRecorderRef.current = null
-      }
-    }
-  }, [recordState, stopClientRecording])
 
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
@@ -474,7 +409,18 @@ export function AndroidViewer({
             URL.revokeObjectURL(url)
           }, 'image/png')
         }}
-        onRecordToggle={() => { if (recordState === 'idle') startClientRecording(); else if (recordState === 'recording') stopClientRecording() }}
+        onRecordToggle={() => {
+          if (recordState === 'idle') {
+            const rc = recordCanvasRef.current; if (!rc) return
+            const dpr = window.devicePixelRatio || 1
+            const container = containerRef.current
+            if (container && container.clientWidth > 0) { rc.width = container.clientWidth * dpr; rc.height = container.clientHeight * dpr }
+            else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
+            startClientRecording(composeFrame)
+          } else if (recordState === 'recording') {
+            stopClientRecording()
+          }
+        }}
         recordState={recordState}
         onRotate={() => send({ type: 'input:rotate', sessionId })}
         platformSlot={platformSlot}

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, Fragment } from 'react';
+import { useCallback, useEffect, useRef, useState, Fragment } from 'react';
+import { useClientRecording } from '@/hooks/useClientRecording';
 import { Home, Keyboard, Loader2, Play } from 'lucide-react';
 import { useFps } from '@/hooks/useFps';
 import { SimulatorToolbar } from './shared/SimulatorToolbar';
@@ -47,8 +48,8 @@ export function IOSViewer({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const screenAreaRef = useRef<HTMLDivElement>(null);
-  const recordCanvasRef = useRef<HTMLCanvasElement>(null);
   const { fps, frameCount } = useFps();
+  const { recordState, recordCanvasRef, startClientRecording, stopClientRecording } = useClientRecording({ sessionId, buildId, onRecordingUploaded });
   const deviceSeq = useRef(0);
 
   const [canvasReady, setCanvasReady] = useState(false);
@@ -115,17 +116,8 @@ export function IOSViewer({
     if (rc && container) { rc.width = container.clientWidth; rc.height = container.clientHeight }
   }, [chrome])
 
-  // ── Recording ─────────────────────────────────────────────────────────────
-  const [recordState, setRecordState] = useState<'idle' | 'recording' | 'uploading' | 'done'>('idle');
-  const recordingRef = useRef(false);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const recordChunksRef = useRef<Blob[]>([]);
-  const recordMimeRef = useRef('');
-  const rafIdRef = useRef(0);
-  const composeFrameRef = useRef<() => void>(() => {});
-
+  // ── Recording (composeFrame only — state/refs/lifecycle in useClientRecording) ──
   const composeFrame = useCallback(() => {
-    if (!recordingRef.current) return
     const rc = recordCanvasRef.current; const fc = canvasRef.current
     if (!rc || !fc) return
     const ctx = rc.getContext('2d')
@@ -188,64 +180,7 @@ export function IOSViewer({
       }
       ctx.restore()
     }
-    rafIdRef.current = requestAnimationFrame(composeFrameRef.current)
   }, [])
-  useLayoutEffect(() => { composeFrameRef.current = composeFrame }, [composeFrame])
-
-  const startClientRecording = useCallback(() => {
-    const rc = recordCanvasRef.current; if (!rc) return
-    const container = containerRef.current
-    if (container && container.clientWidth > 0) { rc.width = container.clientWidth; rc.height = container.clientHeight }
-    else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
-    const ctx0 = rc.getContext('2d'); if (ctx0) { ctx0.fillStyle = '#000'; ctx0.fillRect(0, 0, rc.width, rc.height) }
-    const types = ['video/mp4;codecs=avc1', 'video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm']
-    const mime = types.find((t) => MediaRecorder.isTypeSupported(t)) ?? ''; if (!mime) return
-    recordMimeRef.current = mime; recordChunksRef.current = []
-    const mr = new MediaRecorder(rc.captureStream(30), { mimeType: mime })
-    mr.ondataavailable = (e) => { if (e.data.size > 0) recordChunksRef.current.push(e.data) }
-    mediaRecorderRef.current = mr; mr.start(1000)
-    recordingRef.current = true; rafIdRef.current = requestAnimationFrame(composeFrame)
-    setRecordState('recording')
-  }, [composeFrame])
-
-  const stopClientRecording = useCallback(async () => {
-    setRecordState('uploading'); recordingRef.current = false; cancelAnimationFrame(rafIdRef.current)
-    const mr = mediaRecorderRef.current; if (!mr) { setRecordState('idle'); return }
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, 5000)
-      mr.onstop = () => { clearTimeout(timeout); resolve() }
-      try { mr.stop() } catch { clearTimeout(timeout); resolve() }
-    })
-    mediaRecorderRef.current = null
-    const mime = recordMimeRef.current; const ext = mime.includes('mp4') ? '.mp4' : '.webm'
-    const blob = new Blob(recordChunksRef.current, { type: mime }); recordChunksRef.current = []
-    const formData = new FormData(); formData.append('file', blob, `tapflow-${Date.now()}${ext}`)
-    try {
-      const params = new URLSearchParams({ sessionId }); if (buildId) params.set('buildId', String(buildId))
-      const res = await fetch(`/api/v1/recordings/upload?${params}`, { method: 'POST', credentials: 'include', body: formData })
-      const json = await res.json() as { url?: string }
-      if (res.ok && json.url) {
-        const a = document.createElement('a'); a.href = json.url; a.download = ''; a.click()
-        onRecordingUploaded?.(); setRecordState('done'); setTimeout(() => setRecordState('idle'), 2000)
-      } else { setRecordState('idle') }
-    } catch { setRecordState('idle') }
-  }, [sessionId, buildId, onRecordingUploaded])
-
-  useEffect(() => {
-    if (recordState !== 'recording') return
-    const onVisibility = () => { if (document.visibilityState === 'hidden') stopClientRecording() }
-    document.addEventListener('visibilitychange', onVisibility)
-    return () => {
-      document.removeEventListener('visibilitychange', onVisibility)
-      // Cancel RAF loop on unmount to prevent it from running after component is gone
-      if (recordingRef.current) {
-        recordingRef.current = false
-        cancelAnimationFrame(rafIdRef.current)
-        mediaRecorderRef.current?.stop()
-        mediaRecorderRef.current = null
-      }
-    }
-  }, [recordState, stopClientRecording])
 
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
@@ -498,7 +433,17 @@ export function IOSViewer({
             URL.revokeObjectURL(url)
           }, 'image/png')
         }}
-        onRecordToggle={() => { if (recordState === 'idle') startClientRecording(); else if (recordState === 'recording') stopClientRecording() }}
+        onRecordToggle={() => {
+          if (recordState === 'idle') {
+            const rc = recordCanvasRef.current; if (!rc) return
+            const container = containerRef.current
+            if (container && container.clientWidth > 0) { rc.width = container.clientWidth; rc.height = container.clientHeight }
+            else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
+            startClientRecording(composeFrame)
+          } else if (recordState === 'recording') {
+            stopClientRecording()
+          }
+        }}
         recordState={recordState}
         onRotate={() => { send({ type: 'input:rotate', sessionId }); setIsLandscape(prev => !prev) }}
         platformSlot={platformSlot}

--- a/packages/dashboard/hooks/useClientRecording.ts
+++ b/packages/dashboard/hooks/useClientRecording.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type RecordState = 'idle' | 'recording' | 'uploading' | 'done'
+
+interface UseClientRecordingOptions {
+  sessionId: string
+  buildId?: number
+  onRecordingUploaded?: () => void
+}
+
+const MIME_CANDIDATES = [
+  'video/mp4;codecs=avc1',
+  'video/webm;codecs=vp9',
+  'video/webm;codecs=vp8',
+  'video/webm',
+]
+
+export function useClientRecording({ sessionId, buildId, onRecordingUploaded }: UseClientRecordingOptions) {
+  const [recordState, setRecordState] = useState<RecordState>('idle')
+  const recordCanvasRef = useRef<HTMLCanvasElement>(null)
+
+  // Stable ref so identity changes in the prop never trigger re-subscriptions (#58 regression)
+  const onUploadedRef = useRef(onRecordingUploaded)
+  useEffect(() => { onUploadedRef.current = onRecordingUploaded }, [onRecordingUploaded])
+
+  const recordingRef = useRef(false)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const recordChunksRef = useRef<Blob[]>([])
+  const recordMimeRef = useRef('')
+  const rafIdRef = useRef(0)
+  // Stable ref wrapper so RAF always calls the latest composeFrame without recreating the loop
+  const composeFrameRef = useRef<(() => void) | null>(null)
+
+  const rafLoop = useCallback(() => {
+    if (!recordingRef.current) return
+    composeFrameRef.current?.()
+    rafIdRef.current = requestAnimationFrame(rafLoop)
+  }, [])
+
+  // Caller must set recordCanvasRef.current.width/height before calling this.
+  // (iOS uses container px, Android multiplies by devicePixelRatio — kept as caller responsibility.)
+  const startClientRecording = useCallback((composeFrame: () => void) => {
+    const rc = recordCanvasRef.current
+    if (!rc) return
+    const ctx0 = rc.getContext('2d')
+    if (ctx0) { ctx0.fillStyle = '#000'; ctx0.fillRect(0, 0, rc.width, rc.height) }
+
+    const mime = MIME_CANDIDATES.find((t) => MediaRecorder.isTypeSupported(t)) ?? ''
+    if (!mime) return
+
+    recordMimeRef.current = mime
+    recordChunksRef.current = []
+
+    const mr = new MediaRecorder(rc.captureStream(30), { mimeType: mime })
+    mr.ondataavailable = (e) => { if (e.data.size > 0) recordChunksRef.current.push(e.data) }
+    mediaRecorderRef.current = mr
+    mr.start(1000)
+
+    composeFrameRef.current = composeFrame
+    recordingRef.current = true
+    rafIdRef.current = requestAnimationFrame(rafLoop)
+    setRecordState('recording')
+  }, [rafLoop])
+
+  const stopClientRecording = useCallback(async () => {
+    setRecordState('uploading')
+    recordingRef.current = false
+    cancelAnimationFrame(rafIdRef.current)
+
+    const mr = mediaRecorderRef.current
+    if (!mr) { setRecordState('idle'); return }
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 5000)
+      mr.onstop = () => { clearTimeout(timeout); resolve() }
+      try { mr.stop() } catch { clearTimeout(timeout); resolve() }
+    })
+    mediaRecorderRef.current = null
+
+    const mime = recordMimeRef.current
+    const ext = mime.includes('mp4') ? '.mp4' : '.webm'
+    const blob = new Blob(recordChunksRef.current, { type: mime })
+    recordChunksRef.current = []
+
+    const formData = new FormData()
+    formData.append('file', blob, `tapflow-${Date.now()}${ext}`)
+    try {
+      const params = new URLSearchParams({ sessionId })
+      if (buildId) params.set('buildId', String(buildId))
+      const res = await fetch(`/api/v1/recordings/upload?${params}`, { method: 'POST', credentials: 'include', body: formData })
+      const json = await res.json() as { url?: string }
+      if (res.ok && json.url) {
+        const a = document.createElement('a'); a.href = json.url; a.download = ''; a.click()
+        onUploadedRef.current?.()
+        setRecordState('done')
+        setTimeout(() => setRecordState('idle'), 2000)
+      } else {
+        setRecordState('idle')
+      }
+    } catch {
+      setRecordState('idle')
+    }
+  }, [sessionId, buildId])
+
+  // Auto-stop on tab hide + cleanup on unmount
+  useEffect(() => {
+    if (recordState !== 'recording') return
+    const onVisibility = () => { if (document.visibilityState === 'hidden') stopClientRecording() }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      if (recordingRef.current) {
+        recordingRef.current = false
+        cancelAnimationFrame(rafIdRef.current)
+        mediaRecorderRef.current?.stop()
+        mediaRecorderRef.current = null
+      }
+    }
+  }, [recordState, stopClientRecording])
+
+  return { recordState, recordCanvasRef, startClientRecording, stopClientRecording }
+}


### PR DESCRIPTION
## Summary

- `IOSViewer`와 `AndroidViewer`에 중복된 MediaRecorder 기반 녹화 로직을 `hooks/useClientRecording.ts`로 추출
- 훅이 `recordState`, `recordCanvasRef`, `startClientRecording(composeFrame)`, `stopClientRecording()` 반환
- `onRecordingUploaded`를 내부 ref로 보관 → prop identity 변경이 재구독을 일으키지 않아 #58 류의 버그를 구조적으로 방지
- 캔버스 사이즈 결정(iOS: container px / Android: container × DPR)은 각 viewer 책임으로 유지 — 훅에 플랫폼 분기 없음
- `composeFrame` 합성 로직(chrome 오버레이, 커서, pinch hint)은 각 viewer에 그대로 유지

## Changes

| File | Changes |
|------|---------|
| `hooks/useClientRecording.ts` | 신규 — MediaRecorder + RAF loop + upload + visibilitychange |
| `components/device/IOSViewer.tsx` | -56줄 |
| `components/device/AndroidViewer.tsx` | -54줄 |

## Test plan

- [ ] tsc `--noEmit` 에러 0 (pre-commit hook 통과 확인됨)
- [ ] vitest 40/40 통과
- [ ] iOS simulator — 녹화 시작/정지/업로드 정상 동작 확인
- [ ] Android emulator — 동일 확인
- [ ] 녹화 중 탭 전환 → visibility hidden 자동 정지 확인
- [ ] 부모에서 `onRecordingUploaded` prop을 매 렌더 새 함수로 전달해도 녹화 도중 `mediaRecorderRef`가 null화되지 않는지 확인

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced device recording infrastructure for iOS and Android simulators with improved stability and performance
  * Recording videos now automatically download upon completion
  * Recording automatically stops when the active tab becomes hidden or inactive

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->