### PR TITLE
feat: WebSocket backpressure + docs & skeleton fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
-[▶ Watch demo](https://www.tapflow.dev/guide/introduction.html#introduction)
+[▶ Watch demo](https://www.tapflow.dev/guide/introduction)
 
 ---
 
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://jo-duchan.github.io/tapflow/guide/self-hosting).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
 
@@ -151,20 +151,23 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset` | Shut down all simulators and emulators |
 | `tapflow logs` | Show recent relay log entries |
 
-Full reference → [CLI docs](https://jo-duchan.github.io/tapflow/reference/cli)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
-**[jo-duchan.github.io/tapflow](https://jo-duchan.github.io/tapflow)**
+**[www.tapflow.dev](https://www.tapflow.dev)**
 
-- [Introduction](https://jo-duchan.github.io/tapflow/guide/introduction)
-- [Quick Start](https://jo-duchan.github.io/tapflow/guide/getting-started)
-- [Self-Hosting the Relay](https://jo-duchan.github.io/tapflow/guide/self-hosting)
-- [iOS Agent Setup](https://jo-duchan.github.io/tapflow/guide/ios-agent)
-- [Android Agent Setup](https://jo-duchan.github.io/tapflow/guide/android-agent)
-- [Uploading Builds (CI/CD)](https://jo-duchan.github.io/tapflow/guide/upload-builds)
-- [CLI Reference](https://jo-duchan.github.io/tapflow/reference/cli)
-- [Troubleshooting](https://jo-duchan.github.io/tapflow/guide/troubleshooting)
+- [Introduction](https://www.tapflow.dev/guide/introduction)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
+- [iOS Agent Setup](https://www.tapflow.dev/guide/ios-agent)
+- [Android Agent Setup](https://www.tapflow.dev/guide/android-agent)
+- [App Center — Upload & Manage Builds](https://www.tapflow.dev/guide/app-center)
+- [Team Management & Access Tokens](https://www.tapflow.dev/guide/team-management)
+- [Session Recordings](https://www.tapflow.dev/guide/recordings)
+- [Uploading Builds via CI/CD](https://www.tapflow.dev/guide/upload-builds)
+- [CLI Reference](https://www.tapflow.dev/reference/cli)
+- [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -157,17 +157,27 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
+**Getting Started**
 - [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Quick Start](https://www.tapflow.dev/guide/quick-start)
+- [Requirements](https://www.tapflow.dev/guide/requirements)
+
+**Setup**
 - [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [iOS Agent Setup](https://www.tapflow.dev/guide/ios-agent)
-- [Android Agent Setup](https://www.tapflow.dev/guide/android-agent)
-- [App Center — Upload & Manage Builds](https://www.tapflow.dev/guide/app-center)
-- [Team Management & Access Tokens](https://www.tapflow.dev/guide/team-management)
-- [Session Recordings](https://www.tapflow.dev/guide/recordings)
-- [Uploading Builds via CI/CD](https://www.tapflow.dev/guide/upload-builds)
+- [Agent Setup](https://www.tapflow.dev/guide/agent-setup)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
+
+**Dashboard**
+- [First-time Setup](https://www.tapflow.dev/guide/first-time-setup)
+- [Dashboard Overview](https://www.tapflow.dev/guide/dashboard-overview)
+
+**Reference**
 - [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- [Configuration](https://www.tapflow.dev/reference/configuration)
+- [REST API](https://www.tapflow.dev/reference/rest-api)
+
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Breaking changes may appear in minor versions until `v1.0.0` is tagged.
 | CLI (`start`, `doctor`, `devices`, …) | ✅ Working |
 | Test coverage (cli, dashboard) | ✅ Working |
 | Structured logging | ✅ Working |
-| WebSocket backpressure | ❌ Missing |
+| WebSocket backpressure | ✅ Working |
 
 ---
 
@@ -54,7 +54,7 @@ Developer experience and reliability improvements. `v0.2.0` drops the `-alpha` s
 
 Scalability, extensibility, and CI/CD integration.
 
-- [ ] WebSocket backpressure — check `ws.bufferedAmount` before sending frames; drop or queue frames for slow clients
+- [x] WebSocket backpressure — check `ws.bufferedAmount` before sending frames; drop or queue frames for slow clients
 - [ ] Runtime platform registration — replace `'ios' | 'android'` literal union with a dynamic registry so new platforms require zero changes to `agent-core`, CLI, or Dashboard
 - [ ] CI/CD integration guide — end-to-end walkthrough: upload `.app.zip` / `.apk` via REST API from CI → view results in the dashboard
 - [ ] PAT scope enforcement — apply `scope` checks consistently across all endpoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Developer experience and reliability improvements. `v0.2.0` drops the `-alpha` s
 
 - [x] Pre-commit hooks — add Lefthook with lint + typecheck on staged files to catch errors before push
 - [x] `logger.ts` abstraction — replace 66 direct `console.log/error` calls with a leveled logger (`debug` / `info` / `warn` / `error`)
-- [ ] Custom error classes — `ValidationError`, `PlatformError`, `AuthError`
+- [x] Custom error classes — `ValidationError`, `PlatformError`, `AuthError`
 - [x] CLI smoke tests — `--version`, `--help` subprocess smoke tests via tsx
 - [x] Zod-based config validation — catch `NaN` and invalid values at startup instead of silently at runtime
 - [x] Migration atomic transactions — wrap all migrations in `db.transaction()` to prevent partial failure states

--- a/packages/agent-core/src/__tests__/stream.test.ts
+++ b/packages/agent-core/src/__tests__/stream.test.ts
@@ -1,12 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EventEmitter } from 'events'
 import type { WebSocket as WsType } from 'ws'
-import { registerStreamWs } from '../utils/stream'
+import {
+  registerStreamWs,
+  sendBinaryWithBackpressure,
+  createRateLimitedDropWarn,
+  DEFAULT_BACKPRESSURE_BYTES,
+} from '../utils/stream'
+import type { Logger } from '../logger'
 
-function makeMockWs(): WsType & EventEmitter {
-  const emitter = new EventEmitter() as WsType & EventEmitter
-  emitter.send = vi.fn()
-  return emitter
+function makeMockWs(props?: { readyState?: number; bufferedAmount?: number }): WsType & EventEmitter {
+  const emitter = new EventEmitter()
+  const ws = Object.assign(emitter, {
+    send: vi.fn(),
+    readyState: props?.readyState ?? 1, // OPEN
+    bufferedAmount: props?.bufferedAmount ?? 0,
+    OPEN: 1,
+    CLOSED: 3,
+  }) as unknown as WsType & EventEmitter
+  return ws
+}
+
+function makeMockLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }
 
 describe('registerStreamWs', () => {
@@ -62,5 +78,81 @@ describe('registerStreamWs', () => {
     const promise = registerStreamWs(ws, 'sess-err2')
     ws.emit('error', new Error('early error'))
     await expect(promise).rejects.toThrow('early error')
+  })
+})
+
+describe('sendBinaryWithBackpressure', () => {
+  const THRESHOLD = 1024
+  const frame = Buffer.from('frame')
+
+  it('정상 클라이언트: bufferedAmount < threshold → send 호출', () => {
+    const ws = makeMockWs({ readyState: 1, bufferedAmount: 0 })
+    const onDrop = vi.fn()
+    sendBinaryWithBackpressure(ws, frame, THRESHOLD, onDrop)
+    expect(ws.send).toHaveBeenCalledOnce()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('느린 클라이언트: bufferedAmount >= threshold → drop, send 없음', () => {
+    const ws = makeMockWs({ readyState: 1, bufferedAmount: THRESHOLD })
+    const onDrop = vi.fn()
+    sendBinaryWithBackpressure(ws, frame, THRESHOLD, onDrop)
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(onDrop).toHaveBeenCalledOnce()
+  })
+
+  it('임계치 바로 아래 (threshold - 1) → send 호출', () => {
+    const ws = makeMockWs({ readyState: 1, bufferedAmount: THRESHOLD - 1 })
+    const onDrop = vi.fn()
+    sendBinaryWithBackpressure(ws, frame, THRESHOLD, onDrop)
+    expect(ws.send).toHaveBeenCalledOnce()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('닫힌 소켓(CLOSED): send도 drop도 호출하지 않는다', () => {
+    const ws = makeMockWs({ readyState: 3, bufferedAmount: 0 })
+    const onDrop = vi.fn()
+    sendBinaryWithBackpressure(ws, frame, THRESHOLD, onDrop)
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('DEFAULT_BACKPRESSURE_BYTES는 1MB(1_048_576)이다', () => {
+    expect(DEFAULT_BACKPRESSURE_BYTES).toBe(1_048_576)
+  })
+})
+
+describe('createRateLimitedDropWarn', () => {
+  it('intervalMs 안에서는 warn을 1번만 호출한다', () => {
+    vi.useFakeTimers()
+    const logger = makeMockLogger()
+    const onDrop = createRateLimitedDropWarn(logger, 'test-ctx', 1000)
+
+    for (let i = 0; i < 100; i++) onDrop()
+
+    expect(logger.warn).toHaveBeenCalledOnce()
+    vi.useRealTimers()
+  })
+
+  it('intervalMs 경과 후에는 다시 warn을 호출한다', () => {
+    vi.useFakeTimers()
+    const logger = makeMockLogger()
+    const onDrop = createRateLimitedDropWarn(logger, 'test-ctx', 1000)
+
+    onDrop()
+    vi.advanceTimersByTime(1001)
+    onDrop()
+
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('warn 메시지에 context가 포함된다', () => {
+    vi.useFakeTimers()
+    const logger = makeMockLogger()
+    const onDrop = createRateLimitedDropWarn(logger, 'sess-xyz', 1000)
+    onDrop()
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('sess-xyz')
+    vi.useRealTimers()
   })
 })

--- a/packages/agent-core/src/utils/index.ts
+++ b/packages/agent-core/src/utils/index.ts
@@ -1,2 +1,7 @@
 export { createResourceSampler } from './resources.js'
-export { registerStreamWs } from './stream.js'
+export {
+  registerStreamWs,
+  sendBinaryWithBackpressure,
+  createRateLimitedDropWarn,
+  DEFAULT_BACKPRESSURE_BYTES,
+} from './stream.js'

--- a/packages/agent-core/src/utils/stream.ts
+++ b/packages/agent-core/src/utils/stream.ts
@@ -1,4 +1,41 @@
 import { WebSocket } from 'ws'
+import type { Logger } from '../logger.js'
+
+export const DEFAULT_BACKPRESSURE_BYTES = 1_048_576 // 1 MB
+
+export function sendBinaryWithBackpressure(
+  ws: WebSocket,
+  data: Parameters<WebSocket['send']>[0],
+  threshold: number,
+  onDrop: () => void,
+): void {
+  if (ws.readyState !== WebSocket.OPEN) return
+  if (ws.bufferedAmount >= threshold) {
+    onDrop()
+    return
+  }
+  ws.send(data, { binary: true })
+}
+
+// Returns a rate-limited warn callback for use as onDrop.
+// At most one warn per intervalMs per call site; resets the drop counter after each warn.
+export function createRateLimitedDropWarn(
+  logger: Logger,
+  context: string,
+  intervalMs = 1000,
+): () => void {
+  let lastWarnAt = 0
+  let dropCount = 0
+  return () => {
+    dropCount++
+    const now = Date.now()
+    if (now - lastWarnAt >= intervalMs) {
+      lastWarnAt = now
+      logger.warn(`ws backpressure: ${dropCount} frame(s) dropped [${context}]`)
+      dropCount = 0
+    }
+  }
+}
 
 // Performs the stream:register handshake on an already-created WebSocket.
 // Caller is responsible for creating the WebSocket and storing it for cleanup before calling this.

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -2,7 +2,13 @@ import os from 'os'
 import { WebSocket } from 'ws'
 import type { AndroidButton, Device, DeviceAgent } from '@tapflowio/agent-core'
 import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
-import { createResourceSampler, registerStreamWs } from '@tapflowio/agent-core/utils'
+import {
+  createResourceSampler,
+  registerStreamWs,
+  sendBinaryWithBackpressure,
+  createRateLimitedDropWarn,
+  DEFAULT_BACKPRESSURE_BYTES,
+} from '@tapflowio/agent-core/utils'
 import { AdbWrapper } from './AdbWrapper.js'
 import { EmulatorLauncher } from './EmulatorLauncher.js'
 import { AndroidTouchHelper } from './AndroidTouchHelper.js'
@@ -282,6 +288,9 @@ export class AndroidAgent implements DeviceAgent {
     const stream = session.video.start()
     const reader = stream.getReader()
 
+    const threshold = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) || DEFAULT_BACKPRESSURE_BYTES
+    const onDrop = createRateLimitedDropWarn(logger, state.deviceId)
+
     const pump = async () => {
       try {
         while (true) {
@@ -296,7 +305,7 @@ export class AndroidAgent implements DeviceAgent {
             state.scrcpySession?.control.updateScreenSize(parsed.width, parsed.height)
             logger.info(`video size → ${parsed.width}×${parsed.height}`)
           }
-          if (streamWs.readyState === WebSocket.OPEN) streamWs.send(value)
+          sendBinaryWithBackpressure(streamWs, value, threshold, onDrop)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,17 +157,27 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
+**Getting Started**
 - [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Quick Start](https://www.tapflow.dev/guide/quick-start)
+- [Requirements](https://www.tapflow.dev/guide/requirements)
+
+**Setup**
 - [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [iOS Agent Setup](https://www.tapflow.dev/guide/ios-agent)
-- [Android Agent Setup](https://www.tapflow.dev/guide/android-agent)
-- [App Center — Upload & Manage Builds](https://www.tapflow.dev/guide/app-center)
-- [Team Management & Access Tokens](https://www.tapflow.dev/guide/team-management)
-- [Session Recordings](https://www.tapflow.dev/guide/recordings)
-- [Uploading Builds via CI/CD](https://www.tapflow.dev/guide/upload-builds)
+- [Agent Setup](https://www.tapflow.dev/guide/agent-setup)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
+
+**Dashboard**
+- [First-time Setup](https://www.tapflow.dev/guide/first-time-setup)
+- [Dashboard Overview](https://www.tapflow.dev/guide/dashboard-overview)
+
+**Reference**
 - [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- [Configuration](https://www.tapflow.dev/reference/configuration)
+- [REST API](https://www.tapflow.dev/reference/rest-api)
+
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://jo-duchan.github.io/tapflow/guide/self-hosting).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
 
@@ -151,20 +151,23 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset`                     | Shut down all simulators and emulators          |
 | `tapflow logs`                      | Show recent relay log entries                   |
 
-Full reference → [CLI docs](https://jo-duchan.github.io/tapflow/reference/cli)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
-**[jo-duchan.github.io/tapflow](https://jo-duchan.github.io/tapflow)**
+**[www.tapflow.dev](https://www.tapflow.dev)**
 
-- [Introduction](https://jo-duchan.github.io/tapflow/guide/introduction)
-- [Quick Start](https://jo-duchan.github.io/tapflow/guide/getting-started)
-- [Self-Hosting the Relay](https://jo-duchan.github.io/tapflow/guide/self-hosting)
-- [iOS Agent Setup](https://jo-duchan.github.io/tapflow/guide/ios-agent)
-- [Android Agent Setup](https://jo-duchan.github.io/tapflow/guide/android-agent)
-- [Uploading Builds (CI/CD)](https://jo-duchan.github.io/tapflow/guide/upload-builds)
-- [CLI Reference](https://jo-duchan.github.io/tapflow/reference/cli)
-- [Troubleshooting](https://jo-duchan.github.io/tapflow/guide/troubleshooting)
+- [Introduction](https://www.tapflow.dev/guide/introduction)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
+- [iOS Agent Setup](https://www.tapflow.dev/guide/ios-agent)
+- [Android Agent Setup](https://www.tapflow.dev/guide/android-agent)
+- [App Center — Upload & Manage Builds](https://www.tapflow.dev/guide/app-center)
+- [Team Management & Access Tokens](https://www.tapflow.dev/guide/team-management)
+- [Session Recordings](https://www.tapflow.dev/guide/recordings)
+- [Uploading Builds via CI/CD](https://www.tapflow.dev/guide/upload-builds)
+- [CLI Reference](https://www.tapflow.dev/reference/cli)
+- [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
 
 ## Development
 

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -22,7 +22,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   const port = portResult.data
   initConfigFile()
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port, uploadsDir: path.join(config.server.dataDir, 'uploads') })
+  const server = new RelayServer({ port, uploadsDir: path.join(config.server.dataDir, 'uploads'), wsBackpressureBytes: config.server.wsBackpressureBytes })
   await server.start()
   step(`Relay started on ws://localhost:${port}`)
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -24,7 +24,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
   // ── 1. Relay (always local) ───────────────────────────────────────────────
   initConfigFile()
   initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.server.dataDir, 'uploads') })
+  const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.server.dataDir, 'uploads'), wsBackpressureBytes: config.server.wsBackpressureBytes })
   await server.start()
   step(`Relay started on ws://localhost:${RELAY_PORT}`)
 

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -114,7 +114,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
         <div className="flex items-start gap-8">
           {/* phone body skeleton */}
           <div style={{ background: '#1c1c1e', borderRadius: '34px', padding: '12px', flexShrink: 0 }}>
-            <div className="animate-pulse bg-zinc-800" style={{ width: 324, height: 720, borderRadius: '22px' }} />
+            <div className="animate-pulse bg-zinc-600" style={{ width: 324, height: 720, borderRadius: '22px' }} />
           </div>
           <SimulatorInfoCard
             joined={joined} fps={0} connected={connected}

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -114,7 +114,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
         <div className="flex items-start gap-8">
           {/* phone body skeleton */}
           <div style={{ background: '#1c1c1e', borderRadius: '34px', padding: '12px', flexShrink: 0 }}>
-            <div className="animate-pulse bg-zinc-600" style={{ width: 324, height: 720, borderRadius: '22px' }} />
+            <div className="animate-pulse bg-zinc-700" style={{ width: 324, height: 720, borderRadius: '22px' }} />
           </div>
           <SimulatorInfoCard
             joined={joined} fps={0} connected={connected}

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -455,7 +455,7 @@ export function AndroidViewer({
                 onPointerLeave={handlePointerLeave}
               />
               {!canvasReady && (
-                <div className="absolute inset-0 animate-pulse bg-zinc-600" />
+                <div className="absolute inset-0 animate-pulse bg-zinc-700" />
               )}
               {!canvasReady && deviceReady && (
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -455,7 +455,7 @@ export function AndroidViewer({
                 onPointerLeave={handlePointerLeave}
               />
               {!canvasReady && (
-                <div className="absolute inset-0 animate-pulse bg-zinc-800" />
+                <div className="absolute inset-0 animate-pulse bg-zinc-600" />
               )}
               {!canvasReady && deviceReady && (
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -482,7 +482,7 @@ export function IOSViewer({
               }}
             />
             {!canvasReady && (
-              <div className="absolute animate-pulse bg-zinc-800" style={{
+              <div className="absolute animate-pulse bg-zinc-600" style={{
                 zIndex: 3, left: `${screenPctLeft}%`, top: `${screenPctTop}%`,
                 width: `${screenPctW}%`, height: `${screenPctH}%`,
                 borderRadius: cssCornerRadius > 0 ? `${cssCornerRadius}px` : undefined,

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -482,7 +482,7 @@ export function IOSViewer({
               }}
             />
             {!canvasReady && (
-              <div className="absolute animate-pulse bg-zinc-600" style={{
+              <div className="absolute animate-pulse bg-zinc-700" style={{
                 zIndex: 3, left: `${screenPctLeft}%`, top: `${screenPctTop}%`,
                 width: `${screenPctW}%`, height: `${screenPctH}%`,
                 borderRadius: cssCornerRadius > 0 ? `${cssCornerRadius}px` : undefined,

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -9,7 +9,13 @@ import type { Device, DeviceAgent } from '@tapflowio/agent-core'
 import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 
 const logger = createLogger('ios-agent')
-import { createResourceSampler, registerStreamWs } from '@tapflowio/agent-core/utils'
+import {
+  createResourceSampler,
+  registerStreamWs,
+  sendBinaryWithBackpressure,
+  createRateLimitedDropWarn,
+  DEFAULT_BACKPRESSURE_BYTES,
+} from '@tapflowio/agent-core/utils'
 import { SimctlWrapper } from './SimctlWrapper.js'
 import { ScreenCaptureStreamer } from './ScreenCaptureStreamer.js'
 import { MjpegStreamer } from './MjpegStreamer.js'
@@ -190,14 +196,15 @@ export class IOSAgent implements DeviceAgent {
     const reader = stream.getReader()
     state.streamReader = reader
 
+    const threshold = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) || DEFAULT_BACKPRESSURE_BYTES
+    const onDrop = createRateLimitedDropWarn(logger, state.deviceId)
+
     const pump = async () => {
       try {
         while (true) {
           const { value, done } = await reader.read()
           if (done) break
-          if (streamWs.readyState === WebSocket.OPEN) {
-            streamWs.send(value)
-          }
+          sendBinaryWithBackpressure(streamWs, value, threshold, onDrop)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect

--- a/packages/relay/CLAUDE.md
+++ b/packages/relay/CLAUDE.md
@@ -58,7 +58,7 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 
 ## Compound
 
-### Binary Frame Forwarding
+### Binary Frame Forwarding with Backpressure
 
 **When**: relaying WebSocket binary messages from the Agent to the Browser
 
@@ -66,9 +66,14 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 ```typescript
 ws.on('message', (data, isBinary) => {
   if (isBinary) {
-    const session = this.sessions.getBySocket(ws)
-    if (session?.browserSocket?.readyState === WebSocket.OPEN) {
-      session.browserSocket.send(data, { binary: true })
+    const session = this.sessions.getByStreamSocket(ws)
+    if (session?.browserSocket) {
+      let onDrop = this.dropHandlers.get(session.id)
+      if (!onDrop) {
+        onDrop = createRateLimitedDropWarn(logger, session.id)
+        this.dropHandlers.set(session.id, onDrop)
+      }
+      sendBinaryWithBackpressure(session.browserSocket, data as Buffer, this.backpressureBytes, onDrop)
     }
     return
   }
@@ -79,4 +84,8 @@ ws.on('message', (data, isBinary) => {
 })
 ```
 
-**Why**: Omitting `{ binary: true }` causes the `ws` library to send the Buffer as UTF-8 text, making `e.data` a string in the browser. The relay must be content-agnostic and incur zero parsing cost.
+**Why**:
+- Omitting `{ binary: true }` causes the `ws` library to send the Buffer as UTF-8 text, making `e.data` a string in the browser. The relay must be content-agnostic and incur zero parsing cost.
+- `sendBinaryWithBackpressure` checks `ws.bufferedAmount` before sending. If it exceeds `wsBackpressureBytes` (default 1 MB, override via `TAPFLOW_WS_BACKPRESSURE_BYTES`), the frame is silently dropped. This prevents unbounded memory growth when a browser client is slow.
+- Drop handlers are stored per session (`this.dropHandlers`) and rate-limit warn logs to at most once per second to avoid log flooding.
+- Drop handlers must be deleted from the map on `session:end`.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -9,6 +9,11 @@ import { getDb } from './db.js'
 import { handleLogin, handleLogout, handleMe, handleChangePassword, handleInit } from './api/auth.js'
 import { handleVerify, handleAccept } from './api/invitations.js'
 import { createLogger } from '@tapflowio/agent-core'
+import {
+  sendBinaryWithBackpressure,
+  createRateLimitedDropWarn,
+  DEFAULT_BACKPRESSURE_BYTES,
+} from '@tapflowio/agent-core/utils'
 
 const logger = createLogger('relay')
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
@@ -50,8 +55,11 @@ export class RelayServer {
   private purgeRecordingsTimer: ReturnType<typeof setInterval> | null = null
   private purgeOldResourcesTimer: ReturnType<typeof setInterval> | null = null
   private flushResourcesTimer: ReturnType<typeof setInterval> | null = null
+  private dropHandlers = new Map<string, () => void>()
+  private readonly backpressureBytes: number
 
-  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number }) {
+  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number; wsBackpressureBytes?: number }) {
+    this.backpressureBytes = options.wsBackpressureBytes ?? DEFAULT_BACKPRESSURE_BYTES
     this.sessions = new SessionManager({ idleTimeoutMs: options.idleTimeoutMs })
     this.publicDir = options.publicDir ?? path.join(import.meta.dirname, '../public')
     this.uploadsDir = options.uploadsDir ?? path.join(import.meta.dirname, '../uploads')
@@ -186,8 +194,13 @@ export class RelayServer {
       if (isBinary) {
         // Binary frames arrive on the dedicated stream WS, route to the session's browser
         const session = this.sessions.getByStreamSocket(ws)
-        if (session?.browserSocket?.readyState === WebSocket.OPEN) {
-          session.browserSocket.send(data, { binary: true })
+        if (session?.browserSocket) {
+          let onDrop = this.dropHandlers.get(session.id)
+          if (!onDrop) {
+            onDrop = createRateLimitedDropWarn(logger, session.id)
+            this.dropHandlers.set(session.id, onDrop)
+          }
+          sendBinaryWithBackpressure(session.browserSocket, data as Buffer, this.backpressureBytes, onDrop)
         }
         return
       }
@@ -245,7 +258,10 @@ export class RelayServer {
       // ── Session / Stream lifecycle ─────────────────────────────────────────
       case 'session:start':    this.handleSessionStart(ws, msg); break
       case 'session:end': {
-        if (msg.sessionId) this.sessions.remove(msg.sessionId)
+        if (msg.sessionId) {
+          this.sessions.remove(msg.sessionId)
+          this.dropHandlers.delete(msg.sessionId)
+        }
         break
       }
       case 'stream:register': {

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -367,6 +367,49 @@ describe('RelayServer', () => {
     streamA.close()
   })
 
+  it('wsBackpressureBytes: 0 → binary frames are never forwarded to browser', async () => {
+    // Use a fresh server with threshold=0 so bufferedAmount(0) >= threshold(0) is always true
+    const strictServer = new RelayServer({ port: 0, wsBackpressureBytes: 0 })
+    await strictServer.start()
+    const strictPort = (strictServer.address() as { port: number }).port
+
+    try {
+      const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+      const agent = new WebSocket(`ws://localhost:${strictPort}`)
+      await waitForOpen(agent)
+      agent.send(JSON.stringify({ type: 'agent:register', devices }))
+      const { registeredSessions } = await waitForMessage(agent)
+      const sessionId = registeredSessions![0].sessionId
+
+      const browser = new WebSocket(`ws://localhost:${strictPort}`)
+      browser.binaryType = 'nodebuffer'
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      await waitForMessage(browser) // session:joined
+
+      const streamWs = new WebSocket(`ws://localhost:${strictPort}`)
+      await waitForOpen(streamWs)
+      streamWs.send(JSON.stringify({ type: 'stream:register', sessionId }))
+      await waitForMessage(streamWs) // stream:registered
+
+      let binaryReceived = false
+      browser.on('message', (_d, isBinary) => { if (isBinary) binaryReceived = true })
+
+      streamWs.send(Buffer.from([0xff, 0xd8, 0xff]))
+      // Wait a tick for any forwarding to happen
+      await new Promise<void>((r) => setImmediate(r))
+      await new Promise<void>((r) => setTimeout(r, 20))
+
+      expect(binaryReceived).toBe(false)
+
+      agent.close()
+      browser.close()
+      streamWs.close()
+    } finally {
+      await strictServer.stop()
+    }
+  })
+
   it('agents:listed groups devices by agent and includes sessionId per device', async () => {
     const devices = [
       { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },

--- a/packages/relay/src/__tests__/config.test.ts
+++ b/packages/relay/src/__tests__/config.test.ts
@@ -26,7 +26,23 @@ describe('relay config validation', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { config } = await import('../lib/config.js')
     expect(config.server.port).toBe(4000)
+    expect(config.server.wsBackpressureBytes).toBe(1_048_576)
     expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('TAPFLOW_WS_BACKPRESSURE_BYTES=524288 → 적용됨', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubEnv('TAPFLOW_WS_BACKPRESSURE_BYTES', '524288')
+    const { config } = await import('../lib/config.js')
+    expect(config.server.wsBackpressureBytes).toBe(524288)
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('TAPFLOW_WS_BACKPRESSURE_BYTES=0 → exit(1) (min 1 위반)', async () => {
+    vi.stubEnv('TAPFLOW_WS_BACKPRESSURE_BYTES', '0')
+    await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('wsBackpressureBytes'))
   })
 
   it('TAPFLOW_PORT=abc → exit(1) + 에러 로그', async () => {

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -11,6 +11,7 @@ const configSchema = z.object({
   server: z.object({
     port: z.number().int().min(1).max(65535),
     dataDir: z.string().min(1),
+    wsBackpressureBytes: z.number().int().min(1),
   }),
   smtp: z.object({
     host: z.string(),
@@ -30,6 +31,7 @@ const DEFAULTS = {
   server: {
     port: 4000,
     dataDir: '.tapflow-data',
+    wsBackpressureBytes: 1_048_576,
   },
   smtp: {
     host: '',
@@ -65,6 +67,7 @@ function load(): TapflowConfig {
     server: {
       port: file.server?.port ?? DEFAULTS.server.port,
       dataDir: resolveDataDir(file.server?.dataDir ?? DEFAULTS.server.dataDir),
+      wsBackpressureBytes: DEFAULTS.server.wsBackpressureBytes,
     },
     smtp: {
       host: file.smtp?.host ?? DEFAULTS.smtp.host,
@@ -78,6 +81,7 @@ function load(): TapflowConfig {
 
   if (process.env.TAPFLOW_PORT) cfg.server.port = Number(process.env.TAPFLOW_PORT)
   if (process.env.TAPFLOW_DATA_DIR) cfg.server.dataDir = resolveDataDir(process.env.TAPFLOW_DATA_DIR)
+  if (process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) cfg.server.wsBackpressureBytes = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES)
   if (process.env.SMTP_HOST) cfg.smtp.host = process.env.SMTP_HOST
   if (process.env.SMTP_PORT) cfg.smtp.port = Number(process.env.SMTP_PORT)
   if (process.env.SMTP_SECURE) cfg.smtp.secure = process.env.SMTP_SECURE === 'true'

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -12,7 +12,7 @@ const uploadsDir = path.join(dataDir, 'uploads')
 
 initDb(dbPath)
 
-const server = new RelayServer({ port, uploadsDir })
+const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.server.wsBackpressureBytes })
 
 void server.start().then(() => {
   logger.info(`tapflow relay running on port ${port}`)


### PR DESCRIPTION
## Summary

- **WebSocket backpressure** (Closes #40): `ws.bufferedAmount` 체크를 모든 바이너리 프레임 송신 지점에 추가. 브라우저 클라이언트가 느릴 때 relay 메모리가 무한히 쌓이는 문제를 해결. 임계치 초과 시 프레임을 조용히 드롭하고 rate-limited warn 로그 출력.
- **Docs**: 모든 문서 링크를 `jo-duchan.github.io/tapflow` → `www.tapflow.dev`로 교체, Documentation 섹션을 현재 사이드바 구조에 맞게 업데이트.
- **Dashboard**: 디바이스 부팅 전 스켈레톤 색상 `bg-zinc-800` → `bg-zinc-700`으로 변경해 어두운 폰 배경 대비 가시성 개선.

## Changes

### feat: WebSocket backpressure (`agent-core`, `relay`, `ios-agent`, `android-agent`)
- `agent-core/utils/stream.ts`: `sendBinaryWithBackpressure` + `createRateLimitedDropWarn` + `DEFAULT_BACKPRESSURE_BYTES` 추가
- `relay/RelayServer.ts`: per-session drop handler, `wsBackpressureBytes` 옵션 (기본 1 MB)
- `relay/lib/config.ts`: `TAPFLOW_WS_BACKPRESSURE_BYTES` 환경변수 지원 (Zod 검증)
- `ios-agent/IOSAgent.ts`, `android-agent/AndroidAgent.ts`: agent→relay 경로에 방어적 backpressure 가드 적용
- 테스트: `sendBinaryWithBackpressure` 단위 테스트, relay threshold=0 통합 테스트, config 검증 테스트

### fix: Dashboard skeleton visibility
- `DeviceViewer.tsx`, `IOSViewer.tsx`, `AndroidViewer.tsx`: 스켈레톤 `bg-zinc-800` → `bg-zinc-700`

### docs: Documentation link updates
- root `README.md`, `packages/cli/README.md`: 전체 도메인 교체 + Getting Started / Setup / Dashboard / Reference 섹션 구조 반영

## Test plan

- [ ] `pnpm test` 전체 통과 확인
- [ ] relay `wsBackpressureBytes: 0` 테스트 → 프레임 드롭 로그 출력 확인
- [ ] `TAPFLOW_WS_BACKPRESSURE_BYTES=524288` 설정 후 config 파싱 확인
- [ ] 대시보드 — 디바이스 부팅 전 스켈레톤이 어두운 폰 배경에서 보이는지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented WebSocket backpressure management for device streaming that intelligently controls frame forwarding based on socket buffer state with configurable drop thresholds and automatic rate-limited warnings.
  * Added configurable backpressure byte thresholds via environment variables with sensible defaults.

* **Documentation**
  * Updated documentation links to new domain.

* **Style**
  * Updated device viewer loading placeholder colors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->