### PR TITLE
feat(relay): add screenshot REST endpoint — GET /api/v1/sessions/:sessionId/screenshot

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -685,6 +685,30 @@ export class AndroidAgent implements DeviceAgent {
         this.handleKeyInput(serial, code, modifiers).catch(() => {})
         break
       }
+      case 'screenshot:request': {
+        const raw = msg as unknown as { requestId: string; format?: 'png' | 'jpeg'; sessionId?: string }
+        const { requestId, format } = raw
+        const sessionId = msg.sessionId
+        const state = this.deviceStates.get(sessionId!)
+        const serial = state ? this.adb.getSerial(state.deviceId) : undefined
+        if (!serial) {
+          this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message: 'No booted device' }))
+          break
+        }
+        this.adb.screenshot(serial)
+          .then((buf) => this.ws?.send(JSON.stringify({
+            type: 'screenshot:done',
+            sessionId,
+            requestId,
+            format: format ?? 'png',
+            data: buf.toString('base64'),
+          })))
+          .catch((e: unknown) => {
+            const message = e instanceof Error ? e.message : String(e)
+            this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message }))
+          })
+        break
+      }
     }
   }
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -501,6 +501,24 @@ export class IOSAgent implements DeviceAgent {
           })
         break
       }
+      case 'screenshot:request': {
+        const raw = msg as unknown as { requestId: string; format?: 'png' | 'jpeg'; sessionId?: string }
+        const { requestId, format } = raw
+        const sessionId = msg.sessionId
+        this.simctl.screenshot(format ?? 'png')
+          .then((buf) => this.ws?.send(JSON.stringify({
+            type: 'screenshot:done',
+            sessionId,
+            requestId,
+            format: format ?? 'png',
+            data: buf.toString('base64'),
+          })))
+          .catch((e: unknown) => {
+            const message = e instanceof Error ? e.message : String(e)
+            this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message }))
+          })
+        break
+      }
     }
   }
 

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -125,10 +125,11 @@ export class SimctlWrapper {
     await this.runner.exec('openurl', deviceId, url)
   }
 
-  async screenshot(): Promise<Buffer> {
-    const tmpPath = `${tmpdir()}/tapflow-${randomUUID()}.png`
+  async screenshot(format: 'png' | 'jpeg' = 'png'): Promise<Buffer> {
+    const ext = format === 'jpeg' ? 'jpg' : 'png'
+    const tmpPath = `${tmpdir()}/tapflow-${randomUUID()}.${ext}`
     try {
-      await this.runner.exec('io', 'booted', 'screenshot', tmpPath)
+      await this.runner.exec('io', 'booted', 'screenshot', '--type', format, tmpPath)
       return await fs.readFile(tmpPath)
     } finally {
       await fs.unlink(tmpPath).catch(() => {})

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -226,7 +226,7 @@ describe('SimctlWrapper', () => {
       const buf = await wrapper.screenshot()
 
       expect(runner.exec).toHaveBeenCalledWith(
-        'io', 'booted', 'screenshot',
+        'io', 'booted', 'screenshot', '--type', 'png',
         expect.stringMatching(/tapflow-.+\.png$/)
       )
       expect(buf).toEqual(pngMagic)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1,10 +1,12 @@
 import http from 'http'
 import fs from 'fs'
 import path from 'path'
+import { randomUUID } from 'crypto'
 import { WebSocketServer, WebSocket } from 'ws'
 import { SessionManager } from './SessionManager.js'
 import type { RelayMessage } from './types.js'
-import { Router } from './router.js'
+import { Router, json } from './router.js'
+import { requireAuth } from './middleware/auth.js'
 import { getDb } from './db.js'
 import { handleLogin, handleLogout, handleMe, handleChangePassword, handleInit } from './api/auth.js'
 import { handleVerify, handleAccept } from './api/invitations.js'
@@ -60,9 +62,17 @@ export class RelayServer {
   private flushResourcesTimer: ReturnType<typeof setInterval> | null = null
   private dropHandlers = new Map<string, () => void>()
   private readonly backpressureBytes: number
+  private readonly screenshotTimeoutMs: number
+  private pendingScreenshots = new Map<string, {
+    sessionId: string
+    resolve: (buf: Buffer, format: 'png' | 'jpeg') => void
+    reject: (err: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }>()
 
-  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number; wsBackpressureBytes?: number }) {
+  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number; wsBackpressureBytes?: number; screenshotTimeoutMs?: number }) {
     this.backpressureBytes = options.wsBackpressureBytes ?? DEFAULT_BACKPRESSURE_BYTES
+    this.screenshotTimeoutMs = options.screenshotTimeoutMs ?? 10_000
     this.sessions = new SessionManager({ idleTimeoutMs: options.idleTimeoutMs })
     this.publicDir = options.publicDir ?? path.join(import.meta.dirname, '../public')
     this.uploadsDir = options.uploadsDir ?? path.join(import.meta.dirname, '../uploads')
@@ -141,6 +151,10 @@ export class RelayServer {
     // agent resources
     this.router.get('/api/v1/agents', handleListAgents)
     this.router.get('/api/v1/agents/:name/resources', handleGetAgentResources)
+
+    // screenshot
+    this.router.get('/api/v1/sessions/:sessionId/screenshot',
+      (req, res, params) => this.handleGetScreenshot(req, res, params))
   }
 
   pushLog(msg: string): void {
@@ -227,6 +241,14 @@ export class RelayServer {
       // Agent main socket disconnected → remove all device sessions for this agent
       const agentSessions = this.sessions.getAllByAgentSocket(ws)
       if (agentSessions.length > 0) {
+        const agentSessionIds = new Set(agentSessions.map((s) => s.id))
+        for (const [reqId, pending] of this.pendingScreenshots.entries()) {
+          if (agentSessionIds.has(pending.sessionId)) {
+            clearTimeout(pending.timer)
+            this.pendingScreenshots.delete(reqId)
+            pending.reject(new Error('Agent disconnected'))
+          }
+        }
         for (const s of agentSessions) this.sessions.remove(s.id)
         this.sessions.removeResources(ws)
         return
@@ -261,6 +283,8 @@ export class RelayServer {
       // ── Agent → Relay ─────────────────────────────────────────────────────
       case 'agent:resources':    this.handleAgentResources(ws, msg); break
       case 'agent:register':     this.handleAgentRegister(ws, msg); break
+      case 'screenshot:done':    this.handleScreenshotDone(msg); break
+      case 'screenshot:error':   this.handleScreenshotError(msg); break
       case 'agents:list': {
         ws.send(JSON.stringify({ type: 'agents:listed', sessions: this.sessions.list() }))
         break
@@ -489,6 +513,77 @@ export class RelayServer {
         payload: { bundleId: build.bundle_id },
       }))
     }
+  }
+
+  private async handleGetScreenshot(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    params: Record<string, string>,
+  ): Promise<void> {
+    if (!requireAuth(req, res)) return
+
+    const { sessionId } = params
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      json(res, 404, { error: 'Session not found' })
+      return
+    }
+    if (session.deviceStatus === 'shutdown') {
+      json(res, 409, { error: 'Device is not booted' })
+      return
+    }
+    if (session.agentSocket.readyState !== WebSocket.OPEN) {
+      json(res, 502, { error: 'Agent offline' })
+      return
+    }
+
+    const urlObj = new URL(req.url ?? '/', 'http://x')
+    const format: 'png' | 'jpeg' = urlObj.searchParams.get('format') === 'jpeg' ? 'jpeg' : 'png'
+    const requestId = randomUUID()
+
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingScreenshots.delete(requestId)
+        json(res, 504, { error: 'Screenshot timed out' })
+        resolve()
+      }, this.screenshotTimeoutMs)
+
+      this.pendingScreenshots.set(requestId, {
+        sessionId,
+        resolve: (buf, fmt) => {
+          clearTimeout(timer)
+          this.pendingScreenshots.delete(requestId)
+          const contentType = fmt === 'jpeg' ? 'image/jpeg' : 'image/png'
+          res.writeHead(200, { 'Content-Type': contentType, 'Content-Length': String(buf.length) })
+          res.end(buf)
+          resolve()
+        },
+        reject: (err) => {
+          clearTimeout(timer)
+          this.pendingScreenshots.delete(requestId)
+          json(res, 502, { error: err.message })
+          resolve()
+        },
+        timer,
+      })
+
+      session.agentSocket.send(JSON.stringify({ type: 'screenshot:request', sessionId, requestId, format }))
+    })
+  }
+
+  private handleScreenshotDone(msg: RelayMessage): void {
+    if (!msg.requestId) return
+    const pending = this.pendingScreenshots.get(msg.requestId)
+    if (!pending) return
+    const buf = Buffer.from(msg.data ?? '', 'base64')
+    pending.resolve(buf, msg.format ?? 'png')
+  }
+
+  private handleScreenshotError(msg: RelayMessage): void {
+    if (!msg.requestId) return
+    const pending = this.pendingScreenshots.get(msg.requestId)
+    if (!pending) return
+    pending.reject(new Error(msg.message ?? 'Screenshot failed'))
   }
 
   private flushResourceBuffers(): void {

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import type { RelayMessage } from '../types'
+import { signJwt } from '../middleware/auth'
+
+const FAKE_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) // PNG magic bytes
+const FAKE_JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0]) // JPEG magic bytes
+
+const waitForOpen = (ws: WebSocket) =>
+  new Promise<void>((resolve) => ws.once('open', resolve))
+
+const waitForType = (ws: WebSocket, type: string) =>
+  new Promise<RelayMessage>((resolve) => {
+    const listener = (data: Buffer) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === type) {
+        ws.off('message', listener)
+        resolve(msg)
+      }
+    }
+    ws.on('message', listener)
+  })
+
+function makeAuthCookie(): string {
+  return `tapflow_token=${signJwt({ userId: 1, email: 'test@example.com', role: 'Admin' })}`
+}
+
+function httpGet(
+  port: number,
+  urlPath: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: 'localhost', port, path: urlPath, method: 'GET', headers },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () =>
+          resolve({ status: res.statusCode!, headers: res.headers, body: Buffer.concat(chunks) }),
+        )
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-screenshot-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0, screenshotTimeoutMs: 300 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  async function setupAgent(devices = [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }]) {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const reply = await new Promise<RelayMessage>((resolve) =>
+      agent.once('message', (d) => resolve(JSON.parse(d.toString()))),
+    )
+    const sessionId = reply.registeredSessions![0].sessionId
+    return { agent, sessionId }
+  }
+
+  it('TC1: 정상 PNG 스크린샷 — agent가 screenshot:done 응답 시 200 image/png', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    // Agent: screenshot:request를 수신하면 즉시 screenshot:done 응답
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: msg.requestId,
+          format: 'png',
+          data: FAKE_PNG.toString('base64'),
+        }))
+      }
+    })
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('image/png')
+    expect(res.body).toEqual(FAKE_PNG)
+
+    agent.close()
+  })
+
+  it('TC2: JPEG 포맷 요청 — agent가 jpeg 응답 시 200 image/jpeg', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        expect(msg.format).toBe('jpeg')
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: msg.requestId,
+          format: 'jpeg',
+          data: FAKE_JPEG.toString('base64'),
+        }))
+      }
+    })
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot?format=jpeg`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('image/jpeg')
+    expect(res.body).toEqual(FAKE_JPEG)
+
+    agent.close()
+  })
+
+  it('TC3: 인증 없음 → 401', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    const res = await httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`)
+
+    expect(res.status).toBe(401)
+
+    agent.close()
+  })
+
+  it('TC4: 존재하지 않는 세션 → 404', async () => {
+    const res = await httpGet(
+      port,
+      '/api/v1/sessions/nonexistent-session-id/screenshot',
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it('TC5: agent가 응답 전 연결 끊기면 → 502', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    // agent는 screenshot:request를 받으면 즉시 종료 (응답 없이)
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') agent.close()
+    })
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(502)
+  })
+
+  it('TC6: agent 무응답 — screenshotTimeoutMs 초과 시 504', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    // agent는 screenshot:request를 무시함
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(504)
+
+    agent.close()
+  })
+
+  it('TC7: agent가 screenshot:error 응답 → 502 + 에러 메시지', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        agent.send(JSON.stringify({
+          type: 'screenshot:error',
+          sessionId: msg.sessionId,
+          requestId: msg.requestId,
+          message: 'simulator not booted',
+        }))
+      }
+    })
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(502)
+    const body = JSON.parse(res.body.toString()) as { error: string }
+    expect(body.error).toBe('simulator not booted')
+
+    agent.close()
+  })
+
+  it('TC8: deviceStatus가 shutdown인 세션 → 409', async () => {
+    const { agent, sessionId } = await setupAgent([
+      { id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'shutdown' },
+    ])
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(409)
+
+    agent.close()
+  })
+
+  it('같은 세션에 동시 요청 두 개 — 각각 독립적으로 응답', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: msg.requestId,
+          format: 'png',
+          data: FAKE_PNG.toString('base64'),
+        }))
+      }
+    })
+
+    const [res1, res2] = await Promise.all([
+      httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`, { Cookie: makeAuthCookie() }),
+      httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`, { Cookie: makeAuthCookie() }),
+    ])
+
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+
+    agent.close()
+  })
+
+  it('screenshot:done에서 requestId 불일치 시 응답 무시', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    // 잘못된 requestId로 응답 먼저 보내고, 올바른 requestId로 나중에 응답
+    let correctRequestId: string | undefined
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        correctRequestId = msg.requestId
+        // 잘못된 requestId 먼저
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: 'wrong-request-id',
+          format: 'png',
+          data: Buffer.from('bad').toString('base64'),
+        }))
+        // 올바른 requestId
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: correctRequestId,
+          format: 'png',
+          data: FAKE_PNG.toString('base64'),
+        }))
+      }
+    })
+
+    const res = await httpGet(
+      port,
+      `/api/v1/sessions/${sessionId}/screenshot`,
+      { Cookie: makeAuthCookie() },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(FAKE_PNG)
+
+    agent.close()
+  })
+
+  it('screenshot:request는 relay가 agent에게만 전달 (browser WS로 브로드캐스트되지 않음)', async () => {
+    const { agent, sessionId } = await setupAgent()
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    let browserGotScreenshotRequest = false
+    browser.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') browserGotScreenshotRequest = true
+    })
+
+    agent.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        agent.send(JSON.stringify({
+          type: 'screenshot:done',
+          sessionId: msg.sessionId,
+          requestId: msg.requestId,
+          format: 'png',
+          data: FAKE_PNG.toString('base64'),
+        }))
+      }
+    })
+
+    await httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`, { Cookie: makeAuthCookie() })
+    await new Promise<void>((r) => setImmediate(r))
+
+    expect(browserGotScreenshotRequest).toBe(false)
+
+    agent.close()
+    browser.close()
+  })
+})

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -39,6 +39,9 @@ export type MessageType =
   | 'input:rotate'
   | 'input:keyboard:toggle'
   | 'keyboard:toggled'
+  | 'screenshot:request'
+  | 'screenshot:done'
+  | 'screenshot:error'
   | 'error'
 
 import type { AgentResources } from '@tapflowio/agent-core'
@@ -77,4 +80,7 @@ export interface RelayMessage {
   registeredSessions?: Array<{ deviceId: string; sessionId: string }>
   buildId?: number
   resources?: AgentResources
+  requestId?: string
+  data?: string
+  format?: 'png' | 'jpeg'
 }


### PR DESCRIPTION
## Summary

- `GET /api/v1/sessions/:sessionId/screenshot` 엔드포인트 추가 (JWT 인증 필수)
- `requestId` 기반 pending map으로 HTTP 요청과 WS 응답을 연결하는 req/res 상관 패턴 구현
- ios-agent: `simctl io screenshot --type png|jpeg` — `?format=jpeg` 쿼리 파라미터 지원
- android-agent: ADB 제약으로 항상 PNG 반환, `format` 필드는 에코만

## Architecture

```
Browser HTTP GET /screenshot
  → relay creates requestId, sends screenshot:request over WS
  → agent captures screen, sends screenshot:done { requestId, data: base64 }
  → relay resolves pending promise, returns 200 image/png
```

에이전트 오프라인 → 502, 기기 shutdown → 409, 에이전트 무응답 → 504 (10s timeout)

## Test plan

- [ ] TC1: 인증 없으면 401
- [ ] TC2: 없는 세션 → 404
- [ ] TC3: shutdown 기기 → 409
- [ ] TC4: 오프라인 에이전트 → 502
- [ ] TC5: 정상 PNG/JPEG 반환 200
- [ ] TC6: 에이전트 무응답 → 504
- [ ] TC7: 에이전트 error 응답 → 502
- [ ] TC8: 요청 중 에이전트 disconnect → 502
- [ ] TC9: 동시 요청 — requestId 분리
- [ ] TC10: requestId 불일치 무시
- [ ] TC11: 스크린샷이 다른 브라우저에 브로드캐스트되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added on-demand screenshot capability with a new authenticated HTTP endpoint for browser-based screenshot requests.
  * Screenshots support configurable output formats (PNG and JPEG).
  * Implemented request timeout handling (default 10 seconds) to manage long-running screenshot operations.
  * Relay server now manages screenshot request routing between clients and connected agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->