### PR TITLE
docs: reframe QA as activity, update taglines, fix hero text wrapping

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -116,6 +116,14 @@
 
 .VPHero .text {
   line-height: 1.25;
+  word-break: keep-all;
+}
+
+@media (min-width: 640px) {
+  .VPHero .text,
+  .VPHero .tagline {
+    max-width: none;
+  }
 }
 
 .VPHero .tagline {

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: tapflow
   text: 'Self-hosted simulator <span style="white-space: nowrap">streaming for mobile QA</span>'
-  tagline: Run iOS & Android simulators in the browser — no Xcode, no device management, no cloud uploads.
+  tagline: Run iOS & Android simulators in the browser — no complicated setup, no device management, no data leaving your network.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: tapflow
   text: '모바일 QA를 위한<br>셀프호스팅 시뮬레이터 스트리밍'
-  tagline: 브라우저만 있으면 됩니다. Xcode 없이, 기기 관리 없이, 클라우드 업로드 없이 — 팀 누구나 iOS·Android 시뮬레이터를 바로 실행하세요.
+  tagline: 복잡한 세팅 없이, 기기 관리 없이, 외부 데이터 유출 걱정 없이 — 팀 누구나 iOS·Android 시뮬레이터를 브라우저에서 바로 실행하세요.
   actions:
     - theme: brand
       text: 시작하기


### PR DESCRIPTION
## Summary

- Reframe "QA" from audience → activity throughout README, cli/README, and docs (en/ko)
  - Before: "for QA teams" (QA = 대상)
  - After: "for mobile QA" (QA = 행위, target = 팀 전체)
- Update taglines to remove platform-specific "Xcode" reference
  - EN: `no complicated setup, no device management, no data leaving your network`
  - KO: `복잡한 세팅 없이, 기기 관리 없이, 외부 데이터 유출 걱정 없이 — 팀 누구나 iOS·Android 시뮬레이터를 브라우저에서 바로 실행하세요.`
- Update docs `introduction.md` first sentence (en/ko) to reflect broader audience
- Fix Korean hero text wrapping: override VitePress built-in `max-width: 576px` on `.VPHero .text` and `.tagline` — cards below are wider so the constraint was causing awkward mid-word line breaks

## Files changed

- `README.md`, `packages/cli/README.md`
- `docs/index.md`, `docs/ko/index.md`
- `docs/guide/introduction.md`, `docs/ko/guide/introduction.md`
- `docs/.vitepress/theme/custom.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated homepage hero messaging in English and Korean versions to highlight simplified setup experience without complex configuration.

* **Style**
  * Enhanced hero text display with improved word-breaking behavior for better readability across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->