### PR TITLE
feat: rename config server→local, add relay.url as default relay address

### DIFF
--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -6,9 +6,12 @@
 
 ```json
 {
-  "server": {
+  "local": {
     "port": 4000,
     "dataDir": ".tapflow-data"
+  },
+  "relay": {
+    "url": "https://your-relay-url"
   },
   "smtp": {
     "host": "smtp.example.com",
@@ -20,6 +23,12 @@
 }
 ```
 
+| 키 | 설명 |
+|----|------|
+| `local` | 이 머신에서 실행하는 relay 서버 설정 |
+| `relay.url` | 연결할 relay URL. `tapflow agent start`, `tapflow init`, `tapflow status`, `tapflow logs`의 기본값으로 사용됩니다. 설정 시 `--relay` 플래그 없이 동작합니다. 비어있으면 로컬 모드(`ws://localhost:[local.port]`)를 사용합니다. |
+| `smtp` | 초대·비밀번호 재설정 이메일 발송을 위한 SMTP 설정 |
+
 `smtp.from`은 `smtp.user`가 설정되어 있으면 `tapflow <smtp.user>` 형태로 자동 설정됩니다. 발신자 주소를 다르게 지정하려면 명시적으로 입력합니다.
 
 ## 환경변수 오버라이드
@@ -28,9 +37,10 @@
 
 | 환경변수 | Config 키 | 기본값 | 설명 |
 |---------|-----------|--------|------|
-| `TAPFLOW_PORT` | `server.port` | `4000` | 서버 포트 |
+| `TAPFLOW_PORT` | `local.port` | `4000` | 서버 포트 |
 | `JWT_SECRET` | — | *(개발용 기본값)* | JWT 서명 키 (환경변수 전용) |
-| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow-data` | DB·업로드 디렉토리 (상대 경로 지원) |
+| `TAPFLOW_DATA_DIR` | `local.dataDir` | `.tapflow-data` | DB·업로드 디렉토리 (상대 경로 지원) |
+| `TAPFLOW_RELAY_URL` | `relay.url` | *(비어있음)* | CLI 명령어의 기본 relay URL |
 | `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Done 빌드 파일·레코드 자동 삭제 기간(일). 로컬 테스트 시 `0.001` 등 작은 값으로 즉시 확인 가능. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | 브라우저 소켓당 바이너리 프레임 드롭 임계값. 버퍼가 이 값을 초과하면 프레임이 드롭됩니다. |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP 호스트 |
@@ -65,7 +75,7 @@ your-directory/
       comments/
 ```
 
-데이터 디렉토리 위치를 변경하려면 `TAPFLOW_DATA_DIR` 환경변수 또는 `server.dataDir`을 사용합니다. `.tapflow-data/`를 백업하면 모든 데이터가 보존됩니다.
+데이터 디렉토리 위치를 변경하려면 `TAPFLOW_DATA_DIR` 환경변수 또는 `local.dataDir`을 사용합니다. `.tapflow-data/`를 백업하면 모든 데이터가 보존됩니다.
 
 ## SMTP 설정
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -6,9 +6,12 @@ The relay reads `tapflow.config.json` from the directory where it is started. Th
 
 ```json
 {
-  "server": {
+  "local": {
     "port": 4000,
     "dataDir": ".tapflow-data"
+  },
+  "relay": {
+    "url": "https://your-relay-url"
   },
   "smtp": {
     "host": "smtp.example.com",
@@ -20,6 +23,12 @@ The relay reads `tapflow.config.json` from the directory where it is started. Th
 }
 ```
 
+| Key | Description |
+|-----|-------------|
+| `local` | Settings for the relay server running on this machine. |
+| `relay.url` | URL of the relay to connect to. Used by `tapflow agent start`, `tapflow init`, `tapflow status`, and `tapflow logs` as the default — no `--relay` flag needed when this is set. Leave empty for local mode (`ws://localhost:[local.port]`). |
+| `smtp` | SMTP settings for sending invitation and password reset emails. |
+
 `smtp.from` defaults to `tapflow <smtp.user>` when `smtp.user` is set. Override it explicitly if you need a different sender address.
 
 ## Environment variable overrides
@@ -28,9 +37,10 @@ Environment variables always take precedence over the config file — useful for
 
 | Variable | Config key | Default | Description |
 |----------|------------|---------|-------------|
-| `TAPFLOW_PORT` | `server.port` | `4000` | Server port |
+| `TAPFLOW_PORT` | `local.port` | `4000` | Server port |
 | `JWT_SECRET` | — | *(dev default)* | JWT signing key (env only) |
-| `TAPFLOW_DATA_DIR` | `server.dataDir` | `.tapflow-data` | DB and uploads directory (supports relative paths) |
+| `TAPFLOW_DATA_DIR` | `local.dataDir` | `.tapflow-data` | DB and uploads directory (supports relative paths) |
+| `TAPFLOW_RELAY_URL` | `relay.url` | *(empty)* | Relay URL used as default by CLI commands |
 | `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Days before a Done build's files and record are automatically deleted. Set to a small value (e.g. `0.001`) to verify cleanup quickly in local testing. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | Binary frame drop threshold per browser socket. Frames are silently dropped when the socket buffer exceeds this value. |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP host |
@@ -65,7 +75,7 @@ your-directory/
       comments/
 ```
 
-To change the data directory location, set `TAPFLOW_DATA_DIR` or `server.dataDir`. Back up `.tapflow-data/` to preserve all data.
+To change the data directory location, set `TAPFLOW_DATA_DIR` or `local.dataDir`. Back up `.tapflow-data/` to preserve all data.
 
 ## SMTP
 

--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -5,7 +5,9 @@ vi.mock('@tapflowio/relay', () => ({
     start: vi.fn().mockResolvedValue(undefined),
   })),
   initDb: vi.fn(),
-  config: { server: { port: 4000, dataDir: '/tmp/tapflow-test', wsBackpressureBytes: 1048576 } },
+
+
+  config: { local: { port: 4000, dataDir: '/tmp/tapflow-test', wsBackpressureBytes: 1048576 }, relay: { url: null } },
 }))
 
 import { RelayServer, initDb } from '@tapflowio/relay'

--- a/packages/cli/src/__tests__/commands/start.test.ts
+++ b/packages/cli/src/__tests__/commands/start.test.ts
@@ -6,7 +6,9 @@ vi.mock('@tapflowio/relay', () => ({
     start: vi.fn().mockResolvedValue(undefined),
   })),
   initDb: vi.fn(),
-  config: { server: { port: 4000, dataDir: '/tmp/tapflow-test', wsBackpressureBytes: 1048576 } },
+
+
+  config: { local: { port: 4000, dataDir: '/tmp/tapflow-test', wsBackpressureBytes: 1048576 }, relay: { url: null } },
 }))
 vi.mock('@tapflowio/ios-agent', () => ({}))
 vi.mock('@tapflowio/android-agent', () => ({}))

--- a/packages/cli/src/commands/agent-start.ts
+++ b/packages/cli/src/commands/agent-start.ts
@@ -11,7 +11,7 @@ export interface AgentStartOptions {
   platform?: string
 }
 
-const DEFAULT_RELAY = `ws://localhost:${config.server.port}`
+const DEFAULT_RELAY = config.relay.url ?? `ws://localhost:${config.local.port}`
 
 const relayUrlSchema = z
   .string()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -44,7 +44,7 @@ function readPassword(prompt: string): Promise<string> {
 
 export async function cmdInit(opts: InitOptions): Promise<void> {
   const defaultRelay = config.relay.url ?? `http://localhost:${config.local.port}`
-  const baseUrl = (opts.relay ?? defaultRelay).replace(/^wss?:\/\//, 'http://')
+  const baseUrl = (opts.relay ?? defaultRelay).replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
 
   const rl = readline.createInterface({ input, output })
   const email = (await rl.question('  ? Admin email: ')).trim()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,6 @@
 import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
+import { config } from '@tapflowio/relay'
 import { createSpinner, banner, step } from '../lib/print.js'
 
 export interface InitOptions {
@@ -42,7 +43,8 @@ function readPassword(prompt: string): Promise<string> {
 }
 
 export async function cmdInit(opts: InitOptions): Promise<void> {
-  const baseUrl = (opts.relay ?? 'http://localhost:4000').replace(/^wss?:\/\//, 'http://')
+  const defaultRelay = config.relay.url ?? `http://localhost:${config.local.port}`
+  const baseUrl = (opts.relay ?? defaultRelay).replace(/^wss?:\/\//, 'http://')
 
   const rl = readline.createInterface({ input, output })
   const email = (await rl.question('  ? Admin email: ')).trim()

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,7 +1,9 @@
+import { config } from '@tapflowio/relay'
 import { DIM, RED, R } from '../lib/print.js'
 
 export async function cmdLogs(opts: { relay?: string; lines?: number }): Promise<void> {
-  const base = (opts.relay ?? 'http://localhost:4000').replace(/^ws/, 'http')
+  const defaultRelay = config.relay.url ?? `http://localhost:${config.local.port}`
+  const base = (opts.relay ?? defaultRelay).replace(/^ws/, 'http')
   const lines = opts.lines ?? 100
   const url = `${base}/api/v1/logs?lines=${lines}`
 

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -21,8 +21,8 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const port = portResult.data
   initConfigFile()
-  initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port, uploadsDir: path.join(config.server.dataDir, 'uploads'), wsBackpressureBytes: config.server.wsBackpressureBytes })
+  initDb(path.join(config.local.dataDir, 'tapflow.db'))
+  const server = new RelayServer({ port, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })
   await server.start()
   step(`Relay started on ws://localhost:${port}`)
 

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -8,7 +8,7 @@ export interface RelayStartOptions {
   port?: number
 }
 
-const DEFAULT_PORT = config.server.port
+const DEFAULT_PORT = config.local.port
 
 const portSchema = z.number().int().min(1).max(65535, 'port must be between 1 and 65535')
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -33,8 +33,8 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
   initConfigFile()
-  initDb(path.join(config.server.dataDir, 'tapflow.db'))
-  const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.server.dataDir, 'uploads'), wsBackpressureBytes: config.server.wsBackpressureBytes })
+  initDb(path.join(config.local.dataDir, 'tapflow.db'))
+  const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })
   await server.start()
   step(`Relay started on ws://localhost:${RELAY_PORT}`)
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -11,7 +11,7 @@ export interface StartOptions {
   platform?: string
 }
 
-const RELAY_PORT = config.server.port
+const RELAY_PORT = config.local.port
 
 export async function cmdStart(opts: StartOptions): Promise<void> {
   const relayUrl = `ws://localhost:${RELAY_PORT}`

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,8 +1,10 @@
 import { WebSocket } from 'ws'
+import { config } from '@tapflowio/relay'
 import { DIM, BOLD, GREEN, YELLOW, RED, R } from '../lib/print.js'
 
 export async function cmdStatus(opts: { relay?: string }): Promise<void> {
-  const relayUrl = (opts.relay ?? 'ws://localhost:4000').replace(/^http/, 'ws')
+  const defaultRelay = config.relay.url ?? `ws://localhost:${config.local.port}`
+  const relayUrl = (opts.relay ?? defaultRelay).replace(/^http/, 'ws')
 
   console.log(`\n  Connecting to ${relayUrl}…\n`)
   console.log(`  ${DIM}● agent  ◉ in use  ○ idle${R}\n`)

--- a/packages/cli/src/lib/init-config.ts
+++ b/packages/cli/src/lib/init-config.ts
@@ -2,9 +2,12 @@ import fs from 'fs'
 import path from 'path'
 
 const DEFAULT_CONFIG = {
-  server: {
+  local: {
     port: 4000,
     dataDir: '.tapflow-data',
+  },
+  relay: {
+    url: '',
   },
   smtp: {
     host: '',

--- a/packages/relay/src/__tests__/config.test.ts
+++ b/packages/relay/src/__tests__/config.test.ts
@@ -25,8 +25,8 @@ describe('relay config validation', () => {
   it('유효한 기본값 → 정상 로드', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { config } = await import('../lib/config.js')
-    expect(config.server.port).toBe(4000)
-    expect(config.server.wsBackpressureBytes).toBe(1_048_576)
+    expect(config.local.port).toBe(4000)
+    expect(config.local.wsBackpressureBytes).toBe(1_048_576)
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
@@ -34,7 +34,7 @@ describe('relay config validation', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.stubEnv('TAPFLOW_WS_BACKPRESSURE_BYTES', '524288')
     const { config } = await import('../lib/config.js')
-    expect(config.server.wsBackpressureBytes).toBe(524288)
+    expect(config.local.wsBackpressureBytes).toBe(524288)
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
@@ -49,7 +49,7 @@ describe('relay config validation', () => {
     vi.stubEnv('TAPFLOW_PORT', 'abc')
     await expect(import('../lib/config.js')).rejects.toThrow('process.exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('server.port'))
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('local.port'))
   })
 
   it('TAPFLOW_PORT=99999 → exit(1)', async () => {
@@ -83,7 +83,7 @@ describe('relay config validation', () => {
     const fs = await import('fs')
     vi.mocked(fs.default.existsSync).mockReturnValue(true)
     vi.mocked(fs.default.readFileSync).mockReturnValue(
-      JSON.stringify({ server: { jwtSecret: 'old-secret-value-from-config-file' } })
+      JSON.stringify({ local: { jwtSecret: 'old-secret-value-from-config-file' } })
     )
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await import('../lib/config.js')

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -76,7 +76,7 @@ function load(): TapflowConfig {
       wsBackpressureBytes: DEFAULTS.local.wsBackpressureBytes,
     },
     relay: {
-      url: file.relay?.url ?? DEFAULTS.relay.url,
+      url: file.relay?.url || null,
     },
     smtp: {
       host: file.smtp?.host ?? DEFAULTS.smtp.host,
@@ -91,7 +91,7 @@ function load(): TapflowConfig {
   if (process.env.TAPFLOW_PORT) cfg.local.port = Number(process.env.TAPFLOW_PORT)
   if (process.env.TAPFLOW_DATA_DIR) cfg.local.dataDir = resolveDataDir(process.env.TAPFLOW_DATA_DIR)
   if (process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) cfg.local.wsBackpressureBytes = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES)
-  if (process.env.TAPFLOW_RELAY_URL) cfg.relay.url = process.env.TAPFLOW_RELAY_URL
+  if (process.env.TAPFLOW_RELAY_URL) cfg.relay.url = process.env.TAPFLOW_RELAY_URL || null
   if (process.env.SMTP_HOST) cfg.smtp.host = process.env.SMTP_HOST
   if (process.env.SMTP_PORT) cfg.smtp.port = Number(process.env.SMTP_PORT)
   if (process.env.SMTP_SECURE) cfg.smtp.secure = process.env.SMTP_SECURE === 'true'

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -8,10 +8,13 @@ const logger = createLogger('relay:config')
 const DEV_DEFAULT_SECRET = 'tapflow-dev-secret-change-in-production'
 
 const configSchema = z.object({
-  server: z.object({
+  local: z.object({
     port: z.number().int().min(1).max(65535),
     dataDir: z.string().min(1),
     wsBackpressureBytes: z.number().int().min(1),
+  }),
+  relay: z.object({
+    url: z.string().nullable(),
   }),
   smtp: z.object({
     host: z.string(),
@@ -28,10 +31,13 @@ export type TapflowConfig = z.infer<typeof configSchema>
 type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }
 
 const DEFAULTS = {
-  server: {
+  local: {
     port: 4000,
     dataDir: '.tapflow-data',
     wsBackpressureBytes: 1_048_576,
+  },
+  relay: {
+    url: null,
   },
   smtp: {
     host: '',
@@ -48,7 +54,7 @@ function resolveDataDir(raw: string): string {
 }
 
 function load(): TapflowConfig {
-  let file: DeepPartial<TapflowConfig> & { server?: { jwtSecret?: unknown } } = {}
+  let file: DeepPartial<TapflowConfig> & { local?: { jwtSecret?: unknown } } = {}
 
   const configPath = path.join(process.cwd(), 'tapflow.config.json')
   if (fs.existsSync(configPath)) {
@@ -59,15 +65,18 @@ function load(): TapflowConfig {
     }
   }
 
-  if (file.server != null && 'jwtSecret' in file.server) {
-    logger.warn('server.jwtSecret in tapflow.config.json is deprecated — use JWT_SECRET env var instead')
+  if (file.local != null && 'jwtSecret' in file.local) {
+    logger.warn('local.jwtSecret in tapflow.config.json is deprecated — use JWT_SECRET env var instead')
   }
 
   const cfg: TapflowConfig = {
-    server: {
-      port: file.server?.port ?? DEFAULTS.server.port,
-      dataDir: resolveDataDir(file.server?.dataDir ?? DEFAULTS.server.dataDir),
-      wsBackpressureBytes: DEFAULTS.server.wsBackpressureBytes,
+    local: {
+      port: file.local?.port ?? DEFAULTS.local.port,
+      dataDir: resolveDataDir(file.local?.dataDir ?? DEFAULTS.local.dataDir),
+      wsBackpressureBytes: DEFAULTS.local.wsBackpressureBytes,
+    },
+    relay: {
+      url: file.relay?.url ?? DEFAULTS.relay.url,
     },
     smtp: {
       host: file.smtp?.host ?? DEFAULTS.smtp.host,
@@ -79,9 +88,10 @@ function load(): TapflowConfig {
     },
   }
 
-  if (process.env.TAPFLOW_PORT) cfg.server.port = Number(process.env.TAPFLOW_PORT)
-  if (process.env.TAPFLOW_DATA_DIR) cfg.server.dataDir = resolveDataDir(process.env.TAPFLOW_DATA_DIR)
-  if (process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) cfg.server.wsBackpressureBytes = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES)
+  if (process.env.TAPFLOW_PORT) cfg.local.port = Number(process.env.TAPFLOW_PORT)
+  if (process.env.TAPFLOW_DATA_DIR) cfg.local.dataDir = resolveDataDir(process.env.TAPFLOW_DATA_DIR)
+  if (process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) cfg.local.wsBackpressureBytes = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES)
+  if (process.env.TAPFLOW_RELAY_URL) cfg.relay.url = process.env.TAPFLOW_RELAY_URL
   if (process.env.SMTP_HOST) cfg.smtp.host = process.env.SMTP_HOST
   if (process.env.SMTP_PORT) cfg.smtp.port = Number(process.env.SMTP_PORT)
   if (process.env.SMTP_SECURE) cfg.smtp.secure = process.env.SMTP_SECURE === 'true'

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -6,13 +6,13 @@ import { createLogger } from '@tapflowio/agent-core'
 
 const logger = createLogger('relay')
 
-const { port, dataDir } = config.server
+const { port, dataDir } = config.local
 const dbPath = path.join(dataDir, 'tapflow.db')
 const uploadsDir = path.join(dataDir, 'uploads')
 
 initDb(dbPath)
 
-const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.server.wsBackpressureBytes })
+const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.local.wsBackpressureBytes })
 
 void server.start().then(() => {
   logger.info(`tapflow relay running on port ${port}`)


### PR DESCRIPTION
## Summary

- `tapflow.config.json`의 `server` 키를 `local`로 변경 (이 머신에서 실행하는 relay 서버 설정)
- `relay.url` 추가 — 설정 시 `tapflow agent start`, `tapflow init`, `tapflow status`, `tapflow logs`에서 `--relay` 플래그 없이 동작
- `TAPFLOW_RELAY_URL` 환경변수 추가
- docs(EN/KO) 설정 파일 레퍼런스 업데이트

## Breaking Change

`tapflow.config.json` 스키마 변경:

```json
// Before
{ "server": { "port": 4000, "dataDir": ".tapflow-data" } }

// After
{
  "local": { "port": 4000, "dataDir": ".tapflow-data" },
  "relay": { "url": "" }
}
```

기존 config 파일을 가진 사용자는 `server` → `local`로 키를 변경해야 합니다.

## Test plan

- [ ] `tapflow.config.json` 없이 `tapflow relay start` → 정상 실행 (기본값 4000)
- [ ] `relay.url` 설정 후 `tapflow agent start` (플래그 없음) → relay.url로 연결
- [ ] `relay.url` 설정 후 `tapflow init` (플래그 없음) → relay.url로 연결
- [ ] `--relay` 플래그 명시 시 config보다 우선 적용
- [ ] `TAPFLOW_RELAY_URL` 환경변수 설정 시 config보다 우선 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Schema restructured: `server` replaced by `local` and `relay`.
  * Env var mappings updated: `TAPFLOW_PORT` → `local.port`, `TAPFLOW_DATA_DIR` → `local.dataDir`, added `TAPFLOW_RELAY_URL` → `relay.url`; `JWT_SECRET` remains an env-only dev default.
  * Data-directory guidance and DB/upload paths now reference `local.dataDir`.

* **CLI**
  * Commands now derive default relay URLs, ports and data paths from shared config instead of hardcoded localhost values.

* **Documentation**
  * Configuration reference and examples updated to match new schema and env var mappings.

* **Tests**
  * Tests updated to reflect the new config shape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jo-duchan/tapflow/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->