### PR TITLE
feat(cli): auto-update .gitignore on tapflow init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ tapflow start          # starts relay (no longer creates config as a side effect
 
 ### New
 
+- `tapflow init` now updates `.gitignore` automatically — creates the file if absent, appends `.tapflow-data/` if not already present.
 - `tapflow init --tunnel tailscale` — scaffold config with Tailscale tunnel section
 - `tapflow init --tunnel rathole` — scaffold config with rathole tunnel section placeholder
 - `tapflow init --force` — overwrite existing `tapflow.config.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,31 @@
 # Changelog
 
-## Unreleased
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 
 ### Breaking Changes
 
-#### `tapflow init` — config scaffolding (was: admin creation)
+- `tapflow init` no longer creates an admin account. It now scaffolds `tapflow.config.json`.
+  - **Before:** `tapflow start` (auto-created config) → `tapflow init` (admin creation via CLI)
+  - **After:** `tapflow init` (scaffold config) → `tapflow start` → open `/setup` in browser (admin creation)
+  - **Migrate:** use the `/setup` page on first launch, or `tapflow admin init` in headless environments.
+- `tapflow start` and `tapflow relay start` no longer create `tapflow.config.json` as a side effect. Run `tapflow init` explicitly, or skip it to use built-in defaults (port 4000, `.tapflow-data/`).
 
-`tapflow init` now creates `tapflow.config.json` instead of creating the first admin account.
+### Added
 
-**Before:**
-```sh
-tapflow start          # starts relay (also created tapflow.config.json as a side effect)
-tapflow init           # created the first admin account via CLI
-```
+- `tapflow init` — scaffold `tapflow.config.json` interactively; `--tunnel tailscale|rathole` for non-interactive mode; `--force` to overwrite.
+- `tapflow init` auto-updates `.gitignore` — creates the file if absent, appends `.tapflow-data/` if not already present.
+- `tapflow admin init` — create the first admin account via CLI (headless / CI fallback).
+- Dashboard `/setup` page — web-based first admin account creation; auto-redirected from `/login` when no accounts exist.
+- `GET /api/v1/auth/status` — public endpoint returning `{ initialized: boolean }`.
+- Tailscale tunnel provider (`tunnel.provider: "tailscale"`) — E2E encrypted, no VPS required.
 
-**After:**
-```sh
-tapflow init           # scaffolds tapflow.config.json
-tapflow start          # starts relay (no longer creates config as a side effect)
-# open http://localhost:4000 → /setup page creates the first admin account in the browser
-```
+### Removed
 
-**Migration:**
-- Admin account creation: use the web onboarding page (`/setup`) or `tapflow admin init`.
-- Config file: run `tapflow init` once before `tapflow start`. If you skip it, tapflow uses built-in defaults (port 4000, `.tapflow-data/`).
+- Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-### New
-
-- `tapflow init` now updates `.gitignore` automatically — creates the file if absent, appends `.tapflow-data/` if not already present.
-- `tapflow init --tunnel tailscale` — scaffold config with Tailscale tunnel section
-- `tapflow init --tunnel rathole` — scaffold config with rathole tunnel section placeholder
-- `tapflow init --force` — overwrite existing `tapflow.config.json`
-- `tapflow init` (interactive TTY) — guided tunnel provider selection
-- `tapflow admin init` — create the first admin account via CLI (headless / fallback path)
-- Dashboard `/setup` page — web-based first admin account creation (GitLab/Grafana style)
-- `GET /api/v1/auth/status` — public endpoint returning `{ initialized: boolean }`
-- Tailscale tunnel provider (`tunnel.provider: "tailscale"`) — E2E encrypted, no VPS required
-
-### Changed
-
-- `tapflow start` and `tapflow relay start` no longer create `tapflow.config.json` as a hidden side effect.
-- `tapflow init` is now a config scaffolding command, not an admin creation command.
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.1.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ v0.3.0-rc.1      # release candidate, no new features
 
 **At release time**, rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a fresh empty `## [Unreleased]` above it, and append a comparison link at the bottom:
 
-```
+```markdown
 [x.y.z]: https://github.com/jo-duchan/tapflow/compare/vPREV...vx.y.z
 [Unreleased]: https://github.com/jo-duchan/tapflow/compare/vx.y.z...HEAD
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,33 @@ v0.3.0-beta.1    # feature-complete, external testing
 v0.3.0-rc.1      # release candidate, no new features
 ```
 
+### CHANGELOG
+
+`CHANGELOG.md` follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+**Sections** (use only what applies — omit empty ones):
+
+| Section | When to use |
+|---------|-------------|
+| `### Breaking Changes` | Any change requiring user action to migrate |
+| `### Added` | New features or commands |
+| `### Changed` | Changes to existing behaviour |
+| `### Deprecated` | Features that will be removed in a future release |
+| `### Removed` | Features removed in this release |
+| `### Fixed` | Bug fixes |
+| `### Security` | Security-related fixes |
+
+**On every PR that touches user-facing behaviour**, add an entry under `## [Unreleased]`. Keep entries concise — one line per item, starting with a backtick-quoted identifier when applicable.
+
+**Breaking Changes** go in `### Breaking Changes` with a one-line description and a `Migrate:` hint. For complex migrations, a separate `MIGRATION.md` may be added, but prefer keeping it inline unless the guide exceeds ~10 lines.
+
+**At release time**, rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a fresh empty `## [Unreleased]` above it, and append a comparison link at the bottom:
+
+```
+[x.y.z]: https://github.com/jo-duchan/tapflow/compare/vPREV...vx.y.z
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/vx.y.z...HEAD
+```
+
 ## Tests
 
 All packages:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "postinstall": "node bin/postinstall.js"
   },
   "dependencies": {
+    "@clack/prompts": "^1.5.0",
     "@tapflowio/agent-core": "workspace:*",
     "@tapflowio/android-agent": "workspace:*",
     "@tapflowio/ios-agent": "workspace:*",

--- a/packages/cli/src/__tests__/commands/admin-init.test.ts
+++ b/packages/cli/src/__tests__/commands/admin-init.test.ts
@@ -79,15 +79,16 @@ describe('cmdAdminInit', () => {
     expect(output.join('\n')).toContain('Already initialized')
   })
 
-  it('비밀번호 8자 미만 시 clack validate에서 에러 반환', () => {
-    // clack의 password validate 함수가 올바르게 정의됐는지 확인
-    // (실제 clack은 validate 통과 전까지 입력을 막음 — 여기선 함수 시그니처만 검증)
-    mockInputs('admin@test.com', 'short')
+  it('비밀번호 8자 미만 시 clack validate에서 에러 반환', async () => {
+    mockInputs('admin@test.com', 'password123')
+    mockFetch(201, { ok: true })
+
+    await cmdAdminInit({})
+
     const validateFn = mockPassword.mock.calls[0]?.[0]?.validate
-    if (validateFn) {
-      expect(validateFn('short')).toMatch(/8 characters/)
-      expect(validateFn('password123')).toBeUndefined()
-    }
+    expect(validateFn).toBeDefined()
+    expect(validateFn!('short')).toMatch(/8 characters/)
+    expect(validateFn!('password123')).toBeUndefined()
   })
 
   it('--relay 옵션 URL로 요청', async () => {

--- a/packages/cli/src/__tests__/commands/admin-init.test.ts
+++ b/packages/cli/src/__tests__/commands/admin-init.test.ts
@@ -1,27 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
 
-vi.mock('node:readline/promises', () => ({
-  createInterface: vi.fn(),
+vi.mock('@clack/prompts', () => ({
+  text: vi.fn(),
+  password: vi.fn(),
+  isCancel: vi.fn().mockReturnValue(false),
+  cancel: vi.fn(),
 }))
 
-import * as readline from 'node:readline/promises'
+import * as clack from '@clack/prompts'
 import { cmdAdminInit } from '../../commands/admin-init.js'
 
-const mockCreateInterface = vi.mocked(readline.createInterface)
+const mockText = vi.mocked(clack.text)
+const mockPassword = vi.mocked(clack.password)
 
-function mockRl(email: string, password: string) {
-  mockCreateInterface.mockReturnValue({
-    question: vi.fn()
-      .mockResolvedValueOnce(email)
-      .mockResolvedValueOnce(password),
-    close: vi.fn(),
-  } as never)
+function mockInputs(email: string, pw: string) {
+  mockText.mockResolvedValue(email)
+  mockPassword.mockResolvedValue(pw)
 }
 
 function mockFetch(status: number, body: unknown) {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
+    headers: { get: () => 'application/json' },
     json: vi.fn().mockResolvedValue(body),
   }))
 }
@@ -32,10 +33,7 @@ describe('cmdAdminInit', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    mockCreateInterface.mockReturnValue({
-      question: vi.fn().mockResolvedValue(''),
-      close: vi.fn(),
-    } as never)
+    vi.mocked(clack.isCancel).mockReturnValue(false)
     output = []
     vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
     vi.spyOn(console, 'error').mockImplementation((...args) => output.push(args.join(' ')))
@@ -49,7 +47,7 @@ describe('cmdAdminInit', () => {
   })
 
   it('성공 시 "Admin account created" 출력', async () => {
-    mockRl('admin@test.com', 'password123')
+    mockInputs('admin@test.com', 'password123')
     mockFetch(201, { ok: true })
 
     await cmdAdminInit({})
@@ -57,7 +55,7 @@ describe('cmdAdminInit', () => {
   })
 
   it('성공 시 입력한 email 표시', async () => {
-    mockRl('admin@test.com', 'password123')
+    mockInputs('admin@test.com', 'password123')
     mockFetch(201, { ok: true })
 
     await cmdAdminInit({})
@@ -65,7 +63,7 @@ describe('cmdAdminInit', () => {
   })
 
   it('relay 연결 실패 시 exit(1)', async () => {
-    mockRl('admin@test.com', 'password123')
+    mockInputs('admin@test.com', 'password123')
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
 
     await expect(cmdAdminInit({})).rejects.toThrow('process.exit')
@@ -73,7 +71,7 @@ describe('cmdAdminInit', () => {
   })
 
   it('이미 초기화된 경우(403) exit(1) + 안내 메시지', async () => {
-    mockRl('admin@test.com', 'password123')
+    mockInputs('admin@test.com', 'password123')
     mockFetch(403, { error: 'Already initialized' })
 
     await expect(cmdAdminInit({})).rejects.toThrow('process.exit')
@@ -81,24 +79,24 @@ describe('cmdAdminInit', () => {
     expect(output.join('\n')).toContain('Already initialized')
   })
 
-  it('비밀번호 8자 미만 시 exit(1)', async () => {
-    mockRl('admin@test.com', 'short')
-
-    await expect(cmdAdminInit({})).rejects.toThrow('process.exit')
-    expect(exitSpy).toHaveBeenCalledWith(1)
-    expect(output.join('\n')).toContain('8 characters')
-  })
-
-  it('이메일 미입력 시 exit(1)', async () => {
-    mockRl('', 'password123')
-
-    await expect(cmdAdminInit({})).rejects.toThrow('process.exit')
-    expect(exitSpy).toHaveBeenCalledWith(1)
+  it('비밀번호 8자 미만 시 clack validate에서 에러 반환', () => {
+    // clack의 password validate 함수가 올바르게 정의됐는지 확인
+    // (실제 clack은 validate 통과 전까지 입력을 막음 — 여기선 함수 시그니처만 검증)
+    mockInputs('admin@test.com', 'short')
+    const validateFn = mockPassword.mock.calls[0]?.[0]?.validate
+    if (validateFn) {
+      expect(validateFn('short')).toMatch(/8 characters/)
+      expect(validateFn('password123')).toBeUndefined()
+    }
   })
 
   it('--relay 옵션 URL로 요청', async () => {
-    mockRl('admin@test.com', 'password123')
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ ok: true }) })
+    mockInputs('admin@test.com', 'password123')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: vi.fn().mockResolvedValue({ ok: true }),
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     await cmdAdminInit({ relay: 'http://remote:4000' })
@@ -109,8 +107,12 @@ describe('cmdAdminInit', () => {
   })
 
   it('ws:// relay URL을 http://로 변환', async () => {
-    mockRl('admin@test.com', 'password123')
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ ok: true }) })
+    mockInputs('admin@test.com', 'password123')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: vi.fn().mockResolvedValue({ ok: true }),
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     await cmdAdminInit({ relay: 'ws://remote:4000' })

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -109,4 +109,35 @@ describe('cmdInitConfig', () => {
     const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tapflow.config.json'), 'utf-8'))
     expect(cfg.tunnel).toBeUndefined()
   })
+
+  describe('.gitignore', () => {
+    it('.gitignore 없음 → 새로 생성되고 .tapflow-data/ 포함', async () => {
+      await cmdInitConfig({ tunnel: 'tailscale' })
+
+      const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf-8')
+      expect(content).toContain('.tapflow-data/')
+      expect(output.join('\n')).toContain('.gitignore created')
+    })
+
+    it('.gitignore 있고 항목 없음 → .tapflow-data/ 추가', async () => {
+      fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules/\n', 'utf-8')
+
+      await cmdInitConfig({ tunnel: 'tailscale' })
+
+      const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf-8')
+      expect(content).toContain('node_modules/')
+      expect(content).toContain('.tapflow-data/')
+      expect(output.join('\n')).toContain('.tapflow-data/ added to .gitignore')
+    })
+
+    it('.gitignore에 이미 .tapflow-data/ 있음 → 중복 추가 안 됨', async () => {
+      fs.writeFileSync(path.join(tmpDir, '.gitignore'), '.tapflow-data/\n', 'utf-8')
+
+      await cmdInitConfig({ tunnel: 'tailscale' })
+
+      const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf-8')
+      const count = content.split('\n').filter((l) => l.trim() === '.tapflow-data/').length
+      expect(count).toBe(1)
+    })
+  })
 })

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -3,14 +3,18 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
-vi.mock('node:readline/promises', () => ({
-  createInterface: vi.fn(),
+vi.mock('@clack/prompts', () => ({
+  select: vi.fn(),
+  text: vi.fn(),
+  isCancel: vi.fn().mockReturnValue(false),
+  cancel: vi.fn(),
 }))
 
-import * as readline from 'node:readline/promises'
+import * as clack from '@clack/prompts'
 import { cmdInitConfig } from '../../commands/init.js'
 
-const mockCreateInterface = vi.mocked(readline.createInterface)
+const mockSelect = vi.mocked(clack.select)
+const mockText = vi.mocked(clack.text)
 
 describe('cmdInitConfig', () => {
   let output: string[]
@@ -19,6 +23,7 @@ describe('cmdInitConfig', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.mocked(clack.isCancel).mockReturnValue(false)
     output = []
     vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
     vi.spyOn(console, 'error').mockImplementation((...args) => output.push(args.join(' ')))
@@ -86,10 +91,7 @@ describe('cmdInitConfig', () => {
 
   it('인터랙티브 모드 tailscale 선택 → tailscale config 생성', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-    mockCreateInterface.mockReturnValueOnce({
-      question: vi.fn().mockResolvedValue('2'),
-      close: vi.fn(),
-    } as never)
+    mockSelect.mockResolvedValue('tailscale')
 
     await cmdInitConfig({})
 
@@ -99,15 +101,29 @@ describe('cmdInitConfig', () => {
 
   it('인터랙티브 모드 none 선택 → tunnel 없는 config 생성', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-    mockCreateInterface.mockReturnValueOnce({
-      question: vi.fn().mockResolvedValue('1'),
-      close: vi.fn(),
-    } as never)
+    mockSelect.mockResolvedValue('none')
 
     await cmdInitConfig({})
 
     const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tapflow.config.json'), 'utf-8'))
     expect(cfg.tunnel).toBeUndefined()
+  })
+
+  it('인터랙티브 모드 rathole 선택 → serverAddr/publicUrl 입력 → rathole config 생성', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    mockSelect.mockResolvedValue('rathole')
+    mockText
+      .mockResolvedValueOnce('vps.example.com:2333')
+      .mockResolvedValueOnce('https://vps.example.com')
+      .mockResolvedValueOnce('')  // ssh host blank → skip
+
+    await cmdInitConfig({})
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tapflow.config.json'), 'utf-8'))
+    expect(cfg.tunnel.provider).toBe('rathole')
+    expect(cfg.tunnel.serverAddr).toBe('vps.example.com:2333')
+    expect(cfg.tunnel.publicUrl).toBe('https://vps.example.com')
+    expect(cfg.tunnel.ssh).toBeNull()
   })
 
   describe('.gitignore', () => {

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -127,6 +127,10 @@ describe('cmdInitConfig', () => {
   })
 
   describe('.gitignore', () => {
+    beforeEach(() => {
+      fs.mkdirSync(path.join(tmpDir, '.git'))
+    })
+
     it('.gitignore 없음 → 새로 생성되고 .tapflow-data/ 포함', async () => {
       await cmdInitConfig({ tunnel: 'tailscale' })
 

--- a/packages/cli/src/commands/admin-init.ts
+++ b/packages/cli/src/commands/admin-init.ts
@@ -1,5 +1,4 @@
-import * as readline from 'node:readline/promises'
-import { stdin as input, stdout as output } from 'node:process'
+import { text, password, isCancel, cancel } from '@clack/prompts'
 import { config } from '@tapflowio/relay'
 import { createSpinner, banner, step } from '../lib/print.js'
 
@@ -7,59 +6,22 @@ export interface InitOptions {
   relay?: string
 }
 
-function readPassword(prompt: string): Promise<string> {
-  if (!process.stdin.isTTY) {
-    const rl = readline.createInterface({ input, output })
-    return rl.question(prompt).then((v) => { rl.close(); return v.trim() })
-  }
-  return new Promise((resolve) => {
-    process.stdout.write(prompt)
-    const chars: string[] = []
-    process.stdin.setRawMode(true)
-    process.stdin.resume()
-    process.stdin.setEncoding('utf8')
-    const onData = (ch: string) => {
-      if (ch === '\r' || ch === '\n') {
-        process.stdin.setRawMode(false)
-        process.stdin.pause()
-        process.stdin.removeListener('data', onData)
-        process.stdout.write('\n')
-        resolve(chars.join(''))
-      } else if (ch === '') {
-        process.stdout.write('\n')
-        process.exit(0)
-      } else if (ch === '' || ch === '\b') {
-        if (chars.length > 0) {
-          chars.pop()
-          process.stdout.write('\b \b')
-        }
-      } else if (ch >= ' ') {
-        chars.push(ch)
-        process.stdout.write('*')
-      }
-    }
-    process.stdin.on('data', onData)
-  })
-}
-
 export async function cmdAdminInit(opts: InitOptions): Promise<void> {
   const defaultRelay = config.relay.url ?? `http://localhost:${config.local.port}`
   const baseUrl = (opts.relay ?? defaultRelay).replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
 
-  const rl = readline.createInterface({ input, output })
-  const email = (await rl.question('  ? Admin email: ')).trim()
-  rl.close()
+  const email = await text({
+    message: 'Admin email',
+    placeholder: 'admin@yourteam.com',
+    validate: (v) => !v?.trim() ? 'Required' : undefined,
+  })
+  if (isCancel(email)) { cancel('Cancelled.'); process.exit(0) }
 
-  const password = await readPassword('  ? Password: ')
-
-  if (!email) {
-    banner('error', 'INVALID INPUT', ['Email is required.'])
-    process.exit(1)
-  }
-  if (!password || password.length < 8) {
-    banner('error', 'INVALID INPUT', ['Password must be at least 8 characters.'])
-    process.exit(1)
-  }
+  const pw = await password({
+    message: 'Password',
+    validate: (v) => (v?.length ?? 0) < 8 ? 'Must be at least 8 characters' : undefined,
+  })
+  if (isCancel(pw)) { cancel('Cancelled.'); process.exit(0) }
 
   const spinner = createSpinner('Creating admin account...')
   spinner.start()
@@ -69,7 +31,7 @@ export async function cmdAdminInit(opts: InitOptions): Promise<void> {
     res = await fetch(`${baseUrl}/api/v1/auth/init`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email: email.trim(), password: pw }),
     })
   } catch {
     spinner.stop(false)
@@ -102,6 +64,6 @@ export async function cmdAdminInit(opts: InitOptions): Promise<void> {
   }
 
   spinner.stop(true)
-  banner('success', 'Admin account created', [`Email: ${email}`])
+  banner('success', 'Admin account created', [`Email: ${email.trim()}`])
   step(`Open ${baseUrl} to sign in`)
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { select, text, isCancel, cancel } from '@clack/prompts'
-import { banner } from '../lib/print.js'
+import { banner, warn } from '../lib/print.js'
 
 export interface InitConfigOptions {
   tunnel?: string
@@ -17,6 +17,16 @@ const BASE_CONFIG = {
 type TunnelConfig =
   | { provider: 'tailscale'; publicUrl?: string }
   | { provider: 'rathole'; serverAddr: string; publicUrl: string; ssh: { host: string; user: string; keyPath: string } | null }
+
+function isInsideGitRepo(dir: string): boolean {
+  let current = dir
+  while (true) {
+    if (fs.existsSync(path.join(current, '.git'))) return true
+    const parent = path.dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
+}
 
 function addToGitignore(dir: string, entry: string): 'created' | 'appended' | 'already-present' {
   const gitignorePath = path.join(dir, '.gitignore')
@@ -126,7 +136,14 @@ export async function cmdInitConfig(opts: InitConfigOptions): Promise<void> {
     process.exit(1)
   }
 
-  const gitignoreUpdated = addToGitignore(process.cwd(), '.tapflow-data/')
+  let gitignoreUpdated: 'created' | 'appended' | 'already-present' | 'skipped' = 'skipped'
+  if (isInsideGitRepo(process.cwd())) {
+    try {
+      gitignoreUpdated = addToGitignore(process.cwd(), '.tapflow-data/')
+    } catch (err) {
+      warn(`Could not update .gitignore: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
 
   const lines: string[] = ['tapflow.config.json created.']
   if (gitignoreUpdated === 'created') lines.push('.gitignore created (.tapflow-data/ added).')

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import * as readline from 'node:readline/promises'
-import { stdin as input, stdout as output } from 'node:process'
+import { select, text, isCancel, cancel } from '@clack/prompts'
 import { banner } from '../lib/print.js'
 
 export interface InitConfigOptions {
@@ -14,6 +13,10 @@ const BASE_CONFIG = {
   relay: { url: '' },
   smtp: { host: '', port: 587, secure: false, user: '', pass: '' },
 }
+
+type TunnelConfig =
+  | { provider: 'tailscale'; publicUrl?: string }
+  | { provider: 'rathole'; serverAddr: string; publicUrl: string; ssh: { host: string; user: string; keyPath: string } | null }
 
 function addToGitignore(dir: string, entry: string): 'created' | 'appended' | 'already-present' {
   const gitignorePath = path.join(dir, '.gitignore')
@@ -28,31 +31,60 @@ function addToGitignore(dir: string, entry: string): 'created' | 'appended' | 'a
   return 'created'
 }
 
-type TunnelConfig =
-  | { provider: 'tailscale'; publicUrl?: string }
-  | { provider: 'rathole'; serverAddr: string; publicUrl: string; ssh: { host: string; user: string; keyPath: string } | null }
-
 async function promptTunnel(): Promise<TunnelConfig | null> {
-  const rl = readline.createInterface({ input, output })
-  process.stdout.write('\n  Tunnel provider:\n  [1] none (local only)\n  [2] tailscale (recommended)\n  [3] rathole (VPS)\n')
-  const choice = (await rl.question('  Select [1-3]: ')).trim()
-  rl.close()
+  const provider = await select({
+    message: 'Tunnel provider',
+    options: [
+      { value: 'none', label: 'None', hint: 'local only' },
+      { value: 'tailscale', label: 'Tailscale', hint: 'recommended — E2E encrypted, no VPS required' },
+      { value: 'rathole', label: 'rathole', hint: 'VPS required' },
+    ],
+  })
 
-  if (choice === '2') return { provider: 'tailscale' }
-  if (choice !== '3') return null
+  if (isCancel(provider)) { cancel('Cancelled.'); process.exit(0) }
+  if (provider === 'tailscale') return { provider: 'tailscale' }
+  if (provider !== 'rathole') return null
 
-  const rl2 = readline.createInterface({ input, output })
-  const serverAddr = (await rl2.question('  VPS server address (e.g. example.com:2333): ')).trim()
-  const publicUrl = (await rl2.question('  Public URL (e.g. https://example.com): ')).trim()
-  const sshHost = (await rl2.question('  SSH host (leave blank to skip): ')).trim()
+  const serverAddr = await text({
+    message: 'VPS server address',
+    placeholder: 'example.com:2333',
+    validate: (v) => !v?.trim() ? 'Required' : undefined,
+  })
+  if (isCancel(serverAddr)) { cancel('Cancelled.'); process.exit(0) }
+
+  const publicUrl = await text({
+    message: 'Public URL',
+    placeholder: 'https://example.com',
+    validate: (v) => !v?.trim() ? 'Required' : undefined,
+  })
+  if (isCancel(publicUrl)) { cancel('Cancelled.'); process.exit(0) }
+
+  const sshHost = await text({
+    message: 'SSH host',
+    placeholder: 'example.com  (leave blank to skip)',
+  })
+  if (isCancel(sshHost)) { cancel('Cancelled.'); process.exit(0) }
+
   let ssh: { host: string; user: string; keyPath: string } | null = null
-  if (sshHost) {
-    const sshUser = (await rl2.question('  SSH user [ubuntu]: ')).trim() || 'ubuntu'
-    const sshKeyPath = (await rl2.question('  SSH key path [~/.ssh/id_ed25519]: ')).trim() || '~/.ssh/id_ed25519'
-    ssh = { host: sshHost, user: sshUser, keyPath: sshKeyPath }
+  if (sshHost && sshHost.trim()) {
+    const sshUser = await text({
+      message: 'SSH user',
+      placeholder: 'ubuntu',
+      defaultValue: 'ubuntu',
+    })
+    if (isCancel(sshUser)) { cancel('Cancelled.'); process.exit(0) }
+
+    const sshKeyPath = await text({
+      message: 'SSH key path',
+      placeholder: '~/.ssh/id_ed25519',
+      defaultValue: '~/.ssh/id_ed25519',
+    })
+    if (isCancel(sshKeyPath)) { cancel('Cancelled.'); process.exit(0) }
+
+    ssh = { host: sshHost.trim(), user: sshUser || 'ubuntu', keyPath: sshKeyPath || '~/.ssh/id_ed25519' }
   }
-  rl2.close()
-  return { provider: 'rathole', serverAddr, publicUrl, ssh }
+
+  return { provider: 'rathole', serverAddr: serverAddr.trim(), publicUrl: publicUrl.trim(), ssh }
 }
 
 export async function cmdInitConfig(opts: InitConfigOptions): Promise<void> {
@@ -79,12 +111,7 @@ export async function cmdInitConfig(opts: InitConfigOptions): Promise<void> {
   if (opts.tunnel === 'tailscale') {
     tunnel = { provider: 'tailscale' }
   } else if (opts.tunnel === 'rathole') {
-    tunnel = {
-      provider: 'rathole',
-      serverAddr: '',
-      publicUrl: '',
-      ssh: null,
-    }
+    tunnel = { provider: 'rathole', serverAddr: '', publicUrl: '', ssh: null }
   } else if (process.stdin.isTTY) {
     tunnel = await promptTunnel()
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,19 @@ const BASE_CONFIG = {
   smtp: { host: '', port: 587, secure: false, user: '', pass: '' },
 }
 
+function addToGitignore(dir: string, entry: string): 'created' | 'appended' | 'already-present' {
+  const gitignorePath = path.join(dir, '.gitignore')
+  if (fs.existsSync(gitignorePath)) {
+    const content = fs.readFileSync(gitignorePath, 'utf-8')
+    if (content.split('\n').some((line) => line.trim() === entry)) return 'already-present'
+    const separator = content.endsWith('\n') ? '' : '\n'
+    fs.appendFileSync(gitignorePath, `${separator}\n# tapflow runtime data\n${entry}\n`, 'utf-8')
+    return 'appended'
+  }
+  fs.writeFileSync(gitignorePath, `# tapflow runtime data\n${entry}\n`, 'utf-8')
+  return 'created'
+}
+
 type TunnelConfig =
   | { provider: 'tailscale'; publicUrl?: string }
   | { provider: 'rathole'; serverAddr: string; publicUrl: string; ssh: { host: string; user: string; keyPath: string } | null }
@@ -86,7 +99,11 @@ export async function cmdInitConfig(opts: InitConfigOptions): Promise<void> {
     process.exit(1)
   }
 
+  const gitignoreUpdated = addToGitignore(process.cwd(), '.tapflow-data/')
+
   const lines: string[] = ['tapflow.config.json created.']
+  if (gitignoreUpdated === 'created') lines.push('.gitignore created (.tapflow-data/ added).')
+  else if (gitignoreUpdated === 'appended') lines.push('.tapflow-data/ added to .gitignore.')
   if (tunnel?.provider === 'rathole' && (!tunnel.serverAddr || !tunnel.publicUrl)) {
     lines.push('Fill in tunnel.serverAddr and tunnel.publicUrl in tapflow.config.json.')
   }

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { z } from 'zod'
 import { RelayServer, initDb, config } from '@tapflowio/relay'
-import { banner, step, YELLOW, BOLD, R } from '../lib/print.js'
+import { banner, step, warn } from '../lib/print.js'
 import { RatholeTunnel } from '../lib/rathole-tunnel.js'
 import { TailscaleTunnel } from '../lib/tailscale-tunnel.js'
 import type { TunnelPlugin } from '../lib/tunnel.js'
@@ -25,7 +25,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const port = portResult.data
   if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
-    console.warn(`${YELLOW}${BOLD}  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.${R}`)
+    warn('tapflow.config.json not found — using defaults. Run tapflow init to configure.')
   }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import { z } from 'zod'
 import { RelayServer, initDb, config } from '@tapflowio/relay'
@@ -23,6 +24,9 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
     process.exit(1)
   }
   const port = portResult.data
+  if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
+    console.warn('  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.')
+  }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })
   await server.start()

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { z } from 'zod'
 import { RelayServer, initDb, config } from '@tapflowio/relay'
-import { banner, step } from '../lib/print.js'
+import { banner, step, YELLOW, BOLD, R } from '../lib/print.js'
 import { RatholeTunnel } from '../lib/rathole-tunnel.js'
 import { TailscaleTunnel } from '../lib/tailscale-tunnel.js'
 import type { TunnelPlugin } from '../lib/tunnel.js'
@@ -25,7 +25,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const port = portResult.data
   if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
-    console.warn('  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.')
+    console.warn(`${YELLOW}${BOLD}  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.${R}`)
   }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import '@tapflowio/ios-agent'
 import '@tapflowio/android-agent'
-import { banner, createSpinner, step } from '../lib/print.js'
+import { banner, createSpinner, step, YELLOW, BOLD, R } from '../lib/print.js'
 
 export interface StartOptions {
   device?: string
@@ -33,7 +33,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
   if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
-    console.warn('  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.')
+    console.warn(`${YELLOW}${BOLD}  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.${R}`)
   }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,5 +1,6 @@
 import { RelayServer, initDb, config } from '@tapflowio/relay'
 import { AgentRegistry } from '@tapflowio/agent-core'
+import fs from 'fs'
 import path from 'path'
 import '@tapflowio/ios-agent'
 import '@tapflowio/android-agent'
@@ -31,6 +32,9 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
   }
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
+  if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
+    console.warn('  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.')
+  }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })
   await server.start()

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import '@tapflowio/ios-agent'
 import '@tapflowio/android-agent'
-import { banner, createSpinner, step, YELLOW, BOLD, R } from '../lib/print.js'
+import { banner, createSpinner, step, warn } from '../lib/print.js'
 
 export interface StartOptions {
   device?: string
@@ -33,7 +33,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
 
   // ── 1. Relay (always local) ───────────────────────────────────────────────
   if (!fs.existsSync(path.join(process.cwd(), 'tapflow.config.json'))) {
-    console.warn(`${YELLOW}${BOLD}  ⚠  tapflow.config.json not found — using defaults. Run tapflow init to configure.${R}`)
+    warn('tapflow.config.json not found — using defaults. Run tapflow init to configure.')
   }
   initDb(path.join(config.local.dataDir, 'tapflow.db'))
   const server = new RelayServer({ port: RELAY_PORT, uploadsDir: path.join(config.local.dataDir, 'uploads'), wsBackpressureBytes: config.local.wsBackpressureBytes })

--- a/packages/cli/src/lib/print.ts
+++ b/packages/cli/src/lib/print.ts
@@ -77,3 +77,7 @@ export function createSpinner(msg: string) {
 export function step(msg: string): void {
   console.log(`  ${DIM}→${R}  ${msg}`)
 }
+
+export function warn(msg: string): void {
+  console.warn(`${YELLOW}${BOLD}  ⚠  ${msg}${R}`)
+}

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,2 @@
+# tapflow runtime data
+.tapflow-data/

--- a/playground/CLAUDE.md
+++ b/playground/CLAUDE.md
@@ -28,7 +28,17 @@ tsx ../packages/cli/src/index.ts start --device "iPhone 16"
 # 브라우저 → http://localhost:4000
 ```
 
+### pre-release 검증 (외부 유저 경험과 동일)
+
+dashboard 빌드 후 relay가 단독 서빙 — 실제 설치 사용자가 겪는 흐름을 그대로 재현한다.
+
+```bash
+pnpm pre-release   # dashboard 빌드 → relay 기동 → localhost:4000
+```
+
 ### Playground 스크립트 (개발·디버깅용)
+
+dashboard 소스를 수정하면서 HMR로 빠르게 확인할 때 사용한다. relay API는 4000, dashboard는 3001(Vite dev server).
 
 ```bash
 pnpm dev:up        # relay + ios-agent를 concurrently로 기동

--- a/playground/README.md
+++ b/playground/README.md
@@ -5,9 +5,17 @@
 ## 로컬 개발
 
 ```sh
-pnpm dev:up          # relay + ios-agent
+pnpm dev:up          # relay + ios-agent (Vite dev server 별도 — localhost:3001)
 pnpm dev:up:full     # relay + ios-agent + android-agent
 pnpm mock-agent      # 시뮬레이터 없이 mock으로 테스트
+```
+
+## pre-release 검증 (외부 유저 경험 그대로)
+
+dashboard를 빌드한 뒤 relay가 단독으로 서빙하는 방식 — 실제 설치 사용자가 겪는 경험과 동일하다.
+
+```sh
+pnpm pre-release     # dashboard 빌드 → relay 기동
 ```
 
 브라우저: `http://localhost:4000`

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,6 +15,7 @@
     "mock-agent": "tsx --conditions=source mock-agent.ts",
     "mock-agents": "tsx --conditions=source multi-agent.ts",
     "mcp": "tsx --conditions=source ../packages/mcp-server/src/index.ts",
+    "pre-release": "pnpm --filter @tapflowio/dashboard build && pnpm relay",
     "dev:up": "concurrently -n relay,agent -c cyan,green \"pnpm relay\" \"pnpm ios-agent\"",
     "dev:up:full": "concurrently -k -n relay,ios,android -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm android-agent\"",
     "dev:up:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm mock-agents\""

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,7 +15,7 @@
     "mock-agent": "tsx --conditions=source mock-agent.ts",
     "mock-agents": "tsx --conditions=source multi-agent.ts",
     "mcp": "tsx --conditions=source ../packages/mcp-server/src/index.ts",
-    "pre-release": "pnpm --filter @tapflowio/dashboard build && pnpm relay",
+    "pre-release": "pnpm --filter @tapflowio/dashboard build && pnpm tsx ../packages/cli/src/index.ts relay start",
     "dev:up": "concurrently -n relay,agent -c cyan,green \"pnpm relay\" \"pnpm ios-agent\"",
     "dev:up:full": "concurrently -k -n relay,ios,android -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm android-agent\"",
     "dev:up:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm mock-agents\""

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,7 +15,7 @@
     "mock-agent": "tsx --conditions=source mock-agent.ts",
     "mock-agents": "tsx --conditions=source multi-agent.ts",
     "mcp": "tsx --conditions=source ../packages/mcp-server/src/index.ts",
-    "pre-release": "pnpm --filter @tapflowio/dashboard build && pnpm tsx ../packages/cli/src/index.ts relay start",
+    "pre-release": "pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/dashboard build && pnpm tsx ../packages/cli/src/index.ts relay start",
     "dev:up": "concurrently -n relay,agent -c cyan,green \"pnpm relay\" \"pnpm ios-agent\"",
     "dev:up:full": "concurrently -k -n relay,ios,android -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm android-agent\"",
     "dev:up:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm relay\" \"pnpm ios-agent\" \"pnpm mock-agents\""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@tapflowio/agent-core':
         specifier: workspace:*
         version: link:../agent-core
@@ -659,6 +662,14 @@ packages:
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@clack/core@1.4.0':
+    resolution: {integrity: sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.5.0':
+    resolution: {integrity: sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA==}
+    engines: {node: '>= 20.12.0'}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -3154,8 +3165,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4295,6 +4315,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -5290,6 +5313,18 @@ snapshots:
       prettier: 2.8.8
 
   '@chevrotain/types@11.1.2': {}
+
+  '@clack/core@1.4.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.5.0':
+    dependencies:
+      '@clack/core': 1.4.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -7741,7 +7776,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -8872,6 +8917,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- `tapflow init` now writes `.tapflow-data/` to `.gitignore` automatically
- Creates `.gitignore` if the file doesn't exist
- Appends the entry if `.gitignore` exists but doesn't already contain it
- Skips silently if already present (idempotent)

Prevents accidental commits of the SQLite DB and uploaded build files when the tapflow working directory is a git repo.

## Test plan

- [x] `.gitignore` absent → file created, `.tapflow-data/` included, banner says "created"
- [x] `.gitignore` exists, entry absent → entry appended, banner says "added"
- [x] `.gitignore` exists, entry already present → no duplicate added
- [x] lint + typecheck: pass
- [x] 11 tests: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Init now auto-manages .gitignore (creates when missing, appends .tapflow-data/ without duplicating) and adjusts the success message; init/admin flows use improved interactive prompts and show "Cancelled." on cancel.
  * Start/relay now warn if configuration is missing and instruct to run init.

* **Tests**
  * Added tests for .gitignore handling and updated interactive-prompt tests.

* **Documentation**
  * Added changelog guidance, updated playground docs, and a pre-release script for local verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->