### PR TITLE
feat: web onboarding — /setup page and admin init command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,9 +24,21 @@ process.on('unhandledRejection', (err) => {
 const cli = cac('tapflow')
 
 cli
-  .command('init', 'Create the first admin account on the relay')
+  .command('init', 'Create the first admin account (deprecated: use "tapflow admin init")')
   .option('--relay <url>', 'Relay URL (default: http://localhost:4000)')
-  .action((opts: { relay?: string }) => cmdInit(opts))
+  .action((opts: { relay?: string }) => {
+    console.warn('⚠️  tapflow init is deprecated. Use: tapflow admin init')
+    return cmdInit(opts)
+  })
+
+cli
+  .command('admin <subcommand>', 'Admin account commands (subcommand: init)')
+  .option('--relay <url>', 'Relay URL (default: http://localhost:4000)')
+  .action((subcommand: string, opts: { relay?: string }) => {
+    if (subcommand === 'init') return cmdInit(opts)
+    console.error(`Unknown subcommand: admin ${subcommand}`)
+    process.exit(1)
+  })
 
 cli
   .command('doctor', 'Check system prerequisites')

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster, type ToasterProps } from 'sonner'
 import { useTheme } from 'next-themes'
 import { DashboardLayout } from './layouts/DashboardLayout'
 import { Login } from './pages/Login'
+import { Setup } from './pages/Setup'
 import { Invite } from './pages/Invite'
 import { ResetPassword } from './pages/ResetPassword'
 import { AppCenter } from './pages/AppCenter'
@@ -18,6 +19,7 @@ export function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/setup" element={<Setup />} />
         <Route path="/invite" element={<Invite />} />
         <Route path="/reset-password" element={<ResetPassword />} />
         <Route element={<DashboardLayout />}>

--- a/packages/dashboard/src/__tests__/Setup.test.tsx
+++ b/packages/dashboard/src/__tests__/Setup.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+// next-themes 모킹
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}))
+
+import { Setup } from '@/src/pages/Setup'
+
+function renderSetup(initialPath = '/setup') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/setup" element={<Setup />} />
+        <Route path="/login" element={<div>login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Setup 페이지', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('미초기화 상태 → 폼 렌더링', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ initialized: false }), { status: 200 }),
+    )
+    renderSetup()
+    expect(screen.getByLabelText(/admin email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument()
+  })
+
+  it('이미 초기화됨 → /login 리다이렉트', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ initialized: true }), { status: 200 }),
+    )
+    renderSetup()
+    await waitFor(() => expect(screen.getByText('login page')).toBeInTheDocument())
+  })
+
+  it('폼 제출 성공 → /api/v1/auth/init 호출 후 /login 이동', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ initialized: false }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 201 }))
+
+    renderSetup()
+    await userEvent.type(screen.getByLabelText(/admin email/i), 'admin@team.com')
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'securepass')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'securepass')
+    await userEvent.click(screen.getByRole('button', { name: /create admin account/i }))
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/auth/init', expect.objectContaining({ method: 'POST' })),
+    )
+    await waitFor(() => expect(screen.getByText('login page')).toBeInTheDocument())
+  })
+
+  it('비밀번호 불일치 → 에러 메시지, API 미호출', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ initialized: false }), { status: 200 }),
+    )
+    renderSetup()
+    await userEvent.type(screen.getByLabelText(/admin email/i), 'admin@team.com')
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password1')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'password2')
+    await userEvent.click(screen.getByRole('button', { name: /create admin account/i }))
+
+    await waitFor(() => expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument())
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1) // status check만
+  })
+
+  it('API 실패 → 에러 메시지 표시', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ initialized: false }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Already initialized' }), { status: 403 }))
+
+    renderSetup()
+    await userEvent.type(screen.getByLabelText(/admin email/i), 'admin@team.com')
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'securepass')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'securepass')
+    await userEvent.click(screen.getByRole('button', { name: /create admin account/i }))
+
+    await waitFor(() => expect(screen.getByText('Already initialized')).toBeInTheDocument())
+  })
+})

--- a/packages/dashboard/src/pages/Login.tsx
+++ b/packages/dashboard/src/pages/Login.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from 'next-themes'
 import { useForm } from 'react-hook-form'
@@ -19,6 +20,13 @@ export function Login() {
   const navigate = useNavigate()
   const { resolvedTheme } = useTheme()
   const defaultLogo = resolvedTheme === 'dark' ? '/logo-dark.svg' : '/logo.svg'
+
+  useEffect(() => {
+    fetch('/api/v1/auth/status')
+      .then((r) => r.json() as Promise<{ initialized: boolean }>)
+      .then(({ initialized }) => { if (!initialized) navigate('/setup', { replace: true }) })
+      .catch(() => {})
+  }, [navigate])
 
   const { register, handleSubmit, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -74,12 +82,6 @@ export function Login() {
             <Button type="submit" size="pill" disabled={isSubmitting} className="w-full mt-1">
               {isSubmitting ? 'Signing in…' : 'Sign in'}
             </Button>
-            <p className="text-center text-sm text-muted-foreground">
-              First time here?{' '}
-              <a href="https://www.tapflow.dev/dashboard/setup.html" target="_blank" rel="noopener noreferrer" className="underline underline-offset-4 hover:text-foreground transition-colors">
-                Set up your workspace
-              </a>
-            </p>
           </form>
         </CardContent>
         </Card>

--- a/packages/dashboard/src/pages/Setup.tsx
+++ b/packages/dashboard/src/pages/Setup.tsx
@@ -1,0 +1,111 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const schema = z.object({
+  email: z.string().email('Enter a valid email'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  confirm: z.string(),
+}).refine((d) => d.password === d.confirm, {
+  message: 'Passwords do not match',
+  path: ['confirm'],
+})
+type FormData = z.infer<typeof schema>
+
+export function Setup() {
+  const navigate = useNavigate()
+  const { resolvedTheme } = useTheme()
+  const defaultLogo = resolvedTheme === 'dark' ? '/logo-dark.svg' : '/logo.svg'
+
+  const { register, handleSubmit, setError, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+  })
+
+  useEffect(() => {
+    fetch('/api/v1/auth/status')
+      .then((r) => r.json() as Promise<{ initialized: boolean }>)
+      .then(({ initialized }) => { if (initialized) navigate('/login', { replace: true }) })
+      .catch(() => {})
+  }, [navigate])
+
+  async function onSubmit(data: FormData) {
+    try {
+      const res = await fetch('/api/v1/auth/init', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: data.email, password: data.password }),
+      })
+      if (!res.ok) {
+        const body = await res.json() as { error?: string }
+        setError('root', { message: body.error ?? 'Failed to create account' })
+        return
+      }
+      navigate('/login', { replace: true })
+    } catch {
+      setError('root', { message: 'Network error. Please try again.' })
+    }
+  }
+
+  return (
+    <div className="flex min-h-svh items-center justify-center overflow-hidden p-4">
+      <div className="flex flex-col items-center gap-6 w-full max-w-sm">
+        <div className="flex items-center gap-2">
+          <img src={defaultLogo} alt="tapflow" className="w-6 h-6" />
+          <span className="text-base font-semibold tracking-tight">tapflow</span>
+        </div>
+        <Card level={4} className="w-full">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl tracking-display-md">Set up tapflow</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="email">Admin email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="admin@yourteam.com"
+                  autoComplete="email"
+                  {...register('email')}
+                />
+                {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  {...register('password')}
+                />
+                {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="confirm">Confirm password</Label>
+                <Input
+                  id="confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  {...register('confirm')}
+                />
+                {errors.confirm && <p className="text-sm text-destructive">{errors.confirm.message}</p>}
+              </div>
+              {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
+              <Button type="submit" size="pill" disabled={isSubmitting} className="w-full mt-1">
+                {isSubmitting ? 'Creating account…' : 'Create admin account'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -8,7 +8,7 @@ import type { RelayMessage } from './types.js'
 import { Router, json } from './router.js'
 import { requireViewAuth } from './middleware/auth.js'
 import { getDb } from './db.js'
-import { handleLogin, handleLogout, handleMe, handleChangePassword, handleInit } from './api/auth.js'
+import { handleLogin, handleLogout, handleMe, handleChangePassword, handleInit, handleAuthStatus } from './api/auth.js'
 import { handleVerify, handleAccept } from './api/invitations.js'
 import { createLogger } from '@tapflowio/agent-core'
 import {
@@ -91,6 +91,7 @@ export class RelayServer {
     const u = this.uploadsDir
 
     // auth
+    this.router.get('/api/v1/auth/status', handleAuthStatus)
     this.router.post('/api/v1/auth/init', handleInit)
     this.router.get('/api/v1/auth/me', handleMe)
     this.router.post('/api/v1/auth/login', handleLogin)

--- a/packages/relay/src/__tests__/auth-status.test.ts
+++ b/packages/relay/src/__tests__/auth-status.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { RelayServer } from '../RelayServer'
+import { initDb, getDb, closeDb } from '../db'
+import { makePasswordHash } from '../api/auth'
+
+function httpGet(port: number, urlPath: string): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: 'localhost', port, path: urlPath, method: 'GET' },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () =>
+          resolve({ status: res.statusCode!, body: JSON.parse(Buffer.concat(chunks).toString()) }),
+        )
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('GET /api/v1/auth/status', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-auth-status-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+    // 각 테스트 시작 전 users 테이블 초기화
+    getDb().prepare('DELETE FROM users').run()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  it('유저 없음 → { initialized: false }', async () => {
+    const { status, body } = await httpGet(port, '/api/v1/auth/status')
+    expect(status).toBe(200)
+    expect(body).toEqual({ initialized: false })
+  })
+
+  it('유저 있음 → { initialized: true }', async () => {
+    getDb()
+      .prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    const { status, body } = await httpGet(port, '/api/v1/auth/status')
+    expect(status).toBe(200)
+    expect(body).toEqual({ initialized: true })
+  })
+
+  it('인증 쿠키 없이도 200 응답 (public endpoint)', async () => {
+    const { status } = await httpGet(port, '/api/v1/auth/status')
+    expect(status).toBe(200)
+  })
+})

--- a/packages/relay/src/api/auth.ts
+++ b/packages/relay/src/api/auth.ts
@@ -79,6 +79,12 @@ export function handleLogout(_req: http.IncomingMessage, res: http.ServerRespons
   res.end(JSON.stringify({ ok: true }))
 }
 
+export function handleAuthStatus(_req: http.IncomingMessage, res: http.ServerResponse): void {
+  const db = getDb()
+  const { n } = db.prepare('SELECT COUNT(*) as n FROM users').get() as { n: number }
+  json(res, 200, { initialized: n > 0 })
+}
+
 export async function handleInit(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const db = getDb()
   const { n } = db.prepare('SELECT COUNT(*) as n FROM users').get() as { n: number }


### PR DESCRIPTION
## Summary

- **relay**: `GET /api/v1/auth/status` (public endpoint) → `{ initialized: boolean }`. Used by the dashboard to detect first-run state.
- **dashboard**: `/setup` route — Email + Password + Confirm password form. Calls existing `POST /api/v1/auth/init`, redirects to `/login` on success. If already initialized, auto-redirects to `/login`.
- **dashboard**: `Login` page redirects to `/setup` when `initialized: false` (no admin exists yet).
- **cli**: `tapflow admin init` added as canonical command. `tapflow init` kept with deprecation warning.

## Flow

```
First launch:
  any page → /login → (not initialized) → /setup → fill form → /login

Subsequent visits:
  /login → (initialized) → show login form
  /setup → (initialized) → redirect to /login
```

## Design reference

Based on the "Set up your account" screen from the invite flow. Simplified to Email + Password + Confirm password only (API accepts only email + password; nickname/avatar not applicable for first admin).

## Test plan

- [x] `auth-status.test.ts` (3 tests): uninitialized → `{ initialized: false }`, initialized → `{ initialized: true }`, public access (no auth)
- [x] `Setup.test.tsx` (5 tests): form renders, redirect when initialized, submit success, password mismatch, API error
- [x] All 650+ monorepo tests passing
- [x] lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tapflow admin init` command for workspace initialization management
  * Introduced setup page for first-time configuration of admin credentials
  * Authentication system now detects initialization status and automatically routes uninitialized users to setup
  * Added auth status endpoint to check workspace initialization state

* **Deprecations**
  * `tapflow init` command is now deprecated; use `tapflow admin init` instead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->