### PR TITLE
fix(docs): correct documentation links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html).
 
 ## CLI Reference
 
@@ -151,33 +151,33 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset` | Shut down all simulators and emulators |
 | `tapflow logs` | Show recent relay log entries |
 
-Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli.html)
 
 ## Documentation
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
 **Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/quick-start)
-- [Requirements](https://www.tapflow.dev/guide/requirements)
+- [Introduction](https://www.tapflow.dev/guide/introduction.html)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started.html)
+- [Requirements](https://www.tapflow.dev/guide/requirements.html)
 
 **Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [Agent Setup](https://www.tapflow.dev/guide/agent-setup)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html)
+- [Agent Setup](https://www.tapflow.dev/guide/agent.html)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds.html)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling.html)
 
 **Dashboard**
-- [First-time Setup](https://www.tapflow.dev/guide/first-time-setup)
-- [Dashboard Overview](https://www.tapflow.dev/guide/dashboard-overview)
+- [First-time Setup](https://www.tapflow.dev/dashboard/setup.html)
+- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview.html)
 
 **Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Configuration](https://www.tapflow.dev/reference/configuration)
-- [REST API](https://www.tapflow.dev/reference/rest-api)
+- [CLI Reference](https://www.tapflow.dev/reference/cli.html)
+- [Configuration](https://www.tapflow.dev/reference/configuration.html)
+- [REST API](https://www.tapflow.dev/reference/api.html)
 
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting.html)**
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
 
@@ -151,33 +151,33 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset` | Shut down all simulators and emulators |
 | `tapflow logs` | Show recent relay log entries |
 
-Full reference → [CLI docs](https://www.tapflow.dev/reference/cli.html)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
 **Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction.html)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started.html)
-- [Requirements](https://www.tapflow.dev/guide/requirements.html)
+- [Introduction](https://www.tapflow.dev/guide/introduction)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Requirements](https://www.tapflow.dev/guide/requirements)
 
 **Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html)
-- [Agent Setup](https://www.tapflow.dev/guide/agent.html)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds.html)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling.html)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
+- [Agent Setup](https://www.tapflow.dev/guide/agent)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
 
 **Dashboard**
-- [First-time Setup](https://www.tapflow.dev/dashboard/setup.html)
-- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview.html)
+- [First-time Setup](https://www.tapflow.dev/dashboard/setup)
+- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
 
 **Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli.html)
-- [Configuration](https://www.tapflow.dev/reference/configuration.html)
-- [REST API](https://www.tapflow.dev/reference/api.html)
+- [CLI Reference](https://www.tapflow.dev/reference/cli)
+- [Configuration](https://www.tapflow.dev/reference/configuration)
+- [REST API](https://www.tapflow.dev/reference/api)
 
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting.html)**
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
 
 ## Development
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -100,6 +100,7 @@ const koSidebar = [
 export default withMermaid(defineConfig({
   title: 'tapflow',
   description: 'Self-hosted iOS/Android simulator streaming for QA',
+  cleanUrls: true,
 
   locales: {
     root: {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,3 +1,4 @@
 {
-  "outputDirectory": ".vitepress/dist"
+  "outputDirectory": ".vitepress/dist",
+  "cleanUrls": true
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
 
@@ -151,33 +151,33 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset`                     | Shut down all simulators and emulators          |
 | `tapflow logs`                      | Show recent relay log entries                   |
 
-Full reference → [CLI docs](https://www.tapflow.dev/reference/cli.html)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
 **Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction.html)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started.html)
-- [Requirements](https://www.tapflow.dev/guide/requirements.html)
+- [Introduction](https://www.tapflow.dev/guide/introduction)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started)
+- [Requirements](https://www.tapflow.dev/guide/requirements)
 
 **Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html)
-- [Agent Setup](https://www.tapflow.dev/guide/agent.html)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds.html)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling.html)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
+- [Agent Setup](https://www.tapflow.dev/guide/agent)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
 
 **Dashboard**
-- [First-time Setup](https://www.tapflow.dev/dashboard/setup.html)
-- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview.html)
+- [First-time Setup](https://www.tapflow.dev/dashboard/setup)
+- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
 
 **Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli.html)
-- [Configuration](https://www.tapflow.dev/reference/configuration.html)
-- [REST API](https://www.tapflow.dev/reference/api.html)
+- [CLI Reference](https://www.tapflow.dev/reference/cli)
+- [Configuration](https://www.tapflow.dev/reference/configuration)
+- [REST API](https://www.tapflow.dev/reference/api)
 
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting.html)**
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ pm2 save && pm2 startup
 tapflow agent start --relay wss://your-relay-url
 ```
 
-> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
+> For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html).
 
 ## CLI Reference
 
@@ -151,33 +151,33 @@ tapflow agent start --relay wss://your-relay-url
 | `tapflow reset`                     | Shut down all simulators and emulators          |
 | `tapflow logs`                      | Show recent relay log entries                   |
 
-Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
+Full reference → [CLI docs](https://www.tapflow.dev/reference/cli.html)
 
 ## Documentation
 
 **[www.tapflow.dev](https://www.tapflow.dev)**
 
 **Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/quick-start)
-- [Requirements](https://www.tapflow.dev/guide/requirements)
+- [Introduction](https://www.tapflow.dev/guide/introduction.html)
+- [Quick Start](https://www.tapflow.dev/guide/getting-started.html)
+- [Requirements](https://www.tapflow.dev/guide/requirements.html)
 
 **Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [Agent Setup](https://www.tapflow.dev/guide/agent-setup)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
+- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting.html)
+- [Agent Setup](https://www.tapflow.dev/guide/agent.html)
+- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds.html)
+- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling.html)
 
 **Dashboard**
-- [First-time Setup](https://www.tapflow.dev/guide/first-time-setup)
-- [Dashboard Overview](https://www.tapflow.dev/guide/dashboard-overview)
+- [First-time Setup](https://www.tapflow.dev/dashboard/setup.html)
+- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview.html)
 
 **Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Configuration](https://www.tapflow.dev/reference/configuration)
-- [REST API](https://www.tapflow.dev/reference/rest-api)
+- [CLI Reference](https://www.tapflow.dev/reference/cli.html)
+- [Configuration](https://www.tapflow.dev/reference/configuration.html)
+- [REST API](https://www.tapflow.dev/reference/api.html)
 
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
+**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting.html)**
 
 ## Development
 


### PR DESCRIPTION
## Summary

- 모든 `tapflow.dev` 링크에 `.html` 확장자 추가 (누락 시 빈 페이지 렌더링)
- 잘못된 슬러그 수정 (404 → 정상):
  - `quick-start` → `getting-started`
  - `agent-setup` → `agent`
  - `guide/first-time-setup` → `dashboard/setup`
  - `guide/dashboard-overview` → `dashboard/overview`
  - `rest-api` → `api`
- 존재하지 않는 페이지 제거: `app-center`, `team-management`, `recordings`
- 적용 파일: root `README.md`, `packages/cli/README.md`

## Test plan

- [ ] 모든 링크 클릭 시 404 없이 정상 페이지 로드 확인
- [ ] `.html` 없는 링크와 비교해 콘텐츠가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized docs navigation into Getting Started, Setup, Dashboard and Reference sections for clearer discovery
  * Updated README links to point to the new guide and dashboard locations; CLI reference link refreshed
  * Documentation site now uses clean URLs for simpler, more user‑friendly addresses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->