### PR TITLE
fix(android-agent): implement Android pinch via scrcpy multi-touch

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -557,21 +557,38 @@ export class AndroidAgent implements DeviceAgent {
       }
       case 'input:pinch:start': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
-        const { x1, y1, x2, y2 } = msg.payload as { x1: number; y1: number; x2: number; y2: number }
-        state.touchHelper.pinchStart(x1, y1, x2, y2)
+        if (!state) break
+        const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
+        if (state.scrcpySession && state.videoWidth > 0) {
+          const px1 = Math.round(f0.x * state.videoWidth), py1 = Math.round(f0.y * state.videoHeight)
+          const px2 = Math.round(f1.x * state.videoWidth), py2 = Math.round(f1.y * state.videoHeight)
+          state.scrcpySession.control.pinchStart(px1, py1, px2, py2)
+        } else {
+          state.touchHelper?.pinchStart(f0.x, f0.y, f1.x, f1.y)
+        }
         break
       }
       case 'input:pinch:move': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
-        const { x1, y1, x2, y2 } = msg.payload as { x1: number; y1: number; x2: number; y2: number }
-        state.touchHelper.pinchMove(x1, y1, x2, y2)
+        if (!state) break
+        const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
+        if (state.scrcpySession && state.videoWidth > 0) {
+          const px1 = Math.round(f0.x * state.videoWidth), py1 = Math.round(f0.y * state.videoHeight)
+          const px2 = Math.round(f1.x * state.videoWidth), py2 = Math.round(f1.y * state.videoHeight)
+          state.scrcpySession.control.pinchMove(px1, py1, px2, py2)
+        } else {
+          state.touchHelper?.pinchMove(f0.x, f0.y, f1.x, f1.y)
+        }
         break
       }
       case 'input:pinch:end': {
         const state = this.deviceStates.get(msg.sessionId!)
-        state?.touchHelper?.pinchEnd()
+        if (!state) break
+        if (state.scrcpySession) {
+          state.scrcpySession.control.pinchEnd()
+        } else {
+          state.touchHelper?.pinchEnd()
+        }
         break
       }
       case 'input:rotate': {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -40,7 +40,14 @@ vi.mock('../scrcpy/ScrcpySession', () => ({
         },
       })),
     },
-    control: {},
+    control: {
+      touchDown: vi.fn(),
+      touchMove: vi.fn(),
+      touchUp: vi.fn(),
+      pinchStart: vi.fn(),
+      pinchMove: vi.fn(),
+      pinchEnd: vi.fn(),
+    },
   })),
 }))
 

--- a/packages/android-agent/src/__tests__/ScrcpyControl.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyControl.test.ts
@@ -56,6 +56,53 @@ describe('ScrcpyControl', () => {
     })
   })
 
+  describe('pinchStart', () => {
+    it('sends touchDown for pointerId 0 then pointerId 1', () => {
+      ctrl.pinchStart(100, 200, 300, 400)
+      expect(socket.write).toHaveBeenCalledTimes(2)
+      const buf0: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const buf1: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[1][0]
+      expect(buf0.readUInt8(1)).toBe(0)           // action DOWN
+      expect(buf0.readBigInt64BE(2)).toBe(0n)     // pointerId 0
+      expect(buf0.readInt32BE(10)).toBe(100)
+      expect(buf0.readInt32BE(14)).toBe(200)
+      expect(buf1.readUInt8(1)).toBe(0)           // action DOWN
+      expect(buf1.readBigInt64BE(2)).toBe(1n)     // pointerId 1
+      expect(buf1.readInt32BE(10)).toBe(300)
+      expect(buf1.readInt32BE(14)).toBe(400)
+    })
+  })
+
+  describe('pinchMove', () => {
+    it('sends touchMove for pointerId 0 then pointerId 1', () => {
+      ctrl.pinchMove(110, 210, 310, 410)
+      expect(socket.write).toHaveBeenCalledTimes(2)
+      const buf0: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const buf1: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[1][0]
+      expect(buf0.readUInt8(1)).toBe(2)           // action MOVE
+      expect(buf0.readBigInt64BE(2)).toBe(0n)
+      expect(buf0.readInt32BE(10)).toBe(110)
+      expect(buf1.readUInt8(1)).toBe(2)
+      expect(buf1.readBigInt64BE(2)).toBe(1n)
+      expect(buf1.readInt32BE(10)).toBe(310)
+    })
+  })
+
+  describe('pinchEnd', () => {
+    it('sends touchUp for pointerId 0 then pointerId 1 with zero pressure', () => {
+      ctrl.pinchEnd()
+      expect(socket.write).toHaveBeenCalledTimes(2)
+      const buf0: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const buf1: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[1][0]
+      expect(buf0.readUInt8(1)).toBe(1)           // action UP
+      expect(buf0.readBigInt64BE(2)).toBe(0n)
+      expect(buf0.readUInt16BE(22)).toBe(0)       // pressure = 0
+      expect(buf1.readUInt8(1)).toBe(1)
+      expect(buf1.readBigInt64BE(2)).toBe(1n)
+      expect(buf1.readUInt16BE(22)).toBe(0)
+    })
+  })
+
   describe('keyEvent', () => {
     it('writes TYPE_INJECT_KEYCODE with given keyCode', () => {
       ctrl.keyEvent(4) // BACK

--- a/packages/android-agent/src/scrcpy/ScrcpyControl.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyControl.ts
@@ -43,6 +43,21 @@ export class ScrcpyControl {
     this.writeTouchEvent(ACTION_UP, pointerId, x, y)
   }
 
+  pinchStart(x1: number, y1: number, x2: number, y2: number): void {
+    this.touchDown(0, x1, y1)
+    this.touchDown(1, x2, y2)
+  }
+
+  pinchMove(x1: number, y1: number, x2: number, y2: number): void {
+    this.touchMove(0, x1, y1)
+    this.touchMove(1, x2, y2)
+  }
+
+  pinchEnd(): void {
+    this.touchUp(0)
+    this.touchUp(1)
+  }
+
   keyEvent(keyCode: number): void {
     const buf = Buffer.allocUnsafe(14)
     buf.writeUInt8(TYPE_INJECT_KEYCODE, 0)

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -282,6 +282,7 @@ export function AndroidViewer({
       if (!fingers) return
       isPinchMode.current = true; setPinchActive(true)
       ;(e.target as Element).setPointerCapture(e.pointerId)
+      const _lc = liveCursorRef.current; if (_lc) _lc.style.display = 'none'
       setPinchHint(fingers)
       send({ type: 'input:pinch:start', sessionId, payload: fingers })
       return
@@ -308,7 +309,9 @@ export function AndroidViewer({
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     if (e.buttons === 0) {
       if (isOptionHeld.current) {
-        setPinchHint(toPinchFingers(e)); cursorPosRef.current = null; return
+        setPinchHint(toPinchFingers(e)); cursorPosRef.current = null
+        const _lc = liveCursorRef.current; if (_lc) _lc.style.display = 'none'
+        return
       }
       const norm = toNorm(e)
       const _r = (e.currentTarget as Element).getBoundingClientRect()


### PR DESCRIPTION
## Root cause

Android pinch was visually shown (dashboard hint overlay) but never reached the device. Three bugs stacked:

| # | 위치 | 버그 |
|---|------|------|
| 1 | `AndroidAgent.ts` | `input:pinch:start/move` payload를 `{x1,y1,x2,y2}`로 파싱 — 실제 payload는 `{f0,f1}` 형식이라 항상 `undefined` |
| 2 | `AndroidAgent.ts` | pinch 이벤트가 `touchHelper.pinchStart/Move/End()`(빈 스텁)로만 라우팅됨 — `touch:start/move/end`와 달리 scrcpy 경로가 없었음 |
| 3 | `ScrcpyControl.ts` | `pinchStart/Move/End` 메서드 자체가 없었음 |

## Fix

- `ScrcpyControl`: `pinchStart(x1,y1,x2,y2)` / `pinchMove` / `pinchEnd` 추가 — pointerId 0+1로 두 개의 `INJECT_TOUCH_EVENT` 전송
- `AndroidAgent`: pinch 세 케이스 모두 `touch:start/move/end`와 동일한 scrcpy 우선 라우팅 패턴 적용, payload 파싱을 `{f0, f1}`로 수정

## Test plan

- [x] ScrcpyControl pinch 단위 테스트 3개 신규 추가 (pinchStart/Move/End 각 2회 write 검증)
- [x] AndroidAgent mock `control` 객체에 pinch 메서드 추가 (기존 15개 테스트 회귀 없음)
- [x] Android 에뮬레이터에서 Option 키 + 마우스로 핀치 인/아웃 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced multi-touch pinch gesture support with improved coordinate translation and graceful fallback for more accurate pinch control.

* **Bug Fixes**
  * Live cursor overlay is now hidden immediately when entering pinch mode to prevent visual artifacts.

* **Tests**
  * Added and updated tests to validate multi-touch pinch behavior and to reflect the new control interface used in tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->