### PR TITLE
docs(readme): broaden messaging from QA-only to whole-team access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
 
   <p>
-    Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />
+    Anyone on your team can run simulators in the browser — no toolchain setup, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -43,7 +43,7 @@ If you work on a mobile product, you've probably seen this.
 
 Physical devices are never enough. Covering every OS version is even harder — iOS doesn't support downgrading, so maintaining a range of versions means managing a pool of locked devices, which is overhead nobody wants.
 
-But the bigger friction is access. Simulators only run on a developer's Mac, behind Xcode and a full toolchain. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
+But the bigger friction is access. Simulators only run on a developer's Mac, behind complex developer toolchains. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
 
 > **Server / FE developer** — "How do I install the sandbox build to check what was deployed?"
 >
@@ -60,11 +60,11 @@ So we built tapflow.
 | Appetize / BrowserStack | Expensive — app data leaves your network |
 | Physical devices | Cost, loss, management overhead |
 | Xcode / Android Studio | Every QA member needs their own Mac + full toolchain setup |
-| **tapflow** | Use the Mac you already own — data stays on-prem, QA team uses a browser |
+| **tapflow** | Use the Mac you already own — data stays on-prem, whole team does QA from a browser |
 
 ## Features
 
-- **Browser-based** — QA team needs no installation. Any modern browser works.
+- **Browser-based** — Anyone on the team needs no installation. Any modern browser works.
 - **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
 - **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator.
@@ -77,12 +77,12 @@ So we built tapflow.
 ## How it works
 
 ```
-Browser (QA team)  ←─ WebSocket ─→  Relay Server  ←─ WebSocket (outbound) ─→  Mac Agent
-                                  (Linux / Mac)                           (iOS · Android)
+Browser (your team)  ←─ WebSocket ─→  Relay Server  ←─ WebSocket (outbound) ─→  Mac Agent
+                                    (Linux / Mac)                           (iOS · Android)
 ```
 
 1. The **Mac Agent** connects *outbound* to the relay — no inbound firewall rules needed.
-2. QA opens the **dashboard** in any browser and sees all available devices.
+2. Anyone on the team opens the **dashboard** in any browser and sees all available devices.
 3. Touch events are forwarded in real time; the screen streams back to the browser.
 4. The **relay** also serves the dashboard SPA on the same port — no separate web server needed.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
   <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
 
   <p>
-    Anyone on your team can run simulators in the browser — no Xcode, no device management, no cloud uploads.<br />
+    Anyone on your team can run simulators in the browser — no toolchain setup, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -43,7 +43,7 @@ If you work on a mobile product, you've probably seen this.
 
 Physical devices are never enough. Covering every OS version is even harder — iOS doesn't support downgrading, so maintaining a range of versions means managing a pool of locked devices, which is overhead nobody wants.
 
-But the bigger friction is access. Simulators only run on a developer's Mac, behind Xcode and a full toolchain. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
+But the bigger friction is access. Simulators only run on a developer's Mac, behind complex developer toolchains. Anyone on the team who isn't a mobile developer has to ask one every single time they need to verify something:
 
 > **Server / FE developer** — "How do I install the sandbox build to check what was deployed?"
 >
@@ -60,11 +60,11 @@ So we built tapflow.
 | Appetize / BrowserStack | Expensive — app data leaves your network                                 |
 | Physical devices        | Cost, loss, management overhead                                          |
 | Xcode / Android Studio  | Every QA member needs their own Mac + full toolchain setup               |
-| **tapflow**             | Use the Mac you already own — data stays on-prem, QA team uses a browser |
+| **tapflow**             | Use the Mac you already own — data stays on-prem, whole team does QA from a browser |
 
 ## Features
 
-- **Browser-based** — QA team needs no installation. Any modern browser works.
+- **Browser-based** — Anyone on the team needs no installation. Any modern browser works.
 - **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
 - **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator.
@@ -77,12 +77,12 @@ So we built tapflow.
 ## How it works
 
 ```
-Browser (QA team)  ← WebSocket →  Relay Server  ← WebSocket (outbound) →  Mac Agent
-                                  (Linux / Mac)                           (iOS · Android)
+Browser (your team)  ← WebSocket →  Relay Server  ← WebSocket (outbound) →  Mac Agent
+                                   (Linux / Mac)                           (iOS · Android)
 ```
 
 1. The **Mac Agent** connects _outbound_ to the relay — no inbound firewall rules needed.
-2. QA opens the **dashboard** in any browser and sees all available devices.
+2. Anyone on the team opens the **dashboard** in any browser and sees all available devices.
 3. Touch events are forwarded in real time; the screen streams back to the browser.
 4. The **relay** also serves the dashboard SPA on the same port — no separate web server needed.
 
@@ -127,7 +127,7 @@ Navigate to `http://localhost:4000` and sign in with the account you just create
 | **Relay server**  | Node.js ≥ 20, any OS (Linux/macOS), ~512 MB RAM                                                                           |
 | **iOS Agent**     | macOS, Xcode with iOS Simulator Runtime, Node.js ≥ 20                                                                     |
 | **Android Agent** | macOS, Android SDK (`adb` in `$PATH` or `$ANDROID_HOME` set), AVD with `google_apis/arm64-v8a` (android-34), Node.js ≥ 20 |
-| **Browser (QA)**  | Any modern browser — Chrome, Firefox, Safari, Edge                                                                        |
+| **Browser**       | Any modern browser — Chrome, Firefox, Safari, Edge                                                                        |
 
 ## Self-Hosting
 


### PR DESCRIPTION
## Summary

- "QA team" → "your team" / "anyone on the team" 으로 표현 전반 교체
- "Xcode" / "full toolchain" 같은 기술 특화 문구 → "developer toolchains" / "toolchain setup" 으로 추상화
- ASCII 다이어그램의 `Browser (QA team)` 레이블 수정
- 비교표 Browser 행의 `(QA)` 접미사 제거

## Test plan

- [ ] README.md, packages/cli/README.md 렌더링 확인 (GitHub 웹에서 목록 구조·링크 정상 여부)
- [ ] docs 사이트(`pnpm docs:dev`) 진입 후 hero 텍스트 및 비교표 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product documentation to clarify that simulator streaming is accessible directly in the browser to anyone on your team, eliminating developer toolchain installation and device management requirements.
  * Revised messaging across README files to emphasize team-wide accessibility rather than QA-specific workflows, highlighting ease of use for all team members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->