### PR TITLE
feat(perf): frame-envelope-c2 — per-frame hop timestamps + android rotation fix

### DIFF
--- a/packages/agent-core/src/__tests__/envelope.test.ts
+++ b/packages/agent-core/src/__tests__/envelope.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HEADER_SIZE,
+  TFFE_MAGIC,
+  hasEnvelope,
+  writeEnvelopeHeader,
+  patchRelayedAt,
+} from '../utils/envelope'
+
+describe('HEADER_SIZE', () => {
+  it('is 22', () => {
+    expect(HEADER_SIZE).toBe(22)
+  })
+})
+
+describe('writeEnvelopeHeader', () => {
+  it('prepends 22-byte header to payload', () => {
+    const payload = Buffer.from([0x01, 0x02, 0x03])
+    const result = writeEnvelopeHeader(payload, 1000)
+    expect(result.length).toBe(HEADER_SIZE + payload.length)
+  })
+
+  it('starts with TFFE magic bytes', () => {
+    const result = writeEnvelopeHeader(Buffer.alloc(0), 0)
+    expect([result[0], result[1], result[2], result[3]]).toEqual([...TFFE_MAGIC])
+  })
+
+  it('sets version=1 and flags=0', () => {
+    const result = writeEnvelopeHeader(Buffer.alloc(0), 0)
+    expect(result[4]).toBe(1)
+    expect(result[5]).toBe(0)
+  })
+
+  it('writes capturedAt at offset 6 as u64 BE', () => {
+    const capturedAt = 1_716_000_000_123
+    const result = writeEnvelopeHeader(Buffer.alloc(0), capturedAt)
+    expect(Number(result.readBigUInt64BE(6))).toBe(capturedAt)
+  })
+
+  it('initialises relayedAt at offset 14 to 0', () => {
+    const result = writeEnvelopeHeader(Buffer.alloc(0), 999)
+    expect(Number(result.readBigUInt64BE(14))).toBe(0)
+  })
+
+  it('preserves payload bytes after header', () => {
+    const payload = Buffer.from([0xAA, 0xBB, 0xCC])
+    const result = writeEnvelopeHeader(payload, 0)
+    expect(result.subarray(HEADER_SIZE)).toEqual(payload)
+  })
+})
+
+describe('patchRelayedAt', () => {
+  it('writes relayedAt at offset 14 in-place', () => {
+    const frame = writeEnvelopeHeader(Buffer.alloc(4), 1000)
+    patchRelayedAt(frame, 2000)
+    expect(Number(frame.readBigUInt64BE(14))).toBe(2000)
+  })
+
+  it('does not modify capturedAt or other bytes', () => {
+    const capturedAt = 1_716_000_000_123
+    const payload = Buffer.from([0xDE, 0xAD])
+    const frame = writeEnvelopeHeader(payload, capturedAt)
+    patchRelayedAt(frame, 9999)
+    expect(Number(frame.readBigUInt64BE(6))).toBe(capturedAt)
+    expect(frame[4]).toBe(1)
+    expect(frame.subarray(HEADER_SIZE)).toEqual(payload)
+  })
+
+  it('relayedAt is after capturedAt', () => {
+    const frame = writeEnvelopeHeader(Buffer.alloc(0), 1000)
+    patchRelayedAt(frame, 2000)
+    const captured = Number(frame.readBigUInt64BE(6))
+    const relayed = Number(frame.readBigUInt64BE(14))
+    expect(relayed).toBeGreaterThanOrEqual(captured)
+  })
+})
+
+describe('hasEnvelope', () => {
+  it('returns true for a frame with TFFE magic', () => {
+    const frame = writeEnvelopeHeader(Buffer.from([0xFF, 0xD8]), 1000)
+    expect(hasEnvelope(frame)).toBe(true)
+  })
+
+  it('returns false for a plain JPEG buffer', () => {
+    const jpeg = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10])
+    expect(hasEnvelope(jpeg)).toBe(false)
+  })
+
+  it('returns false for a buffer shorter than HEADER_SIZE', () => {
+    const short = Buffer.from([0x54, 0x46, 0x46, 0x45])
+    expect(hasEnvelope(short)).toBe(false)
+  })
+
+  it('returns false for an empty buffer', () => {
+    expect(hasEnvelope(Buffer.alloc(0))).toBe(false)
+  })
+})

--- a/packages/agent-core/src/utils/envelope.ts
+++ b/packages/agent-core/src/utils/envelope.ts
@@ -1,0 +1,26 @@
+export const TFFE_MAGIC = [0x54, 0x46, 0x46, 0x45] as const
+export const HEADER_SIZE = 22
+
+export function hasEnvelope(frame: Buffer): boolean {
+  return (
+    frame.length >= HEADER_SIZE &&
+    frame[0] === 0x54 &&
+    frame[1] === 0x46 &&
+    frame[2] === 0x46 &&
+    frame[3] === 0x45
+  )
+}
+
+export function writeEnvelopeHeader(payload: Buffer, capturedAt: number): Buffer {
+  const header = Buffer.allocUnsafe(HEADER_SIZE)
+  header[0] = 0x54; header[1] = 0x46; header[2] = 0x46; header[3] = 0x45
+  header[4] = 1   // version
+  header[5] = 0   // flags (reserved)
+  header.writeBigUInt64BE(BigInt(capturedAt), 6)
+  header.writeBigUInt64BE(0n, 14) // relayedAt: filled in by relay
+  return Buffer.concat([header, payload])
+}
+
+export function patchRelayedAt(frame: Buffer, relayedAt: number): void {
+  frame.writeBigUInt64BE(BigInt(relayedAt), 14)
+}

--- a/packages/agent-core/src/utils/index.ts
+++ b/packages/agent-core/src/utils/index.ts
@@ -5,3 +5,10 @@ export {
   createRateLimitedDropWarn,
   DEFAULT_BACKPRESSURE_BYTES,
 } from './stream.js'
+export {
+  TFFE_MAGIC,
+  HEADER_SIZE,
+  hasEnvelope,
+  writeEnvelopeHeader,
+  patchRelayedAt,
+} from './envelope.js'

--- a/packages/android-agent/src/AdbWrapper.ts
+++ b/packages/android-agent/src/AdbWrapper.ts
@@ -134,12 +134,9 @@ export class AdbWrapper {
     return this.runner.execBinary('-s', serial, 'exec-out', 'screencap', '-p')
   }
 
-  async enableAutoRotate(serial: string): Promise<void> {
-    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'accelerometer_rotation', '1')
-  }
-
-  async emuRotate(serial: string): Promise<void> {
-    await this.runner.exec('-s', serial, 'emu', 'rotate')
+  async setRotation(serial: string, rotation: 0 | 1): Promise<void> {
+    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'accelerometer_rotation', '0')
+    await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'user_rotation', String(rotation))
   }
 
   async sendInput(serial: string, ...args: string[]): Promise<void> {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -640,12 +640,11 @@ export class AndroidAgent implements DeviceAgent {
         if (!state) break
         const serial = this.adb.getSerial(state.deviceId)
         if (!serial) break
-        // Optimistically advance rotation by 90° so the view updates immediately.
-        // ROTATION_NOTIFICATION will reconcile the actual value; dedup logic in handleRotationNotification
-        // prevents a double-swap if prediction matches.
-        this.handleRotationNotification(state, (state.deviceRotation + 1) % 4)
-        this.adb.enableAutoRotate(serial).catch(() => {})
-        this.adb.emuRotate(serial).catch(() => {})
+        // Toggle portrait (0) ↔ landscape (1). Odd rotation values (1, 3) are landscape.
+        // Optimistically update so the view responds immediately; scrcpy notification reconciles.
+        const targetRotation: 0 | 1 = state.deviceRotation % 2 === 1 ? 0 : 1
+        this.handleRotationNotification(state, targetRotation)
+        this.adb.setRotation(serial, targetRotation).catch(() => {})
         break
       }
       case 'input:button': {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -640,11 +640,13 @@ export class AndroidAgent implements DeviceAgent {
         if (!state) break
         const serial = this.adb.getSerial(state.deviceId)
         if (!serial) break
-        // Toggle portrait (0) ↔ landscape (1). Odd rotation values (1, 3) are landscape.
-        // Optimistically update so the view responds immediately; scrcpy notification reconciles.
-        const targetRotation: 0 | 1 = state.deviceRotation % 2 === 1 ? 0 : 1
+        // Toggle portrait (0) ↔ landscape (1); optimistic update — roll back if ADB fails.
+        const prevRotation = state.deviceRotation
+        const targetRotation: 0 | 1 = prevRotation % 2 === 1 ? 0 : 1
         this.handleRotationNotification(state, targetRotation)
-        this.adb.setRotation(serial, targetRotation).catch(() => {})
+        this.adb.setRotation(serial, targetRotation).catch(() => {
+          this.handleRotationNotification(state, prevRotation)
+        })
         break
       }
       case 'input:button': {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -8,6 +8,7 @@ import {
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
   DEFAULT_BACKPRESSURE_BYTES,
+  writeEnvelopeHeader,
 } from '@tapflowio/agent-core/utils'
 import { AdbWrapper } from './AdbWrapper.js'
 import { EmulatorLauncher } from './EmulatorLauncher.js'
@@ -339,7 +340,7 @@ export class AndroidAgent implements DeviceAgent {
             state.scrcpySession?.control.updateScreenSize(parsed.width, parsed.height)
             logger.info(`video size → ${parsed.width}×${parsed.height}`)
           }
-          sendBinaryWithBackpressure(streamWs, value, threshold, onDrop)
+          sendBinaryWithBackpressure(streamWs, writeEnvelopeHeader(value, Date.now()), threshold, onDrop)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -29,13 +29,15 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   // statsRef is set by StatsOverlay; perfMetricsPushRef is set by MetricsPanel
   const statsRef = useRef<PerfHook | null>(null);
   const perfMetricsPushRef = useRef<((t: FrameTiming) => void) | null>(null);
-  const lastEnvelopeRef = useRef<{ capturedAt: number; relayedAt: number } | null>(null);
+  // FIFO queue: one entry pushed per incoming frame, shifted on paint completion.
+  // Prevents mis-attribution when multiple frames are in-flight through async decoders.
+  const envelopeQueueRef = useRef<Array<{ capturedAt: number; relayedAt: number } | null>>([]);
 
   // Viewers call these; both are no-ops when overlays are not mounted
   const perfHookRef = useRef<PerfHook>({
     onFrameBegin: () => statsRef.current?.onFrameBegin(),
     onFrameEnd: (t) => {
-      const env = lastEnvelopeRef.current;
+      const env = envelopeQueueRef.current.shift() ?? null;
       const timing: FrameTiming = env ? { ...t, capturedAt: env.capturedAt, relayedAt: env.relayedAt } : t;
       statsRef.current?.onFrameEnd(timing);
       perfMetricsPushRef.current?.(timing);
@@ -96,7 +98,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
 
   const handleBinaryFrame = useCallback((data: ArrayBuffer) => {
     const envelope = parseEnvelopeHeader(data);
-    lastEnvelopeRef.current = envelope;
+    envelopeQueueRef.current.push(envelope);
     const payload = envelope ? data.slice(HEADER_SIZE) : data;
     binaryFrameHandlerRef.current?.(payload);
   }, []);

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useRelay } from '@/hooks/useRelay';
 import { usePerfMode } from '@/hooks/usePerfMode';
 import { IOSViewer } from './device/IOSViewer';
@@ -8,6 +8,7 @@ import { AndroidViewer } from './device/AndroidViewer';
 import { SimulatorInfoCard } from './device/shared/SimulatorInfoCard';
 import type { AndroidButton, ChromeData, RelayMessage } from '@/lib/types';
 import type { FrameTiming, PerfHook } from './perf/types';
+import { parseEnvelopeHeader, HEADER_SIZE } from '@/lib/envelope';
 import { StatsOverlay } from './perf/StatsOverlay';
 import { MetricsPanel } from './perf/MetricsPanel';
 
@@ -28,11 +29,17 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   // statsRef is set by StatsOverlay; perfMetricsPushRef is set by MetricsPanel
   const statsRef = useRef<PerfHook | null>(null);
   const perfMetricsPushRef = useRef<((t: FrameTiming) => void) | null>(null);
+  const lastEnvelopeRef = useRef<{ capturedAt: number; relayedAt: number } | null>(null);
 
   // Viewers call these; both are no-ops when overlays are not mounted
   const perfHookRef = useRef<PerfHook>({
     onFrameBegin: () => statsRef.current?.onFrameBegin(),
-    onFrameEnd: (t) => { statsRef.current?.onFrameEnd(t); perfMetricsPushRef.current?.(t) },
+    onFrameEnd: (t) => {
+      const env = lastEnvelopeRef.current;
+      const timing: FrameTiming = env ? { ...t, capturedAt: env.capturedAt, relayedAt: env.relayedAt } : t;
+      statsRef.current?.onFrameEnd(timing);
+      perfMetricsPushRef.current?.(timing);
+    },
   });
 
   const [joined, setJoined] = useState(false);
@@ -88,11 +95,14 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   }, [sessionId, deviceId, buildId]);
 
   const handleBinaryFrame = useCallback((data: ArrayBuffer) => {
-    binaryFrameHandlerRef.current?.(data);
+    const envelope = parseEnvelopeHeader(data);
+    lastEnvelopeRef.current = envelope;
+    const payload = envelope ? data.slice(HEADER_SIZE) : data;
+    binaryFrameHandlerRef.current?.(payload);
   }, []);
 
   const { send, connected } = useRelay(handleMessage, handleBinaryFrame);
-  sendRef.current = send;
+  useLayoutEffect(() => { sendRef.current = send; });
 
   useEffect(() => {
     if (connected) send({ type: 'session:start', sessionId });

--- a/packages/dashboard/components/perf/MetricsPanel.tsx
+++ b/packages/dashboard/components/perf/MetricsPanel.tsx
@@ -44,15 +44,26 @@ export function MetricsPanel({ pushRef }: Props) {
 
       pane.addButton({ title: 'Export trace' }).on('click', () => {
         if (traceBuffer.length === 0) return
+        const hasAgentHops = traceBuffer.some((t) => t.capturedAt !== undefined)
         const events: object[] = [
           { ph: 'M', pid: 1, tid: 1, name: 'thread_name', args: { name: 'ws-recv' } },
           { ph: 'M', pid: 1, tid: 2, name: 'thread_name', args: { name: 'decode' } },
           { ph: 'M', pid: 1, tid: 3, name: 'thread_name', args: { name: 'paint' } },
         ]
+        if (hasAgentHops) {
+          events.push({ ph: 'M', pid: 1, tid: 4, name: 'thread_name', args: { name: 'relay' } })
+          events.push({ ph: 'M', pid: 1, tid: 5, name: 'thread_name', args: { name: 'agent-capture' } })
+        }
         for (const t of traceBuffer) {
           const recvUs = t.recvAt * 1000
           const decodeUs = t.decodeMs * 1000
           const paintUs = t.paintMs * 1000
+          if (t.capturedAt !== undefined && t.relayedAt !== undefined) {
+            const capturedUs = t.capturedAt * 1000
+            const relayedUs = t.relayedAt * 1000
+            events.push({ ph: 'i', ts: capturedUs, pid: 1, tid: 5, name: 'agent-capture', s: 't' })
+            events.push({ ph: 'X', ts: relayedUs, dur: Math.max(1, recvUs - relayedUs), pid: 1, tid: 4, name: 'relay' })
+          }
           events.push({ ph: 'i', ts: recvUs, pid: 1, tid: 1, name: 'ws-recv', s: 't' })
           events.push({ ph: 'X', ts: recvUs, dur: Math.max(1, decodeUs), pid: 1, tid: 2, name: 'decode' })
           events.push({ ph: 'X', ts: recvUs + decodeUs, dur: Math.max(1, paintUs), pid: 1, tid: 3, name: 'paint' })

--- a/packages/dashboard/components/perf/types.ts
+++ b/packages/dashboard/components/perf/types.ts
@@ -3,6 +3,8 @@ export interface FrameTiming {
   recvInterval: number
   decodeMs: number
   paintMs: number
+  capturedAt?: number
+  relayedAt?: number
 }
 
 export interface PerfHook {

--- a/packages/dashboard/lib/envelope.ts
+++ b/packages/dashboard/lib/envelope.ts
@@ -1,0 +1,17 @@
+export const HEADER_SIZE = 22
+
+const MAGIC = [0x54, 0x46, 0x46, 0x45]
+
+export function parseEnvelopeHeader(
+  frame: ArrayBuffer,
+): { capturedAt: number; relayedAt: number } | null {
+  if (frame.byteLength < HEADER_SIZE) return null
+  const view = new DataView(frame)
+  for (let i = 0; i < MAGIC.length; i++) {
+    if (view.getUint8(i) !== MAGIC[i]) return null
+  }
+  return {
+    capturedAt: Number(view.getBigUint64(6)),
+    relayedAt: Number(view.getBigUint64(14)),
+  }
+}

--- a/packages/dashboard/lib/envelope.ts
+++ b/packages/dashboard/lib/envelope.ts
@@ -1,6 +1,7 @@
 export const HEADER_SIZE = 22
 
 const MAGIC = [0x54, 0x46, 0x46, 0x45]
+const SUPPORTED_VERSION = 1
 
 export function parseEnvelopeHeader(
   frame: ArrayBuffer,
@@ -10,6 +11,7 @@ export function parseEnvelopeHeader(
   for (let i = 0; i < MAGIC.length; i++) {
     if (view.getUint8(i) !== MAGIC[i]) return null
   }
+  if (view.getUint8(4) !== SUPPORTED_VERSION) return null
   return {
     capturedAt: Number(view.getBigUint64(6)),
     relayedAt: Number(view.getBigUint64(14)),

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -15,6 +15,7 @@ import {
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
   DEFAULT_BACKPRESSURE_BYTES,
+  writeEnvelopeHeader,
 } from '@tapflowio/agent-core/utils'
 import { SimctlWrapper } from './SimctlWrapper.js'
 import { ScreenCaptureStreamer } from './ScreenCaptureStreamer.js'
@@ -238,7 +239,7 @@ export class IOSAgent implements DeviceAgent {
         while (true) {
           const { value, done } = await reader.read()
           if (done) break
-          sendBinaryWithBackpressure(streamWs, value, threshold, onDrop)
+          sendBinaryWithBackpressure(streamWs, writeEnvelopeHeader(value, Date.now()), threshold, onDrop)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -13,6 +13,8 @@ import {
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
   DEFAULT_BACKPRESSURE_BYTES,
+  hasEnvelope,
+  patchRelayedAt,
 } from '@tapflowio/agent-core/utils'
 
 const logger = createLogger('relay')
@@ -207,7 +209,9 @@ export class RelayServer {
             onDrop = createRateLimitedDropWarn(logger, session.id)
             this.dropHandlers.set(session.id, onDrop)
           }
-          sendBinaryWithBackpressure(session.browserSocket, data as Buffer, this.backpressureBytes, onDrop)
+          const frame = data as Buffer
+          if (hasEnvelope(frame)) patchRelayedAt(frame, Date.now())
+          sendBinaryWithBackpressure(session.browserSocket, frame, this.backpressureBytes, onDrop)
         }
         return
       }

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -6,6 +6,7 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
+import { writeEnvelopeHeader, HEADER_SIZE } from '@tapflowio/agent-core/utils'
 
 const waitForOpen = (ws: WebSocket) =>
   new Promise<void>((resolve) => ws.once('open', resolve))
@@ -311,6 +312,80 @@ describe('RelayServer', () => {
     streamWs.send(frame)
     const received = await framePromise
     expect(received).toEqual(frame)
+
+    agent.close()
+    browser.close()
+    streamWs.close()
+  })
+
+  it('relay patches relayedAt in TFFE envelope frames and forwards to browser', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    browser.binaryType = 'nodebuffer'
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForMessage(browser) // session:joined
+
+    const streamWs = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(streamWs)
+    streamWs.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    await waitForMessage(streamWs) // stream:registered
+
+    const capturedAt = Date.now() - 10
+    const envelopedFrame = writeEnvelopeHeader(Buffer.from([0xFF, 0xD8]), capturedAt)
+
+    const framePromise = new Promise<Buffer>((r) =>
+      browser.once('message', (d, isBinary) => { if (isBinary) r(d as Buffer) })
+    )
+    const beforeSend = Date.now()
+    streamWs.send(envelopedFrame)
+    const received = await framePromise
+    const afterSend = Date.now()
+
+    expect(received.length).toBe(envelopedFrame.length)
+    const relayedAt = Number(received.readBigUInt64BE(14))
+    expect(relayedAt).toBeGreaterThanOrEqual(beforeSend)
+    expect(relayedAt).toBeLessThanOrEqual(afterSend + 50)
+    // payload bytes preserved
+    expect(received.subarray(HEADER_SIZE)).toEqual(Buffer.from([0xFF, 0xD8]))
+
+    agent.close()
+    browser.close()
+    streamWs.close()
+  })
+
+  it('relay forwards plain (non-envelope) binary frames unchanged', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    browser.binaryType = 'nodebuffer'
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForMessage(browser) // session:joined
+
+    const streamWs = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(streamWs)
+    streamWs.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    await waitForMessage(streamWs) // stream:registered
+
+    const framePromise = new Promise<Buffer>((r) =>
+      browser.once('message', (d, isBinary) => { if (isBinary) r(d as Buffer) })
+    )
+    const plain = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0])
+    streamWs.send(plain)
+    const received = await framePromise
+    expect(received).toEqual(plain)
 
     agent.close()
     browser.close()


### PR DESCRIPTION
## Summary

- **Phase C-2**: 각 프레임 바이너리 앞에 22바이트 TFFE 헤더(`capturedAt` + `relayedAt`)를 추가해 Perfetto trace를 3개 hop(ws-recv/decode/paint)에서 5개 hop(agent-capture/relay/ws-recv/decode/paint)으로 확장 (closes #121)
- **Bugfix**: Android 에뮬레이터 rotation이 4방향 순환으로 퇴행된 문제 수정 — `adb emu rotate` → `user_rotation` 직접 설정으로 portrait↔landscape 2방향 토글 (regressed in #110 revert)
- **Bugfix**: `DeviceViewer.tsx`에 있던 `react-hooks/refs` ESLint 위반 수정 (`sendRef.current = send` → `useLayoutEffect`)

## Changes

### agent-core
- `src/utils/envelope.ts` 신규: `writeEnvelopeHeader`, `patchRelayedAt`, `hasEnvelope`, `HEADER_SIZE`, `TFFE_MAGIC`
- 헤더 포맷: `[magic 4B 'TFFE'][version u8][flags u8][capturedAt u64 BE][relayedAt u64 BE][payload...]`

### ios-agent / android-agent
- 프레임 송신 직전에 `writeEnvelopeHeader(frame, Date.now())` 래핑

### relay
- binary 수신 시 `hasEnvelope` 감지 후 `patchRelayedAt(frame, Date.now())` in-place 기록 (zero-copy)

### dashboard
- `lib/envelope.ts` 신규: `parseEnvelopeHeader(ArrayBuffer)` — magic 불일치 시 null (하위 호환)
- `FrameTiming`에 `capturedAt?` / `relayedAt?` 추가
- `DeviceViewer`: 수신 프레임에서 헤더 파싱·스트립 후 payload만 viewer로 전달, 타임스탬프를 perfHook에 주입
- `MetricsPanel`: Perfetto export에 `agent-capture`, `relay` 트랙 추가 (두 필드가 없는 구형 프레임은 자동 생략)

### android-agent
- `AdbWrapper.enableAutoRotate` + `emuRotate` → `setRotation(0|1)`: `accelerometer_rotation=0` + `user_rotation=N`으로 직접 설정
- `input:rotate`: `(rotation + 1) % 4` → `rotation % 2 === 1 ? 0 : 1` (홀수=landscape 감지 후 portrait↔landscape 토글)

## Test plan

- [ ] agent-core: `envelope.test.ts` 14개 신규 테스트 (write/patch/has 경계값 포함)
- [ ] relay: `RelayServer.test.ts` 2개 신규 테스트 (TFFE 프레임 relayedAt 기록 검증, 일반 JPEG 무변경 통과)
- [ ] Perfetto 수동 검증: perf 모드(`?perf=1`)에서 스트리밍 후 "Export trace" → ui.perfetto.dev에서 5개 트랙 확인
- [ ] Android rotation: 에뮬레이터에서 회전 버튼 클릭 시 portrait↔landscape 2방향만 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an envelope protocol for frames: capture/relay timestamps are encoded and propagated end-to-end, used by agents, relay, and dashboard to preserve payloads while tracking timing.
  * Dashboard now parses envelope timestamps and includes them in performance traces and metrics exports.
  * Android rotation control simplified to a single setRotation API.

* **Tests**
  * Added tests covering envelope framing, detection, timestamp patching, and relay handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->