### PR TITLE
fix(cli): wrap banner text at word boundaries

### DIFF
--- a/packages/cli/src/__tests__/lib/print.test.ts
+++ b/packages/cli/src/__tests__/lib/print.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { wrap } from '../../lib/print.js'
+
+describe('wrap', () => {
+  it('returns short lines unchanged', () => {
+    expect(wrap('tapflow doctor', 72)).toEqual(['tapflow doctor'])
+  })
+
+  it('wraps at word boundaries before the maximum width', () => {
+    expect(wrap('Fix the issues above before running `tapflow start`.', 24)).toEqual([
+      'Fix the issues above',
+      'before running `tapflow',
+      'start`.',
+    ])
+  })
+
+  it('hard-cuts only when a single word is longer than the width', () => {
+    expect(wrap('supercalifragilistic', 8)).toEqual(['supercal', 'ifragili', 'stic'])
+  })
+})

--- a/packages/cli/src/__tests__/lib/print.test.ts
+++ b/packages/cli/src/__tests__/lib/print.test.ts
@@ -17,4 +17,9 @@ describe('wrap', () => {
   it('hard-cuts only when a single word is longer than the width', () => {
     expect(wrap('supercalifragilistic', 8)).toEqual(['supercal', 'ifragili', 'stic'])
   })
+
+  it('rejects invalid maximum widths', () => {
+    expect(() => wrap('tapflow doctor', 0)).toThrow('maxWidth must be a positive integer')
+    expect(() => wrap('tapflow doctor', 1.5)).toThrow('maxWidth must be a positive integer')
+  })
 })

--- a/packages/cli/src/lib/print.ts
+++ b/packages/cli/src/lib/print.ts
@@ -8,6 +8,10 @@ export const YELLOW = '\x1b[33m'
 const MAX_WIDTH = 72
 
 export function wrap(line: string, maxWidth: number): string[] {
+  if (!Number.isInteger(maxWidth) || maxWidth < 1) {
+    throw new Error('maxWidth must be a positive integer')
+  }
+
   if (line.length <= maxWidth) return [line]
   const chunks: string[] = []
 

--- a/packages/cli/src/lib/print.ts
+++ b/packages/cli/src/lib/print.ts
@@ -7,12 +7,24 @@ export const YELLOW = '\x1b[33m'
 
 const MAX_WIDTH = 72
 
-function wrap(line: string, maxWidth: number): string[] {
+export function wrap(line: string, maxWidth: number): string[] {
   if (line.length <= maxWidth) return [line]
   const chunks: string[] = []
-  for (let i = 0; i < line.length; i += maxWidth) {
-    chunks.push(line.slice(i, i + maxWidth))
+
+  let remaining = line
+  while (remaining.length > maxWidth) {
+    const breakAt = remaining.lastIndexOf(' ', maxWidth)
+    if (breakAt > 0) {
+      chunks.push(remaining.slice(0, breakAt))
+      remaining = remaining.slice(breakAt + 1).trimStart()
+      continue
+    }
+
+    chunks.push(remaining.slice(0, maxWidth))
+    remaining = remaining.slice(maxWidth)
   }
+
+  if (remaining.length > 0) chunks.push(remaining)
   return chunks
 }
 


### PR DESCRIPTION
﻿Fixes #139

## Changes
- Wrap banner text at the last space before the configured width instead of slicing every 72 characters.
- Keep a hard-cut fallback for a single word that is longer than the width.
- Add focused unit coverage for short lines, word-boundary wrapping, and long-word fallback behavior.

## Verification
- `pnpm --filter tapflow exec vitest run src/__tests__/lib/print.test.ts`
- `pnpm --filter tapflow typecheck`
- pre-commit hook: root workspace `typecheck` and `lint` passed

Note: I also tried `pnpm --filter tapflow test` on Windows. The new print test passes, but the existing smoke/start suites hit workspace/bin resolution issues around package-local `tsx` and internal workspace package entries, so I kept the verification focused on this change plus typecheck/lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-wrapping so lines break at word boundaries when possible, avoid mid-word cuts, and handle very long words gracefully.

* **Tests**
  * Added comprehensive tests covering normal wrapping behavior, hard-cut fallback, and boundary/invalid input scenarios to ensure consistent formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->