### PR TITLE
docs: move release steps to .internal/RELEASING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,26 +43,6 @@ v0.3.0-beta.1    # feature-complete, external testing
 v0.3.0-rc.1      # release candidate, no new features
 ```
 
-#### Cutting a release
-
-```sh
-# 1. confirm you are on an up-to-date main
-git checkout main && git pull origin main
-
-# 2. record what changed
-pnpm changeset add
-
-# 3. bump all package versions (edits package.json files and CHANGELOG.md)
-pnpm changeset version
-
-# 4. commit the version bump
-git add -A && git commit -m "chore: release v<new-version>"
-
-# 5. tag and push — GitHub Actions publishes to npm and creates a GitHub Release
-git tag v<new-version>
-git push origin main v<new-version>
-```
-
 ## Tests
 
 All packages:


### PR DESCRIPTION
## Summary

- Remove "Cutting a release" section from `CONTRIBUTING.md` — contributors don't cut releases
- Release process is maintainer-only, documented in `.internal/RELEASING.md` (gitignored, local only)
- Updated flow uses PR-based release instead of direct main push (blocked by pre-push hook anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor documentation by removing outdated release procedure guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->