### PR TITLE
docs(readme): broaden positioning from QA-only to every team member

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for every team member</h3>
+  <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
 
   <p>
     Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for QA teams</h3>
+  <h3>Self-hosted iOS & Android simulator streaming for every team member</h3>
 
   <p>
-    Run simulators in the browser — no Appetize, no BrowserStack, no monthly fees.<br />
+    Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -14,6 +14,14 @@
     <img src="https://img.shields.io/badge/platform-macOS-lightgrey" alt="macOS Agent" />
     <a href="https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a>
     <a href="ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-v0.x→v1.0-blueviolet" alt="Roadmap" /></a>
+  </p>
+
+  <p>
+    <a href="https://www.tapflow.dev">📖 Docs</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/getting-started">🚀 Quick Start</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/introduction">🎥 Demo</a>
   </p>
 </div>
 
@@ -30,6 +38,22 @@
 ---
 
 ## Why tapflow?
+
+If you work on a mobile product, you've probably seen this.
+
+Physical devices are never enough. Covering every OS version is even harder — iOS doesn't support downgrading, so maintaining a range of versions means managing a pool of locked devices, which is overhead nobody wants.
+
+But the bigger friction is access. Simulators only run on a developer's Mac, behind Xcode and a full toolchain. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
+
+> **Server / FE developer** — "How do I install the sandbox build to check what was deployed?"
+>
+> **Product manager** — "I keep having to install and remove different versions just to compare behavior."
+>
+> **Designer** — "I need to check the layout across screen sizes, but I don't have the right devices."
+
+Cloud simulator services exist. But uploading internal app builds to an external service — and paying monthly fees for simulators already running on Macs you own — was never something we wanted to do.
+
+So we built tapflow.
 
 | Solution | Problem |
 |----------|---------|

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-**tapflow** lets your QA run iOS simulators and Android emulators directly in the browser — without Appetize, BrowserStack, or any external cloud.
+**tapflow** lets your entire team run mobile QA directly in the browser — no Xcode, no device management, no external cloud.
 
 <VideoPlayer src="/tapflow-demo.mp4" poster="/demo-thumbnail.png" />
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: tapflow
-  text: 'Self-hosted simulator <span style="white-space: nowrap">streaming for QA</span>'
-  tagline: Run iOS & Android simulators in the browser — no cloud, no data leaks, no monthly fees.
+  text: 'Self-hosted simulator <span style="white-space: nowrap">streaming for mobile QA</span>'
+  tagline: Run iOS & Android simulators in the browser — no Xcode, no device management, no cloud uploads.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/ko/guide/introduction.md
+++ b/docs/ko/guide/introduction.md
@@ -1,6 +1,6 @@
 # 소개
 
-**tapflow**는 QA가 iOS 시뮬레이터와 Android 에뮬레이터를 브라우저에서 직접 실행할 수 있도록 해줍니다. Appetize, BrowserStack, 또는 외부 클라우드 없이 사용 가능합니다.
+**tapflow**는 팀 누구나 iOS 시뮬레이터와 Android 에뮬레이터를 브라우저에서 직접 모바일 QA를 수행할 수 있도록 해줍니다. Xcode 없이, 기기 관리 없이 — Appetize, BrowserStack, 또는 외부 클라우드가 필요하지 않습니다.
 
 <VideoPlayer src="/tapflow-demo.mp4" poster="/demo-thumbnail.png" />
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: tapflow
-  text: 'QA를 위한 셀프호스팅<br>시뮬레이터 스트리밍'
-  tagline: 클라우드 없이, 데이터 유출 없이, 월 구독료 없이 — 브라우저에서 iOS·Android 시뮬레이터를 바로 실행하세요.
+  text: '모바일 QA를 위한<br>셀프호스팅 시뮬레이터 스트리밍'
+  tagline: 브라우저만 있으면 됩니다. Xcode 없이, 기기 관리 없이, 클라우드 업로드 없이 — 팀 누구나 iOS·Android 시뮬레이터를 바로 실행하세요.
   actions:
     - theme: brand
       text: 시작하기

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for QA teams</h3>
+  <h3>Self-hosted iOS & Android simulator streaming for every team member</h3>
 
   <p>
-    Run simulators in the browser — no Appetize, no BrowserStack, no monthly fees.<br />
+    Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -13,6 +13,14 @@
     <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="Node.js ≥ 20" /></a>
     <img src="https://img.shields.io/badge/platform-macOS-lightgrey" alt="macOS Agent" />
     <a href="https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a>
+  </p>
+
+  <p>
+    <a href="https://www.tapflow.dev">📖 Docs</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/getting-started">🚀 Quick Start</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/introduction">🎥 Demo</a>
   </p>
 </div>
 
@@ -30,6 +38,22 @@
 ---
 
 ## Why tapflow?
+
+If you work on a mobile product, you've probably seen this.
+
+Physical devices are never enough. Covering every OS version is even harder — iOS doesn't support downgrading, so maintaining a range of versions means managing a pool of locked devices, which is overhead nobody wants.
+
+But the bigger friction is access. Simulators only run on a developer's Mac, behind Xcode and a full toolchain. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
+
+> **Server / FE developer** — "How do I install the sandbox build to check what was deployed?"
+>
+> **Product manager** — "I keep having to install and remove different versions just to compare behavior."
+>
+> **Designer** — "I need to check the layout across screen sizes, but I don't have the right devices."
+
+Cloud simulator services exist. But uploading internal app builds to an external service — and paying monthly fees for simulators already running on Macs you own — was never something we wanted to do.
+
+So we built tapflow.
 
 | Solution                | Problem                                                                  |
 | ----------------------- | ------------------------------------------------------------------------ |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for every team member</h3>
+  <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
 
   <p>
     Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />


### PR DESCRIPTION
## Summary

- Expand tagline from `"for QA teams"` → `"for every team member"`
- Rewrite `Why tapflow?` narrative around real pain points: physical device shortage, OS version coverage limits, and simulator access barrier for non-mobile developers
- Add persona quotes (server/FE dev, PM, designer) to surface concrete friction from different roles
- Add Docs / Quick Start / Demo CTA links to top of both READMEs (`README.md`, `packages/cli/README.md`)

## Background

The previous positioning narrowed the audience to "QA teams," but the actual problem tapflow solves extends to anyone on the team who needs to verify a mobile build — planners, designers, and non-mobile developers included. This change aligns the public-facing copy with that broader definition.

## Files changed

- `README.md` — GitHub repository page
- `packages/cli/README.md` — npm package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Broadened hero/messaging to speak to mobile QA / anyone on your team and emphasize browser-based simulator access without Xcode, device management, or cloud uploads.
  * Added prominent Docs / Quick Start / Demo quick-links near the top.
  * Expanded "Why tapflow?" with role-based friction scenarios and new narrative copy.
  * Updated corresponding Korean documentation translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->