### PR TITLE
feat: resource-aware session blocking with Mac card health indicator

### DIFF
--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -97,6 +97,11 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     }
     if (msg.type === 'open-url:done') { toast.success('Deeplink opened'); }
     if (msg.type === 'open-url:error') { toast.error(msg.message); }
+    if (msg.type === 'error' && msg.message === 'Agent resources exhausted') {
+      toast.error('Could not start session — this Mac is currently overloaded.', {
+        description: 'Go back and select a different Mac.',
+      })
+    }
   }, [sessionId, deviceId, buildId]);
 
   const handleBinaryFrame = useCallback((data: ArrayBuffer) => {

--- a/packages/dashboard/lib/resource-health.ts
+++ b/packages/dashboard/lib/resource-health.ts
@@ -1,0 +1,17 @@
+import type { AgentResources } from '@/lib/types'
+
+export const RESOURCE_WARN_THRESHOLD = 70
+export const RESOURCE_BLOCK_THRESHOLD = 80
+
+export type ResourceHealth = 'unknown' | 'healthy' | 'warning' | 'overloaded'
+
+export function getResourceHealth(
+  res: AgentResources | undefined,
+  isStale: boolean,
+): ResourceHealth {
+  if (!res || isStale) return 'unknown'
+  const memPercent = (res.memUsedMB / res.memTotalMB) * 100
+  if (res.cpuPercent > RESOURCE_BLOCK_THRESHOLD || memPercent > RESOURCE_BLOCK_THRESHOLD) return 'overloaded'
+  if (res.cpuPercent >= RESOURCE_WARN_THRESHOLD || memPercent >= RESOURCE_WARN_THRESHOLD) return 'warning'
+  return 'healthy'
+}

--- a/packages/dashboard/src/__tests__/PoolView.test.tsx
+++ b/packages/dashboard/src/__tests__/PoolView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { getResourceHealth } from '@/src/pages/QASession'
 
 // ResourceBar를 직접 inline으로 정의 — QASession.tsx와 동일한 로직
 function ResourceBar({ label, percent, colorClass }: { label: string; percent: number; colorClass: string }) {
@@ -37,9 +38,17 @@ function MacCard({ session, onClick }: { session: SessionInfo; onClick?: () => v
   const cpuPercent = res?.cpuPercent ?? 0
   const memPercent = res ? (res.memUsedMB / res.memTotalMB) * 100 : 0
   const deviceCount = session.devices.length
+  const health = getResourceHealth(res, isStale)
+  const isOverloaded = health === 'overloaded'
 
   return (
-    <button data-testid="mac-card" onClick={onClick}>
+    <button
+      data-testid="mac-card"
+      disabled={isOverloaded}
+      onClick={onClick}
+      title={isOverloaded ? 'This Mac is currently overloaded. Try again later.' : undefined}
+    >
+      <span data-testid="health-dot" data-health={health} />
       <span data-testid="agent-name">{session.agentName ?? 'Unknown'}</span>
       {isStale && <span data-testid="stale-label">Stale</span>}
       <span data-testid="device-count">{deviceCount} device{deviceCount !== 1 ? 's' : ''}</span>
@@ -53,6 +62,49 @@ function MacCard({ session, onClick }: { session: SessionInfo; onClick?: () => v
     </button>
   )
 }
+
+const makeResources = (cpuPercent: number, memPercent: number, stale = false) => ({
+  cpuPercent,
+  memUsedMB: Math.round(memPercent * 160),
+  memTotalMB: 16000,
+  slotsAvailable: 2,
+  slotsTotal: 4,
+  reportedAt: stale ? Date.now() - 31_000 : Date.now(),
+})
+
+describe('getResourceHealth', () => {
+  it('resources가 없으면 unknown을 반환한다', () => {
+    expect(getResourceHealth(undefined, false)).toBe('unknown')
+  })
+
+  it('stale이면 unknown을 반환한다', () => {
+    expect(getResourceHealth(makeResources(10, 10), true)).toBe('unknown')
+  })
+
+  it('CPU와 RAM 모두 70% 미만이면 healthy를 반환한다', () => {
+    expect(getResourceHealth(makeResources(50, 50), false)).toBe('healthy')
+  })
+
+  it('CPU가 70% 이상이면 warning을 반환한다', () => {
+    expect(getResourceHealth(makeResources(70, 30), false)).toBe('warning')
+  })
+
+  it('RAM이 70% 이상이면 warning을 반환한다', () => {
+    expect(getResourceHealth(makeResources(30, 70), false)).toBe('warning')
+  })
+
+  it('CPU가 80%를 초과하면 overloaded를 반환한다', () => {
+    expect(getResourceHealth(makeResources(81, 30), false)).toBe('overloaded')
+  })
+
+  it('RAM이 80%를 초과하면 overloaded를 반환한다', () => {
+    expect(getResourceHealth(makeResources(30, 81), false)).toBe('overloaded')
+  })
+
+  it('CPU가 정확히 80%이면 블록하지 않는다 (relay와 동일한 > 기준)', () => {
+    expect(getResourceHealth(makeResources(80, 30), false)).toBe('warning')
+  })
+})
 
 describe('ResourceBar', () => {
   it('레이블과 퍼센트를 렌더링한다', () => {
@@ -150,5 +202,45 @@ describe('MacCard', () => {
     render(<MacCard session={baseSession} onClick={() => { clicked = true }} />)
     await user.click(screen.getByTestId('mac-card'))
     expect(clicked).toBe(true)
+  })
+
+  it('healthy 상태에서 health-dot이 healthy로 렌더링된다', () => {
+    render(<MacCard session={baseSession} />)
+    expect(screen.getByTestId('health-dot')).toHaveAttribute('data-health', 'healthy')
+  })
+
+  it('CPU 71%일 때 warning 상태 닷을 렌더링한다', () => {
+    const session = { ...baseSession, resources: makeResources(71, 30) }
+    render(<MacCard session={session} />)
+    expect(screen.getByTestId('health-dot')).toHaveAttribute('data-health', 'warning')
+  })
+
+  it('CPU 81%일 때 overloaded 상태 닷을 렌더링하고 카드를 disable한다', () => {
+    const session = { ...baseSession, resources: makeResources(81, 30) }
+    render(<MacCard session={session} />)
+    expect(screen.getByTestId('health-dot')).toHaveAttribute('data-health', 'overloaded')
+    expect(screen.getByTestId('mac-card')).toBeDisabled()
+  })
+
+  it('overloaded 카드에 tooltip title이 있다', () => {
+    const session = { ...baseSession, resources: makeResources(81, 30) }
+    render(<MacCard session={session} />)
+    expect(screen.getByTestId('mac-card')).toHaveAttribute('title', 'This Mac is currently overloaded. Try again later.')
+  })
+
+  it('overloaded 카드는 클릭해도 onClick이 호출되지 않는다', async () => {
+    const user = userEvent.setup()
+    let clicked = false
+    const session = { ...baseSession, resources: makeResources(81, 30) }
+    render(<MacCard session={session} onClick={() => { clicked = true }} />)
+    await user.click(screen.getByTestId('mac-card'))
+    expect(clicked).toBe(false)
+  })
+
+  it('resources 없으면 unknown 닷을 렌더링하고 카드는 활성 상태다', () => {
+    const session: SessionInfo = { agentName: 'Mac-B', devices: [], resources: undefined }
+    render(<MacCard session={session} />)
+    expect(screen.getByTestId('health-dot')).toHaveAttribute('data-health', 'unknown')
+    expect(screen.getByTestId('mac-card')).not.toBeDisabled()
   })
 })

--- a/packages/dashboard/src/__tests__/PoolView.test.tsx
+++ b/packages/dashboard/src/__tests__/PoolView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { getResourceHealth } from '@/src/pages/QASession'
+import { getResourceHealth } from '@/lib/resource-health'
 
 // ResourceBar를 직접 inline으로 정의 — QASession.tsx와 동일한 로직
 function ResourceBar({ label, percent, colorClass }: { label: string; percent: number; colorClass: string }) {

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -259,7 +259,7 @@ export function QASession() {
                         title={isOverloaded ? 'This Mac is currently overloaded. Try again later.' : undefined}
                         className={cn(
                           'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px]',
-                          isOverloaded ? 'opacity-50 cursor-not-allowed' : 'hover:bg-accent',
+                          isOverloaded ? 'cursor-not-allowed' : 'hover:bg-accent',
                         )}
                       >
                         <div className="flex items-start justify-between gap-2">

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -26,21 +26,8 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SearchInput } from '@/components/ui/search-input';
-import type { AgentDevice, AgentResources, SessionInfo } from '@/lib/types';
-
-const RESOURCE_WARN_THRESHOLD = 70
-const RESOURCE_BLOCK_THRESHOLD = 80
-
-export function getResourceHealth(
-  res: AgentResources | undefined,
-  isStale: boolean,
-): 'unknown' | 'healthy' | 'warning' | 'overloaded' {
-  if (!res || isStale) return 'unknown'
-  const memPercent = (res.memUsedMB / res.memTotalMB) * 100
-  if (res.cpuPercent > RESOURCE_BLOCK_THRESHOLD || memPercent > RESOURCE_BLOCK_THRESHOLD) return 'overloaded'
-  if (res.cpuPercent >= RESOURCE_WARN_THRESHOLD || memPercent >= RESOURCE_WARN_THRESHOLD) return 'warning'
-  return 'healthy'
-}
+import type { AgentDevice, SessionInfo } from '@/lib/types';
+import { getResourceHealth, type ResourceHealth } from '@/lib/resource-health';
 
 export function QASession() {
   const [searchParams] = useSearchParams();
@@ -326,7 +313,7 @@ export function QASession() {
   );
 }
 
-function ResourceHealthDot({ health }: { health: ReturnType<typeof getResourceHealth> }) {
+function ResourceHealthDot({ health }: { health: ResourceHealth }) {
   const colorClass = {
     unknown: 'bg-muted-foreground/40',
     healthy: 'bg-emerald-400',

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -252,43 +252,56 @@ export function QASession() {
                     const health = getResourceHealth(res, isStale)
                     const isOverloaded = health === 'overloaded'
                     return (
-                      <button
-                        key={s.agentName}
-                        disabled={isOverloaded}
-                        onClick={() => setSelectedAgent(s.agentName ?? null)}
-                        title={isOverloaded ? 'This Mac is currently overloaded. Try again later.' : undefined}
-                        className={cn(
-                          'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px]',
-                          isOverloaded ? 'cursor-not-allowed' : 'hover:bg-accent',
-                        )}
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <ResourceHealthDot health={health} />
-                            <span className="text-sm font-medium leading-tight truncate">
-                              {s.agentName ?? 'Unknown'}
+                      <TooltipProvider key={s.agentName}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span
+                              tabIndex={isOverloaded ? 0 : undefined}
+                              className={isOverloaded ? 'cursor-not-allowed' : undefined}
+                            >
+                              <button
+                                disabled={isOverloaded}
+                                aria-disabled={isOverloaded}
+                                onClick={() => setSelectedAgent(s.agentName ?? null)}
+                                className={cn(
+                                  'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px] w-full',
+                                  isOverloaded ? 'pointer-events-none' : 'hover:bg-accent',
+                                )}
+                              >
+                                <div className="flex items-start justify-between gap-2">
+                                  <div className="flex items-center gap-2 min-w-0">
+                                    <ResourceHealthDot health={health} />
+                                    <span className="text-sm font-medium leading-tight truncate">
+                                      {s.agentName ?? 'Unknown'}
+                                    </span>
+                                  </div>
+                                  {isStale && (
+                                    <span className="shrink-0 text-[10px] font-medium text-amber-500">Stale</span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                  <span>{deviceCount} device{deviceCount !== 1 ? 's' : ''}</span>
+                                  {res && (
+                                    <>
+                                      <span>·</span>
+                                      <span>{res.slotsAvailable}/{res.slotsTotal} slots</span>
+                                    </>
+                                  )}
+                                </div>
+                                {res && !isStale && (
+                                  <div className="flex flex-col gap-1.5 w-full">
+                                    <ResourceBar label="CPU" percent={cpuPercent} colorClass="bg-blue-400" />
+                                    <ResourceBar label="RAM" percent={memPercent} colorClass="bg-violet-400" />
+                                  </div>
+                                )}
+                              </button>
                             </span>
-                          </div>
-                          {isStale && (
-                            <span className="shrink-0 text-[10px] font-medium text-amber-500">Stale</span>
+                          </TooltipTrigger>
+                          {isOverloaded && (
+                            <TooltipContent>This Mac is currently overloaded. Try again later.</TooltipContent>
                           )}
-                        </div>
-                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                          <span>{deviceCount} device{deviceCount !== 1 ? 's' : ''}</span>
-                          {res && (
-                            <>
-                              <span>·</span>
-                              <span>{res.slotsAvailable}/{res.slotsTotal} slots</span>
-                            </>
-                          )}
-                        </div>
-                        {res && !isStale && (
-                          <div className="flex flex-col gap-1.5 w-full">
-                            <ResourceBar label="CPU" percent={cpuPercent} colorClass="bg-blue-400" />
-                            <ResourceBar label="RAM" percent={memPercent} colorClass="bg-violet-400" />
-                          </div>
-                        )}
-                      </button>
+                        </Tooltip>
+                      </TooltipProvider>
                     )
                   })}
                 </div>

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -26,7 +26,21 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SearchInput } from '@/components/ui/search-input';
-import type { AgentDevice, SessionInfo } from '@/lib/types';
+import type { AgentDevice, AgentResources, SessionInfo } from '@/lib/types';
+
+const RESOURCE_WARN_THRESHOLD = 70
+const RESOURCE_BLOCK_THRESHOLD = 80
+
+export function getResourceHealth(
+  res: AgentResources | undefined,
+  isStale: boolean,
+): 'unknown' | 'healthy' | 'warning' | 'overloaded' {
+  if (!res || isStale) return 'unknown'
+  const memPercent = (res.memUsedMB / res.memTotalMB) * 100
+  if (res.cpuPercent > RESOURCE_BLOCK_THRESHOLD || memPercent > RESOURCE_BLOCK_THRESHOLD) return 'overloaded'
+  if (res.cpuPercent >= RESOURCE_WARN_THRESHOLD || memPercent >= RESOURCE_WARN_THRESHOLD) return 'warning'
+  return 'healthy'
+}
 
 export function QASession() {
   const [searchParams] = useSearchParams();
@@ -248,19 +262,26 @@ export function QASession() {
                     const deviceCount = s.devices.filter((d) => d.platform === os).length
                     const cpuPercent = res?.cpuPercent ?? 0
                     const memPercent = res ? (res.memUsedMB / res.memTotalMB) * 100 : 0
+                    const health = getResourceHealth(res, isStale)
+                    const isOverloaded = health === 'overloaded'
                     return (
                       <button
                         key={s.agentName}
+                        disabled={isOverloaded}
                         onClick={() => setSelectedAgent(s.agentName ?? null)}
+                        title={isOverloaded ? 'This Mac is currently overloaded. Try again later.' : undefined}
                         className={cn(
                           'flex flex-col gap-3 rounded-lg border p-3 text-left transition-colors min-h-[100px]',
-                          'hover:bg-accent',
+                          isOverloaded ? 'opacity-50 cursor-not-allowed' : 'hover:bg-accent',
                         )}
                       >
                         <div className="flex items-start justify-between gap-2">
-                          <span className="text-sm font-medium leading-tight truncate">
-                            {s.agentName ?? 'Unknown'}
-                          </span>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <ResourceHealthDot health={health} />
+                            <span className="text-sm font-medium leading-tight truncate">
+                              {s.agentName ?? 'Unknown'}
+                            </span>
+                          </div>
                           {isStale && (
                             <span className="shrink-0 text-[10px] font-medium text-amber-500">Stale</span>
                           )}
@@ -303,6 +324,16 @@ export function QASession() {
       )}
     </div>
   );
+}
+
+function ResourceHealthDot({ health }: { health: ReturnType<typeof getResourceHealth> }) {
+  const colorClass = {
+    unknown: 'bg-muted-foreground/40',
+    healthy: 'bg-emerald-400',
+    warning: 'bg-amber-400',
+    overloaded: 'bg-red-500',
+  }[health]
+  return <span data-testid="resource-health-dot" className={cn('inline-block h-2 w-2 shrink-0 rounded-full', colorClass)} />
 }
 
 function ResourceBar({ label, percent, colorClass }: { label: string; percent: number; colorClass: string }) {

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -46,7 +46,8 @@ const MIME_TYPES: Record<string, string> = {
   '.woff': 'font/woff',
 }
 
-const RESOURCE_THRESHOLD = parseInt(process.env['TAPFLOW_RESOURCE_THRESHOLD_PERCENT'] ?? '80')
+const _parsedThreshold = parseInt(process.env['TAPFLOW_RESOURCE_THRESHOLD_PERCENT'] ?? '80', 10)
+const RESOURCE_THRESHOLD = Number.isFinite(_parsedThreshold) ? _parsedThreshold : 80
 
 export class RelayServer {
   private httpServer: http.Server

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -46,6 +46,8 @@ const MIME_TYPES: Record<string, string> = {
   '.woff': 'font/woff',
 }
 
+const RESOURCE_THRESHOLD = parseInt(process.env['TAPFLOW_RESOURCE_THRESHOLD_PERCENT'] ?? '80')
+
 export class RelayServer {
   private httpServer: http.Server
   private wss: WebSocketServer
@@ -456,6 +458,14 @@ export class RelayServer {
     if (!session) {
       ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }))
       return
+    }
+    const resources = this.sessions.getResources(session.agentSocket)
+    if (resources) {
+      const memPercent = (resources.memUsedMB / resources.memTotalMB) * 100
+      if (resources.cpuPercent > RESOURCE_THRESHOLD || memPercent > RESOURCE_THRESHOLD) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Agent resources exhausted' }))
+        return
+      }
     }
     try {
       this.sessions.join(msg.sessionId!, ws)

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -123,6 +123,10 @@ export class SessionManager {
     this.agentResources.set(agentSocket, resources)
   }
 
+  getResources(agentSocket: WebSocket): AgentResources | undefined {
+    return this.agentResources.get(agentSocket)
+  }
+
   removeResources(agentSocket: WebSocket): void {
     this.agentResources.delete(agentSocket)
   }

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -956,6 +956,93 @@ describe('RelayServer', () => {
     browser.close()
   })
 
+  describe('resource-based session rejection', () => {
+    async function setupAgentWithSession(p: number) {
+      const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+      const agent = new WebSocket(`ws://localhost:${p}`)
+      await waitForOpen(agent)
+      agent.send(JSON.stringify({ type: 'agent:register', devices }))
+      const { registeredSessions } = await waitForMessage(agent)
+      const sessionId = registeredSessions![0].sessionId
+      return { agent, sessionId }
+    }
+
+    it('rejects session:start when CPU exceeds threshold', async () => {
+      const { agent, sessionId } = await setupAgentWithSession(port)
+      agent.send(JSON.stringify({ type: 'agent:resources', resources: { cpuPercent: 85, memUsedMB: 4000, memTotalMB: 16000, slotsAvailable: 2, slotsTotal: 4, reportedAt: Date.now() } }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+      expect(msg.type).toBe('error')
+      expect(msg.message).toBe('Agent resources exhausted')
+
+      agent.close()
+      browser.close()
+    })
+
+    it('rejects session:start when RAM exceeds threshold', async () => {
+      const { agent, sessionId } = await setupAgentWithSession(port)
+      agent.send(JSON.stringify({ type: 'agent:resources', resources: { cpuPercent: 20, memUsedMB: 15000, memTotalMB: 16000, slotsAvailable: 2, slotsTotal: 4, reportedAt: Date.now() } }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+      expect(msg.type).toBe('error')
+      expect(msg.message).toBe('Agent resources exhausted')
+
+      agent.close()
+      browser.close()
+    })
+
+    it('allows session:start when both CPU and RAM are within threshold', async () => {
+      const { agent, sessionId } = await setupAgentWithSession(port)
+      agent.send(JSON.stringify({ type: 'agent:resources', resources: { cpuPercent: 50, memUsedMB: 6000, memTotalMB: 16000, slotsAvailable: 2, slotsTotal: 4, reportedAt: Date.now() } }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+      expect(msg.type).toBe('session:joined')
+
+      agent.close()
+      browser.close()
+    })
+
+    it('allows session:start when CPU is exactly at threshold (> not >=)', async () => {
+      const { agent, sessionId } = await setupAgentWithSession(port)
+      agent.send(JSON.stringify({ type: 'agent:resources', resources: { cpuPercent: 80, memUsedMB: 4000, memTotalMB: 16000, slotsAvailable: 2, slotsTotal: 4, reportedAt: Date.now() } }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+      expect(msg.type).toBe('session:joined')
+
+      agent.close()
+      browser.close()
+    })
+
+    it('allows session:start (fail-open) when no resource data reported yet', async () => {
+      const { agent, sessionId } = await setupAgentWithSession(port)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+      expect(msg.type).toBe('session:joined')
+
+      agent.close()
+      browser.close()
+    })
+  })
+
   describe('stop', () => {
     let stopServer: RelayServer
 


### PR DESCRIPTION
Closes #107

## Summary

- **Layer 1 (dashboard):** colored status dot (🟢/🟡/🔴) added to Mac agent name on the Select Mac page; card is disabled with tooltip when CPU or RAM exceeds 80%
- **Layer 2 (relay):** `session:start` rejected with `Agent resources exhausted` when agent resources exceed `TAPFLOW_RESOURCE_THRESHOLD_PERCENT` (default 80%) — includes 5 integration tests covering CPU threshold, RAM threshold, exact boundary, fail-open with no data
- **Layer 3 (dashboard):** `DeviceViewer` shows `toast.error` when the relay rejects a session due to resource exhaustion (race condition safety net)

## Threshold logic

| State | Condition | Card |
|-------|-----------|------|
| 🟢 Green | CPU < 70% **and** RAM < 70% | Clickable |
| 🟡 Yellow | CPU ≥ 70% **or** RAM ≥ 70% | Clickable (warning) |
| 🔴 Red | CPU > 80% **or** RAM > 80% | Disabled |

Red threshold matches the relay's block threshold exactly — no false disables.

## Test plan

- [ ] `pnpm --filter @tapflowio/dashboard test` — 73 tests pass
- [ ] `pnpm --filter @tapflowio/relay test` — 154 tests pass (5 new resource-block tests)
- [ ] Select Mac page shows colored dot on each agent card
- [ ] Card with CPU/RAM > 80% is not clickable, shows tooltip on hover
- [ ] Starting a session on an overloaded Mac (race condition) shows toast error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource health monitoring with visual status indicators: unknown, healthy, warning, overloaded.
  * Selection cards show health dots, are disabled when a device is overloaded, and display an overloaded tooltip.
  * Starting a session on an overloaded Mac now shows a clear toast: “Mac is currently overloaded” with guidance to pick a different Mac.

* **Tests**
  * Expanded tests cover health classification, UI states, and session-start behavior around resource limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->