### PR TITLE
feat: add MCP server (experimental) + prepare v0.3.0 release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@tapflowio/dashboard", "@tapflowio/playground"]
+  "ignore": ["@tapflowio/dashboard", "@tapflowio/playground", "@tapflowio/mcp-server"]
 }

--- a/.changeset/release-v0.3.0.md
+++ b/.changeset/release-v0.3.0.md
@@ -1,0 +1,17 @@
+---
+"tapflow": minor
+"@tapflowio/agent-core": minor
+"@tapflowio/ios-agent": minor
+"@tapflowio/android-agent": minor
+"@tapflowio/relay": minor
+---
+
+Release v0.3.0
+
+- relay: add screenshot REST endpoint (`GET /api/v1/sessions/:id/screenshot`) for CI and AI agent use
+- relay: enforce PAT scope checks on builds endpoints; new tokens include `view` scope by default
+- relay: add `session:leave` message type — MCP clients can disconnect without ending the session
+- relay: fix `.app` bundle names with spaces in zip upload validation
+- dashboard: add deeplink URL execution from QA session toolbar
+- dashboard: add keyboard shortcuts and Kbd UI to simulator toolbar
+- dashboard: add streaming performance overlay

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
       - run: pnpm changeset publish --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish mcp-server (experimental)
+        run: pnpm --filter @tapflowio/mcp-server publish --tag experimental --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What's included:
 - **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents
 - **Mac resource monitoring** — CPU & RAM per agent, spot overloaded hosts before assigning sessions
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens
-- **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
+- **MCP Server** *(experimental)* — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 ## How it works
 
@@ -201,7 +201,7 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 - [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
 
 **AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
+- [MCP Server](https://www.tapflow.dev/guide/mcp-server) *(experimental)*
 
 **Reference**
 - [CLI Reference](https://www.tapflow.dev/reference/cli)

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,5 +1,12 @@
 # MCP Server
 
+::: warning Experimental
+`@tapflowio/mcp-server` is experimental. APIs and tool schemas may change between releases. Install with the `experimental` tag:
+```sh
+npm install @tapflowio/mcp-server@experimental
+```
+:::
+
 `@tapflowio/mcp-server` exposes tapflow as a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. Claude Code, Codex, and any other MCP-compatible LLM agent can control iOS simulators and Android emulators as native tools — no scripting, no hardcoded selectors.
 
 ## When to use this

--- a/docs/ko/guide/mcp-server.md
+++ b/docs/ko/guide/mcp-server.md
@@ -1,5 +1,12 @@
 # MCP 서버
 
+::: warning 실험적 기능
+`@tapflowio/mcp-server`는 실험적 기능입니다. API와 툴 스키마는 릴리즈 간에 변경될 수 있습니다. `experimental` 태그로 설치하세요:
+```sh
+npm install @tapflowio/mcp-server@experimental
+```
+:::
+
 `@tapflowio/mcp-server`는 tapflow를 [Model Context Protocol(MCP)](https://modelcontextprotocol.io) 서버로 노출합니다. Claude Code, Codex 등 MCP를 지원하는 LLM 에이전트가 iOS 시뮬레이터와 Android 에뮬레이터를 네이티브 도구로 직접 제어할 수 있습니다. 스크립팅도, 좌표 하드코딩도 필요 없습니다.
 
 ## 이럴 때 쓰세요

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,7 +78,7 @@ What's included:
 - **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents
 - **Mac resource monitoring** — CPU & RAM per agent, spot overloaded hosts before assigning sessions
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), Personal Access Tokens
-- **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
+- **MCP Server** *(experimental)* — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 ## How it works
 
@@ -208,7 +208,7 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 - [REST API](https://www.tapflow.dev/reference/api)
 
 **AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
+- [MCP Server](https://www.tapflow.dev/guide/mcp-server) *(experimental)*
 
 **[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.0-experimental.0",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -98,10 +98,10 @@ describe('TapflowClient', () => {
   })
 
   describe('disconnectDevice', () => {
-    it('sends session:end', async () => {
+    it('sends session:leave', async () => {
       client.disconnectDevice('sess-1')
-      const msg = await waitForMessage(relay, 'session:end')
-      expect(msg).toMatchObject({ type: 'session:end', sessionId: 'sess-1' })
+      const msg = await waitForMessage(relay, 'session:leave')
+      expect(msg).toMatchObject({ type: 'session:leave', sessionId: 'sess-1' })
     })
   })
 

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -16,6 +16,23 @@ export interface AgentSession {
   devices: DeviceInfo[]
 }
 
+export interface BuildInfo {
+  id: number
+  versionName: string
+  buildNumber: string
+  platform: string
+  statusLabel: string | null
+  createdAt: string
+}
+
+export interface AppInfo {
+  id: number
+  name: string
+  bundleId: string
+  platform: string
+  builds: BuildInfo[]
+}
+
 type RelayMsg = Record<string, unknown>
 
 interface Waiter {
@@ -114,7 +131,7 @@ export class TapflowClient {
   }
 
   disconnectDevice(sessionId: string): void {
-    this.send({ type: 'session:end', sessionId })
+    this.send({ type: 'session:leave', sessionId })
   }
 
   async bootDevice(sessionId: string, deviceId: string): Promise<void> {
@@ -220,5 +237,46 @@ export class TapflowClient {
       throw new Error(message)
     }
     return Buffer.from(await res.arrayBuffer())
+  }
+
+  async listBuilds(): Promise<AppInfo[]> {
+    const httpBase = this.relayUrl.replace(/^wss?/, (p) => (p === 'wss' ? 'https' : 'http'))
+    const headers = { Authorization: `Bearer ${this.token}` }
+
+    const [appsRes, buildsRes] = await Promise.all([
+      fetch(new URL('/api/v1/apps', httpBase).toString(), { headers }),
+      fetch(new URL('/api/v1/builds', httpBase).toString(), { headers }),
+    ])
+
+    if (!appsRes.ok) throw new Error(`Failed to fetch apps: ${appsRes.status}`)
+    if (!buildsRes.ok) throw new Error(`Failed to fetch builds: ${buildsRes.status}`)
+
+    const apps = (await appsRes.json()) as Array<{ id: number; name: string; bundle_id: string; platform: string }>
+    const builds = (await buildsRes.json()) as Array<{
+      id: number
+      app_id: number
+      version_name: string
+      build_number: string
+      platform: string
+      status_label: string | null
+      created_at: string
+    }>
+
+    return apps.map((app) => ({
+      id: app.id,
+      name: app.name,
+      bundleId: app.bundle_id,
+      platform: app.platform,
+      builds: builds
+        .filter((b) => b.app_id === app.id)
+        .map((b) => ({
+          id: b.id,
+          versionName: b.version_name,
+          buildNumber: b.build_number,
+          platform: b.platform,
+          statusLabel: b.status_label,
+          createdAt: b.created_at,
+        })),
+    }))
   }
 }

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,6 +1,23 @@
 import * as z from 'zod'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { TapflowClient } from './client.js'
+
+function getImageDimensions(buf: Buffer, format: string): { width: number; height: number } | null {
+  if (format === 'png' && buf.length >= 24) {
+    return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
+  }
+  if (format === 'jpeg') {
+    for (let i = 2; i < buf.length - 8; i++) {
+      if (buf[i] === 0xff && buf[i + 1] === 0xc0) {
+        return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) }
+      }
+    }
+  }
+  return null
+}
 
 type ToolResult = { content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>; isError?: boolean }
 
@@ -13,6 +30,19 @@ function err(text: string): ToolResult {
 }
 
 export function registerTools(server: McpServer, client: TapflowClient): void {
+  server.registerTool(
+    'list_builds',
+    { description: 'List all apps and their builds available on the relay. Use this to find buildId before calling install_app or launch_app.' },
+    async () => {
+      try {
+        const apps = await client.listBuilds()
+        return ok(JSON.stringify(apps, null, 2))
+      } catch (e) {
+        return err(`list_builds failed: ${(e as Error).message}`)
+      }
+    },
+  )
+
   server.registerTool(
     'list_devices',
     { description: 'List all available simulators and emulators registered on the tapflow relay.' },
@@ -92,10 +122,20 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
     },
     async ({ sessionId, format }) => {
       try {
-        const buf = await client.screenshot(sessionId, format ?? 'png')
-        const mimeType = format === 'jpeg' ? 'image/jpeg' : 'image/png'
+        const fmt = format ?? 'png'
+        const buf = await client.screenshot(sessionId, fmt)
+        const mimeType = fmt === 'jpeg' ? 'image/jpeg' : 'image/png'
+        const ext = fmt === 'jpeg' ? 'jpg' : 'png'
+        const filename = `tapflow-${sessionId.slice(0, 8)}-${Date.now()}.${ext}`
+        const filePath = path.join(os.tmpdir(), filename)
+        fs.writeFileSync(filePath, buf)
+        const dims = getImageDimensions(buf, fmt)
+        const dimText = dims ? ` (${dims.width}×${dims.height}px)` : ''
         return {
-          content: [{ type: 'image' as const, data: buf.toString('base64'), mimeType }],
+          content: [
+            { type: 'image' as const, data: buf.toString('base64'), mimeType },
+            { type: 'text' as const, text: `Screenshot saved: ${filePath}${dimText}` },
+          ],
         }
       } catch (e) {
         return err(`screenshot failed: ${(e as Error).message}`)
@@ -106,16 +146,18 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
   server.registerTool(
     'tap',
     {
-      description: 'Tap at a screen coordinate.',
+      description: 'Tap at a pixel coordinate matching the screenshot. Use the width and height from the screenshot tool response.',
       inputSchema: {
         sessionId: z.string().describe('Session ID from list_devices'),
-        x: z.number().describe('X coordinate in points'),
-        y: z.number().describe('Y coordinate in points'),
+        x: z.number().describe('X pixel coordinate (from screenshot)'),
+        y: z.number().describe('Y pixel coordinate (from screenshot, 0 = top)'),
+        screenshotWidth: z.number().int().describe('Screenshot width in pixels (from screenshot tool)'),
+        screenshotHeight: z.number().int().describe('Screenshot height in pixels (from screenshot tool)'),
       },
     },
-    async ({ sessionId, x, y }) => {
+    async ({ sessionId, x, y, screenshotWidth, screenshotHeight }) => {
       try {
-        client.tap(sessionId, x, y)
+        client.tap(sessionId, x / screenshotWidth, y / screenshotHeight)
         return ok(JSON.stringify({ tapped: true, x, y }))
       } catch (e) {
         return err(`tap failed: ${(e as Error).message}`)
@@ -126,19 +168,28 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
   server.registerTool(
     'swipe',
     {
-      description: 'Swipe from one coordinate to another.',
+      description: 'Swipe from one pixel coordinate to another. Use the width and height from the screenshot tool response.',
       inputSchema: {
         sessionId: z.string().describe('Session ID from list_devices'),
-        startX: z.number().describe('Start X coordinate'),
-        startY: z.number().describe('Start Y coordinate'),
-        endX: z.number().describe('End X coordinate'),
-        endY: z.number().describe('End Y coordinate'),
+        startX: z.number().describe('Start X pixel coordinate (from screenshot)'),
+        startY: z.number().describe('Start Y pixel coordinate (from screenshot, 0 = top)'),
+        endX: z.number().describe('End X pixel coordinate (from screenshot)'),
+        endY: z.number().describe('End Y pixel coordinate (from screenshot)'),
+        screenshotWidth: z.number().int().describe('Screenshot width in pixels (from screenshot tool)'),
+        screenshotHeight: z.number().int().describe('Screenshot height in pixels (from screenshot tool)'),
         durationMs: z.number().optional().describe('Swipe duration in milliseconds (default: 300)'),
       },
     },
-    async ({ sessionId, startX, startY, endX, endY, durationMs }) => {
+    async ({ sessionId, startX, startY, endX, endY, screenshotWidth, screenshotHeight, durationMs }) => {
       try {
-        await client.swipe(sessionId, startX, startY, endX, endY, durationMs)
+        await client.swipe(
+          sessionId,
+          startX / screenshotWidth,
+          startY / screenshotHeight,
+          endX / screenshotWidth,
+          endY / screenshotHeight,
+          durationMs,
+        )
         return ok(JSON.stringify({ swiped: true, from: { x: startX, y: startY }, to: { x: endX, y: endY } }))
       } catch (e) {
         return err(`swipe failed: ${(e as Error).message}`)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -299,6 +299,13 @@ export class RelayServer {
         }
         break
       }
+      case 'session:leave': {
+        if (msg.sessionId) {
+          this.sessions.clearBrowser(msg.sessionId)
+          this.dropHandlers.delete(msg.sessionId)
+        }
+        break
+      }
       case 'stream:register': {
         const session = this.sessions.get(msg.sessionId!)
         if (session) {

--- a/packages/relay/src/api/apps.ts
+++ b/packages/relay/src/api/apps.ts
@@ -1,10 +1,10 @@
 import http from 'http'
 import { getDb } from '../db.js'
-import { requireAuth } from '../middleware/auth.js'
+import { requireAuth, requireViewAuth } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
 
 export function handleListApps(req: http.IncomingMessage, res: http.ServerResponse): void {
-  const auth = requireAuth(req, res)
+  const auth = requireViewAuth(req, res)
   if (!auth) return
 
   const items = getDb().prepare(`

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -9,6 +9,7 @@ export type MessageType =
   | 'session:chrome'
   | 'session:deviceInfo'
   | 'session:end'
+  | 'session:leave'
   | 'stream:register'
   | 'stream:registered'
   | 'device:boot'

--- a/playground/CLAUDE.md
+++ b/playground/CLAUDE.md
@@ -38,6 +38,8 @@ pnpm relay                              # 릴레이 단독
 pnpm ios-agent                          # 첫 번째 booted 시뮬레이터
 pnpm ios-agent -- --device "iPhone 16" # 디바이스 지정
 pnpm android-agent
+pnpm mock-agent                         # 시뮬레이터 없이 테스트할 때 사용하는 mock 에이전트
+TAPFLOW_TOKEN=<pat> pnpm mcp            # MCP 서버 (빌드 없이 소스에서 직접 실행)
 ```
 
 ### 진단 · 초기화

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,6 +13,7 @@
     "dev:reset": "tsx --conditions=source ../packages/cli/src/index.ts reset",
     "mock-agent": "tsx --conditions=source mock-agent.ts",
     "mock-agents": "tsx --conditions=source multi-agent.ts",
+    "mcp": "tsx --conditions=source ../packages/mcp-server/src/index.ts",
     "dev:up": "concurrently -n relay,agent -c cyan,green \"pnpm relay\" \"pnpm ios-agent\"",
     "dev:up:full": "concurrently -k -n relay,ios,android -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm android-agent\"",
     "dev:up:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm mock-agents\""


### PR DESCRIPTION
## Summary

- Add `@tapflowio/mcp-server` — LLM agents (Claude Code, Codex, etc.) can control iOS simulators and Android emulators via Model Context Protocol
- Improve MCP tool UX based on live testing: pixel-coordinate tap/swipe, `list_builds` tool, screenshot dimension reporting, `session:leave` fix
- Prepare v0.3.0 release: stable packages → `latest`, mcp-server → `experimental` dist-tag

## Changes

### New package — `@tapflowio/mcp-server`
- 13 tools: `list_builds`, `list_devices`, `connect_device`, `disconnect_device`, `boot_device`, `screenshot`, `tap`, `swipe`, `type_text`, `press_key`, `press_button`, `install_app`, `launch_app`
- `tap`/`swipe` accept pixel coordinates + `screenshotWidth`/`screenshotHeight`; normalization to 0–1 is handled internally
- `screenshot` saves to `/tmp` and returns image dimensions in text response so the LLM can use them for subsequent taps
- `list_builds` queries `/api/v1/apps` + `/api/v1/builds` and joins them, so the LLM can find a `buildId` before calling `install_app`

### relay
- Add `session:leave` message type — MCP clients can release a session without ending it entirely
- `GET /api/v1/apps` now accepts PAT tokens with `view` scope (`requireViewAuth`)
- New tokens include `view` scope by default
- Fix `.app` bundle names with spaces in zip upload validation

### Release setup
- `@tapflowio/mcp-server` excluded from changeset versioning; versioned independently at `0.3.0-experimental.0`
- `release.yml`: mcp-server published with `--tag experimental`; stable packages continue with `latest`
- README, CLI README, docs (en + ko): MCP marked as experimental with install instructions

## Test plan

- [ ] `pnpm test` passes across all packages
- [ ] MCP server starts via `pnpm mcp` in playground without build step
- [ ] `list_devices`, `boot_device`, `screenshot`, `tap` tools work end-to-end in a Claude Code session
- [ ] `disconnect_device` sends `session:leave` (not `session:end`) — session remains visible in dashboard after MCP disconnects
- [ ] `list_builds` returns apps + builds with PAT token
- [ ] After merge: `pnpm changeset version` bumps stable packages to 0.3.0; mcp-server stays at 0.3.0-experimental.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `list_builds` tool to retrieve app builds information
  * Enhanced screenshot tool to save outputs and report image dimensions
  * Updated tap/swipe tools to accept pixel-based coordinate inputs
  * Introduced `session:leave` message type for session management

* **Documentation**
  * Marked MCP Server capability as experimental in all documentation and guides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->