### PR TITLE
chore: release v0.2.1

### DIFF
--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/agent-core
 
+## 0.2.1
+
+### Patch Changes
+
+- fix: WebSocket backpressure, Android pinch via scrcpy multi-touch, dashboard skeleton visibility
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/android-agent
 
+## 0.2.1
+
+### Patch Changes
+
+- fix: WebSocket backpressure, Android pinch via scrcpy multi-touch, dashboard skeleton visibility
+- Updated dependencies
+  - @tapflowio/agent-core@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # tapflow
 
+## 0.2.1
+
+### Patch Changes
+
+- fix: WebSocket backpressure, Android pinch via scrcpy multi-touch, dashboard skeleton visibility
+- Updated dependencies
+  - @tapflowio/agent-core@0.2.1
+  - @tapflowio/relay@0.2.1
+  - @tapflowio/ios-agent@0.2.1
+  - @tapflowio/android-agent@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Self-hosted iOS/Android simulator streaming for QA teams",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/ios-agent
 
+## 0.2.1
+
+### Patch Changes
+
+- fix: WebSocket backpressure, Android pinch via scrcpy multi-touch, dashboard skeleton visibility
+- Updated dependencies
+  - @tapflowio/agent-core@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/relay
 
+## 0.2.1
+
+### Patch Changes
+
+- fix: WebSocket backpressure, Android pinch via scrcpy multi-touch, dashboard skeleton visibility
+- Updated dependencies
+  - @tapflowio/agent-core@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

- Bump all packages `0.2.0` → `0.2.1`
- Includes changes from #96 (WebSocket backpressure, Android pinch fix, dashboard skeleton) and #97 (README doc links, cleanUrls)

## After merging

Tag and push to trigger npm publish + GitHub Release:

```sh
git checkout main && git pull origin main
git tag v0.2.1
git push origin main v0.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved WebSocket backpressure issues
  * Fixed Android pinch gesture behavior
  * Enhanced dashboard skeleton visibility

* **Chores**
  * Bumped version to 0.2.1 across all packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->