### PR TITLE
fix(android): replace CSS border-radius with mask.webp overlay for screen masking

### DIFF
--- a/contributing/android-video-streaming-diagnosis.md
+++ b/contributing/android-video-streaming-diagnosis.md
@@ -196,3 +196,88 @@ this.adb.setUserRotation(serial, target) // user_rotation=0 or 3
 | `android-agent/src/AdbWrapper.ts` | `disableAutoRotate`, `setUserRotation` 추가 |
 | `android-agent/src/AndroidAgent.ts` | `input:rotate` → 0↔3 토글 |
 | `dashboard/components/device/AndroidViewer.tsx` | 스킨 모드 iOS 패턴으로 단순화 |
+
+---
+
+## Issue 4 — status bar 양끝 잘림: CSS border-radius / back.webp 이중 레이어 한계 (2026-05-25 분석 완료)
+
+### 핵심 결론
+
+`mask.webp`를 스크린 영역에 CSS `mask-image`(또는 `<img>` 오버레이)로 적용해야 한다. `corner_radius` 기반 CSS border-radius는 근본 해결책이 아니다. 구현 계획: `.work/2026-05-25-android-skin-mask-plan.md`.
+
+### 증상
+
+1. **canvas에 `border-radius: skinCornerRadiusCss` 적용 상태**: status bar 우측 wifi/배터리 아이콘이 canvas의 곡률 클리핑에 잘림. 좌측 시간도 일부 잘림.
+2. **canvas border-radius 제거 시도**: 우측 아이콘은 보임. 그러나 좌측 시간은 여전히 `.32`처럼 앞 글자가 잘림.
+
+### 잘못된 가정
+
+**Phase 2 구현 시 판단**: `mask.webp` 기반 `corner_radius` 자동 감지로 충분 → **틀렸음**.
+
+실제로 두 가지 문제가 겹쳐 있었다:
+
+1. **canvas CSS border-radius** → canvas DOM element를 직접 클리핑하므로, status bar 모서리 픽셀이 잘림. 실제 Android OS는 `WindowInsets`로 앱 콘텐츠를 모서리 곡률 안쪽으로 inset 시키므로 화면이 잘리지 않는다. 에뮬레이터는 직사각형 화면 인식이라 inset 없음 → CSS 클리핑이 이 차이를 부각.
+
+2. **back.webp 이중 레이어(zIndex 5) 오버레이** → 동일한 composite back.webp를 canvas 위에 한 번 더 깔아 canvas 가장자리 아티팩트를 가린다. 그런데 back.webp 자체의 불투명 베젤이 스크린 좌상단 모서리(시계 아이콘 영역)를 살짝 덮는다.
+
+### `corner_radius=87`의 정확한 의미
+
+공식 스킨 파일 포맷(ANDROID-SKIN-FILES.TXT)과 실제 스킨 파일 분석 결과:
+
+- `corner_radius`는 **외부 유리(outer glass)의 곡률 힌트** — display 경계의 inner corner radius가 아님.
+- 오래된 에뮬레이터의 화면 클리핑 fallback 용도. 실제 Android Studio는 이것으로 클리핑하지 않는다.
+- `Pixel_6` 스킨: rounded 스크린이지만 `corner_radius` 속성이 없음 → 이 값이 주된 마스킹 메커니즘이 아님을 직접 증명.
+
+### `mask.webp`의 정확한 의미
+
+```
+mask.webp (신형 스킨 구조):
+  - 크기: display 해상도 (예: Pixel 9 = 1080 × 2424)
+  - 내용: 불투명(검정) 베젤 + 투명 스크린 영역 + 투명 카메라 펀치홀
+  - 위치: composite에서 스크린 영역(screenPctLeft, screenPctTop)에 1:1 오버레이
+```
+
+**back.webp와의 역할 분리**:
+- `back.webp` (composite 크기: 1198×2531) = 디바이스 외형(베젤, 버튼, 프레임)
+- `mask.webp` (display 크기: 1080×2424) = 스크린 경계의 정밀 마스킹 (카메라 홀, 모서리 곡률)
+
+### Android Studio가 이 문제를 회피하는 방법
+
+Android Studio 에뮬레이터 창 렌더링 파이프라인:
+1. `back.webp` → OpenGL 텍스처로 그림 (composite 크기)
+2. 스크린 OpenGL 뷰포트에 에뮬레이터 프레임버퍼 직접 렌더
+3. `mask.webp` → OpenGL 알파 마스크로 스크린 영역에 합성
+
+CSS `border-radius`를 사용하지 않음 → 클리핑 없음. `mask.webp`의 알파 채널이 곡률 마스킹을 정확히 처리.
+
+### 올바른 해결 방법
+
+**canvas `border-radius` 제거** + **second back.webp 제거** + **mask.webp를 스크린 영역에 오버레이**:
+
+```tsx
+// 현재 (잘못된 구현)
+<canvas style={{ borderRadius: skinCornerRadiusCss }} />
+<img src={back.webp} style={{ zIndex: 5 }} />  {/* second overlay hack */}
+
+// 올바른 구현
+<canvas />  {/* border-radius 없음 */}
+<img
+  src={`data:image/webp;base64,${skinMaskPng}`}
+  style={{
+    position: 'absolute',
+    left: `${screenPctLeft}%`, top: `${screenPctTop}%`,
+    width: `${screenPctW}%`,  height: `${screenPctH}%`,
+    zIndex: 5,
+  }}
+/>
+```
+
+### 변경이 필요한 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `android-agent/src/SkinLoader.ts` | `mask.webp` 파일 읽기 → base64 |
+| `dashboard/lib/types.ts` | `AndroidChrome`에 `skinMaskPng?: string` 추가 |
+| `android-agent/src/AndroidAgent.ts` | `session:chrome` 페이로드에 `skinMaskPng` 포함 |
+| `dashboard/components/device/DeviceViewer.tsx` | `skinMaskPng` prop 전달 |
+| `dashboard/components/device/AndroidViewer.tsx` | canvas `borderRadius` 제거, second back.webp → mask.webp 오버레이 교체 |

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -472,6 +472,7 @@ export class AndroidAgent implements DeviceAgent {
           screenHeight: state.displayHeight,
           ...(skin ? {
             skinBackPng: skin.backPng,
+            ...(skin.maskPng ? { skinMaskPng: skin.maskPng } : {}),
             skinScreenRect: skin.screenRect,
             skinCompositeSize: skin.compositeSize,
             skinCornerRadius: skin.cornerRadius,

--- a/packages/android-agent/src/SkinLoader.ts
+++ b/packages/android-agent/src/SkinLoader.ts
@@ -8,7 +8,8 @@ import { createLogger } from '@tapflowio/agent-core'
 const logger = createLogger('android-agent:skin')
 
 export interface SkinData {
-  backPng: string  // base64-encoded image (webp)
+  backPng: string   // base64-encoded webp, composite-sized device chassis
+  maskPng?: string  // base64-encoded webp, display-sized alpha mask (opaque bezel + transparent screen)
   screenRect: { x: number; y: number; width: number; height: number }
   compositeSize: { width: number; height: number }
   cornerRadius: number
@@ -69,8 +70,17 @@ export function loadSkin(
       }
     }
 
+    let maskPng: string | undefined
+    if (layout.maskImage) {
+      const maskPath = join(skinPath, layout.maskImage)
+      if (existsSync(maskPath)) {
+        maskPng = readFileSync(maskPath).toString('base64')
+      }
+    }
+
     return {
       backPng: readFileSync(bgPath).toString('base64'),
+      maskPng,
       screenRect: { x: layout.screenX, y: layout.screenY, width: layout.displayWidth, height: layout.displayHeight },
       compositeSize: { width: layout.compositeWidth, height: layout.compositeHeight },
       cornerRadius,

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -135,6 +135,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
         screenHeight={androidChrome.screenHeight}
         deviceRotation={deviceRotation}
         skinBackPng={androidChrome.skinBackPng}
+        skinMaskPng={androidChrome.skinMaskPng}
         skinScreenRect={androidChrome.skinScreenRect}
         skinCompositeSize={androidChrome.skinCompositeSize}
         skinCornerRadius={androidChrome.skinCornerRadius}

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -39,6 +39,7 @@ interface AndroidViewerProps {
   screenHeight?: number;
   deviceRotation?: number;
   skinBackPng?: string;
+  skinMaskPng?: string;
   skinScreenRect?: { x: number; y: number; width: number; height: number };
   skinCompositeSize?: { width: number; height: number };
   skinCornerRadius?: number;
@@ -50,7 +51,7 @@ export function AndroidViewer({
   launching, setLaunching, androidButtons,
   binaryFrameHandlerRef, onRecordingUploaded,
   screenWidth, screenHeight, deviceRotation = 0,
-  skinBackPng, skinScreenRect, skinCompositeSize, skinCornerRadius = 0,
+  skinBackPng, skinMaskPng, skinScreenRect, skinCompositeSize, skinCornerRadius = 0,
 }: AndroidViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -373,9 +374,7 @@ export function AndroidViewer({
   const screenPctTop  = hasSkin ? (skinScreenRect!.y / skinCompositeSize!.height) * 100 : 0;
   const screenPctW    = hasSkin ? (skinScreenRect!.width  / skinCompositeSize!.width) * 100 : 0;
   const screenPctH    = hasSkin ? (skinScreenRect!.height / skinCompositeSize!.height) * 100 : 0;
-  const skinCornerRadiusCss = hasSkin && skinCornerRadius > 0
-    ? `${Math.round(skinCornerRadius * compositeDisplayH / skinCompositeSize!.height)}px`
-    : '0px';
+  const hasMask = hasSkin && Boolean(skinMaskPng);
 
   // Container uses landscape dims; canvas inside rotated 90° to show portrait content in landscape shell
   const containerW = needsCSSRotation ? androidDisplayH : androidDisplayW;
@@ -523,7 +522,6 @@ export function AndroidViewer({
                       position: 'absolute',
                       left: `${screenPctLeft}%`, top: `${screenPctTop}%`,
                       width: `${screenPctW}%`, height: `${screenPctH}%`,
-                      borderRadius: skinCornerRadiusCss,
                       visibility: canvasReady ? 'visible' : 'hidden',
                       cursor: 'none', backgroundColor: '#010101',
                     }}
@@ -534,7 +532,7 @@ export function AndroidViewer({
                     onPointerLeave={handlePointerLeave}
                   />
                   {!canvasReady && (
-                    <div className="absolute animate-pulse bg-zinc-700" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, borderRadius: skinCornerRadiusCss }} />
+                    <div className="absolute animate-pulse bg-zinc-700" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%` }} />
                   )}
                   {!canvasReady && deviceReady && (
                     <div className="absolute pointer-events-none" style={{ left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -558,12 +556,21 @@ export function AndroidViewer({
                   )}
                 </>
               )}
-              {/* back.webp overlay — frame edges opaque, covers canvas edge artifacts */}
-              <img
-                src={`data:image/webp;base64,${skinBackPng}`}
-                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none', display: 'block', zIndex: 5 }}
-                alt="" draggable={false}
-              />
+              {/* mask.webp: display-sized alpha overlay — opaque bezel masks canvas corners precisely */}
+              {/* fallback: second back.webp for skins without mask.webp */}
+              {hasMask ? (
+                <img
+                  src={`data:image/webp;base64,${skinMaskPng}`}
+                  style={{ position: 'absolute', left: `${screenPctLeft}%`, top: `${screenPctTop}%`, width: `${screenPctW}%`, height: `${screenPctH}%`, pointerEvents: 'none', userSelect: 'none', display: 'block', zIndex: 5 }}
+                  alt="" draggable={false}
+                />
+              ) : (
+                <img
+                  src={`data:image/webp;base64,${skinBackPng}`}
+                  style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', userSelect: 'none', display: 'block', zIndex: 5 }}
+                  alt="" draggable={false}
+                />
+              )}
             </div>
             {/* cursor — in outer non-rotating div so position maps directly to client coords */}
             <div ref={liveCursorRef} style={{ display: 'none', position: 'absolute', zIndex: 15, borderRadius: '50%', transform: 'translate(-50%, -50%)', pointerEvents: 'none', transition: 'width 0.1s ease, height 0.1s ease, background 0.1s ease, box-shadow 0.1s ease' }} />

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -73,7 +73,8 @@ export interface AndroidChrome {
   streamType: 'h264'
   screenWidth?: number
   screenHeight?: number
-  skinBackPng?: string        // base64-encoded webp, portrait background image
+  skinBackPng?: string        // base64-encoded webp, composite-sized device chassis
+  skinMaskPng?: string        // base64-encoded webp, display-sized alpha mask (opaque bezel + transparent screen)
   skinScreenRect?: { x: number; y: number; width: number; height: number }
   skinCompositeSize?: { width: number; height: number }
   skinCornerRadius?: number


### PR DESCRIPTION
## Summary

- `mask.webp`(display 크기 alpha 마스크)를 canvas 위에 오버레이해 status bar 양끝 잘림 수정
- canvas CSS `border-radius` 제거 — OS가 `WindowInsets`로 처리하는 내용을 CSS로 흉내내면 status bar 픽셀이 잘림
- second `back.webp` overlay 제거 — composite 크기 이미지를 다시 올리면 스크린 좌측 모서리(시계 아이콘)를 덮음
- `mask.webp` 없는 구형 스킨은 기존 second `back.webp` 방식 유지 (폴백)

## Root cause

상세 분석: [`contributing/android-video-streaming-diagnosis.md` §Issue 4](../contributing/android-video-streaming-diagnosis.md)

- `corner_radius=87`은 outer glass 곡률 힌트 — CSS border-radius로 canvas를 클리핑하는 근거가 아님
- Android Studio는 `mask.webp`(display 크기, opaque bezel + transparent screen)를 alpha overlay로 사용
- tapflow의 기존 CSS 방식은 에뮬레이터 status bar가 `WindowInsets` 없이 직사각형 화면으로 인식하는 상황에서 잘림을 부각시킴

## Changes

| File | Change |
|------|--------|
| `android-agent/src/SkinLoader.ts` | `mask.webp` 로드 → base64 인코딩 → `SkinData.maskPng` |
| `dashboard/lib/types.ts` | `AndroidChrome.skinMaskPng?: string` 추가 |
| `android-agent/src/AndroidAgent.ts` | `session:chrome` 페이로드에 `skinMaskPng` 포함 |
| `dashboard/components/DeviceViewer.tsx` | `skinMaskPng` prop 전달 |
| `dashboard/components/device/AndroidViewer.tsx` | canvas `borderRadius` 제거, mask overlay 교체 |

## Test plan

- [ ] Pixel 9 에뮬레이터 연결 후 status bar 좌측 시간 전체 표시 확인
- [ ] status bar 우측 wifi/배터리 아이콘 전체 표시 확인
- [ ] iOS 세션 병렬 진입 시 `framePng` discriminator 정상 동작 확인
- [ ] `mask.webp` 없는 구형 스킨에서 second back.webp 폴백 동작 확인

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display clipping at status bar edges and screen corners in the Android device viewer.

* **Documentation**
  * Added diagnostic guide for Android device display rendering issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->