### PR TITLE
feat(ios-agent,android-agent): auto-reconnect to relay on connection drop

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -152,6 +152,8 @@ export class AndroidAgent implements DeviceAgent {
   }
 
   async connect(relayUrl: string): Promise<void> {
+    this._stopping = false
+    if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null }
     this.relayUrl = relayUrl
     const allDevices = await this.adb.listDevices()
     const devices = this.deviceFilter

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -134,6 +134,9 @@ export class AndroidAgent implements DeviceAgent {
   private relayUrl: string | null = null
   private resourcesTimer: ReturnType<typeof setInterval> | null = null
   private readonly resources = createResourceSampler()
+  private _stopping = false
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private _reconnectAttempt = 0
 
   private readonly deviceFilter?: string
 
@@ -185,6 +188,7 @@ export class AndroidAgent implements DeviceAgent {
           })
           this.reportResources()
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
+          ws.on('close', () => this._scheduleReconnect())
           resolve()
         } else {
           reject(new PlatformError(`Unexpected message during handshake: ${msg.type}`))
@@ -218,6 +222,8 @@ export class AndroidAgent implements DeviceAgent {
   }
 
   disconnect(): void {
+    this._stopping = true
+    if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null }
     if (this.resourcesTimer) { clearInterval(this.resourcesTimer); this.resourcesTimer = null }
     for (const state of this.deviceStates.values()) {
       this.cleanupDeviceState(state)
@@ -226,6 +232,32 @@ export class AndroidAgent implements DeviceAgent {
     this.ws?.close()
     this.ws = null
     this.relayUrl = null
+  }
+
+  private _scheduleReconnect(): void {
+    if (this._stopping) return
+    if (this.resourcesTimer) { clearInterval(this.resourcesTimer); this.resourcesTimer = null }
+    for (const state of this.deviceStates.values()) {
+      this.cleanupDeviceState(state)
+    }
+    this.deviceStates.clear()
+    this.ws = null
+
+    const delays = [1000, 2000, 4000, 8000, 16000, 30000]
+    const delay = delays[Math.min(this._reconnectAttempt, delays.length - 1)]
+    this._reconnectAttempt++
+    logger.warn(`relay disconnected — reconnecting in ${delay / 1000}s (attempt ${this._reconnectAttempt})`)
+
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null
+      if (this._stopping || !this.relayUrl) return
+      this.connect(this.relayUrl).then(() => {
+        this._reconnectAttempt = 0
+        logger.info('reconnected to relay')
+      }).catch(() => {
+        this._scheduleReconnect()
+      })
+    }, delay)
   }
 
   private reportResources(): void {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -452,4 +452,62 @@ describe('AndroidAgent', () => {
       })
     })
   })
+
+  describe('reconnect', () => {
+    it('disconnect() sets _stopping and cancels pending reconnect timer', async () => {
+      const agent = new AndroidAgent({}, mockAdb())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._reconnectTimer = setTimeout(() => {}, 10000)
+
+      agent.disconnect()
+
+      expect((agent as any)._stopping).toBe(true)
+      expect((agent as any)._reconnectTimer).toBeNull()
+    })
+
+    it('_scheduleReconnect() increments attempt and sets timer', async () => {
+      const agent = new AndroidAgent({}, mockAdb())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._scheduleReconnect()
+
+      expect((agent as any)._reconnectAttempt).toBe(1)
+      expect((agent as any)._reconnectTimer).not.toBeNull()
+
+      agent.disconnect()
+    })
+
+    it('_scheduleReconnect() is no-op when _stopping is true', async () => {
+      const agent = new AndroidAgent({}, mockAdb())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._stopping = true
+      ;(agent as any)._scheduleReconnect()
+
+      expect((agent as any)._reconnectTimer).toBeNull()
+      expect((agent as any)._reconnectAttempt).toBe(0)
+
+      agent.disconnect()
+    })
+
+    it('reconnects automatically when connection drops and relay is available', async () => {
+      const agent = new AndroidAgent({}, mockAdb())
+      await agent.connect(`ws://localhost:${port}`)
+
+      // Terminate the ws to simulate network drop (relay stays up)
+      ;(agent as any).ws.terminate()
+
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect((agent as any)._reconnectAttempt).toBe(1)
+
+      // Relay is still running — wait for 1s backoff then reconnect
+      await new Promise(resolve => setTimeout(resolve, 1500))
+
+      expect((agent as any)._reconnectAttempt).toBe(0)
+      expect((agent as any).ws).not.toBeNull()
+
+      agent.disconnect()
+    }, 5000)
+  })
 })

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -70,6 +70,8 @@ export class IOSAgent implements DeviceAgent {
   }
 
   async connect(relayUrl: string): Promise<void> {
+    this._stopping = false
+    if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null }
     this.relayUrl = relayUrl
     const devices = await this.simctl.listDevices()
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -53,6 +53,9 @@ export class IOSAgent implements DeviceAgent {
   private relayUrl: string | null = null
   private resourcesTimer: ReturnType<typeof setInterval> | null = null
   private readonly resources = createResourceSampler()
+  private _stopping = false
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private _reconnectAttempt = 0
 
   constructor(options: IOSAgentOptions = {}, simctl?: SimctlWrapper) {
     this.simctl = simctl ?? new SimctlWrapper()
@@ -100,6 +103,7 @@ export class IOSAgent implements DeviceAgent {
           })
           this.reportResources()
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
+          ws.on('close', () => this._scheduleReconnect())
           resolve()
         } else {
           reject(new PlatformError(`Unexpected message during handshake: ${msg.type}`))
@@ -129,6 +133,8 @@ export class IOSAgent implements DeviceAgent {
   }
 
   disconnect(): void {
+    this._stopping = true
+    if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null }
     if (this.resourcesTimer) { clearInterval(this.resourcesTimer); this.resourcesTimer = null }
     for (const state of this.deviceStates.values()) {
       this.cleanupDeviceState(state)
@@ -138,6 +144,32 @@ export class IOSAgent implements DeviceAgent {
     this.ws = null
     this.relayUrl = null
     this.simctl.stopKeyboardDaemon()
+  }
+
+  private _scheduleReconnect(): void {
+    if (this._stopping) return
+    if (this.resourcesTimer) { clearInterval(this.resourcesTimer); this.resourcesTimer = null }
+    for (const state of this.deviceStates.values()) {
+      this.cleanupDeviceState(state)
+    }
+    this.deviceStates.clear()
+    this.ws = null
+
+    const delays = [1000, 2000, 4000, 8000, 16000, 30000]
+    const delay = delays[Math.min(this._reconnectAttempt, delays.length - 1)]
+    this._reconnectAttempt++
+    logger.warn(`relay disconnected — reconnecting in ${delay / 1000}s (attempt ${this._reconnectAttempt})`)
+
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null
+      if (this._stopping || !this.relayUrl) return
+      this.connect(this.relayUrl).then(() => {
+        this._reconnectAttempt = 0
+        logger.info('reconnected to relay')
+      }).catch(() => {
+        this._scheduleReconnect()
+      })
+    }, delay)
   }
 
   private reportResources(): void {

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -501,4 +501,62 @@ describe('IOSAgent', () => {
     })
   })
 
+  describe('reconnect', () => {
+    it('disconnect() sets _stopping and cancels pending reconnect timer', async () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._reconnectTimer = setTimeout(() => {}, 10000)
+
+      agent.disconnect()
+
+      expect((agent as any)._stopping).toBe(true)
+      expect((agent as any)._reconnectTimer).toBeNull()
+    })
+
+    it('_scheduleReconnect() increments attempt and sets timer', async () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._scheduleReconnect()
+
+      expect((agent as any)._reconnectAttempt).toBe(1)
+      expect((agent as any)._reconnectTimer).not.toBeNull()
+
+      agent.disconnect()
+    })
+
+    it('_scheduleReconnect() is no-op when _stopping is true', async () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+
+      ;(agent as any)._stopping = true
+      ;(agent as any)._scheduleReconnect()
+
+      expect((agent as any)._reconnectTimer).toBeNull()
+      expect((agent as any)._reconnectAttempt).toBe(0)
+
+      agent.disconnect()
+    })
+
+    it('reconnects automatically when connection drops and relay is available', async () => {
+      const agent = new IOSAgent({}, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+
+      // Terminate the ws to simulate network drop (relay stays up)
+      ;(agent as any).ws.terminate()
+
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect((agent as any)._reconnectAttempt).toBe(1)
+
+      // Relay is still running — wait for 1s backoff then reconnect
+      await new Promise(resolve => setTimeout(resolve, 1500))
+
+      expect((agent as any)._reconnectAttempt).toBe(0)
+      expect((agent as any).ws).not.toBeNull()
+
+      agent.disconnect()
+    }, 5000)
+  })
+
 })


### PR DESCRIPTION
## Summary

- `IOSAgent`, `AndroidAgent` 모두 relay WebSocket 연결이 끊기면 exponential backoff(1s→2s→4s→8s→16s→30s cap)로 자동 재연결 시도
- `disconnect()` (SIGINT 등 명시적 종료) 시 `_stopping = true` 설정으로 재연결 없이 즉시 종료
- 재연결 성공 후 backoff 카운터 리셋

Closes #108

## Test plan

- [ ] `_scheduleReconnect()` 호출 시 attempt 증가 및 timer 설정 확인
- [ ] `disconnect()` 호출 시 `_stopping=true`, pending timer 취소 확인
- [ ] `_stopping=true` 상태에서 `_scheduleReconnect()` no-op 확인
- [ ] ws.terminate() 후 1s backoff → relay 재연결 성공 → `_reconnectAttempt` 리셋 확인 (ios/android 각각)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android and iOS agents now automatically reconnect to the relay after unexpected disconnects, using exponential backoff and guarded retry logic to avoid interfering with intentional shutdowns.

* **Tests**
  * Added tests covering reconnect behavior: graceful disconnect cancellation, backoff scheduling, no-op when stopping, and end-to-end recovery after simulated network drops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->