### PR TITLE
docs: consolidate contributor guide — CONTRIBUTING.md as canonical source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,22 @@ pnpm install
 pnpm dev
 ```
 
+`pnpm dev` starts the relay, dashboard, iOS agent, and Android agent concurrently.
+
+## Project structure
+
+```
+packages/
+  agent-core/     ← shared DeviceAgent interface
+  ios-agent/      ← IOSAgent (macOS)
+  android-agent/  ← AndroidAgent (macOS)
+  relay/          ← relay server + REST API + SQLite
+  dashboard/      ← React SPA (served by relay)
+  cli/            ← tapflow CLI
+docs/             ← documentation site (VitePress)
+playground/       ← local integration test environment
+```
+
 ## Branches & releases
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
@@ -85,3 +101,7 @@ Platform-specific implementation notes for contributors:
 
 - type: `feat` · `fix` · `test` · `refactor` · `docs` · `chore` · `perf`
 - scope: the changed package name (`agent-core` · `ios-agent` · `android-agent` · `relay` · `dashboard` · `cli` · `playground`)
+
+## Reporting bugs
+
+Use the [Bug Report](https://github.com/jo-duchan/tapflow/issues/new?template=bug_report.yml) issue template. Include steps to reproduce, expected vs. actual behavior, and your environment (tapflow version, Node.js version, and Xcode version for iOS issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ pnpm dev
 
 ## Project structure
 
-```
+```text
 packages/
   agent-core/     ← shared DeviceAgent interface
   ios-agent/      ← IOSAgent (macOS)

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -1,19 +1,6 @@
 # Contributing
 
-Contributions are welcome. See [`CONTRIBUTING.md`](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md) in the repository for branch strategy, commit conventions, and PR guidelines.
-
-## Local development
-
-**Requirements**: Node.js ≥ 20, pnpm ≥ 9
-
-```sh
-git clone https://github.com/jo-duchan/tapflow.git
-cd tapflow
-pnpm install
-pnpm dev
-```
-
-`pnpm dev` starts the relay, dashboard, iOS agent, and Android agent concurrently.
+Contributions are welcome. See [`CONTRIBUTING.md`](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md) in the repository for the full contributing guide — development setup, branch strategy, test principles, versioning, and commit conventions.
 
 ## Project structure
 
@@ -26,55 +13,7 @@ packages/
   dashboard/      ← React SPA (served by relay)
   cli/            ← tapflow CLI
 docs/             ← this documentation site (VitePress)
-internal/         ← team-internal docs (PRD, design system, architecture)
 playground/       ← local integration test environment
-```
-
-## Running tests
-
-All packages:
-
-```sh
-pnpm test
-```
-
-A specific package:
-
-```sh
-pnpm --filter @tapflowio/ios-agent test
-pnpm --filter @tapflowio/android-agent test
-pnpm --filter @tapflowio/relay test
-pnpm --filter @tapflowio/cli test
-```
-
-Run the relevant package tests before opening a PR. New behavior should be covered by tests.
-
-## Versioning
-
-tapflow follows [Semantic Versioning](https://semver.org) (`MAJOR.MINOR.PATCH`).
-
-| Bump | When |
-|------|------|
-| `patch` | Bug fixes, performance improvements, docs, refactors — no API change |
-| `minor` | New features, backward-compatible |
-| `major` | Breaking changes (public API, DB schema, WebSocket protocol, CLI flags) |
-
-If a release contains mixed commit types, the highest bump wins (`major` > `minor` > `patch`).
-
-**Before `v1.0.0`:** breaking changes may appear in `minor` releases. Once `v1.0.0` is tagged, the table above is strictly enforced.
-
-### Pre-release versions
-
-| Tag | Meaning |
-|-----|---------|
-| `v0.3.0-alpha.1` | Unstable, internal testing |
-| `v0.3.0-beta.1` | Feature-complete, external testing |
-| `v0.3.0-rc.1` | Release candidate, no new features |
-
-To install a specific pre-release version:
-
-```sh
-npm install tapflow@0.3.0-beta.1
 ```
 
 ## Reporting bugs

--- a/docs/ko/guide/contributing.md
+++ b/docs/ko/guide/contributing.md
@@ -1,19 +1,6 @@
 # 기여 가이드
 
-기여를 환영합니다. 브랜치 전략, 커밋 컨벤션, PR 가이드라인은 저장소의 [`CONTRIBUTING.md`](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md)를 참고하세요.
-
-## 로컬 개발 환경
-
-**요구사항**: Node.js ≥ 20, pnpm ≥ 9
-
-```sh
-git clone https://github.com/jo-duchan/tapflow.git
-cd tapflow
-pnpm install
-pnpm dev
-```
-
-`pnpm dev`는 릴레이, 대시보드, iOS 에이전트, Android 에이전트를 동시에 시작합니다.
+기여를 환영합니다. 개발 환경 설정, 브랜치 전략, 테스트 원칙, 버저닝, 커밋 컨벤션은 저장소의 [`CONTRIBUTING.md`](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md)를 참고하세요.
 
 ## 프로젝트 구조
 
@@ -26,55 +13,7 @@ packages/
   dashboard/      ← React SPA (릴레이가 서빙)
   cli/            ← tapflow CLI
 docs/             ← 이 문서 사이트 (VitePress)
-internal/         ← 팀 내부 문서 (PRD, 디자인 시스템, 아키텍처)
 playground/       ← 로컬 통합 테스트 환경
-```
-
-## 테스트 실행
-
-전체 패키지:
-
-```sh
-pnpm test
-```
-
-특정 패키지만:
-
-```sh
-pnpm --filter @tapflowio/ios-agent test
-pnpm --filter @tapflowio/android-agent test
-pnpm --filter @tapflowio/relay test
-pnpm --filter @tapflowio/cli test
-```
-
-PR을 올리기 전에 변경된 패키지의 테스트가 통과하는지 확인합니다. 새 동작을 추가할 때는 테스트를 먼저 작성합니다.
-
-## 버저닝
-
-tapflow는 [유의적 버전(Semantic Versioning)](https://semver.org/lang/ko/)을 따릅니다 (`MAJOR.MINOR.PATCH`).
-
-| 범프 | 기준 |
-|------|------|
-| `patch` | 버그 수정, 성능 개선, 문서, 리팩터 — API 변경 없음 |
-| `minor` | 새 기능 추가, 하위 호환 |
-| `major` | 브레이킹 체인지 (공개 API, DB 스키마, WebSocket 프로토콜, CLI 플래그) |
-
-하나의 릴리즈에 여러 타입의 커밋이 포함된 경우 가장 높은 범프를 적용합니다 (`major` > `minor` > `patch`).
-
-**`v1.0.0` 이전**: 브레이킹 체인지가 `minor` 버전에 포함될 수 있습니다. `v1.0.0` 태깅 이후에는 위 표를 엄격하게 적용합니다.
-
-### 프리릴리즈 버전
-
-| 태그 | 의미 |
-|------|------|
-| `v0.3.0-alpha.1` | 불안정, 내부 테스트 |
-| `v0.3.0-beta.1` | 기능 완성, 외부 테스트 |
-| `v0.3.0-rc.1` | 릴리즈 후보, 새 기능 없음 |
-
-특정 프리릴리즈 설치:
-
-```sh
-npm install tapflow@0.3.0-beta.1
 ```
 
 ## 버그 신고

--- a/packages/relay/CLAUDE.md
+++ b/packages/relay/CLAUDE.md
@@ -48,14 +48,11 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 
 ## Environment Variables
 
-| 변수 | 기본값 | 설명 |
-|------|--------|------|
-| `TAPFLOW_PORT` | `4000` | relay 서버 포트 |
-| `TAPFLOW_DATA_DIR` | `.tapflow-data` | DB·uploads 저장 루트 디렉토리 |
-| `TAPFLOW_WS_BACKPRESSURE_BYTES` | `1048576` (1 MB) | 브라우저 소켓 backpressure 임계값. 초과 시 바이너리 프레임 드롭 |
-| `TAPFLOW_BUILD_TTL_DAYS` | `7` | Done 빌드 자동 삭제 기간(일). **로컬 테스트 시 `0.001` 등 작은 값으로 즉시 확인 가능** |
-| `JWT_SECRET` | dev 기본값 | JWT 서명 키. 프로덕션에서는 반드시 32자 이상으로 설정 |
-| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` | — | 이메일 발송 설정 |
+전체 목록 및 설명: [`docs/reference/configuration.md`](../../docs/reference/configuration.md)
+
+로컬 테스트 시 자주 쓰는 값:
+- `TAPFLOW_BUILD_TTL_DAYS=0.001` — 빌드 자동 삭제를 즉시 확인할 때
+- `TAPFLOW_WS_BACKPRESSURE_BYTES` — 브라우저 소켓 backpressure 임계값 (기본 1 MB)
 
 ## HOW NOT
 


### PR DESCRIPTION
## 변경 내용

- `CONTRIBUTING.md`를 canonical 소스로 확정하고, docs에만 있던 내용 이식
  - `pnpm dev` 설명, project structure, reporting bugs 섹션 추가
- `docs/guide/contributing.md` (EN/KO): 중복 섹션 제거, CONTRIBUTING.md 링크 + 고유 섹션만 유지
- `packages/relay/CLAUDE.md`: env vars 표 → `docs/reference/configuration.md` 링크로 교체

## 체크리스트

- [x] `CONTRIBUTING.md`에 project structure, pnpm dev 설명, reporting bugs 섹션 있음
- [x] `docs/guide/contributing.md` (EN/KO)에 중복 섹션 없음
- [x] `packages/relay/CLAUDE.md`에 중복 env vars 표 없음
- [x] VitePress docs 빌드 오류 없음

## 관련 .work/ 문서

`.work/2026-05-25-contributor-docs-cleanup-todo.md` → `done` → `archive/`로 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor onboarding with full development setup, project structure (including a local playground), branch strategy, versioning and commit conventions.
  * Added structured bug-report guidelines referencing the issue template and required reproduction/environment details.
  * Consolidated and synchronized contributor guides across locales.
  * Updated relay configuration docs and added Korean guidance for common local testing environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->