### PR TITLE
feat(dashboard): keyboard shortcuts and Kbd UI for simulator toolbar

### DIFF
--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -180,11 +180,49 @@ export function AndroidViewer({
     ctx.restore()
   }, [])
 
+  const handleScreenshot = useCallback(() => {
+    const src = canvasRef.current; if (!src) return
+    const c = document.createElement('canvas'); const ctx = c.getContext('2d'); if (!ctx) return
+    c.width = src.width; c.height = src.height; ctx.drawImage(src, 0, 0)
+    c.toBlob((blob) => {
+      if (!blob) return
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a'); a.href = url; a.download = `tapflow-${Date.now()}.png`; a.click()
+      URL.revokeObjectURL(url)
+    }, 'image/png')
+  }, [])
+
+  const handleRecordToggle = useCallback(() => {
+    if (recordState === 'idle') {
+      const rc = recordCanvasRef.current; if (!rc) return
+      const dpr = window.devicePixelRatio || 1
+      const container = containerRef.current
+      if (container && container.clientWidth > 0) { rc.width = container.clientWidth * dpr; rc.height = container.clientHeight * dpr }
+      else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
+      startClientRecording(composeFrame)
+    } else if (recordState === 'recording') {
+      stopClientRecording()
+    }
+  }, [recordState, startClientRecording, stopClientRecording, composeFrame])
+
+  const handleRotate = useCallback(() => {
+    send({ type: 'input:rotate', sessionId })
+  }, [send, sessionId])
+
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
     const MODIFIER_CODES = new Set(['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'MetaLeft', 'MetaRight'])
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code === 'AltLeft' || e.code === 'AltRight') { isOptionHeld.current = true; return }
+      if (e.metaKey) {
+        const el = document.activeElement
+        if (!el || (el.tagName !== 'INPUT' && el.tagName !== 'TEXTAREA')) {
+          if (!e.shiftKey && e.code === 'KeyK') { e.preventDefault(); setDeepLinkOpen(true); return }
+          if (!e.shiftKey && e.code === 'KeyS') { e.preventDefault(); handleScreenshot(); return }
+          if (e.shiftKey && e.code === 'KeyY') { e.preventDefault(); handleRecordToggle(); return }
+          if (e.shiftKey && e.code === 'KeyO') { e.preventDefault(); handleRotate(); return }
+        }
+      }
       if (!keyboardActive) return
       if (MODIFIER_CODES.has(e.code)) return
       e.preventDefault()
@@ -207,7 +245,7 @@ export function AndroidViewer({
       window.removeEventListener('keyup', onKeyUp)
       window.removeEventListener('blur', onBlur)
     }
-  }, [keyboardActive, send, sessionId])
+  }, [keyboardActive, send, sessionId, handleScreenshot, handleRecordToggle, handleRotate])
 
   useEffect(() => {
     if (!keyboardActive) return
@@ -428,31 +466,10 @@ export function AndroidViewer({
       <SimulatorToolbar
         joined={joined}
         onDeepLink={() => setDeepLinkOpen(true)}
-        onScreenshot={() => {
-          const src = canvasRef.current; if (!src) return
-          const c = document.createElement('canvas'); const ctx = c.getContext('2d'); if (!ctx) return
-          c.width = src.width; c.height = src.height; ctx.drawImage(src, 0, 0)
-          c.toBlob((blob) => {
-            if (!blob) return
-            const url = URL.createObjectURL(blob)
-            const a = document.createElement('a'); a.href = url; a.download = `tapflow-${Date.now()}.png`; a.click()
-            URL.revokeObjectURL(url)
-          }, 'image/png')
-        }}
-        onRecordToggle={() => {
-          if (recordState === 'idle') {
-            const rc = recordCanvasRef.current; if (!rc) return
-            const dpr = window.devicePixelRatio || 1
-            const container = containerRef.current
-            if (container && container.clientWidth > 0) { rc.width = container.clientWidth * dpr; rc.height = container.clientHeight * dpr }
-            else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
-            startClientRecording(composeFrame)
-          } else if (recordState === 'recording') {
-            stopClientRecording()
-          }
-        }}
+        onScreenshot={handleScreenshot}
+        onRecordToggle={handleRecordToggle}
         recordState={recordState}
-        onRotate={() => send({ type: 'input:rotate', sessionId })}
+        onRotate={handleRotate}
         platformSlot={platformSlot}
         launchSlot={launchSlot}
       />

--- a/packages/dashboard/components/device/DeepLinkDialog.tsx
+++ b/packages/dashboard/components/device/DeepLinkDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
@@ -14,9 +14,14 @@ interface Props {
 
 export function DeepLinkDialog({ open, onOpenChange, sessionId, send }: Props) {
   const [url, setUrl] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!open) setUrl('');
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } else {
+      setUrl('');
+    }
   }, [open]);
 
   const handleSubmit = () => {
@@ -36,6 +41,7 @@ export function DeepLinkDialog({ open, onOpenChange, sessionId, send }: Props) {
           <div className="flex-1 h-[32px] flex items-center gap-2 pl-[4px] pb-[1px]">
             <Search className="h-4 w-4 text-muted-foreground shrink-0" />
             <input
+              ref={inputRef}
               className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground min-w-0"
               placeholder="myapp://home..."
               value={url}
@@ -43,7 +49,6 @@ export function DeepLinkDialog({ open, onOpenChange, sessionId, send }: Props) {
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleSubmit();
               }}
-              autoFocus
             />
           </div>
           <Button

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -296,10 +296,20 @@ export function IOSViewer({
   }, [toNormScreen])
 
   const toButton = useCallback((e: { clientX: number; clientY: number }): string | null => {
-    if (!containerRef.current || isLandscape) return null
+    if (!containerRef.current) return null
     const rect = containerRef.current.getBoundingClientRect()
-    const cx = (e.clientX - rect.left) * (chrome.compositeWidth / rect.width)
-    const cy = (e.clientY - rect.top) * (chrome.compositeHeight / rect.height)
+    let cx: number, cy: number
+    if (isLandscape) {
+      // rotate(-90deg) swaps rect dimensions: rect.width=displayH, rect.height=displayW
+      // inverse transform: (lx, ly) → portrait composite coords
+      const lx = rect.height - (e.clientY - rect.top)
+      const ly = e.clientX - rect.left
+      cx = lx * (chrome.compositeWidth / rect.height)
+      cy = ly * (chrome.compositeHeight / rect.width)
+    } else {
+      cx = (e.clientX - rect.left) * (chrome.compositeWidth / rect.width)
+      cy = (e.clientY - rect.top) * (chrome.compositeHeight / rect.height)
+    }
     for (const btn of chrome.buttons) {
       const dx = cx - btn.normalOffset.x; const dy = cy - btn.normalOffset.y
       if (dx * dx + dy * dy < BUTTON_HIT_RADIUS ** 2) return btn.name
@@ -566,7 +576,7 @@ export function IOSViewer({
               const isBottomAnchor = btn.anchor === 'bottom'; const isTopAnchor = btn.anchor === 'top'
               const imgTopPct = isBottomAnchor ? ((btn.normalOffset.y - btn.buttonH / 2) / chrome.compositeHeight) * 100
                 : isTopAnchor ? (btn.rolloverOffset.y / chrome.compositeHeight) * 100
-                : (btn.normalOffset.y / chrome.compositeHeight) * 100
+                : ((btn.normalOffset.y - btn.buttonH / 2) / chrome.compositeHeight) * 100
               const imgHPct = (btn.buttonH / chrome.compositeHeight) * 100
               const imgWPct = (btn.buttonW / chrome.compositeWidth) * 100
               const halfW = btn.buttonW / 2
@@ -575,7 +585,7 @@ export function IOSViewer({
               const tooltipLeftPct = (btn.rolloverOffset.x / chrome.compositeWidth) * 100
               const tooltipTopPct = isBottomAnchor ? ((btn.normalOffset.y - btn.buttonH / 2) / chrome.compositeHeight) * 100
                 : isTopAnchor ? (btn.rolloverOffset.y / chrome.compositeHeight) * 100
-                : (btn.normalOffset.y / chrome.compositeHeight) * 100
+                : ((btn.normalOffset.y - btn.buttonH / 2) / chrome.compositeHeight) * 100
               const hoverTopPct = isTopAnchor ? ((2 * btn.rolloverOffset.y - btn.normalOffset.y) / chrome.compositeHeight) * 100 : 0
               const btnZ = btn.onTop ? 4 : 1
               return (

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -9,6 +9,7 @@ import { SimulatorInfoCard } from './shared/SimulatorInfoCard';
 import { DeepLinkDialog } from './DeepLinkDialog';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
 import type { ChromeData } from '@/lib/types'
 import { iosToNormScreen, toPinchFingers as makePinchFingers, iosDisplayScale } from '@/lib/coordinate-transform';
 import type { MutableRefObject } from 'react';
@@ -200,11 +201,50 @@ export function IOSViewer({
     }
   }, [])
 
+  const handleScreenshot = useCallback(() => {
+    const src = canvasRef.current; if (!src) return
+    const c = document.createElement('canvas'); const ctx = c.getContext('2d'); if (!ctx) return
+    c.width = src.width; c.height = src.height; ctx.drawImage(src, 0, 0)
+    c.toBlob((blob) => {
+      if (!blob) return
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a'); a.href = url; a.download = `tapflow-${Date.now()}.png`; a.click()
+      URL.revokeObjectURL(url)
+    }, 'image/png')
+  }, [])
+
+  const handleRecordToggle = useCallback(() => {
+    if (recordState === 'idle') {
+      const rc = recordCanvasRef.current; if (!rc) return
+      const container = containerRef.current
+      if (container && container.clientWidth > 0) { rc.width = container.clientWidth; rc.height = container.clientHeight }
+      else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
+      startClientRecording(composeFrame)
+    } else if (recordState === 'recording') {
+      stopClientRecording()
+    }
+  }, [recordState, startClientRecording, stopClientRecording, composeFrame])
+
+  const handleRotate = useCallback(() => {
+    send({ type: 'input:rotate', sessionId }); setIsLandscape(prev => !prev)
+  }, [send, sessionId])
+
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
     const MODIFIER_CODES = new Set(['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'MetaLeft', 'MetaRight'])
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code === 'AltLeft' || e.code === 'AltRight') { isOptionHeld.current = true; return }
+      if (e.metaKey) {
+        const el = document.activeElement
+        if (!el || (el.tagName !== 'INPUT' && el.tagName !== 'TEXTAREA')) {
+          if (!e.shiftKey && e.code === 'KeyK') { e.preventDefault(); setDeepLinkOpen(true); return }
+          if (!e.shiftKey && e.code === 'KeyS') { e.preventDefault(); handleScreenshot(); return }
+          if (e.shiftKey && e.code === 'KeyY') { e.preventDefault(); handleRecordToggle(); return }
+          if (e.shiftKey && e.code === 'KeyO') { e.preventDefault(); handleRotate(); return }
+          if (e.shiftKey && e.code === 'KeyU') { e.preventDefault(); send({ type: 'input:button', sessionId, payload: { name: 'home' } }); return }
+          if (e.shiftKey && e.code === 'KeyK') { e.preventDefault(); onKbdToggle(); return }
+        }
+      }
       if (!keyboardActive) return
       if (MODIFIER_CODES.has(e.code)) return
       e.preventDefault()
@@ -219,7 +259,7 @@ export function IOSViewer({
     const onBlur = () => { if (isOptionHeld.current) endPinch() }
     window.addEventListener('keydown', onKeyDown); window.addEventListener('keyup', onKeyUp); window.addEventListener('blur', onBlur)
     return () => { window.removeEventListener('keydown', onKeyDown); window.removeEventListener('keyup', onKeyUp); window.removeEventListener('blur', onBlur) }
-  }, [keyboardActive, send, sessionId])
+  }, [keyboardActive, send, sessionId, handleScreenshot, handleRecordToggle, handleRotate, onKbdToggle])
 
   useEffect(() => {
     if (!keyboardActive) return
@@ -402,7 +442,7 @@ export function IOSViewer({
             <Home className="h-4 w-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="left">Home</TooltipContent>
+        <TooltipContent side="left"><span className="flex items-center gap-3">Home <KbdGroup><Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>U</Kbd></KbdGroup></span></TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -443,30 +483,10 @@ export function IOSViewer({
       <SimulatorToolbar
         joined={joined}
         onDeepLink={() => setDeepLinkOpen(true)}
-        onScreenshot={() => {
-          const src = canvasRef.current; if (!src) return
-          const c = document.createElement('canvas'); const ctx = c.getContext('2d'); if (!ctx) return
-          c.width = src.width; c.height = src.height; ctx.drawImage(src, 0, 0)
-          c.toBlob((blob) => {
-            if (!blob) return
-            const url = URL.createObjectURL(blob)
-            const a = document.createElement('a'); a.href = url; a.download = `tapflow-${Date.now()}.png`; a.click()
-            URL.revokeObjectURL(url)
-          }, 'image/png')
-        }}
-        onRecordToggle={() => {
-          if (recordState === 'idle') {
-            const rc = recordCanvasRef.current; if (!rc) return
-            const container = containerRef.current
-            if (container && container.clientWidth > 0) { rc.width = container.clientWidth; rc.height = container.clientHeight }
-            else { const fc = canvasRef.current; if (fc && fc.width > 0) { rc.width = fc.width; rc.height = fc.height } else return }
-            startClientRecording(composeFrame)
-          } else if (recordState === 'recording') {
-            stopClientRecording()
-          }
-        }}
+        onScreenshot={handleScreenshot}
+        onRecordToggle={handleRecordToggle}
         recordState={recordState}
-        onRotate={() => { send({ type: 'input:rotate', sessionId }); setIsLandscape(prev => !prev) }}
+        onRotate={handleRotate}
         platformSlot={platformSlot}
         launchSlot={launchSlot}
       />
@@ -581,11 +601,13 @@ export function IOSViewer({
                     }} draggable={false} alt="" />
                   )}
                   {isHovered && (
-                    <div style={{
-                      position: 'absolute', zIndex: 5, left: `${tooltipLeftPct}%`, top: `${tooltipTopPct}%`,
-                      transform: 'translate(-50%, calc(-100% - 8px))', background: 'rgba(0,0,0,0.72)',
-                      color: '#fff', fontSize: 11, padding: '2px 7px', borderRadius: 4, whiteSpace: 'nowrap', pointerEvents: 'none',
-                    }}>
+                    <div
+                      className="bg-foreground/85 text-background text-[11px] px-[7px] py-1.5 rounded-lg whitespace-nowrap pointer-events-none"
+                      style={{
+                        position: 'absolute', zIndex: 5, left: `${tooltipLeftPct}%`, top: `${tooltipTopPct}%`,
+                        transform: 'translate(-50%, calc(-100% - 8px))',
+                      }}
+                    >
                       {btn.accessibilityTitle}
                     </div>
                   )}

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -229,6 +229,13 @@ export function IOSViewer({
     send({ type: 'input:rotate', sessionId }); setIsLandscape(prev => !prev)
   }, [send, sessionId])
 
+  const isLandscapeRef = useRef(isLandscape)
+  useEffect(() => { isLandscapeRef.current = isLandscape }, [isLandscape])
+  useEffect(() => {
+    return () => { if (isLandscapeRef.current) send({ type: 'input:rotate', sessionId }) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
     const MODIFIER_CODES = new Set(['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'MetaLeft', 'MetaRight'])

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -249,7 +249,7 @@ export function IOSViewer({
           if (e.shiftKey && e.code === 'KeyY') { e.preventDefault(); handleRecordToggle(); return }
           if (e.shiftKey && e.code === 'KeyO') { e.preventDefault(); handleRotate(); return }
           if (e.shiftKey && e.code === 'KeyU') { e.preventDefault(); send({ type: 'input:button', sessionId, payload: { name: 'home' } }); return }
-          if (e.shiftKey && e.code === 'KeyK') { e.preventDefault(); onKbdToggle(); return }
+          if (e.shiftKey && e.code === 'KeyK') { e.preventDefault(); if (!swKeyboardPending) onKbdToggle(); return }
         }
       }
       if (!keyboardActive) return
@@ -266,7 +266,7 @@ export function IOSViewer({
     const onBlur = () => { if (isOptionHeld.current) endPinch() }
     window.addEventListener('keydown', onKeyDown); window.addEventListener('keyup', onKeyUp); window.addEventListener('blur', onBlur)
     return () => { window.removeEventListener('keydown', onKeyDown); window.removeEventListener('keyup', onKeyUp); window.removeEventListener('blur', onBlur) }
-  }, [keyboardActive, send, sessionId, handleScreenshot, handleRecordToggle, handleRotate, onKbdToggle])
+  }, [keyboardActive, send, sessionId, handleScreenshot, handleRecordToggle, handleRotate, onKbdToggle, swKeyboardPending])
 
   useEffect(() => {
     if (!keyboardActive) return
@@ -303,12 +303,13 @@ export function IOSViewer({
   }, [toNormScreen])
 
   const toButton = useCallback((e: { clientX: number; clientY: number }): string | null => {
-    if (!containerRef.current) return null
-    const rect = containerRef.current.getBoundingClientRect()
+    const target = (isLandscape ? screenAreaRef.current : containerRef.current)
+    if (!target) return null
+    const rect = target.getBoundingClientRect()
     let cx: number, cy: number
     if (isLandscape) {
-      // rotate(-90deg) swaps rect dimensions: rect.width=displayH, rect.height=displayW
-      // inverse transform: (lx, ly) → portrait composite coords
+      // screenAreaRef is the untransformed wrapper (width=displayH, height=displayW in landscape)
+      // inverse of rotate(-90deg): portrait X ← bottom edge distance, portrait Y ← left edge distance
       const lx = rect.height - (e.clientY - rect.top)
       const ly = e.clientX - rect.left
       cx = lx * (chrome.compositeWidth / rect.height)
@@ -473,7 +474,7 @@ export function IOSViewer({
               : <Keyboard className="h-4 w-4" />}
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="left">Software keyboard</TooltipContent>
+        <TooltipContent side="left"><span className="flex items-center gap-3">Software keyboard <KbdGroup><Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>K</Kbd></KbdGroup></span></TooltipContent>
       </Tooltip>
     </>
   );

--- a/packages/dashboard/components/device/shared/SimulatorToolbar.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorToolbar.tsx
@@ -5,6 +5,18 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { ReactNode } from 'react';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+
+function ShortcutTooltip({ label, keys }: { label: string; keys: string[] }) {
+  return (
+    <span className="flex items-center gap-3">
+      {label}
+      <KbdGroup>
+        {keys.map((k) => <Kbd key={k}>{k}</Kbd>)}
+      </KbdGroup>
+    </span>
+  );
+}
 
 interface SimulatorToolbarProps {
   joined: boolean;
@@ -43,7 +55,7 @@ export function SimulatorToolbar({
               <Link2 className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="left">Deeplink</TooltipContent>
+          <TooltipContent side="left"><ShortcutTooltip label="Deeplink" keys={['⌘', 'K']} /></TooltipContent>
         </Tooltip>
 
         <div className="w-4 h-px bg-border my-1" />
@@ -54,7 +66,7 @@ export function SimulatorToolbar({
               <Camera className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="left">Screenshot</TooltipContent>
+          <TooltipContent side="left"><ShortcutTooltip label="Screenshot" keys={['⌘', 'S']} /></TooltipContent>
         </Tooltip>
 
         <Tooltip>
@@ -73,8 +85,10 @@ export function SimulatorToolbar({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="left">
-            {recordState === 'idle' ? 'Start recording'
-              : recordState === 'recording' ? 'Stop recording'
+            {recordState === 'idle'
+              ? <ShortcutTooltip label="Start recording" keys={['⌘', '⇧', 'Y']} />
+              : recordState === 'recording'
+              ? <ShortcutTooltip label="Stop recording" keys={['⌘', '⇧', 'Y']} />
               : 'Processing…'}
           </TooltipContent>
         </Tooltip>
@@ -87,7 +101,7 @@ export function SimulatorToolbar({
               <RotateCw className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="left">Rotate</TooltipContent>
+          <TooltipContent side="left"><ShortcutTooltip label="Rotate" keys={['⌘', '⇧', 'O']} /></TooltipContent>
         </Tooltip>
       </div>
     </TooltipProvider>

--- a/packages/dashboard/components/ui/kbd.tsx
+++ b/packages/dashboard/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/packages/dashboard/components/ui/tooltip.tsx
+++ b/packages/dashboard/components/ui/tooltip.tsx
@@ -1,15 +1,15 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const TooltipProvider = TooltipPrimitive.Provider
+const TooltipProvider = TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root
+const Tooltip = TooltipPrimitive.Root;
 
-const TooltipTrigger = TooltipPrimitive.Trigger
+const TooltipTrigger = TooltipPrimitive.Trigger;
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
@@ -19,14 +19,15 @@ const TooltipContent = React.forwardRef<
     <TooltipPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      data-slot="tooltip-content"
       className={cn(
-        "z-[50] overflow-hidden rounded bg-black/75 px-[7px] py-0.5 text-[11px] text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
-        className
+        'z-[50] overflow-hidden rounded-lg bg-foreground/85 px-[7px] py-1.5 text-[11px] text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
+        className,
       )}
       {...props}
     />
   </TooltipPrimitive.Portal>
-))
-TooltipContent.displayName = TooltipPrimitive.Content.displayName
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION
## Summary

- `Kbd` / `KbdGroup` shadcn 컴포넌트 추가 — tooltip 안에 단축키 힌트 표시
- 시뮬레이터 툴바 전 기능에 키보드 단축키 추가
  - `⌘K` Deeplink, `⌘S` Screenshot
  - `⌘⇧Y` Record, `⌘⇧O` Rotate
  - `⌘⇧U` iOS Home, `⌘⇧K` iOS Keyboard toggle
- `e.key` → `e.code + e.shiftKey` 체크로 전환 — 한국어 IME 환경에서도 안정적으로 동작
- screenshot / record / rotate 핸들러를 `useCallback`으로 추출해 stable dependency 확보
- Tooltip 스타일 개선: `bg-foreground/85`, `rounded-lg`, `py-1.5`, `data-slot="tooltip-content"` 추가

## Test plan

- [ ] `⌘K` → DeepLink 다이얼로그 열림
- [ ] `⌘S` → 스크린샷 다운로드
- [ ] `⌘⇧Y` → 녹화 시작/정지
- [ ] `⌘⇧O` → 화면 회전
- [ ] `⌘⇧U` → iOS 홈 버튼 (iOS only)
- [ ] `⌘⇧K` → 소프트 키보드 토글 (iOS only)
- [ ] 한국어 IME 활성화 상태에서 단축키 정상 동작 확인
- [ ] 툴팁 hover 시 Kbd 힌트 표시 확인 (라이트/다크 모드 모두)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolbar shortcuts for screenshot, recording toggle, and rotate are now active and shown in tooltips.
  * Visual keyboard key UI added to shortcut displays.

* **Bug Fixes**
  * Button hit detection improved in landscape so controls respond correctly.
  * Rotate state now cleans up correctly when leaving the simulator.

* **Style**
  * Tooltip visuals and placement refined; recording tooltip shows contextual shortcut hints.

* **UX**
  * Deep link dialog input is auto-focused when opened.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->