### PR TITLE
docs: update roadmap and README for PRs #127–#130, add SEO sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,9 @@
   </p>
 </div>
 
-> **v0.x**: tapflow is under active development. Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for the full plan.
-
----
-
-## Demo
-
 <video src="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" controls width="100%"></video>
 
-[▶ Watch demo](https://www.tapflow.dev/guide/introduction)
+> **v0.x**: tapflow is under active development. Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for the full plan.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
+  <h3>A self-hosted Appetize / BrowserStack alternative for mobile QA teams</h3>
 
   <p>
-    Anyone on your team can run simulators in the browser — no toolchain setup, no device management, no cloud uploads.<br />
+    Run iOS simulators and Android emulators in any browser — no toolchain setup, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -25,7 +25,7 @@
   </p>
 </div>
 
-> **alpha**: tapflow is in active development (v0.x). Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for known gaps.
+> **v0.x**: tapflow is under active development. Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for the full plan.
 
 ---
 
@@ -64,18 +64,24 @@ So we built tapflow.
 
 ## Features
 
-- **Browser-based** — Anyone on the team needs no installation. Any modern browser works.
-- **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
-- **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
-- **Touch, swipe & pinch** — real-time input forwarded to the simulator.
-- **Deeplink** — enter a URL from the QA toolbar to jump directly to a specific screen without manual navigation.
-- **Keyboard shortcuts** — simulator toolbar actions available as keyboard shortcuts for faster interactions.
-- **App Center** — upload `.app.zip` (iOS) or `.apk` (Android), manage builds by status (Backlog / In Progress / Done / Rejected).
-- **Session Recordings** — record QA sessions, share with your team. Retained for 72 hours.
-- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic capture and AI agent integration.
-- **Mac Resources** — CPU & RAM monitoring per agent. Spot overloaded hosts before assigning sessions.
-- **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens for CI/CD.
-- **Self-hosted** — deploy anywhere. No cloud dependency.
+tapflow focuses on:
+
+- **Zero setup for QA** — any browser, no toolchain. Designers, PMs, and server devs test without asking a mobile developer.
+- **Data on-premises** — app binaries and session recordings never leave your network.
+- **Your existing Mac** — no new hardware, no monthly cloud subscription.
+- **API-first** — REST endpoints and PATs built in, ready for CI/CD and AI agent workflows.
+
+What's included:
+
+- **iOS & Android streaming** — ~30 fps, no additional app required on the device
+- **Touch, swipe & pinch** — real-time input forwarded to the simulator
+- **Deeplink** — jump directly to any screen from the QA toolbar, no manual navigation
+- **Keyboard shortcuts** — simulator toolbar actions without leaving the keyboard
+- **App Center** — upload `.app.zip` / `.apk`, track builds by status (Backlog / In Progress / Done / Rejected)
+- **Session recordings** — record and share QA sessions, retained 72 hours
+- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents
+- **Mac resource monitoring** — CPU & RAM per agent, spot overloaded hosts before assigning sessions
+- **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ So we built tapflow.
 - **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
 - **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator.
+- **Deeplink** — enter a URL from the QA toolbar to jump directly to a specific screen without manual navigation.
+- **Keyboard shortcuts** — simulator toolbar actions available as keyboard shortcuts for faster interactions.
 - **App Center** — upload `.app.zip` (iOS) or `.apk` (Android), manage builds by status (Backlog / In Progress / Done / Rejected).
 - **Session Recordings** — record QA sessions, share with your team. Retained for 72 hours.
+- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic capture and AI agent integration.
 - **Mac Resources** — CPU & RAM monitoring per agent. Spot overloaded hosts before assigning sessions.
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens for CI/CD.
 - **Self-hosted** — deploy anywhere. No cloud dependency.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Live tracking → [GitHub Projects](https://github.com/users/jo-duchan/projects/1)
 
-tapflow is currently in **alpha** (`v0.x`). The roadmap below reflects the path to a stable `v1.0.0`.
+tapflow is currently at `v0.x`. The roadmap below reflects the path to a stable `v1.0.0`.
 Breaking changes may appear in minor versions until `v1.0.0` is tagged.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Scalability, extensibility, and CI/CD integration.
 - [x] WebSocket backpressure — check `ws.bufferedAmount` before sending frames; drop or queue frames for slow clients
 - [x] Runtime platform registration — replace `'ios' | 'android'` literal union with a dynamic registry so new platforms require zero changes to `agent-core`, CLI, or Dashboard
 - [ ] CI/CD integration guide — end-to-end walkthrough: upload `.app.zip` / `.apk` via REST API from CI → view results in the dashboard
-- [ ] PAT scope enforcement — apply `scope` checks consistently across all endpoints
+- [x] PAT scope enforcement — apply `scope` checks consistently across all endpoints
 - [ ] Tier 2 integration tests — real simulator / emulator touch and stream smoke tests in GitHub Actions (`macos-latest` for iOS, `ubuntu-latest` + `reactivecircus/android-emulator-runner` for Android)
 
 ---
@@ -68,7 +68,8 @@ Streaming performance, resource-aware scheduling, and AI agent integration.
 
 - [ ] Streaming performance improvements — encoding and transport optimization for iOS (JPEG pipeline) and Android (scrcpy parameters)
 - [ ] Block new session when agent resource usage is high — prevent overloading the host Mac
-- [ ] AI agent integration — LLM-driven simulator control via screenshot REST endpoint + MCP server package (`@tapflowio/mcp-server`)
+- [x] Screenshot REST endpoint — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic screen capture and LLM perception-action loops
+- [ ] MCP server package (`@tapflowio/mcp-server`) — LLM-driven simulator control via MCP tools; prerequisite: screenshot REST endpoint ✅
 
 ---
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -102,6 +102,10 @@ export default withMermaid(defineConfig({
   description: 'Self-hosted iOS/Android simulator streaming for QA',
   cleanUrls: true,
 
+  sitemap: {
+    hostname: 'https://tapflow.dev',
+  },
+
   locales: {
     root: {
       label: 'English',

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://tapflow.dev/sitemap.xml

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="docs/public/logo-hero.svg" height="72" alt="tapflow" />
 
-  <h3>Self-hosted iOS & Android simulator streaming for mobile QA</h3>
+  <h3>A self-hosted Appetize / BrowserStack alternative for mobile QA teams</h3>
 
   <p>
-    Anyone on your team can run simulators in the browser — no toolchain setup, no device management, no cloud uploads.<br />
+    Run iOS simulators and Android emulators in any browser — no toolchain setup, no device management, no cloud uploads.<br />
     App data never leaves your network.
   </p>
 
@@ -64,18 +64,24 @@ So we built tapflow.
 
 ## Features
 
-- **Browser-based** — Anyone on the team needs no installation. Any modern browser works.
-- **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
-- **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
-- **Touch, swipe & pinch** — real-time input forwarded to the simulator.
-- **Deeplink** — enter a URL from the QA toolbar to jump directly to a specific screen without manual navigation.
-- **Keyboard shortcuts** — simulator toolbar actions available as keyboard shortcuts for faster interactions.
-- **App Center** — upload `.app.zip` (iOS) or `.apk` (Android), manage builds by status (Backlog / In Progress / Done / Rejected).
-- **Session Recordings** — record QA sessions, share with your team. Retained for 72 hours.
-- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic capture and AI agent integration.
-- **Mac Resources** — CPU & RAM monitoring per agent. Spot overloaded hosts before assigning sessions.
-- **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens for CI/CD.
-- **Self-hosted** — deploy anywhere. No cloud dependency.
+tapflow focuses on:
+
+- **Zero setup for QA** — any browser, no toolchain. Designers, PMs, and server devs test without asking a mobile developer.
+- **Data on-premises** — app binaries and session recordings never leave your network.
+- **Your existing Mac** — no new hardware, no monthly cloud subscription.
+- **API-first** — REST endpoints and PATs built in, ready for CI/CD and AI agent workflows.
+
+What's included:
+
+- **iOS & Android streaming** — ~30 fps, no additional app required on the device
+- **Touch, swipe & pinch** — real-time input forwarded to the simulator
+- **Deeplink** — jump directly to any screen from the QA toolbar, no manual navigation
+- **Keyboard shortcuts** — simulator toolbar actions without leaving the keyboard
+- **App Center** — upload `.app.zip` / `.apk`, track builds by status (Backlog / In Progress / Done / Rejected)
+- **Session recordings** — record and share QA sessions, retained 72 hours
+- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents
+- **Mac resource monitoring** — CPU & RAM per agent, spot overloaded hosts before assigning sessions
+- **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens
 
 ## How it works
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,10 +24,6 @@
   </p>
 </div>
 
----
-
-## Demo
-
 <div align="center">
   <a href="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" target="_blank" rel="noopener noreferrer">
     <img src="https://raw.githubusercontent.com/jo-duchan/tapflow/main/docs/public/demo-thumbnail.png" alt="tapflow demo — click to play" width="100%" />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,8 +68,11 @@ So we built tapflow.
 - **iOS Simulator** — JPEG frame streaming at ~30 fps via SimulatorKit IOSurface. No WebDriverAgent required.
 - **Android Emulator** — H.264 streaming via [scrcpy](https://github.com/Genymobile/scrcpy) at ~30 fps.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator.
+- **Deeplink** — enter a URL from the QA toolbar to jump directly to a specific screen without manual navigation.
+- **Keyboard shortcuts** — simulator toolbar actions available as keyboard shortcuts for faster interactions.
 - **App Center** — upload `.app.zip` (iOS) or `.apk` (Android), manage builds by status (Backlog / In Progress / Done / Rejected).
 - **Session Recordings** — record QA sessions, share with your team. Retained for 72 hours.
+- **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic capture and AI agent integration.
 - **Mac Resources** — CPU & RAM monitoring per agent. Spot overloaded hosts before assigning sessions.
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens for CI/CD.
 - **Self-hosted** — deploy anywhere. No cloud dependency.


### PR DESCRIPTION
## Summary

- **ROADMAP**: PAT scope enforcement `[x]` (PR #129); AI agent 항목을 screenshot REST `[x]` + MCP server `[ ]` 두 줄로 분리; alpha 표현 제거 (Phase 2 완료 기준 충족, v0.2.2)
- **README** (root + cli): Hero를 "Appetize / BrowserStack alternative" 포지셔닝으로 전환; Features를 가치 블록(4개) + 기능 목록(9개) 이중 구조로 재편; 구현 세부사항(JPEG/H.264/SimulatorKit) 제거
- **README** (root + cli): Deeplink, Keyboard shortcuts, Screenshot REST endpoint 추가
- **docs SEO**: VitePress `sitemap` 설정 추가 (`tapflow.dev/sitemap.xml` 자동 생성) + `robots.txt` 추가 — Google Search Console 404 경고 해소

## Test plan

- [ ] `pnpm build` in `docs/` — `sitemap.xml` and `robots.txt` present in `.vitepress/dist/`
- [ ] ROADMAP.md 체크박스 상태가 실제 PR 이력과 일치하는지 확인
- [ ] README Hero/Features가 root와 packages/cli/ 양쪽에 동일하게 반영됐는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Screenshot REST endpoint for capturing session screenshots

* **Documentation**
  * Updated product positioning and feature descriptions
  * Updated version status messaging from alpha to v0.x and roadmap milestones
  * Enhanced site discoverability with sitemap configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->