### PR TITLE
refactor(dashboard): split QASession into focused custom hooks (issue #60)

### DIFF
--- a/packages/dashboard/hooks/useAgentSession.ts
+++ b/packages/dashboard/hooks/useAgentSession.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRelay } from '@/hooks/useRelay'
+import type { AgentDevice, RelayMessage, SessionInfo } from '@/lib/types'
+
+export function useAgentSession(os: string) {
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
+  const [deviceId, setDeviceId] = useState('')
+  const [booting, setBooting] = useState(false)
+  const [status, setStatus] = useState('')
+
+  const handleMessage = useCallback((msg: RelayMessage) => {
+    if (msg.type === 'agents:listed') setSessions(msg.sessions)
+    if (msg.type === 'session:joined') { setBooting(false); setStatus('Connected') }
+    if (msg.type === 'error') { setBooting(false); setStatus(`Error: ${msg.message}`) }
+  }, [])
+
+  const { send, connected } = useRelay(handleMessage)
+
+  useEffect(() => {
+    if (!connected) return
+    send({ type: 'agents:list' })
+    const id = setInterval(() => send({ type: 'agents:list' }), 5000)
+    return () => clearInterval(id)
+  }, [connected, send])
+
+  // ref to avoid stale closure in shutdown callbacks
+  const activeSessionRef = useRef({ sessionId: activeSessionId, deviceId })
+  useEffect(() => {
+    activeSessionRef.current = { sessionId: activeSessionId, deviceId }
+  }, [activeSessionId, deviceId])
+
+  // unmount cleanup — runs before useRelay's ws.close
+  useEffect(() => {
+    return () => {
+      const { sessionId, deviceId: dId } = activeSessionRef.current
+      if (sessionId && dId) {
+        send({ type: 'device:shutdown', sessionId, payload: { deviceId: dId } })
+      }
+    }
+  }, [send])
+
+  const agentGroups = sessions.filter((s) => s.devices.some((d) => d.platform === os))
+
+  const startDevice = useCallback((d: AgentDevice) => {
+    setDeviceId(d.id)
+    setBooting(true)
+    setStatus('Booting…')
+    setActiveSessionId(d.sessionId)
+  }, [])
+
+  const resetDevice = useCallback(() => setDeviceId(''), [])
+
+  const handleBack = useCallback(() => {
+    const { sessionId, deviceId: dId } = activeSessionRef.current
+    if (sessionId && dId) {
+      send({ type: 'device:shutdown', sessionId, payload: { deviceId: dId } })
+    }
+    setActiveSessionId(null)
+    setBooting(false)
+    setStatus('')
+  }, [send])
+
+  const handleBackToMacs = useCallback(() => {
+    const { sessionId, deviceId: dId } = activeSessionRef.current
+    if (sessionId && dId) {
+      send({ type: 'device:shutdown', sessionId, payload: { deviceId: dId } })
+    }
+    setActiveSessionId(null)
+    setSelectedAgent(null)
+    setBooting(false)
+    setStatus('')
+  }, [send])
+
+  return {
+    sessions,
+    selectedAgent,
+    setSelectedAgent,
+    activeSessionId,
+    deviceId,
+    booting,
+    status,
+    send,
+    connected,
+    agentGroups,
+    startDevice,
+    resetDevice,
+    handleBack,
+    handleBackToMacs,
+  }
+}

--- a/packages/dashboard/hooks/useBuildLoader.ts
+++ b/packages/dashboard/hooks/useBuildLoader.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import { getBuild } from '@/lib/queries'
+import type { Build } from '@/lib/types'
+
+export function useBuildLoader(buildId: string | null): { build: Build | null } {
+  const [build, setBuild] = useState<Build | null>(null)
+
+  useEffect(() => {
+    if (!buildId) return
+    getBuild(buildId).then(setBuild)
+  }, [buildId])
+
+  return { build }
+}

--- a/packages/dashboard/hooks/useDeviceSelector.ts
+++ b/packages/dashboard/hooks/useDeviceSelector.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import type { AgentDevice, SessionInfo } from '@/lib/types'
+
+export function useDeviceSelector(
+  selectedSession: SessionInfo | undefined,
+  os: string,
+) {
+  const [osVersion, setOsVersion] = useState('')
+  const [deviceSearch, setDeviceSearch] = useState('')
+  const [resetMode, setResetMode] = useState<'app-only' | 'full-erase'>('app-only')
+
+  const filteredDevices = selectedSession?.devices.filter((d) => d.platform === os) ?? []
+
+  const osVersions = [
+    ...new Set(filteredDevices.map((d) => d.osVersion).filter(Boolean)),
+  ].sort((a, b) => {
+    const parts = (s: string) => s.replace(/^[^\d]*/, '').split('.').map(Number)
+    const [aParts, bParts] = [parts(a as string), parts(b as string)]
+    for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+      const diff = (bParts[i] ?? 0) - (aParts[i] ?? 0)
+      if (diff !== 0) return diff
+    }
+    return 0
+  }) as string[]
+
+  const versionedDevices = (osVersion
+    ? filteredDevices.filter((d) => d.osVersion === osVersion)
+    : filteredDevices
+  ).filter((d) => !deviceSearch || d.name.toLowerCase().includes(deviceSearch.toLowerCase()))
+
+  return {
+    filteredDevices,
+    osVersions,
+    osVersion,
+    setOsVersion,
+    deviceSearch,
+    setDeviceSearch,
+    versionedDevices,
+    resetMode,
+    setResetMode,
+  }
+}

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { AgentDevice, Build, RelayMessage, SessionInfo } from '@/lib/types'
+
+vi.mock('@/lib/queries', () => ({
+  getBuild: vi.fn(),
+}))
+
+vi.mock('@/hooks/useRelay', () => ({
+  useRelay: vi.fn(),
+}))
+
+import { getBuild } from '@/lib/queries'
+import { useRelay } from '@/hooks/useRelay'
+import { useBuildLoader } from '@/hooks/useBuildLoader'
+import { useAgentSession } from '@/hooks/useAgentSession'
+import { useDeviceSelector } from '@/hooks/useDeviceSelector'
+
+const mockSend = vi.fn()
+let capturedOnMessage: (msg: RelayMessage) => void = () => {}
+
+const makeSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+  agentName: 'test-mac',
+  devices: [],
+  ...overrides,
+})
+
+const makeDevice = (overrides: Partial<AgentDevice> = {}): AgentDevice => ({
+  id: 'avd:Pixel_7',
+  name: 'Pixel 7',
+  platform: 'android',
+  status: 'booted',
+  sessionId: 'sess-1',
+  busy: false,
+  ...overrides,
+})
+
+// ─── useBuildLoader ────────────────────────────────────────────────────────────
+
+describe('useBuildLoader', () => {
+  beforeEach(() => vi.mocked(getBuild).mockReset())
+
+  it('returns null and does not fetch when buildId is null', () => {
+    const { result } = renderHook(() => useBuildLoader(null))
+    expect(result.current.build).toBeNull()
+    expect(getBuild).not.toHaveBeenCalled()
+  })
+
+  it('fetches build and updates state when buildId is provided', async () => {
+    const fakeBuild = { id: 42, name: 'MyApp' } as Build
+    vi.mocked(getBuild).mockResolvedValue(fakeBuild)
+
+    const { result } = renderHook(() => useBuildLoader('42'))
+    await act(async () => {})
+
+    expect(getBuild).toHaveBeenCalledWith('42')
+    expect(result.current.build).toBe(fakeBuild)
+  })
+
+  it('re-fetches when buildId changes', async () => {
+    const build42 = { id: 42, name: 'A' } as Build
+    const build99 = { id: 99, name: 'B' } as Build
+    vi.mocked(getBuild).mockResolvedValueOnce(build42).mockResolvedValueOnce(build99)
+
+    const { result, rerender } = renderHook(({ id }) => useBuildLoader(id), {
+      initialProps: { id: '42' as string | null },
+    })
+    await act(async () => {})
+    expect(result.current.build).toBe(build42)
+
+    rerender({ id: '99' })
+    await act(async () => {})
+    expect(result.current.build).toBe(build99)
+  })
+})
+
+// ─── useAgentSession ───────────────────────────────────────────────────────────
+
+describe('useAgentSession', () => {
+  beforeEach(() => {
+    mockSend.mockReset()
+    vi.mocked(useRelay).mockImplementation((onMessage) => {
+      capturedOnMessage = onMessage
+      return { send: mockSend, connected: false }
+    })
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('sends agents:list immediately and on interval when connected', () => {
+    vi.useFakeTimers()
+    vi.mocked(useRelay).mockImplementation((onMessage) => {
+      capturedOnMessage = onMessage
+      return { send: mockSend, connected: true }
+    })
+
+    renderHook(() => useAgentSession('android'))
+
+    expect(mockSend).toHaveBeenCalledWith({ type: 'agents:list' })
+    const callCount = mockSend.mock.calls.length
+
+    vi.advanceTimersByTime(5000)
+    expect(mockSend.mock.calls.length).toBe(callCount + 1)
+
+    vi.advanceTimersByTime(5000)
+    expect(mockSend.mock.calls.length).toBe(callCount + 2)
+  })
+
+  it('updates sessions on agents:listed message', async () => {
+    const { result } = renderHook(() => useAgentSession('android'))
+    const sessions = [makeSession({ agentName: 'mac-1' })]
+
+    act(() => capturedOnMessage({ type: 'agents:listed', sessions } as RelayMessage))
+
+    expect(result.current.sessions).toEqual(sessions)
+  })
+
+  it('clears booting flag and sets status on session:joined', async () => {
+    const { result } = renderHook(() => useAgentSession('android'))
+
+    act(() => {
+      result.current.startDevice(makeDevice())
+    })
+    expect(result.current.booting).toBe(true)
+
+    act(() => capturedOnMessage({ type: 'session:joined' } as RelayMessage))
+    expect(result.current.booting).toBe(false)
+    expect(result.current.status).toBe('Connected')
+  })
+
+  it('clears booting flag and sets error status on error message', () => {
+    const { result } = renderHook(() => useAgentSession('android'))
+
+    act(() => result.current.startDevice(makeDevice()))
+    act(() => capturedOnMessage({ type: 'error', message: 'boom' } as RelayMessage))
+
+    expect(result.current.booting).toBe(false)
+    expect(result.current.status).toBe('Error: boom')
+  })
+
+  it('sends device:shutdown and resets state on handleBack', async () => {
+    const { result } = renderHook(() => useAgentSession('android'))
+    const device = makeDevice({ id: 'avd:Pixel_7', sessionId: 'sess-1' })
+
+    act(() => result.current.startDevice(device))
+    // flush ref update effect
+    await act(async () => {})
+
+    act(() => result.current.handleBack())
+
+    expect(mockSend).toHaveBeenCalledWith({
+      type: 'device:shutdown',
+      sessionId: 'sess-1',
+      payload: { deviceId: 'avd:Pixel_7' },
+    })
+    expect(result.current.activeSessionId).toBeNull()
+    expect(result.current.booting).toBe(false)
+    expect(result.current.status).toBe('')
+  })
+
+  it('sends device:shutdown and clears selectedAgent on handleBackToMacs', async () => {
+    const { result } = renderHook(() => useAgentSession('android'))
+    const device = makeDevice({ id: 'avd:Pixel_7', sessionId: 'sess-1' })
+
+    act(() => result.current.setSelectedAgent('mac-1'))
+    act(() => result.current.startDevice(device))
+    await act(async () => {})
+
+    act(() => result.current.handleBackToMacs())
+
+    expect(mockSend).toHaveBeenCalledWith({
+      type: 'device:shutdown',
+      sessionId: 'sess-1',
+      payload: { deviceId: 'avd:Pixel_7' },
+    })
+    expect(result.current.activeSessionId).toBeNull()
+    expect(result.current.selectedAgent).toBeNull()
+  })
+
+  it('sends device:shutdown on unmount when a session is active', async () => {
+    const { result, unmount } = renderHook(() => useAgentSession('android'))
+    const device = makeDevice({ id: 'avd:Pixel_7', sessionId: 'sess-1' })
+
+    act(() => result.current.startDevice(device))
+    await act(async () => {})
+
+    unmount()
+
+    expect(mockSend).toHaveBeenCalledWith({
+      type: 'device:shutdown',
+      sessionId: 'sess-1',
+      payload: { deviceId: 'avd:Pixel_7' },
+    })
+  })
+})
+
+// ─── useDeviceSelector ─────────────────────────────────────────────────────────
+
+describe('useDeviceSelector', () => {
+  const devices: AgentDevice[] = [
+    makeDevice({ id: 'd1', name: 'Pixel 7', osVersion: 'Android 14', platform: 'android' }),
+    makeDevice({ id: 'd2', name: 'Pixel 6', osVersion: 'Android 13', platform: 'android' }),
+    makeDevice({ id: 'd3', name: 'iPhone 15', osVersion: 'iOS 17', platform: 'ios' }),
+  ]
+  const session: SessionInfo = { agentName: 'mac', devices }
+
+  it('filters devices by osVersion when set', () => {
+    const { result } = renderHook(() => useDeviceSelector(session, 'android'))
+
+    act(() => result.current.setOsVersion('Android 14'))
+
+    expect(result.current.versionedDevices).toEqual([devices[0]])
+  })
+
+  it('filters devices by name search', () => {
+    const { result } = renderHook(() => useDeviceSelector(session, 'android'))
+
+    act(() => result.current.setDeviceSearch('Pixel 6'))
+
+    expect(result.current.versionedDevices).toEqual([devices[1]])
+  })
+
+  it('returns osVersions sorted descending (newest first)', () => {
+    const mixedDevices: AgentDevice[] = [
+      makeDevice({ osVersion: 'Android 13', platform: 'android' }),
+      makeDevice({ osVersion: 'Android 15', platform: 'android' }),
+      makeDevice({ osVersion: 'Android 14', platform: 'android' }),
+    ]
+    const sess: SessionInfo = { agentName: 'mac', devices: mixedDevices }
+    const { result } = renderHook(() => useDeviceSelector(sess, 'android'))
+
+    expect(result.current.osVersions).toEqual(['Android 15', 'Android 14', 'Android 13'])
+  })
+})

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useRelay } from '@/hooks/useRelay';
 import { useBreadcrumb } from '@/hooks/useBreadcrumb';
+import { useBuildLoader } from '@/hooks/useBuildLoader';
+import { useAgentSession } from '@/hooks/useAgentSession';
+import { useDeviceSelector } from '@/hooks/useDeviceSelector';
 import { DeviceViewer } from '@/components/DeviceViewer';
 import { SessionPanel } from '@/components/session-panel';
 import {
@@ -17,7 +19,6 @@ import {
   Breadcrumb, BreadcrumbItem, BreadcrumbLink,
   BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { getBuild } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { STATUS_TONE, buildLabel } from '@/lib/build-format';
 import { Info } from 'lucide-react';
@@ -25,121 +26,39 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SearchInput } from '@/components/ui/search-input';
-import type { AgentDevice, Build, RelayMessage, SessionInfo } from '@/lib/types';
+import type { AgentDevice, SessionInfo } from '@/lib/types';
 
 export function QASession() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const buildId = searchParams.get('id');
 
-  const [build, setBuild] = useState<Build | null>(null);
-  const [sessions, setSessions] = useState<SessionInfo[]>([]);
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
-  const [deviceId, setDeviceId] = useState<string>('');
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
-  const [booting, setBooting] = useState(false);
-  const [status, setStatus] = useState('');
+  const { build } = useBuildLoader(buildId);
   const [recordingsKey, setRecordingsKey] = useState(0);
-  const [resetMode, setResetMode] = useState<'app-only' | 'full-erase'>('app-only');
-
-  useEffect(() => {
-    if (!buildId) return;
-    getBuild(buildId).then(setBuild);
-  }, [buildId]);
-
-  const handleMessage = useCallback((msg: RelayMessage) => {
-    if (msg.type === 'agents:listed') {
-      setSessions(msg.sessions);
-    }
-    if (msg.type === 'session:joined') {
-      setBooting(false);
-      setStatus('Connected');
-    }
-    if (msg.type === 'error') {
-      setBooting(false);
-      setStatus(`Error: ${msg.message}`);
-    }
-  }, []);
-
-  const { send, connected } = useRelay(handleMessage);
-
-  // 5초마다 polling — 슬롯·자원 최신화
-  useEffect(() => {
-    if (!connected) return;
-    send({ type: 'agents:list' });
-    const id = setInterval(() => send({ type: 'agents:list' }), 5000);
-    return () => clearInterval(id);
-  }, [connected, send]);
 
   const os = build?.platform ?? 'ios';
-  const agentGroups = sessions.filter((s) => s.devices.some((d) => d.platform === os));
+  const {
+    sessions, selectedAgent, setSelectedAgent,
+    activeSessionId, deviceId, booting, status,
+    send, connected, agentGroups,
+    startDevice, resetDevice, handleBack, handleBackToMacs,
+  } = useAgentSession(os);
+
   const selectedSession = agentGroups.find((s) => s.agentName === selectedAgent);
-  const filteredDevices = selectedSession?.devices.filter((d) => d.platform === os) ?? [];
+  const {
+    osVersions, osVersion, setOsVersion,
+    deviceSearch, setDeviceSearch, versionedDevices,
+    resetMode, setResetMode,
+  } = useDeviceSelector(selectedSession, os);
+
   const allDevices = sessions.flatMap((s) => s.devices);
   const selectedDevice = allDevices.find((d) => d.id === deviceId);
   const deviceLabel = selectedDevice
     ? `${selectedDevice.name}${selectedDevice.osVersion ? ` · ${selectedDevice.osVersion}` : ''}`
     : '';
 
-  const osVersions = [
-    ...new Set(filteredDevices.map((d) => d.osVersion).filter(Boolean)),
-  ].sort((a, b) => {
-    const parts = (s: string) => s.replace(/^[^\d]*/, '').split('.').map(Number)
-    const [aParts, bParts] = [parts(a as string), parts(b as string)]
-    for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-      const diff = (bParts[i] ?? 0) - (aParts[i] ?? 0)
-      if (diff !== 0) return diff
-    }
-    return 0
-  }) as string[];
-  const [osVersion, setOsVersion] = useState<string>('');
-  const [deviceSearch, setDeviceSearch] = useState('');
-
-  const versionedDevices = (osVersion
-    ? filteredDevices.filter((d) => d.osVersion === osVersion)
-    : filteredDevices
-  ).filter((d) => !deviceSearch || d.name.toLowerCase().includes(deviceSearch.toLowerCase()));
-
-  // DeviceViewer → 디바이스 선택
-  const handleBack = useCallback(() => {
-    if (activeSessionId && deviceId) {
-      send({ type: 'device:shutdown', sessionId: activeSessionId, payload: { deviceId } });
-    }
-    setActiveSessionId(null);
-    setBooting(false);
-    setStatus('');
-  }, [activeSessionId, deviceId, send]);
-
-  // 디바이스 선택 → Mac 선택
   const handleRecordingUploaded = useCallback(() => setRecordingsKey((k) => k + 1), []);
 
-  const handleBackToMacs = useCallback(() => {
-    if (activeSessionId && deviceId) {
-      send({ type: 'device:shutdown', sessionId: activeSessionId, payload: { deviceId } });
-    }
-    setActiveSessionId(null);
-    setSelectedAgent(null);
-    setBooting(false);
-    setStatus('');
-  }, [activeSessionId, deviceId, send]);
-
-  // ref로 최신 session 정보를 추적 — cleanup 클로저에서 stale state 방지
-  const activeSessionRef = useRef({ sessionId: activeSessionId, deviceId });
-  useEffect(() => {
-    activeSessionRef.current = { sessionId: activeSessionId, deviceId };
-  }, [activeSessionId, deviceId]);
-
-  // 언마운트 시 디바이스 shutdown — useRelay cleanup(ws.close)보다 먼저 실행됨
-  useEffect(() => {
-    return () => {
-      const { sessionId, deviceId: dId } = activeSessionRef.current;
-      if (sessionId && dId) {
-        send({ type: 'device:shutdown', sessionId, payload: { deviceId: dId } });
-      }
-    };
-  }, [send]);
-
-  // 헤더 breadcrumb 설정
   const { setNode: setBreadcrumb } = useBreadcrumb();
   useEffect(() => {
     if (!build) return;
@@ -236,7 +155,7 @@ export function QASession() {
                     value={osVersion || '__all__'}
                     onValueChange={(v) => {
                       setOsVersion(v === '__all__' ? '' : v);
-                      setDeviceId('');
+                      resetDevice();
                     }}
                   >
                     <SelectTrigger className="h-8 w-36 shrink-0">
@@ -291,12 +210,7 @@ export function QASession() {
                       <button
                         key={d.id}
                         disabled={isBusy || booting || !connected}
-                        onClick={() => {
-                          setDeviceId(d.id)
-                          setBooting(true)
-                          setStatus('Booting…')
-                          setActiveSessionId(d.sessionId)
-                        }}
+                        onClick={() => startDevice(d)}
                         className={cn(
                           'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px]',
                           'hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50',

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -40,7 +40,7 @@ export function QASession() {
   const {
     sessions, selectedAgent, setSelectedAgent,
     activeSessionId, deviceId, booting, status,
-    send, connected, agentGroups,
+    connected, agentGroups,
     startDevice, resetDevice, handleBack, handleBackToMacs,
   } = useAgentSession(os);
 


### PR DESCRIPTION
## Summary

- `useBuildLoader(buildId)` — 빌드 메타데이터 fetch
- `useAgentSession(os)` — WebSocket 연결, agents:list 폴링, 세션 시작/종료, 언마운트 cleanup
- `useDeviceSelector(selectedSession, os)` — OS 버전 필터, 검색, 리셋 모드 상태

QASession 컴포넌트는 세 훅의 조합 레이어로 단순화 (useState/useEffect 직접 선언 제거). 렌더링 결과 및 기존 동작 완전 보존.

## Test plan

- [x] 3개 훅 13개 unit test 추가 (`src/__tests__/useQASessionHooks.test.tsx`)
- [x] 전체 dashboard 테스트 59/59 통과
- [x] lint / typecheck 통과
- [x] `useBuildLoader` — null/fetch/re-fetch 케이스
- [x] `useAgentSession` — 폴링, 메시지 핸들링, handleBack/ToMacs, 언마운트 cleanup
- [x] `useDeviceSelector` — OS 필터, 이름 검색, 버전 정렬

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for dashboard session management, build loading, and device selection workflows.

* **Refactor**
  * Improved code organization and maintainability in the QA session dashboard by consolidating state management logic into reusable patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->