### PR TITLE
feat: add Tailscale tunnel provider

### DIFF
--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -78,9 +78,56 @@ Teammates connect to `http://MACHINE_LOCAL_IP:4000` in their browser. The port m
 
 Keep the relay and agents on the same internal network at all times. External access works by opening an outbound tunnel from the relay Mac to a public endpoint — browsers connect to the public URL, which forwards traffic back to the relay.
 
-### VPS + Tunnel (recommended)
+### Tailscale (recommended)
 
-The most reliable option for external access. Traffic passes through your own VPS, so the "data stays in your infrastructure" principle is maintained.
+The easiest and most private option for external access. Tailscale connects team members through a WireGuard-based mesh VPN — no VPS, no port forwarding, no static IP required.
+
+```text
+browser (tailnet) ──[WireGuard E2E]──► relay Mac (tailnet)
+                                             ↑
+                                      agent Macs (same internal network)
+```
+
+Traffic never leaves your infrastructure in plaintext. Even when Tailscale's DERP relay is used as a fallback, only encrypted WireGuard packets pass through — Tailscale servers cannot decrypt them.
+
+**Prerequisites**: Install Tailscale on the relay Mac and on any browser machine that needs access. Free plan supports up to 3 users; paid plans for larger teams.
+
+1. Install and connect Tailscale:
+
+```sh
+brew install tailscale   # macOS
+sudo tailscale up
+```
+
+2. Add the `tunnel` section to `tapflow.config.json`:
+
+```json
+{
+  "tunnel": {
+    "provider": "tailscale"
+  }
+}
+```
+
+3. Start the relay:
+
+```sh
+tapflow relay start
+```
+
+tapflow reads the Tailscale MagicDNS hostname (or tailnet IP) automatically and prints the public URL in the banner. Teammates with Tailscale installed connect to that URL in their browser.
+
+::: tip Custom URL
+Set `"publicUrl": "http://your-hostname.tailnet.ts.net:4000"` in the tunnel config to override the auto-detected URL.
+:::
+
+::: info Agents stay on the internal network
+Tailscale only provides the browser→relay path. Agents (simulator Macs) still connect to the relay's internal IP over your LAN — no change needed there.
+:::
+
+### VPS + Tunnel
+
+Use this when you need a fully public URL — for external collaborators, anonymous demos, or when Tailscale isn't an option. Traffic is routed through a VPS you own.
 
 ```text
 browser → VPS (public URL) → tunnel → relay Mac (office)
@@ -88,7 +135,7 @@ browser → VPS (public URL) → tunnel → relay Mac (office)
                                  agent Macs (same internal network)
 ```
 
-The relay Mac opens an outbound tunnel to the VPS, so no port forwarding or static IP is required — CGNAT is not a problem.
+The relay Mac opens an outbound tunnel to the VPS over SSH, so no port forwarding or static IP is required — CGNAT is not a problem.
 
 #### 1. Set up Caddy for HTTPS on the VPS
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -78,9 +78,56 @@ JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
 
 릴레이와 에이전트는 항상 같은 내부 네트워크에 유지합니다. 외부 접속은 릴레이 Mac에서 외부로 아웃바운드 터널을 열어 브라우저가 공개 URL로 접근하도록 합니다.
 
-### VPS + Tunnel (권장)
+### Tailscale (권장)
 
-가장 안정적인 외부 접속 방법입니다. 트래픽이 팀 소유 VPS를 경유하므로 tapflow의 "데이터가 팀 인프라 안에" 원칙을 유지합니다.
+외부 접속 방법 중 가장 간편하고 프라이빗한 옵션입니다. Tailscale은 WireGuard 기반 메시 VPN으로 팀원을 연결합니다 — VPS, 포트 포워딩, 공인 IP가 필요 없습니다.
+
+```text
+브라우저 (tailnet) ──[WireGuard E2E]──► 릴레이 Mac (tailnet)
+                                               ↑
+                                       에이전트 Mac (같은 내부 네트워크)
+```
+
+트래픽이 평문으로 팀 인프라를 벗어나지 않습니다. Tailscale의 DERP 릴레이를 폴백으로 사용하더라도 암호화된 WireGuard 패킷만 중계되며 Tailscale 서버도 복호화할 수 없습니다.
+
+**사전 조건**: 릴레이 Mac과 접속할 브라우저 머신에 Tailscale을 설치합니다. 무료 플랜은 최대 3인, 더 큰 팀은 유료 플랜을 사용합니다.
+
+1. Tailscale 설치 및 연결:
+
+```sh
+brew install tailscale   # macOS
+sudo tailscale up
+```
+
+2. `tapflow.config.json`에 `tunnel` 섹션 추가:
+
+```json
+{
+  "tunnel": {
+    "provider": "tailscale"
+  }
+}
+```
+
+3. 릴레이 시작:
+
+```sh
+tapflow relay start
+```
+
+tapflow가 Tailscale MagicDNS 호스트명(또는 tailnet IP)을 자동으로 읽어 배너에 공개 URL을 출력합니다. Tailscale이 설치된 팀원은 그 URL로 브라우저에서 접속합니다.
+
+::: tip 커스텀 URL
+config의 `tunnel` 섹션에 `"publicUrl": "http://your-hostname.tailnet.ts.net:4000"` 을 추가하면 자동 감지 URL을 덮어쓸 수 있습니다.
+:::
+
+::: info 에이전트는 내부 네트워크 유지
+Tailscale은 브라우저→릴레이 경로만 제공합니다. 에이전트(시뮬레이터 Mac)는 계속 LAN 내부 IP로 릴레이에 연결합니다 — 에이전트 설정 변경 없이 사용 가능합니다.
+:::
+
+### VPS + Tunnel
+
+외부 협력사, 익명 데모, 또는 Tailscale을 사용할 수 없을 때 완전한 공개 URL이 필요한 경우에 사용합니다. 트래픽은 팀 소유 VPS를 경유합니다.
 
 ```text
 브라우저 → VPS (공개 URL) → 터널 → 릴레이 Mac (사무실)
@@ -88,7 +135,7 @@ JWT_SECRET=YOUR_JWT_SECRET tapflow relay start
                                  에이전트 Mac (같은 내부 네트워크)
 ```
 
-릴레이 Mac에서 VPS로 아웃바운드 터널을 열기 때문에 포트 포워딩이나 CGNAT 없이도 외부 접속이 가능합니다.
+릴레이 Mac에서 SSH를 통해 VPS로 아웃바운드 터널을 열기 때문에 포트 포워딩이나 CGNAT 없이도 외부 접속이 가능합니다.
 
 #### 1. VPS에 Caddy 설치
 

--- a/docs/ko/reference/cli.md
+++ b/docs/ko/reference/cli.md
@@ -77,9 +77,27 @@ tapflow relay start
 | 옵션 | 기본값 | 설명 |
 |------|--------|------|
 | `--port <n>` | `4000` | 리슨 포트 |
-| `--tunnel <provider>` | — | 사용할 터널 프로바이더 (예: `rathole`). `tapflow.config.json`의 `tunnel` 섹션과 `TAPFLOW_TUNNEL_TOKEN` 환경변수가 필요합니다 |
+| `--tunnel <provider>` | — | 사용할 터널 프로바이더 (`tailscale` 또는 `rathole`). `tapflow.config.json`의 `tunnel` 섹션이 필요합니다 |
 
-**터널 사용**
+**Tailscale (권장)**
+
+```sh
+tapflow relay start
+```
+
+`tapflow.config.json`:
+
+```json
+{
+  "tunnel": {
+    "provider": "tailscale"
+  }
+}
+```
+
+tapflow가 Tailscale MagicDNS 호스트명을 자동으로 읽어 URL을 구성합니다. `"publicUrl"`을 설정하면 자동 감지 URL을 덮어씁니다.
+
+**VPS + rathole**
 
 ```sh
 TAPFLOW_TUNNEL_TOKEN=your-secret tapflow relay start
@@ -106,7 +124,7 @@ TAPFLOW_TUNNEL_TOKEN=your-secret tapflow relay start
 
 터널이 연결되면 배너에 공개 URL이 출력됩니다. 터널 연결에 실패해도 릴레이는 계속 동작합니다 — 터널만 사용 불가 상태가 됩니다.
 
-VPS 전체 세팅 방법은 [릴레이 배포 — VPS + Tunnel](/ko/guide/self-hosting#vps-tunnel-권장)을 참고하세요.
+전체 세팅 방법은 [릴레이 배포](/ko/guide/self-hosting)를 참고하세요.
 
 
 ## `tapflow agent start`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -77,9 +77,27 @@ tapflow relay start
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--port <n>` | `4000` | Port to listen on |
-| `--tunnel <provider>` | — | Tunnel provider to use (e.g. `rathole`). Requires a `tunnel` section in `tapflow.config.json` and `TAPFLOW_TUNNEL_TOKEN` env var |
+| `--tunnel <provider>` | — | Tunnel provider to use (`tailscale` or `rathole`). Requires a `tunnel` section in `tapflow.config.json` |
 
-**Tunnel usage**
+**Tailscale (recommended)**
+
+```sh
+tapflow relay start
+```
+
+`tapflow.config.json`:
+
+```json
+{
+  "tunnel": {
+    "provider": "tailscale"
+  }
+}
+```
+
+tapflow reads the Tailscale MagicDNS hostname automatically. Set `"publicUrl"` to override the auto-detected URL.
+
+**VPS + rathole**
 
 ```sh
 TAPFLOW_TUNNEL_TOKEN=your-secret tapflow relay start
@@ -106,7 +124,7 @@ The `ssh` section lets tapflow connect to the VPS and manage the rathole server 
 
 When the tunnel is ready, the public URL is printed in the banner. If the tunnel fails to connect, the relay continues to run — only the tunnel is unavailable.
 
-See [Self-Hosting — VPS + Tunnel](/guide/self-hosting#vps-tunnel-recommended) for full VPS setup instructions.
+See [Self-Hosting](/guide/self-hosting) for full setup instructions.
 
 
 ## `tapflow agent start`

--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -12,9 +12,13 @@ const mockTunnel = { setupServer: vi.fn(), start: vi.fn(), stop: vi.fn() }
 vi.mock('../../lib/rathole-tunnel.js', () => ({
   RatholeTunnel: vi.fn().mockImplementation(() => mockTunnel),
 }))
+vi.mock('../../lib/tailscale-tunnel.js', () => ({
+  TailscaleTunnel: vi.fn().mockImplementation(() => mockTunnel),
+}))
 
 import { RelayServer, initDb, config } from '@tapflowio/relay'
 import { RatholeTunnel } from '../../lib/rathole-tunnel.js'
+import { TailscaleTunnel } from '../../lib/tailscale-tunnel.js'
 import { cmdRelayStart } from '../../commands/relay-start.js'
 
 describe('cmdRelayStart', () => {
@@ -33,6 +37,7 @@ describe('cmdRelayStart', () => {
     mockTunnel.start.mockResolvedValue({ publicUrl: 'https://vps.example.com' })
     mockTunnel.stop.mockResolvedValue(undefined)
     vi.mocked(RatholeTunnel).mockImplementation(() => mockTunnel as never)
+    vi.mocked(TailscaleTunnel).mockImplementation(() => mockTunnel as never)
     vi.mocked(config).tunnel = null
   })
 
@@ -100,7 +105,7 @@ describe('cmdRelayStart', () => {
   describe('--tunnel 옵션', () => {
     beforeEach(() => {
       vi.stubEnv('TAPFLOW_TUNNEL_TOKEN', 'secret-token')
-      vi.mocked(config).tunnel = { provider: 'rathole', serverAddr: 'vps.example.com:2333', publicUrl: 'https://vps.example.com' }
+      vi.mocked(config).tunnel = { provider: 'rathole', serverAddr: 'vps.example.com:2333', publicUrl: 'https://vps.example.com', ssh: null }
     })
 
     afterEach(() => vi.unstubAllEnvs())
@@ -142,6 +147,25 @@ describe('cmdRelayStart', () => {
       await cmdRelayStart({})
       expect(RelayServer).toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('connection refused'))
+    })
+  })
+
+  describe('tailscale 터널', () => {
+    beforeEach(() => {
+      vi.mocked(config).tunnel = { provider: 'tailscale' }
+      mockTunnel.start.mockResolvedValue({ publicUrl: 'http://my-mac.tailnet.ts.net:4000' })
+    })
+
+    it('provider tailscale → TailscaleTunnel 생성, 토큰 불필요', async () => {
+      await cmdRelayStart({})
+      expect(TailscaleTunnel).toHaveBeenCalledWith({ publicUrl: undefined })
+      expect(RatholeTunnel).not.toHaveBeenCalled()
+      expect(output.join('\n')).toContain('my-mac.tailnet.ts.net')
+    })
+
+    it('TAPFLOW_TUNNEL_TOKEN 없어도 Tailscale 정상 기동', async () => {
+      await expect(cmdRelayStart({})).resolves.toBeUndefined()
+      expect(TailscaleTunnel).toHaveBeenCalled()
     })
   })
 })

--- a/packages/cli/src/__tests__/lib/tailscale-tunnel.test.ts
+++ b/packages/cli/src/__tests__/lib/tailscale-tunnel.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+import { execSync } from 'child_process'
+import { TailscaleTunnel } from '../../lib/tailscale-tunnel.js'
+
+const RUNNING_WITH_DNS = JSON.stringify({
+  BackendState: 'Running',
+  Self: {
+    DNSName: 'my-mac.tailnet-test.ts.net.',
+    TailscaleIPs: ['100.64.1.2', 'fd7a::1'],
+  },
+})
+
+const RUNNING_WITHOUT_DNS = JSON.stringify({
+  BackendState: 'Running',
+  Self: {
+    DNSName: '',
+    TailscaleIPs: ['100.64.1.2'],
+  },
+})
+
+describe('TailscaleTunnel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(execSync).mockReturnValue(Buffer.from('') as never)
+  })
+
+  it('setupServer() — no-op, execSync 미호출', async () => {
+    const tunnel = new TailscaleTunnel({})
+    await expect(tunnel.setupServer()).resolves.toBeUndefined()
+    expect(execSync).not.toHaveBeenCalled()
+  })
+
+  it('stop() — no-op, execSync 미호출', async () => {
+    const tunnel = new TailscaleTunnel({})
+    await expect(tunnel.stop()).resolves.toBeUndefined()
+    expect(execSync).not.toHaveBeenCalled()
+  })
+
+  it('start() — publicUrl 설정 시 tailscale 없이 즉시 반환', async () => {
+    const tunnel = new TailscaleTunnel({ publicUrl: 'http://my.custom.url:4000' })
+    const result = await tunnel.start(4000)
+    expect(result.publicUrl).toBe('http://my.custom.url:4000')
+    expect(execSync).not.toHaveBeenCalled()
+  })
+
+  it('start() — Tailscale 미설치 → 에러 + 설치 안내', async () => {
+    vi.mocked(execSync).mockImplementation(() => { throw new Error('command not found') })
+    const tunnel = new TailscaleTunnel({})
+    const error = await tunnel.start(4000).catch((e: Error) => e)
+    expect(error.message).toMatch(/not installed/)
+    expect(error.message).toMatch(/brew install tailscale/)
+  })
+
+  it('start() — Running + MagicDNS → DNS 이름으로 URL 반환 (trailing dot 제거)', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(Buffer.from('1.0.0') as never)
+      .mockReturnValueOnce(Buffer.from(RUNNING_WITH_DNS) as never)
+    const tunnel = new TailscaleTunnel({})
+    const result = await tunnel.start(4000)
+    expect(result.publicUrl).toBe('http://my-mac.tailnet-test.ts.net:4000')
+  })
+
+  it('start() — Running + MagicDNS 없음 → tailnet IP로 URL 반환', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(Buffer.from('1.0.0') as never)
+      .mockReturnValueOnce(Buffer.from(RUNNING_WITHOUT_DNS) as never)
+    const tunnel = new TailscaleTunnel({})
+    const result = await tunnel.start(4000)
+    expect(result.publicUrl).toBe('http://100.64.1.2:4000')
+  })
+
+  it('start() — BackendState !== Running → 에러 + tailscale up 안내', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(Buffer.from('1.0.0') as never)
+      .mockReturnValueOnce(Buffer.from(JSON.stringify({ BackendState: 'Stopped', Self: {} })) as never)
+    const tunnel = new TailscaleTunnel({})
+    const error = await tunnel.start(4000).catch((e: Error) => e)
+    expect(error.message).toMatch(/not connected/)
+    expect(error.message).toMatch(/tailscale up/)
+  })
+})

--- a/packages/cli/src/__tests__/lib/tailscale-tunnel.test.ts
+++ b/packages/cli/src/__tests__/lib/tailscale-tunnel.test.ts
@@ -23,6 +23,14 @@ const RUNNING_WITHOUT_DNS = JSON.stringify({
   },
 })
 
+const RUNNING_IPV6_ONLY = JSON.stringify({
+  BackendState: 'Running',
+  Self: {
+    DNSName: '',
+    TailscaleIPs: ['fd7a:115c:a1e0::1'],
+  },
+})
+
 describe('TailscaleTunnel', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -69,6 +77,28 @@ describe('TailscaleTunnel', () => {
     vi.mocked(execSync)
       .mockReturnValueOnce(Buffer.from('1.0.0') as never)
       .mockReturnValueOnce(Buffer.from(RUNNING_WITHOUT_DNS) as never)
+    const tunnel = new TailscaleTunnel({})
+    const result = await tunnel.start(4000)
+    expect(result.publicUrl).toBe('http://100.64.1.2:4000')
+  })
+
+  it('start() — IPv6 전용 → 브래킷 URL 반환', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(Buffer.from('1.0.0') as never)
+      .mockReturnValueOnce(Buffer.from(RUNNING_IPV6_ONLY) as never)
+    const tunnel = new TailscaleTunnel({})
+    const result = await tunnel.start(4000)
+    expect(result.publicUrl).toBe('http://[fd7a:115c:a1e0::1]:4000')
+  })
+
+  it('start() — IPv4 + IPv6 혼재 → IPv4 우선 선택', async () => {
+    const mixed = JSON.stringify({
+      BackendState: 'Running',
+      Self: { DNSName: '', TailscaleIPs: ['fd7a::1', '100.64.1.2'] },
+    })
+    vi.mocked(execSync)
+      .mockReturnValueOnce(Buffer.from('1.0.0') as never)
+      .mockReturnValueOnce(Buffer.from(mixed) as never)
     const tunnel = new TailscaleTunnel({})
     const result = await tunnel.start(4000)
     expect(result.publicUrl).toBe('http://100.64.1.2:4000')

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -4,6 +4,7 @@ import { RelayServer, initDb, config } from '@tapflowio/relay'
 import { banner, step } from '../lib/print.js'
 import { initConfigFile } from '../lib/init-config.js'
 import { RatholeTunnel } from '../lib/rathole-tunnel.js'
+import { TailscaleTunnel } from '../lib/tailscale-tunnel.js'
 import type { TunnelPlugin } from '../lib/tunnel.js'
 
 export interface RelayStartOptions {
@@ -29,7 +30,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   await server.start()
   step(`Relay started on ws://localhost:${port}`)
 
-  const SUPPORTED_PROVIDERS = ['rathole']
+  const SUPPORTED_PROVIDERS = ['rathole', 'tailscale']
   if (opts.tunnel && !SUPPORTED_PROVIDERS.includes(opts.tunnel)) {
     banner('error', 'TUNNEL CONFIG ERROR', [`Unsupported tunnel provider: "${opts.tunnel}". Supported: ${SUPPORTED_PROVIDERS.join(', ')}`])
     process.exit(1)
@@ -43,12 +44,16 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
       banner('error', 'TUNNEL CONFIG ERROR', ['tunnel section is required in tapflow.config.json when using --tunnel'])
       process.exit(1)
     }
-    const token = process.env.TAPFLOW_TUNNEL_TOKEN ?? ''
-    if (!token) {
-      banner('error', 'TUNNEL CONFIG ERROR', ['TAPFLOW_TUNNEL_TOKEN env var is required when tunnel is configured'])
-      process.exit(1)
+    if (tunnelCfg.provider === 'tailscale') {
+      tunnel = new TailscaleTunnel({ publicUrl: tunnelCfg.publicUrl })
+    } else {
+      const token = process.env.TAPFLOW_TUNNEL_TOKEN ?? ''
+      if (!token) {
+        banner('error', 'TUNNEL CONFIG ERROR', ['TAPFLOW_TUNNEL_TOKEN env var is required for rathole tunnel'])
+        process.exit(1)
+      }
+      tunnel = new RatholeTunnel({ serverAddr: tunnelCfg.serverAddr, publicUrl: tunnelCfg.publicUrl, token, ssh: tunnelCfg.ssh ?? undefined })
     }
-    tunnel = new RatholeTunnel({ serverAddr: tunnelCfg.serverAddr, publicUrl: tunnelCfg.publicUrl, token, ssh: tunnelCfg.ssh ?? undefined })
     try {
       await tunnel.setupServer()
       const { publicUrl } = await tunnel.start(port)

--- a/packages/cli/src/lib/tailscale-tunnel.ts
+++ b/packages/cli/src/lib/tailscale-tunnel.ts
@@ -53,8 +53,12 @@ export class TailscaleTunnel implements TunnelPlugin {
     const dnsName = status.Self?.DNSName?.replace(/\.$/, '')
     if (dnsName) return { publicUrl: `http://${dnsName}:${relayPort}` }
 
-    const ip = status.Self?.TailscaleIPs?.[0]
-    if (ip) return { publicUrl: `http://${ip}:${relayPort}` }
+    const ips = status.Self?.TailscaleIPs ?? []
+    const ip = ips.find(a => !a.includes(':')) ?? ips[0]
+    if (ip) {
+      const host = ip.includes(':') ? `[${ip}]` : ip
+      return { publicUrl: `http://${host}:${relayPort}` }
+    }
 
     throw new Error('Could not determine Tailscale IP. Make sure Tailscale is connected: tailscale up')
   }

--- a/packages/cli/src/lib/tailscale-tunnel.ts
+++ b/packages/cli/src/lib/tailscale-tunnel.ts
@@ -1,0 +1,65 @@
+import { execSync } from 'child_process'
+import type { TunnelPlugin } from './tunnel.js'
+
+interface TailscaleStatus {
+  BackendState?: string
+  Self?: {
+    DNSName?: string
+    TailscaleIPs?: string[]
+  }
+}
+
+export interface TailscaleTunnelOptions {
+  publicUrl?: string
+}
+
+export class TailscaleTunnel implements TunnelPlugin {
+  name = 'tailscale'
+
+  constructor(private opts: TailscaleTunnelOptions) {}
+
+  async setupServer(): Promise<void> {
+    // no-op — Tailscale manages its own network layer
+  }
+
+  async start(relayPort: number): Promise<{ publicUrl: string }> {
+    if (this.opts.publicUrl) return { publicUrl: this.opts.publicUrl }
+
+    try {
+      execSync('tailscale version', { stdio: 'pipe' })
+    } catch {
+      throw new Error(
+        'Tailscale is not installed or not in PATH.\n' +
+        'Install: brew install tailscale  (macOS) · https://tailscale.com/download\n' +
+        'Then run: sudo tailscale up'
+      )
+    }
+
+    let status: TailscaleStatus
+    try {
+      const raw = execSync('tailscale status --json', { stdio: 'pipe' }).toString()
+      status = JSON.parse(raw) as TailscaleStatus
+    } catch {
+      throw new Error('Failed to query Tailscale status. Run: tailscale up')
+    }
+
+    if (status.BackendState !== 'Running') {
+      throw new Error(
+        `Tailscale is not connected (state: ${status.BackendState ?? 'unknown'}).\n` +
+        'Run: tailscale up'
+      )
+    }
+
+    const dnsName = status.Self?.DNSName?.replace(/\.$/, '')
+    if (dnsName) return { publicUrl: `http://${dnsName}:${relayPort}` }
+
+    const ip = status.Self?.TailscaleIPs?.[0]
+    if (ip) return { publicUrl: `http://${ip}:${relayPort}` }
+
+    throw new Error('Could not determine Tailscale IP. Make sure Tailscale is connected: tailscale up')
+  }
+
+  async stop(): Promise<void> {
+    // no-op — tapflow does not manage the Tailscale lifecycle
+  }
+}

--- a/packages/relay/src/__tests__/config.test.ts
+++ b/packages/relay/src/__tests__/config.test.ts
@@ -145,6 +145,28 @@ describe('relay config validation', () => {
     expect(exitSpy).toHaveBeenCalledWith(1)
   })
 
+  it('tunnel.provider tailscale → 파싱됨 (publicUrl 선택)', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.default.existsSync).mockReturnValue(true)
+    vi.mocked(fs.default.readFileSync).mockReturnValue(
+      JSON.stringify({ tunnel: { provider: 'tailscale' } })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { config } = await import('../lib/config.js')
+    expect(config.tunnel).toMatchObject({ provider: 'tailscale' })
+  })
+
+  it('tunnel.provider tailscale + publicUrl → publicUrl 파싱됨', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.default.existsSync).mockReturnValue(true)
+    vi.mocked(fs.default.readFileSync).mockReturnValue(
+      JSON.stringify({ tunnel: { provider: 'tailscale', publicUrl: 'http://my-mac.tailnet.ts.net:4000' } })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { config } = await import('../lib/config.js')
+    expect(config.tunnel).toMatchObject({ provider: 'tailscale', publicUrl: 'http://my-mac.tailnet.ts.net:4000' })
+  })
+
   it('tunnel.provider 미지원 값 → exit(1)', async () => {
     const fs = await import('fs')
     vi.mocked(fs.default.existsSync).mockReturnValue(true)

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -13,12 +13,19 @@ const tunnelSshSchema = z.object({
   keyPath: z.string().optional(),
 })
 
-const tunnelSchema = z.object({
-  provider: z.enum(['rathole']),
+const ratholeTunnelSchema = z.object({
+  provider: z.literal('rathole'),
   serverAddr: z.string().min(1),
   publicUrl: z.string().min(1),
   ssh: tunnelSshSchema.nullable(),
 })
+
+const tailscaleTunnelSchema = z.object({
+  provider: z.literal('tailscale'),
+  publicUrl: z.string().optional(),
+})
+
+const tunnelSchema = z.discriminatedUnion('provider', [ratholeTunnelSchema, tailscaleTunnelSchema])
 
 const configSchema = z.object({
   local: z.object({
@@ -93,20 +100,22 @@ function load(): TapflowConfig {
     relay: {
       url: file.relay?.url || null,
     },
-    tunnel: file.tunnel != null
-      ? {
-          provider: file.tunnel.provider as 'rathole',
-          serverAddr: file.tunnel.serverAddr ?? '',
-          publicUrl: file.tunnel.publicUrl ?? '',
-          ssh: (file.tunnel as { ssh?: { host?: string; user?: string; keyPath?: string } }).ssh != null
-            ? {
-                host: (file.tunnel as { ssh?: { host?: string } }).ssh?.host ?? '',
-                user: (file.tunnel as { ssh?: { user?: string } }).ssh?.user ?? '',
-                keyPath: (file.tunnel as { ssh?: { keyPath?: string } }).ssh?.keyPath,
-              }
-            : null,
-        }
-      : null,
+    tunnel: (() => {
+      if (file.tunnel == null) return null
+      const t = file.tunnel as { provider?: string; serverAddr?: string; publicUrl?: string; ssh?: { host?: string; user?: string; keyPath?: string } | null }
+      if (t.provider === 'tailscale') {
+        return { provider: 'tailscale' as const, publicUrl: t.publicUrl }
+      }
+      // Pass the actual provider value so zod's discriminated union rejects unknown values
+      return {
+        provider: t.provider as 'rathole',
+        serverAddr: t.serverAddr ?? '',
+        publicUrl: t.publicUrl ?? '',
+        ssh: t.ssh != null
+          ? { host: t.ssh.host ?? '', user: t.ssh.user ?? '', keyPath: t.ssh.keyPath }
+          : null,
+      }
+    })(),
     smtp: {
       host: file.smtp?.host ?? DEFAULTS.smtp.host,
       port: file.smtp?.port ?? DEFAULTS.smtp.port,


### PR DESCRIPTION
## Summary

- **`TailscaleTunnel`** (new): implements `TunnelPlugin` using `tailscale status --json` — reads MagicDNS hostname or tailnet IP automatically, no VPS or port forwarding needed
- **`config.tunnel.provider`** extended to discriminated union `'rathole' | 'tailscale'`; Tailscale config only needs `{ "provider": "tailscale" }`, `TAPFLOW_TUNNEL_TOKEN` is not required
- **Docs**: Tailscale added as recommended external access method in `self-hosting.md` and CLI reference (both EN/KO)

## Architecture

```
before: tunnel.provider = z.enum(['rathole'])
after:  tunnel.provider = z.discriminatedUnion('provider', [rathole, tailscale])
```

Tailscale is OCP-compliant — no changes to relay, agent-core, or rathole code paths.

## Test plan

- [x] `tailscale-tunnel.test.ts` (7 tests): not installed, MagicDNS, IP fallback, not connected, publicUrl override, no-op stop/setup
- [x] `relay-start.test.ts`: Tailscale creates `TailscaleTunnel`, no token required
- [x] `config.test.ts`: `provider: 'tailscale'` parses correctly, unknown provider still exits(1)
- [x] All 650 monorepo tests passing
- [x] lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tailscale as a recommended tunnel provider for external access.
  * CLI relay start now accepts a tunnel provider option and works with Tailscale, including optional public URL overrides.

* **Documentation**
  * Self-hosting guides (EN/KO) now prioritize Tailscale with step‑by‑step setup.
  * CLI reference updated with Tailscale examples and links to the self-hosting guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->