### PR TITLE
feat(relay): enforce PAT scope checks on all builds endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ playground/multi-agent.ts
 docs/.vitepress/cache
 docs/.vitepress/dist
 .internal/
+
+# curl test artifacts
+cookies.txt

--- a/packages/relay/src/__tests__/auth.test.ts
+++ b/packages/relay/src/__tests__/auth.test.ts
@@ -15,6 +15,7 @@ import {
   requireRole,
   hashPat,
   verifyPat,
+  requireBuildAuth,
 } from '../middleware/auth.js'
 import type { AuthContext } from '../middleware/auth.js'
 import { AuthError } from '@tapflowio/agent-core'
@@ -223,5 +224,83 @@ describe('verifyPat', () => {
 
     const req = makeReq({ authorization: 'Bearer tflw_pat_unknown-token' })
     expect(verifyPat(req)).toBeNull()
+  })
+})
+
+// --- requireBuildAuth ---
+
+describe('requireBuildAuth', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('PAT가 있고 builds:write scope이면 userId 반환', () => {
+    const rawToken = 'tflw_pat_test-build-token'
+    const preparedGet = vi.fn().mockReturnValue({ user_id: 3, scope: 'builds:write' })
+    const preparedRun = vi.fn()
+    mockGet.mockReturnValue({
+      prepare: vi.fn()
+        .mockReturnValueOnce({ get: preparedGet })
+        .mockReturnValueOnce({ run: preparedRun }),
+    })
+
+    const req = makeReq({ authorization: `Bearer ${rawToken}` })
+    const res = makeRes()
+    const result = requireBuildAuth(req, res)
+
+    expect(result).toEqual({ userId: 3 })
+    expect(res.writeHead).not.toHaveBeenCalled()
+  })
+
+  it('PAT가 있지만 scope이 부족하면 403 반환 후 null', () => {
+    const rawToken = 'tflw_pat_test-wrong-scope'
+    const preparedGet = vi.fn().mockReturnValue({ user_id: 5, scope: 'other:scope' })
+    const preparedRun = vi.fn()
+    mockGet.mockReturnValue({
+      prepare: vi.fn()
+        .mockReturnValueOnce({ get: preparedGet })
+        .mockReturnValueOnce({ run: preparedRun }),
+    })
+
+    const req = makeReq({ authorization: `Bearer ${rawToken}` })
+    const res = makeRes()
+    const result = requireBuildAuth(req, res)
+
+    expect(result).toBeNull()
+    expect(res._calls[0]?.status).toBe(403)
+    expect(JSON.parse(res._calls[0]?.body ?? '{}')).toMatchObject({ error: 'Insufficient scope' })
+  })
+
+  it('PAT 없고 유효한 JWT 쿠키면 userId 반환', () => {
+    const token = signJwt(SAMPLE)
+    const req = makeReq({ cookie: `tapflow_token=${token}` })
+    const res = makeRes()
+    const result = requireBuildAuth(req, res)
+
+    expect(result).toEqual({ userId: SAMPLE.userId })
+    expect(res.writeHead).not.toHaveBeenCalled()
+  })
+
+  it('PAT 없고 JWT 쿠키도 없으면 401 반환 후 null', () => {
+    const req = makeReq()
+    const res = makeRes()
+    const result = requireBuildAuth(req, res)
+
+    expect(result).toBeNull()
+    expect(res._calls[0]?.status).toBe(401)
+  })
+
+  it('PAT가 만료/무효이면 JWT 쿠키로 fallback', () => {
+    mockGet.mockReturnValue({
+      prepare: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue(undefined) }),
+    })
+
+    const token = signJwt(SAMPLE)
+    const req = makeReq({
+      authorization: 'Bearer tflw_pat_expired-token',
+      cookie: `tapflow_token=${token}`,
+    })
+    const res = makeRes()
+    const result = requireBuildAuth(req, res)
+
+    expect(result).toEqual({ userId: SAMPLE.userId })
   })
 })

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { spawnSync } from 'child_process'
 import busboy from 'busboy'
 import { getDb } from '../db.js'
-import { requireAuth, verifyPat } from '../middleware/auth.js'
+import { requireAuth, requireBuildAuth } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
 
 // ── zip / plist helpers ────────────────────────────────────────────────────
@@ -165,7 +165,7 @@ export function upsertApp(name: string, bundleIdKey: string, platform: string): 
 // ── handlers ──────────────────────────────────────────────────────────────
 
 export function handleListBuilds(req: http.IncomingMessage, res: http.ServerResponse): void {
-  const auth = requireAuth(req, res)
+  const auth = requireBuildAuth(req, res)
   if (!auth) return
 
   const u = new URL(req.url ?? '/', 'http://x')
@@ -218,8 +218,7 @@ export function handleGetBuild(
   res: http.ServerResponse,
   params: Record<string, string>
 ): void {
-  const auth = requireAuth(req, res)
-  if (!auth) return
+  if (!requireBuildAuth(req, res)) return
 
   const build = getDb().prepare(`
     SELECT b.id, b.app_id, ap.name, b.version_name, b.build_number,
@@ -281,13 +280,8 @@ export function handleUploadBuild(
   res: http.ServerResponse,
   uploadsDir: string
 ): void {
-  const pat  = verifyPat(req)
-  const auth = pat ? { userId: pat.userId } : requireAuth(req, res)
+  const auth = requireBuildAuth(req, res)
   if (!auth) return
-
-  if (pat && !pat.scope.includes('builds:write')) {
-    return json(res, 403, { error: 'Insufficient scope' })
-  }
 
   const bb = busboy({ headers: req.headers, limits: { fileSize: 500 * 1024 * 1024 } })
   const fields: Record<string, string> = {}

--- a/packages/relay/src/middleware/auth.ts
+++ b/packages/relay/src/middleware/auth.ts
@@ -88,3 +88,21 @@ export function verifyPat(req: http.IncomingMessage): { userId: number; scope: s
 export function hashPat(token: string): string {
   return crypto.createHash('sha256').update(token).digest('hex')
 }
+
+export function requireBuildAuth(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+): { userId: number } | null {
+  const pat = verifyPat(req)
+  if (pat !== null) {
+    if (!pat.scope.split(',').map((s) => s.trim()).includes('builds:write')) {
+      res.writeHead(403, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Insufficient scope' }))
+      return null
+    }
+    return { userId: pat.userId }
+  }
+  const auth = requireAuth(req, res)
+  if (!auth) return null
+  return { userId: auth.userId }
+}


### PR DESCRIPTION
## Summary

- `requireBuildAuth` 헬퍼 추가 — PAT 우선 시도 (builds:write scope 검사), 없으면 JWT 쿠키 fallback
- `GET /api/v1/builds`, `GET /api/v1/builds/:id` 에 PAT 지원 추가 → CI/CD 파이프라인이 업로드 후 빌드 조회 가능
- 업로드 핸들러의 분산된 PAT+scope 로직을 동일 헬퍼로 통합
- `requireBuildAuth` 단위 테스트 5개 추가

## Test plan

- [x] `GET /api/v1/builds` — PAT(`builds:write`) → 200 빌드 목록 반환 확인 (curl)
- [x] `GET /api/v1/builds` — 잘못된 PAT → 401 확인 (curl)
- [x] `GET /api/v1/builds` — 인증 없음 → 401 확인 (curl)
- [x] 단위 테스트 137개 전체 통과

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build operations now accept personal access tokens with the required build scope, falling back to session-based authentication when a PAT is not present.

* **Tests**
  * Added comprehensive tests covering PAT scope validation, session fallback, missing credentials, and expired/invalid token scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->