### PR TITLE
feat(android): render real SDK device skin as frame

### DIFF
--- a/contributing/android-video-streaming-diagnosis.md
+++ b/contributing/android-video-streaming-diagnosis.md
@@ -143,3 +143,66 @@ emulator gRPC API의 `streamScreenshot` RPC를 사용해 scrcpy를 완전히 대
 emulator -avd <name> -grpc 8554 -gpu host
 # 이후 grpcurl로 streamScreenshot 호출 후 FPS 측정
 ```
+
+---
+
+## Issue 3 — 디바이스 회전 시 scrcpy 스트림 해상도 변경 (2026-05-24 해결)
+
+### 핵심 결론
+
+`capture_orientation=@0` 서버 옵션을 추가해 스트림을 portrait로 고정한다.
+디바이스가 회전해도 스트림 해상도가 변하지 않으므로 대시보드는 CSS rotation만으로 landscape 뷰를 전환할 수 있다.
+
+```typescript
+// ScrcpySession.ts — scrcpy 서버 인수
+'capture_orientation=@0',  // lock stream to portrait
+```
+
+### 원인
+
+`sdk_gphone64_arm64` (google_apis/arm64-v8a, android-34) AVD에서 디바이스를 회전하면 scrcpy 스트림 해상도가 실시간으로 바뀐다.
+
+```
+rotation 0 → 1: stream 1080×2400 → 2400×1080  (H.264 SPS 변경 + 디코더 재초기화)
+rotation 1 → 2: stream 2400×1080 → 1080×2400
+rotation 2 → 3: stream 1080×2400 → 2400×1080
+```
+
+이 때문에:
+- `videoSize` 상태가 비동기로 업데이트 → 스킨 프레임 방향과 스트림 방향이 잠깐 불일치
+- rotation=2(upside-down portrait)에서 스트림이 landscape로 유지 → portrait 프레임 안에 landscape 스트림 → letterbox 발생
+
+### `capture_orientation=@0`의 동작 원리
+
+scrcpy 서버가 display orientation을 0(portrait)으로 고정한다. 물리 회전은 Android 시스템이 감지하지만, 스크린 렌더링은 portrait 기준으로 유지되므로 스트림 해상도가 변하지 않는다.
+
+scrcpy는 회전 이벤트(`DEVICE_MSG_TYPE_ROTATION_CHANGED`)는 여전히 물리 회전 기준으로 전송하므로 대시보드가 현재 방향을 정확히 알 수 있다.
+
+### 스킨 렌더링 단순화 (iOS 패턴 통일)
+
+스트림이 항상 portrait로 고정되면, iOS viewer와 동일한 방식으로 렌더할 수 있다:
+- composite(back.webp) 전체를 portrait 기준으로 유지
+- landscape 전환 시 inner div에 `rotate(90deg)` CSS 한 줄
+- canvas 위치: `skinScreenRect`의 퍼센트 기반 좌표 (픽셀 계산 불필요)
+
+### 회전 방향 선택 — landscape(3) 고정
+
+`capture_orientation=@0` 적용 후 CSS `rotate(90deg)` CW가 scrcpy 보정과 상쇄되는 방향은 `rotation=3`(CW landscape)이다. `rotation=1`(CCW landscape)에서는 scrcpy 보정 방향이 반대라 CSS rotation을 더하면 180° 뒤집힘이 발생한다.
+
+따라서 rotate 버튼은 **portrait(0) ↔ landscape(3)** 2방향 토글로 구현한다:
+
+```typescript
+// AndroidAgent.ts
+const target = isLandscape ? 0 : 3
+this.adb.disableAutoRotate(serial)       // accelerometer_rotation=0
+this.adb.setUserRotation(serial, target) // user_rotation=0 or 3
+```
+
+### 관련 코드
+
+| 파일 | 변경 |
+|------|------|
+| `android-agent/src/scrcpy/ScrcpySession.ts` | `capture_orientation=@0` 추가 |
+| `android-agent/src/AdbWrapper.ts` | `disableAutoRotate`, `setUserRotation` 추가 |
+| `android-agent/src/AndroidAgent.ts` | `input:rotate` → 0↔3 토글 |
+| `dashboard/components/device/AndroidViewer.tsx` | 스킨 모드 iOS 패턴으로 단순화 |

--- a/contributing/android-video-streaming-diagnosis.md
+++ b/contributing/android-video-streaming-diagnosis.md
@@ -134,16 +134,6 @@ const proc = spawn(getEmulatorPath(), [
 - Google의 `android-emulator-webrtc`(gRPC + WebRTC로 emulator 스트리밍)는 2025년 9월 archive 처리됐고, 처음부터 Linux + NVIDIA 전용이었다. Google조차 macOS에서 이 문제를 해결하지 않고 Linux로 회피한 것.
 - `NSWindowOcclusionState`를 끄는 plist 키나 system API는 존재하지 않는다 (Apple 의도적 설계).
 - `-gpu angle_indirect`, `-gpu auto-no-window` 등은 macOS에서 미지원이거나 존재하지 않는 옵션이다.
-
-### 대안 접근 (만약 `-no-window`가 요구사항과 충돌할 경우)
-
-emulator gRPC API의 `streamScreenshot` RPC를 사용해 scrcpy를 완전히 대체하는 방법이 있다. emulator 프로세스 내부에서 프레임을 직접 생성하므로 SurfaceFlinger의 vsync 경로를 우회할 가능성이 있다. 검증은 아직 미진행.
-
-```bash
-emulator -avd <name> -grpc 8554 -gpu host
-# 이후 grpcurl로 streamScreenshot 호출 후 FPS 측정
-```
-
 ---
 
 ## Issue 3 — 디바이스 회전 시 scrcpy 스트림 해상도 변경 (2026-05-24 해결)

--- a/packages/android-agent/src/AdbWrapper.ts
+++ b/packages/android-agent/src/AdbWrapper.ts
@@ -134,12 +134,12 @@ export class AdbWrapper {
     return this.runner.execBinary('-s', serial, 'exec-out', 'screencap', '-p')
   }
 
-  async enableAutoRotate(serial: string): Promise<void> {
-    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'accelerometer_rotation', '1')
+  async disableAutoRotate(serial: string): Promise<void> {
+    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'accelerometer_rotation', '0')
   }
 
-  async emuRotate(serial: string): Promise<void> {
-    await this.runner.exec('-s', serial, 'emu', 'rotate')
+  async setUserRotation(serial: string, rotation: 0 | 1 | 2 | 3): Promise<void> {
+    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'user_rotation', String(rotation))
   }
 
   async sendInput(serial: string, ...args: string[]): Promise<void> {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -614,12 +614,15 @@ export class AndroidAgent implements DeviceAgent {
         if (!state) break
         const serial = this.adb.getSerial(state.deviceId)
         if (!serial) break
-        // Optimistically advance rotation by 90° so the view updates immediately.
-        // ROTATION_NOTIFICATION will reconcile the actual value; dedup logic in handleRotationNotification
-        // prevents a double-swap if prediction matches.
-        this.handleRotationNotification(state, (state.deviceRotation + 1) % 4)
-        this.adb.enableAutoRotate(serial).catch(() => {})
-        this.adb.emuRotate(serial).catch(() => {})
+        // Toggle portrait(0) ↔ landscape(3). rotation=3 (CW landscape) is used because
+        // capture_orientation=@0 compensates rotation=3 with a CCW counterrotation, which the dashboard
+        // CSS rotate(90deg) CW undoes correctly. rotation=1 (CCW landscape) needs the opposite CSS
+        // direction, so it cannot share the same correction as no-skin mode.
+        const isLandscape = state.deviceRotation === 1 || state.deviceRotation === 3
+        const target = isLandscape ? 0 : 3
+        this.handleRotationNotification(state, target)
+        this.adb.disableAutoRotate(serial).catch(() => {})
+        this.adb.setUserRotation(serial, target as 0 | 3).catch(() => {})
         break
       }
       case 'input:button': {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -13,6 +13,7 @@ import { AdbWrapper } from './AdbWrapper.js'
 import { EmulatorLauncher } from './EmulatorLauncher.js'
 import { AndroidTouchHelper } from './AndroidTouchHelper.js'
 import { ScrcpySession } from './scrcpy/ScrcpySession.js'
+import { loadSkin } from './SkinLoader.js'
 
 const logger = createLogger('android-agent')
 
@@ -425,6 +426,8 @@ export class AndroidAgent implements DeviceAgent {
 
       await this.startVideoStream(state, streamWs)
       if (seq !== state.bootSeq) return
+
+      const skin = loadSkin(avdName)
       this.ws?.send(JSON.stringify({
         type: 'session:chrome',
         sessionId: state.sessionId,
@@ -433,6 +436,12 @@ export class AndroidAgent implements DeviceAgent {
           streamType: 'h264',
           screenWidth: state.displayWidth,
           screenHeight: state.displayHeight,
+          ...(skin ? {
+            skinBackPng: skin.backPng,
+            skinScreenRect: skin.screenRect,
+            skinCompositeSize: skin.compositeSize,
+            skinCornerRadius: skin.cornerRadius,
+          } : {}),
         },
       }))
       this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: avdId } }))

--- a/packages/android-agent/src/SkinLoader.ts
+++ b/packages/android-agent/src/SkinLoader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, unlinkSync } from 'fs'
-import { join } from 'path'
+import { join, isAbsolute } from 'path'
 import { inflateSync } from 'zlib'
 import { execSync } from 'child_process'
 import os from 'os'
@@ -47,7 +47,7 @@ export function loadSkin(
 
     // skin.path may be relative (e.g. "skins/pixel_9") — resolve against ANDROID_HOME
     const androidHome = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || ''
-    const skinPath = rawSkinPath.startsWith('/') ? rawSkinPath : join(androidHome, rawSkinPath)
+    const skinPath = isAbsolute(rawSkinPath) ? rawSkinPath : join(androidHome, rawSkinPath)
 
     const layoutPath = join(skinPath, 'layout')
     if (!existsSync(layoutPath)) return null

--- a/packages/android-agent/src/SkinLoader.ts
+++ b/packages/android-agent/src/SkinLoader.ts
@@ -1,5 +1,7 @@
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
+import { inflateSync } from 'zlib'
+import { execSync } from 'child_process'
 import os from 'os'
 import { createLogger } from '@tapflowio/agent-core'
 
@@ -14,6 +16,7 @@ export interface SkinData {
 
 interface ParsedLayout {
   backgroundImage: string
+  maskImage?: string
   displayWidth: number
   displayHeight: number
   cornerRadius: number
@@ -38,9 +41,13 @@ export function loadSkin(
 
     const config = parseIni(readFileSync(configPath, 'utf-8'))
     const skinName = config['skin.name']
-    const skinPath = config['skin.path']
+    const rawSkinPath = config['skin.path']
 
-    if (!skinName || skinName === '_no_skin' || !skinPath) return null
+    if (!skinName || skinName === '_no_skin' || !rawSkinPath) return null
+
+    // skin.path may be relative (e.g. "skins/pixel_9") — resolve against ANDROID_HOME
+    const androidHome = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || ''
+    const skinPath = rawSkinPath.startsWith('/') ? rawSkinPath : join(androidHome, rawSkinPath)
 
     const layoutPath = join(skinPath, 'layout')
     if (!existsSync(layoutPath)) return null
@@ -51,15 +58,63 @@ export function loadSkin(
     const bgPath = join(skinPath, layout.backgroundImage)
     if (!existsSync(bgPath)) return null
 
+    // If layout has no corner_radius but skin provides mask.webp, detect radius from mask.
+    // mask.webp for modern Pixel skins has opaque corner areas and a transparent screen interior.
+    // The first transparent pixel on the top row = corner radius in display pixels.
+    let cornerRadius = layout.cornerRadius
+    if (cornerRadius === 0 && layout.maskImage) {
+      const maskPath = join(skinPath, layout.maskImage)
+      if (existsSync(maskPath)) {
+        cornerRadius = detectMaskCornerRadius(maskPath, layout.displayWidth)
+      }
+    }
+
     return {
       backPng: readFileSync(bgPath).toString('base64'),
       screenRect: { x: layout.screenX, y: layout.screenY, width: layout.displayWidth, height: layout.displayHeight },
       compositeSize: { width: layout.compositeWidth, height: layout.compositeHeight },
-      cornerRadius: layout.cornerRadius,
+      cornerRadius,
     }
   } catch (e) {
     logger.warn('skin load failed:', (e as Error).message)
     return null
+  }
+}
+
+// Uses sips (macOS built-in) to export the first row of the mask image as PNG,
+// then scans for the first fully-transparent pixel to determine the screen corner radius.
+function detectMaskCornerRadius(maskPath: string, displayWidth: number): number {
+  const tmpPng = join(os.tmpdir(), `tapflow_mask_cr_${process.pid}.png`)
+  try {
+    execSync(
+      `sips -s format png --cropToHeightWidth 1 ${displayWidth} "${maskPath}" --out "${tmpPng}" 2>/dev/null`,
+      { stdio: 'pipe', timeout: 5000 },
+    )
+    const buf = readFileSync(tmpPng)
+
+    // Collect all IDAT chunks and decompress
+    const idatParts: Buffer[] = []
+    let pos = 8
+    while (pos + 12 <= buf.length) {
+      const len = buf.readUInt32BE(pos)
+      const type = buf.subarray(pos + 4, pos + 8).toString()
+      if (type === 'IDAT') idatParts.push(buf.subarray(pos + 8, pos + 8 + len))
+      if (type === 'IEND') break
+      pos += 12 + len
+    }
+    if (!idatParts.length) return 0
+
+    const raw = inflateSync(Buffer.concat(idatParts))
+    // First scanline: 1 filter byte + W×4 RGBA bytes. Only handle filter 0 (None).
+    if (raw[0] !== 0) return 0
+    for (let x = 0; x < displayWidth; x++) {
+      if (raw[1 + x * 4 + 3] === 0) return x
+    }
+    return 0
+  } catch {
+    return 0
+  } finally {
+    try { unlinkSync(tmpPng) } catch { /* cleanup best-effort */ }
   }
 }
 
@@ -87,6 +142,7 @@ export function parseLayout(text: string): ParsedLayout | null {
   const displayHeight = num(partsDevice.children['display']?.values['height'])
   const cornerRadius = num(partsDevice.children['display']?.values['corner_radius'])
   const backgroundImage = partsPortrait?.children['background']?.values['image'] ?? ''
+  const maskImage = partsPortrait?.children['foreground']?.values['mask'] || undefined
   const compositeWidth = num(layoutsPortrait.values['width'])
   const compositeHeight = num(layoutsPortrait.values['height'])
 
@@ -103,7 +159,7 @@ export function parseLayout(text: string): ParsedLayout | null {
     }
   }
 
-  return { backgroundImage, displayWidth, displayHeight, cornerRadius, compositeWidth, compositeHeight, screenX, screenY }
+  return { backgroundImage, maskImage, displayWidth, displayHeight, cornerRadius, compositeWidth, compositeHeight, screenX, screenY }
 }
 
 function num(v: string | undefined): number {

--- a/packages/android-agent/src/SkinLoader.ts
+++ b/packages/android-agent/src/SkinLoader.ts
@@ -1,0 +1,137 @@
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import os from 'os'
+import { createLogger } from '@tapflowio/agent-core'
+
+const logger = createLogger('android-agent:skin')
+
+export interface SkinData {
+  backPng: string  // base64-encoded image (webp)
+  screenRect: { x: number; y: number; width: number; height: number }
+  compositeSize: { width: number; height: number }
+  cornerRadius: number
+}
+
+interface ParsedLayout {
+  backgroundImage: string
+  displayWidth: number
+  displayHeight: number
+  cornerRadius: number
+  compositeWidth: number
+  compositeHeight: number
+  screenX: number
+  screenY: number
+}
+
+interface Block {
+  values: Record<string, string>
+  children: Record<string, Block>
+}
+
+export function loadSkin(
+  avdName: string,
+  avdDir = join(os.homedir(), '.android', 'avd'),
+): SkinData | null {
+  try {
+    const configPath = join(avdDir, `${avdName}.avd`, 'config.ini')
+    if (!existsSync(configPath)) return null
+
+    const config = parseIni(readFileSync(configPath, 'utf-8'))
+    const skinName = config['skin.name']
+    const skinPath = config['skin.path']
+
+    if (!skinName || skinName === '_no_skin' || !skinPath) return null
+
+    const layoutPath = join(skinPath, 'layout')
+    if (!existsSync(layoutPath)) return null
+
+    const layout = parseLayout(readFileSync(layoutPath, 'utf-8'))
+    if (!layout) return null
+
+    const bgPath = join(skinPath, layout.backgroundImage)
+    if (!existsSync(bgPath)) return null
+
+    return {
+      backPng: readFileSync(bgPath).toString('base64'),
+      screenRect: { x: layout.screenX, y: layout.screenY, width: layout.displayWidth, height: layout.displayHeight },
+      compositeSize: { width: layout.compositeWidth, height: layout.compositeHeight },
+      cornerRadius: layout.cornerRadius,
+    }
+  } catch (e) {
+    logger.warn('skin load failed:', (e as Error).message)
+    return null
+  }
+}
+
+function parseIni(text: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of text.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    result[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
+  }
+  return result
+}
+
+// Exported for testing
+export function parseLayout(text: string): ParsedLayout | null {
+  const root = parseBlock(text.split('\n'), 0).block
+
+  const partsDevice = root.children['parts']?.children['device']
+  const partsPortrait = root.children['parts']?.children['portrait']
+  const layoutsPortrait = root.children['layouts']?.children['portrait']
+
+  if (!partsDevice || !layoutsPortrait) return null
+
+  const displayWidth = num(partsDevice.children['display']?.values['width'])
+  const displayHeight = num(partsDevice.children['display']?.values['height'])
+  const cornerRadius = num(partsDevice.children['display']?.values['corner_radius'])
+  const backgroundImage = partsPortrait?.children['background']?.values['image'] ?? ''
+  const compositeWidth = num(layoutsPortrait.values['width'])
+  const compositeHeight = num(layoutsPortrait.values['height'])
+
+  if (!displayWidth || !displayHeight || !backgroundImage || !compositeWidth || !compositeHeight) return null
+
+  // Find the part block whose name=device to determine screen position in the composite
+  let screenX = 0
+  let screenY = 0
+  for (const part of Object.values(layoutsPortrait.children)) {
+    if (part.values['name'] === 'device') {
+      screenX = num(part.values['x'])
+      screenY = num(part.values['y'])
+      break
+    }
+  }
+
+  return { backgroundImage, displayWidth, displayHeight, cornerRadius, compositeWidth, compositeHeight, screenX, screenY }
+}
+
+function num(v: string | undefined): number {
+  if (!v) return 0
+  const n = parseInt(v, 10)
+  return isNaN(n) ? 0 : n
+}
+
+function parseBlock(lines: string[], start: number): { block: Block; end: number } {
+  const block: Block = { values: {}, children: {} }
+  let i = start
+  while (i < lines.length) {
+    const line = lines[i].trim()
+    i++
+    if (!line || line.startsWith('#')) continue
+    if (line === '}') break
+    if (line.endsWith('{')) {
+      const key = line.slice(0, -1).trim()
+      const inner = parseBlock(lines, i)
+      block.children[key] = inner.block
+      i = inner.end
+    } else {
+      const sp = line.indexOf(' ')
+      if (sp !== -1) {
+        const key = line.slice(0, sp)
+        if (!(key in block.values)) block.values[key] = line.slice(sp + 1).trim()
+      }
+    }
+  }
+  return { block, end: i }
+}

--- a/packages/android-agent/src/__tests__/SkinLoader.test.ts
+++ b/packages/android-agent/src/__tests__/SkinLoader.test.ts
@@ -102,6 +102,7 @@ describe('parseLayout', () => {
     const result = parseLayout(PIXEL_9_LAYOUT)
     expect(result).toEqual({
       backgroundImage: 'back.webp',
+      maskImage: 'mask.webp',
       displayWidth: 1080,
       displayHeight: 2424,
       cornerRadius: 87,

--- a/packages/android-agent/src/__tests__/SkinLoader.test.ts
+++ b/packages/android-agent/src/__tests__/SkinLoader.test.ts
@@ -1,0 +1,231 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}))
+
+import { existsSync, readFileSync } from 'fs'
+import { loadSkin, parseLayout } from '../SkinLoader.js'
+
+const mockExists = vi.mocked(existsSync)
+const mockRead = vi.mocked(readFileSync)
+
+// ── Layout fixtures ──────────────────────────────────────────────────────────
+
+const PIXEL_9_LAYOUT = `
+parts {
+  device {
+    display {
+      width 1080
+      height 2424
+      x 0
+      y 0
+      corner_radius 87
+    }
+  }
+  portrait {
+    background {
+      image back.webp
+    }
+    foreground {
+      mask mask.webp
+      cutout hole
+    }
+  }
+}
+layouts {
+  portrait {
+    width 1198
+    height 2531
+    event EV_SW:0:1
+    part1 {
+      name portrait
+      x 0
+      y 0
+    }
+    part2 {
+      name device
+      x 55
+      y 58
+    }
+  }
+}
+`
+
+const GALAXY_NEXUS_LAYOUT = `
+parts {
+  device {
+    display {
+      width 720
+      height 1280
+      x 0
+      y 0
+    }
+  }
+  portrait {
+    background {
+      image port_back.webp
+    }
+    onion {
+      image port_fore.webp
+    }
+  }
+}
+layouts {
+  portrait {
+    width 1101
+    height 1709
+    event EV_SW:0:1
+    part1 {
+      name portrait
+      x 0
+      y 0
+    }
+    part2 {
+      name device
+      x 192
+      y 213
+    }
+  }
+}
+`
+
+const PIXEL_9_CONFIG = `skin.name=pixel_9\nskin.path=/mock/sdk/skins/pixel_9\nhw.lcd.width=1080\nhw.lcd.height=2424\n`
+const NO_SKIN_CONFIG = `skin.name=_no_skin\nskin.path=_no_skin\n`
+const DUMMY_WEBP = Buffer.from([0x52, 0x49, 0x46, 0x46]) // "RIFF" — placeholder bytes
+
+// ── parseLayout ──────────────────────────────────────────────────────────────
+
+describe('parseLayout', () => {
+  it('parses pixel_9 layout (modern format with corner_radius)', () => {
+    const result = parseLayout(PIXEL_9_LAYOUT)
+    expect(result).toEqual({
+      backgroundImage: 'back.webp',
+      displayWidth: 1080,
+      displayHeight: 2424,
+      cornerRadius: 87,
+      compositeWidth: 1198,
+      compositeHeight: 2531,
+      screenX: 55,
+      screenY: 58,
+    })
+  })
+
+  it('parses galaxy_nexus layout (legacy format, non-zero screen offset, no corner_radius)', () => {
+    const result = parseLayout(GALAXY_NEXUS_LAYOUT)
+    expect(result).toEqual({
+      backgroundImage: 'port_back.webp',
+      displayWidth: 720,
+      displayHeight: 1280,
+      cornerRadius: 0,
+      compositeWidth: 1101,
+      compositeHeight: 1709,
+      screenX: 192,
+      screenY: 213,
+    })
+  })
+
+  it('finds device part regardless of part key name (not hardcoded to part2)', () => {
+    const layout = `
+parts {
+  device {
+    display {
+      width 1080
+      height 2424
+      x 0
+      y 0
+      corner_radius 87
+    }
+  }
+  portrait {
+    background {
+      image back.webp
+    }
+  }
+}
+layouts {
+  portrait {
+    width 1198
+    height 2531
+    part99 {
+      name device
+      x 55
+      y 58
+    }
+  }
+}
+`
+    const result = parseLayout(layout)
+    expect(result?.screenX).toBe(55)
+    expect(result?.screenY).toBe(58)
+  })
+
+  it('returns null when display width is missing', () => {
+    const broken = PIXEL_9_LAYOUT.replace('width 1080', '')
+    expect(parseLayout(broken)).toBeNull()
+  })
+
+  it('returns null when background image is missing', () => {
+    const broken = PIXEL_9_LAYOUT.replace('image back.webp', '')
+    expect(parseLayout(broken)).toBeNull()
+  })
+
+  it('returns null when layouts section is absent', () => {
+    const broken = PIXEL_9_LAYOUT.replace(/layouts \{[\s\S]*\}/, '')
+    expect(parseLayout(broken)).toBeNull()
+  })
+})
+
+// ── loadSkin ─────────────────────────────────────────────────────────────────
+
+describe('loadSkin', () => {
+  beforeEach(() => {
+    mockExists.mockReturnValue(true)
+    mockRead.mockImplementation((path: unknown) => {
+      const p = String(path)
+      if (p.endsWith('config.ini')) return PIXEL_9_CONFIG
+      if (p.endsWith('layout')) return PIXEL_9_LAYOUT
+      return DUMMY_WEBP
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns SkinData with correct fields for a valid skin', () => {
+    const skin = loadSkin('Pixel_9', '/mock/avd')
+    expect(skin).not.toBeNull()
+    expect(skin?.screenRect).toEqual({ x: 55, y: 58, width: 1080, height: 2424 })
+    expect(skin?.compositeSize).toEqual({ width: 1198, height: 2531 })
+    expect(skin?.cornerRadius).toBe(87)
+    expect(skin?.backPng).toBe(DUMMY_WEBP.toString('base64'))
+  })
+
+  it('returns null for skin.name=_no_skin', () => {
+    mockRead.mockReturnValue(NO_SKIN_CONFIG)
+    expect(loadSkin('NoSkinAvd', '/mock/avd')).toBeNull()
+  })
+
+  it('returns null when config.ini does not exist', () => {
+    mockExists.mockReturnValue(false)
+    expect(loadSkin('Pixel_9', '/mock/avd')).toBeNull()
+  })
+
+  it('returns null when layout file does not exist', () => {
+    mockExists.mockImplementation((p: unknown) => !String(p).endsWith('layout'))
+    expect(loadSkin('Pixel_9', '/mock/avd')).toBeNull()
+  })
+
+  it('returns null when background image file does not exist', () => {
+    mockExists.mockImplementation((p: unknown) => !String(p).endsWith('.webp'))
+    expect(loadSkin('Pixel_9', '/mock/avd')).toBeNull()
+  })
+
+  it('returns null and does not throw when readFileSync throws', () => {
+    mockRead.mockImplementation(() => { throw new Error('permission denied') })
+    expect(() => loadSkin('Pixel_9', '/mock/avd')).not.toThrow()
+    expect(loadSkin('Pixel_9', '/mock/avd')).toBeNull()
+  })
+})

--- a/packages/android-agent/src/scrcpy/ScrcpySession.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpySession.ts
@@ -87,6 +87,7 @@ export class ScrcpySession {
       'send_frame_meta=false',   // raw Annex B stream (no length prefix per frame)
       'send_dummy_byte=false',   // skip the 1-byte connection-check byte
       'video_codec_options=i-frame-interval:int=1', // 1s IDR interval for faster keyframe recovery after restart
+      'capture_orientation=@0',  // lock stream to portrait — prevents dimension changes on device rotation
     ], { stdio: ['ignore', 'pipe', 'ignore'] })
 
     this.serverProc = serverProc

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useRelay } from '@/hooks/useRelay';
 import { IOSViewer } from './device/IOSViewer';
 import { AndroidViewer } from './device/AndroidViewer';
 import { SimulatorInfoCard } from './device/shared/SimulatorInfoCard';
-import type { AndroidButton, ChromeData, RelayMessage } from '@/lib/types';
+import type { AndroidChrome, ChromeData, RelayMessage } from '@/lib/types';
 
 interface Props {
   sessionId: string;
@@ -14,8 +14,6 @@ interface Props {
   resetMode?: 'app-only' | 'full-erase';
   onRecordingUploaded?: () => void;
 }
-
-type AndroidChrome = { buttons: AndroidButton[]; streamType: 'h264'; screenWidth?: number; screenHeight?: number };
 
 export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecordingUploaded }: Props) {
   const sendRef = useRef<(msg: object) => void>(() => {});
@@ -77,7 +75,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   }, []);
 
   const { send, connected } = useRelay(handleMessage, handleBinaryFrame);
-  sendRef.current = send;
+  useLayoutEffect(() => { sendRef.current = send; });
 
   useEffect(() => {
     if (connected) send({ type: 'session:start', sessionId });
@@ -130,7 +128,17 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   return (
     <>
       {iosChrome && <IOSViewer {...commonProps} chrome={iosChrome} />}
-      {androidChrome && <AndroidViewer {...commonProps} androidButtons={androidChrome.buttons} screenWidth={androidChrome.screenWidth} screenHeight={androidChrome.screenHeight} deviceRotation={deviceRotation} />}
+      {androidChrome && <AndroidViewer
+        {...commonProps}
+        androidButtons={androidChrome.buttons}
+        screenWidth={androidChrome.screenWidth}
+        screenHeight={androidChrome.screenHeight}
+        deviceRotation={deviceRotation}
+        skinBackPng={androidChrome.skinBackPng}
+        skinScreenRect={androidChrome.skinScreenRect}
+        skinCompositeSize={androidChrome.skinCompositeSize}
+        skinCornerRadius={androidChrome.skinCornerRadius}
+      />}
     </>
   );
 }

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -38,6 +38,10 @@ interface AndroidViewerProps {
   screenWidth?: number;
   screenHeight?: number;
   deviceRotation?: number;
+  skinBackPng?: string;
+  skinScreenRect?: { x: number; y: number; width: number; height: number };
+  skinCompositeSize?: { width: number; height: number };
+  skinCornerRadius?: number;
 }
 
 export function AndroidViewer({
@@ -46,6 +50,7 @@ export function AndroidViewer({
   launching, setLaunching, androidButtons,
   binaryFrameHandlerRef, onRecordingUploaded,
   screenWidth, screenHeight, deviceRotation = 0,
+  skinBackPng, skinScreenRect, skinCompositeSize, skinCornerRadius = 0,
 }: AndroidViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -327,7 +332,23 @@ export function AndroidViewer({
   }, [])
 
   // ── Layout ────────────────────────────────────────────────────────────────
-  // Scale by longest side so portrait and landscape stay the same physical size on screen
+  const hasSkin = Boolean(skinBackPng && skinScreenRect && skinCompositeSize);
+
+  // Skin mode: scale composite so its longest side fits MAX_ANDROID_LONG
+  const skinScale = hasSkin
+    ? Math.min(1, MAX_ANDROID_LONG / Math.max(skinCompositeSize!.width, skinCompositeSize!.height))
+    : 0;
+  const compositeDisplayW = hasSkin ? Math.round(skinCompositeSize!.width * skinScale) : 0;
+  const compositeDisplayH = hasSkin ? Math.round(skinCompositeSize!.height * skinScale) : 0;
+
+  // Skin screen position as % of composite (for CSS absolute positioning)
+  const screenPctLeft = hasSkin ? (skinScreenRect!.x / skinCompositeSize!.width) * 100 : 0;
+  const screenPctTop = hasSkin ? (skinScreenRect!.y / skinCompositeSize!.height) * 100 : 0;
+  const screenPctW = hasSkin ? (skinScreenRect!.width / skinCompositeSize!.width) * 100 : 0;
+  const screenPctH = hasSkin ? (skinScreenRect!.height / skinCompositeSize!.height) * 100 : 0;
+  const skinCornerRadiusCss = hasSkin ? `${Math.round(skinCornerRadius * skinScale)}px` : '0px';
+
+  // Fallback (no-skin) mode: scale by longest screen side
   const effectiveSize = videoSize ?? (screenWidth && screenHeight ? { width: screenWidth, height: screenHeight } : null);
   const androidScale = effectiveSize
     ? Math.min(1, MAX_ANDROID_LONG / Math.max(effectiveSize.width, effectiveSize.height))
@@ -337,9 +358,10 @@ export function AndroidViewer({
 
   // CSS rotation: applied when device is landscape but video content is portrait (portrait-locked app).
   // Matches native Android emulator behavior — chrome rotates even when app content stays portrait.
+  // Not applied in skin mode (landscape skin is out of scope).
   const isLandscapeDevice = deviceRotation === 1 || deviceRotation === 3;
   const isLandscapeContent = effectiveSize ? effectiveSize.width > effectiveSize.height : false;
-  const needsCSSRotation = isLandscapeDevice && !isLandscapeContent;
+  const needsCSSRotation = !hasSkin && isLandscapeDevice && !isLandscapeContent;
   useLayoutEffect(() => { needsCSSRotationRef.current = needsCSSRotation }, [needsCSSRotation])
   // Container uses landscape dims; canvas inside rotated 90° to show portrait content in landscape shell
   const containerW = needsCSSRotation ? androidDisplayH : androidDisplayW;
@@ -431,64 +453,131 @@ export function AndroidViewer({
       />
 
       <div className="flex items-start gap-8">
-        {/* phone body bezel */}
-        <div style={{ background: '#1c1c1e', borderRadius: '34px', padding: '12px', flexShrink: 0, boxShadow: '0 8px 32px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06)' }}>
-        <div
-          ref={containerRef}
-          className="relative"
-          style={{ width: containerW, height: containerH, backgroundColor: '#010101', borderRadius: '22px', overflow: 'hidden' }}
-        >
-          {glError ? (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>WebGL2 not supported</span>
-            </div>
-          ) : (
-            <>
-              <canvas
-                ref={canvasRef}
-                className={needsCSSRotation ? undefined : 'block w-full h-full'}
-                style={rotatedCanvasStyle}
-                onPointerDown={handlePointerDown}
-                onPointerMove={handlePointerMove}
-                onPointerUp={handlePointerUp}
-                onPointerCancel={handlePointerCancel}
-                onPointerLeave={handlePointerLeave}
-              />
-              {!canvasReady && (
-                <div className="absolute inset-0 animate-pulse bg-zinc-700" />
-              )}
-              {!canvasReady && deviceReady && (
-                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                  <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>Waiting for stream…</span>
+        {hasSkin ? (
+          // ── Skin mode: real device frame from SDK ─────────────────────────
+          <div style={{ position: 'relative', width: compositeDisplayW, height: compositeDisplayH, flexShrink: 0 }}>
+            {/* background device image */}
+            <img
+              src={`data:image/webp;base64,${skinBackPng}`}
+              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none' }}
+              alt=""
+              draggable={false}
+            />
+            {/* screen area overlay — canvas sits inside this */}
+            <div
+              ref={containerRef}
+              style={{
+                position: 'absolute',
+                left: `${screenPctLeft}%`,
+                top: `${screenPctTop}%`,
+                width: `${screenPctW}%`,
+                height: `${screenPctH}%`,
+                overflow: 'hidden',
+                borderRadius: skinCornerRadiusCss,
+              }}
+            >
+              {glError ? (
+                <div className="absolute inset-0 flex items-center justify-center" style={{ backgroundColor: '#010101' }}>
+                  <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>WebGL2 not supported</span>
                 </div>
-              )}
-              <div
-                ref={liveCursorRef}
-                style={{
-                  display: 'none', position: 'absolute', zIndex: 20, borderRadius: '50%',
-                  transform: 'translate(-50%, -50%)', pointerEvents: 'none',
-                  transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease',
-                }}
-              />
-              {pinchHint && (
+              ) : (
                 <>
-                  {([pinchHint.f0, pinchHint.f1] as const).map((f, i) => (
-                    <div key={i} style={{
-                      position: 'absolute', zIndex: 10, borderRadius: '50%',
-                      transform: 'translate(-50%, -50%)', pointerEvents: 'none',
-                      transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease',
-                      left: `${f.x * 100}%`, top: `${f.y * 100}%`,
-                      ...(pinchActive
-                        ? { width: CURSOR_DOT_R * 2, height: CURSOR_DOT_R * 2, background: 'rgba(255,255,255,0.92)', border: '1.5px solid rgba(0,0,0,0.2)', boxShadow: '0 0 0 1px rgba(0,0,0,0.15), 0 0 8px rgba(255,255,255,0.25)' }
-                        : { width: CURSOR_RING_R * 2, height: CURSOR_RING_R * 2, background: 'transparent', border: '1.5px solid rgba(255,255,255,0.6)', boxShadow: '0 0 0 1px rgba(0,0,0,0.3)' }),
-                    }} />
-                  ))}
+                  <canvas
+                    ref={canvasRef}
+                    className="block w-full h-full"
+                    style={{ visibility: canvasReady ? 'visible' : 'hidden', cursor: 'none', backgroundColor: '#010101' }}
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerCancel}
+                    onPointerLeave={handlePointerLeave}
+                  />
+                  {!canvasReady && <div className="absolute inset-0 animate-pulse bg-zinc-700" />}
+                  {!canvasReady && deviceReady && (
+                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                      <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>Waiting for stream…</span>
+                    </div>
+                  )}
+                  <div ref={liveCursorRef} style={{ display: 'none', position: 'absolute', zIndex: 20, borderRadius: '50%', transform: 'translate(-50%, -50%)', pointerEvents: 'none', transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease' }} />
+                  {pinchHint && (
+                    <>
+                      {([pinchHint.f0, pinchHint.f1] as const).map((f, i) => (
+                        <div key={i} style={{
+                          position: 'absolute', zIndex: 10, borderRadius: '50%',
+                          transform: 'translate(-50%, -50%)', pointerEvents: 'none',
+                          transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease',
+                          left: `${f.x * 100}%`, top: `${f.y * 100}%`,
+                          ...(pinchActive
+                            ? { width: CURSOR_DOT_R * 2, height: CURSOR_DOT_R * 2, background: 'rgba(255,255,255,0.92)', border: '1.5px solid rgba(0,0,0,0.2)', boxShadow: '0 0 0 1px rgba(0,0,0,0.15), 0 0 8px rgba(255,255,255,0.25)' }
+                            : { width: CURSOR_RING_R * 2, height: CURSOR_RING_R * 2, background: 'transparent', border: '1.5px solid rgba(255,255,255,0.6)', boxShadow: '0 0 0 1px rgba(0,0,0,0.3)' }),
+                        }} />
+                      ))}
+                    </>
+                  )}
                 </>
               )}
-            </>
-          )}
-        </div>
-        </div>{/* /phone body bezel */}
+            </div>
+          </div>
+        ) : (
+          // ── Fallback: CSS bezel ───────────────────────────────────────────
+          <div style={{ background: '#1c1c1e', borderRadius: '34px', padding: '12px', flexShrink: 0, boxShadow: '0 8px 32px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06)' }}>
+          <div
+            ref={containerRef}
+            className="relative"
+            style={{ width: containerW, height: containerH, backgroundColor: '#010101', borderRadius: '22px', overflow: 'hidden' }}
+          >
+            {glError ? (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>WebGL2 not supported</span>
+              </div>
+            ) : (
+              <>
+                <canvas
+                  ref={canvasRef}
+                  className={needsCSSRotation ? undefined : 'block w-full h-full'}
+                  style={rotatedCanvasStyle}
+                  onPointerDown={handlePointerDown}
+                  onPointerMove={handlePointerMove}
+                  onPointerUp={handlePointerUp}
+                  onPointerCancel={handlePointerCancel}
+                  onPointerLeave={handlePointerLeave}
+                />
+                {!canvasReady && (
+                  <div className="absolute inset-0 animate-pulse bg-zinc-700" />
+                )}
+                {!canvasReady && deviceReady && (
+                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                    <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>Waiting for stream…</span>
+                  </div>
+                )}
+                <div
+                  ref={liveCursorRef}
+                  style={{
+                    display: 'none', position: 'absolute', zIndex: 20, borderRadius: '50%',
+                    transform: 'translate(-50%, -50%)', pointerEvents: 'none',
+                    transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease',
+                  }}
+                />
+                {pinchHint && (
+                  <>
+                    {([pinchHint.f0, pinchHint.f1] as const).map((f, i) => (
+                      <div key={i} style={{
+                        position: 'absolute', zIndex: 10, borderRadius: '50%',
+                        transform: 'translate(-50%, -50%)', pointerEvents: 'none',
+                        transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease',
+                        left: `${f.x * 100}%`, top: `${f.y * 100}%`,
+                        ...(pinchActive
+                          ? { width: CURSOR_DOT_R * 2, height: CURSOR_DOT_R * 2, background: 'rgba(255,255,255,0.92)', border: '1.5px solid rgba(0,0,0,0.2)', boxShadow: '0 0 0 1px rgba(0,0,0,0.15), 0 0 8px rgba(255,255,255,0.25)' }
+                          : { width: CURSOR_RING_R * 2, height: CURSOR_RING_R * 2, background: 'transparent', border: '1.5px solid rgba(255,255,255,0.6)', boxShadow: '0 0 0 1px rgba(0,0,0,0.3)' }),
+                      }} />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+          </div>
+        )}{/* /device frame */}
 
         <SimulatorInfoCard
           joined={joined} fps={fps} connected={connected}

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -60,6 +60,7 @@ export function AndroidViewer({
 
   const [canvasReady, setCanvasReady] = useState(false);
   const [glError, setGlError] = useState(false);
+  const [pressedButton, setPressedButton] = useState<string | null>(null);
   const videoSizeRef = useRef<{ width: number; height: number } | null>(null);
   const [videoSize, setVideoSize] = useState<{ width: number; height: number } | null>(null);
 
@@ -79,6 +80,10 @@ export function AndroidViewer({
   const cursorPosRef = useRef<{ x: number; y: number } | null>(null);
   const cursorStateRef = useRef<'idle' | 'down' | 'release'>('idle');
   const releaseAnimRef = useRef<{ startTime: number } | null>(null);
+  // In skin mode the cursor div lives in the outer composite wrapper; compositeWrapperRef tracks it.
+  const compositeWrapperRef = useRef<HTMLDivElement>(null);
+  const coordNeedsRotationRef = useRef(false);
+  const hasSkinRef = useRef(false);
 
   // ── WebGL init + H264Decoder lifecycle ───────────────────────────────────
   useEffect(() => {
@@ -201,13 +206,11 @@ export function AndroidViewer({
   }, [keyboardActive])
 
   // ── Pointer interaction ───────────────────────────────────────────────────
-  const needsCSSRotationRef = useRef(false)
-
   const toNorm = useCallback((e: { clientX: number; clientY: number }) => {
     const canvas = canvasRef.current
     if (!canvas) return null
     const rect = canvas.getBoundingClientRect()
-    return toNormPure({ x: e.clientX, y: e.clientY }, rect, needsCSSRotationRef.current)
+    return toNormPure({ x: e.clientX, y: e.clientY }, rect, coordNeedsRotationRef.current)
   }, [])
 
   const toPinchFingers = useCallback((e: { clientX: number; clientY: number }) => {
@@ -237,8 +240,9 @@ export function AndroidViewer({
     cursorStateRef.current = 'down'; releaseAnimRef.current = null
     const _lc = liveCursorRef.current
     if (_lc) {
+      const _pr = (hasSkinRef.current ? compositeWrapperRef : containerRef).current?.getBoundingClientRect()
       _lc.style.display = 'block'
-      _lc.style.left = `${e.clientX - _rect.left}px`; _lc.style.top = `${e.clientY - _rect.top}px`
+      if (_pr) { _lc.style.left = `${e.clientX - _pr.left}px`; _lc.style.top = `${e.clientY - _pr.top}px` }
       _lc.style.width = `${CURSOR_DOT_R * 2}px`; _lc.style.height = `${CURSOR_DOT_R * 2}px`
       _lc.style.background = 'rgba(255,255,255,0.92)'; _lc.style.border = '1.5px solid rgba(0,0,0,0.2)'
       _lc.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.15), 0 0 8px rgba(255,255,255,0.25)'
@@ -260,8 +264,9 @@ export function AndroidViewer({
         cursorPosRef.current = { x: e.clientX - _r.left, y: e.clientY - _r.top }
         if (cursorStateRef.current !== 'down') cursorStateRef.current = 'idle'
         if (_lc) {
+          const _pr = (hasSkinRef.current ? compositeWrapperRef : containerRef).current?.getBoundingClientRect()
           _lc.style.display = 'block'
-          _lc.style.left = `${e.clientX - _r.left}px`; _lc.style.top = `${e.clientY - _r.top}px`
+          if (_pr) { _lc.style.left = `${e.clientX - _pr.left}px`; _lc.style.top = `${e.clientY - _pr.top}px` }
           _lc.style.width = `${CURSOR_RING_R * 2}px`; _lc.style.height = `${CURSOR_RING_R * 2}px`
           _lc.style.background = 'transparent'; _lc.style.border = '1.5px solid rgba(255,255,255,0.6)'
           _lc.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.3)'
@@ -293,7 +298,8 @@ export function AndroidViewer({
     cursorPosRef.current = { x: e.clientX - _r.left, y: e.clientY - _r.top }
     const _lc = liveCursorRef.current
     if (_lc && _lc.style.display !== 'none') {
-      _lc.style.left = `${e.clientX - _r.left}px`; _lc.style.top = `${e.clientY - _r.top}px`
+      const _pr = (hasSkinRef.current ? compositeWrapperRef : containerRef).current?.getBoundingClientRect()
+      if (_pr) { _lc.style.left = `${e.clientX - _pr.left}px`; _lc.style.top = `${e.clientY - _pr.top}px` }
     }
     send({ type: 'input:touch:move', sessionId, payload: pos })
   }, [toNorm, toPinchFingers, send, sessionId])
@@ -341,13 +347,6 @@ export function AndroidViewer({
   const compositeDisplayW = hasSkin ? Math.round(skinCompositeSize!.width * skinScale) : 0;
   const compositeDisplayH = hasSkin ? Math.round(skinCompositeSize!.height * skinScale) : 0;
 
-  // Skin screen position as % of composite (for CSS absolute positioning)
-  const screenPctLeft = hasSkin ? (skinScreenRect!.x / skinCompositeSize!.width) * 100 : 0;
-  const screenPctTop = hasSkin ? (skinScreenRect!.y / skinCompositeSize!.height) * 100 : 0;
-  const screenPctW = hasSkin ? (skinScreenRect!.width / skinCompositeSize!.width) * 100 : 0;
-  const screenPctH = hasSkin ? (skinScreenRect!.height / skinCompositeSize!.height) * 100 : 0;
-  const skinCornerRadiusCss = hasSkin ? `${Math.round(skinCornerRadius * skinScale)}px` : '0px';
-
   // Fallback (no-skin) mode: scale by longest screen side
   const effectiveSize = videoSize ?? (screenWidth && screenHeight ? { width: screenWidth, height: screenHeight } : null);
   const androidScale = effectiveSize
@@ -356,13 +355,28 @@ export function AndroidViewer({
   const androidDisplayW = effectiveSize ? Math.round(effectiveSize.width * androidScale) : 324;
   const androidDisplayH = effectiveSize ? Math.round(effectiveSize.height * androidScale) : 720;
 
-  // CSS rotation: applied when device is landscape but video content is portrait (portrait-locked app).
-  // Matches native Android emulator behavior — chrome rotates even when app content stays portrait.
-  // Not applied in skin mode (landscape skin is out of scope).
   const isLandscapeDevice = deviceRotation === 1 || deviceRotation === 3;
   const isLandscapeContent = effectiveSize ? effectiveSize.width > effectiveSize.height : false;
+  // Stream is locked portrait by scrcpy capture_orientation=@0, so skin and no-skin both use
+  // isLandscapeDevice to drive CSS rotation — same as iOS pattern.
+  const skinIsLandscape = hasSkin && isLandscapeDevice;
   const needsCSSRotation = !hasSkin && isLandscapeDevice && !isLandscapeContent;
-  useLayoutEffect(() => { needsCSSRotationRef.current = needsCSSRotation }, [needsCSSRotation])
+  // Both skin landscape and no-skin CSS-rotate the canvas 90° CW → same coordinate correction.
+  const coordNeedsRotation = needsCSSRotation || skinIsLandscape;
+  useLayoutEffect(() => {
+    coordNeedsRotationRef.current = coordNeedsRotation;
+    hasSkinRef.current = hasSkin;
+  }, [coordNeedsRotation, hasSkin])
+
+  // Skin: percentage-based screen position — scales with compositeDisplay dims automatically.
+  const screenPctLeft = hasSkin ? (skinScreenRect!.x / skinCompositeSize!.width) * 100 : 0;
+  const screenPctTop  = hasSkin ? (skinScreenRect!.y / skinCompositeSize!.height) * 100 : 0;
+  const screenPctW    = hasSkin ? (skinScreenRect!.width  / skinCompositeSize!.width) * 100 : 0;
+  const screenPctH    = hasSkin ? (skinScreenRect!.height / skinCompositeSize!.height) * 100 : 0;
+  const skinCornerRadiusCss = hasSkin && skinCornerRadius > 0
+    ? `${Math.round(skinCornerRadius * compositeDisplayH / skinCompositeSize!.height)}px`
+    : '0px';
+
   // Container uses landscape dims; canvas inside rotated 90° to show portrait content in landscape shell
   const containerW = needsCSSRotation ? androidDisplayH : androidDisplayW;
   const containerH = needsCSSRotation ? androidDisplayW : androidDisplayH;
@@ -381,20 +395,33 @@ export function AndroidViewer({
     cursor: 'none',
   };
 
+  const navButtons = androidButtons ?? []
+
+  const sendButton = (name: string) => {
+    send({ type: 'input:button', sessionId, payload: { name } })
+    setPressedButton(name)
+    setTimeout(() => setPressedButton(null), 150)
+  }
+
+  const btnIcon = (name: string) =>
+    name === 'back' ? <ArrowLeft className="h-4 w-4" />
+    : name === 'recent_apps' ? <LayoutGrid className="h-4 w-4" />
+    : name === 'volume_up' ? <Volume2 className="h-4 w-4" />
+    : name === 'volume_down' ? <Volume1 className="h-4 w-4" />
+    : name === 'power' ? <Power className="h-4 w-4" />
+    : <Home className="h-4 w-4" />
+
+  const toolbarButtons = navButtons
+
   const platformSlot = (
     <>
-      {androidButtons?.map((btn) => (
+      {toolbarButtons.map((btn) => (
         <Tooltip key={btn.name}>
           <TooltipTrigger asChild>
             <Button variant="ghost" size="icon" className="h-8 w-8"
-              onClick={() => send({ type: 'input:button', sessionId, payload: { name: btn.name } })}
+              onClick={() => sendButton(btn.name)}
             >
-              {btn.name === 'back' ? <ArrowLeft className="h-4 w-4" />
-                : btn.name === 'recent_apps' ? <LayoutGrid className="h-4 w-4" />
-                : btn.name === 'volume_up' ? <Volume2 className="h-4 w-4" />
-                : btn.name === 'volume_down' ? <Volume1 className="h-4 w-4" />
-                : btn.name === 'power' ? <Power className="h-4 w-4" />
-                : <Home className="h-4 w-4" />}
+              {btnIcon(btn.name)}
             </Button>
           </TooltipTrigger>
           <TooltipContent side="left">{btn.accessibilityTitle}</TooltipContent>
@@ -454,51 +481,66 @@ export function AndroidViewer({
 
       <div className="flex items-start gap-8">
         {hasSkin ? (
-          // ── Skin mode: real device frame from SDK ─────────────────────────
-          <div style={{ position: 'relative', width: compositeDisplayW, height: compositeDisplayH, flexShrink: 0 }}>
-            {/* background device image */}
-            <img
-              src={`data:image/webp;base64,${skinBackPng}`}
-              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none' }}
-              alt=""
-              draggable={false}
-            />
-            {/* screen area overlay — canvas sits inside this */}
+          // ── Skin mode: iOS-pattern — whole composite rotates as one unit ──
+          // Outer div: non-rotating, swaps W/H for landscape to occupy correct visual space.
+          // Inner div: CSS rotate(90deg) CW in landscape — same direction as no-skin canvas rotation.
+          // Canvas: percent-based position within inner div; no coordinate re-calculation on rotation.
+          <div
+            ref={compositeWrapperRef}
+            style={{
+              position: 'relative', flexShrink: 0,
+              width: skinIsLandscape ? compositeDisplayH : compositeDisplayW,
+              height: skinIsLandscape ? compositeDisplayW : compositeDisplayH,
+            }}
+          >
             <div
-              ref={containerRef}
               style={{
-                position: 'absolute',
-                left: `${screenPctLeft}%`,
-                top: `${screenPctTop}%`,
-                width: `${screenPctW}%`,
-                height: `${screenPctH}%`,
-                overflow: 'hidden',
-                borderRadius: skinCornerRadiusCss,
+                width: compositeDisplayW, height: compositeDisplayH,
+                position: 'relative',
+                ...(skinIsLandscape ? {
+                  position: 'absolute',
+                  top:  (compositeDisplayW - compositeDisplayH) / 2,
+                  left: (compositeDisplayH - compositeDisplayW) / 2,
+                  transform: 'rotate(90deg)', transformOrigin: 'center center',
+                } : {}),
               }}
             >
+              {/* back.webp background — fills composite, screen interior is transparent */}
+              <img
+                src={`data:image/webp;base64,${skinBackPng}`}
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none', display: 'block' }}
+                alt="" draggable={false}
+              />
               {glError ? (
-                <div className="absolute inset-0 flex items-center justify-center" style={{ backgroundColor: '#010101' }}>
+                <div className="absolute" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#010101' }}>
                   <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>WebGL2 not supported</span>
                 </div>
               ) : (
                 <>
                   <canvas
                     ref={canvasRef}
-                    className="block w-full h-full"
-                    style={{ visibility: canvasReady ? 'visible' : 'hidden', cursor: 'none', backgroundColor: '#010101' }}
+                    style={{
+                      position: 'absolute',
+                      left: `${screenPctLeft}%`, top: `${screenPctTop}%`,
+                      width: `${screenPctW}%`, height: `${screenPctH}%`,
+                      borderRadius: skinCornerRadiusCss,
+                      visibility: canvasReady ? 'visible' : 'hidden',
+                      cursor: 'none', backgroundColor: '#010101',
+                    }}
                     onPointerDown={handlePointerDown}
                     onPointerMove={handlePointerMove}
                     onPointerUp={handlePointerUp}
                     onPointerCancel={handlePointerCancel}
                     onPointerLeave={handlePointerLeave}
                   />
-                  {!canvasReady && <div className="absolute inset-0 animate-pulse bg-zinc-700" />}
+                  {!canvasReady && (
+                    <div className="absolute animate-pulse bg-zinc-700" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, borderRadius: skinCornerRadiusCss }} />
+                  )}
                   {!canvasReady && deviceReady && (
-                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                    <div className="absolute pointer-events-none" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                       <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.875rem' }}>Waiting for stream…</span>
                     </div>
                   )}
-                  <div ref={liveCursorRef} style={{ display: 'none', position: 'absolute', zIndex: 20, borderRadius: '50%', transform: 'translate(-50%, -50%)', pointerEvents: 'none', transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease' }} />
                   {pinchHint && (
                     <>
                       {([pinchHint.f0, pinchHint.f1] as const).map((f, i) => (
@@ -506,7 +548,7 @@ export function AndroidViewer({
                           position: 'absolute', zIndex: 10, borderRadius: '50%',
                           transform: 'translate(-50%, -50%)', pointerEvents: 'none',
                           transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease',
-                          left: `${f.x * 100}%`, top: `${f.y * 100}%`,
+                          left: `${screenPctLeft + f.x * screenPctW}%`, top: `${screenPctTop + f.y * screenPctH}%`,
                           ...(pinchActive
                             ? { width: CURSOR_DOT_R * 2, height: CURSOR_DOT_R * 2, background: 'rgba(255,255,255,0.92)', border: '1.5px solid rgba(0,0,0,0.2)', boxShadow: '0 0 0 1px rgba(0,0,0,0.15), 0 0 8px rgba(255,255,255,0.25)' }
                             : { width: CURSOR_RING_R * 2, height: CURSOR_RING_R * 2, background: 'transparent', border: '1.5px solid rgba(255,255,255,0.6)', boxShadow: '0 0 0 1px rgba(0,0,0,0.3)' }),
@@ -516,7 +558,15 @@ export function AndroidViewer({
                   )}
                 </>
               )}
+              {/* back.webp overlay — frame edges opaque, covers canvas edge artifacts */}
+              <img
+                src={`data:image/webp;base64,${skinBackPng}`}
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none', display: 'block', zIndex: 5 }}
+                alt="" draggable={false}
+              />
             </div>
+            {/* cursor — in outer non-rotating div so position maps directly to client coords */}
+            <div ref={liveCursorRef} style={{ display: 'none', position: 'absolute', zIndex: 15, borderRadius: '50%', transform: 'translate(-50%, -50%)', pointerEvents: 'none', transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease' }} />
           </div>
         ) : (
           // ── Fallback: CSS bezel ───────────────────────────────────────────

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -68,6 +68,17 @@ export interface AndroidButton {
   keyCode: number
 }
 
+export interface AndroidChrome {
+  buttons: AndroidButton[]
+  streamType: 'h264'
+  screenWidth?: number
+  screenHeight?: number
+  skinBackPng?: string        // base64-encoded webp, portrait background image
+  skinScreenRect?: { x: number; y: number; width: number; height: number }
+  skinCompositeSize?: { width: number; height: number }
+  skinCornerRadius?: number
+}
+
 export interface ChromeData {
   framePng: string         // full composite PDF at 2× — device frame visible, screen hole transparent
   bezelWidth: number
@@ -131,7 +142,7 @@ export interface ReleaseGroup {
 export type RelayMessage =
   | { type: 'agents:listed'; sessions: SessionInfo[] }
   | { type: 'session:joined'; sessionId: string }
-  | { type: 'session:chrome'; payload: ChromeData | { buttons: AndroidButton[]; streamType: 'h264' } }
+  | { type: 'session:chrome'; payload: ChromeData | AndroidChrome }
   | { type: 'session:deviceInfo'; payload: DeviceInfo }
   | { type: 'device:boot'; sessionId: string; payload: { deviceId: string; resetMode?: 'app-only' | 'full-erase' } }
   | { type: 'device:booting' }


### PR DESCRIPTION
## Summary

- `SkinLoader.ts` (new): AVD `config.ini` + `layout` 파일 파싱 → 배경 이미지(webp) + 화면 좌표 추출
- `AndroidChrome` 타입에 skin 필드 추가 (`skinBackPng`, `skinScreenRect`, `skinCompositeSize`, `skinCornerRadius`)
- `AndroidAgent`: 부트 완료 후 `loadSkin()` 호출, 기존 `session:chrome` 페이로드에 skin 데이터 포함 (relay 변경 없음)
- `AndroidViewer`: skin 데이터가 있으면 SDK webp 이미지로 디바이스 프레임 렌더, 없으면 기존 CSS bezel 폴백
- `DeviceViewer`: `sendRef` render-time 뮤테이션 → `useLayoutEffect` 교체 (`refs-during-render` 린트 경고 수정)

## 구조

iOS `ChromeData`와 동일한 `session:chrome` 채널 재사용. `'framePng' in chrome` discriminator 유지.

## Test plan

- [ ] `SkinLoader.test.ts` 12개 테스트 확인 (parseLayout + loadSkin 폴백 케이스)
- [ ] Galaxy S23 API 35 에뮬레이터 부트 후 pixel_8 스킨 PNG 프레임 표시 확인
- [ ] `_no_skin` AVD 부트 시 CSS 페이크 프레임 폴백 동작 확인
- [ ] iOS 세션 병렬 진입 시 IOSViewer 정상 동작 회귀 확인

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android emulators now display authentic device skins (background, frame, screen bounds, corner radius) for a more realistic viewer.
* **Bug Fixes / UX**
  * Improved rotation handling: stream stays portrait to avoid resolution jumps; rotation toggles align visual and pointer behavior without layout shifts.
* **Documentation**
  * Added guidance on rotation behavior and streaming/renderer expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->