### PR TITLE
fix(docs): correct Tailscale free plan — up to 6 users, not 3

### DIFF
--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -83,7 +83,7 @@ tapflow supports two tunnel providers:
 | | Tailscale | VPS + rathole |
 |---|-----------|---------------|
 | **Setup** | Install app + sign in | VPS with SSH access required |
-| **Cost** | Free (≤ 3 users) or paid | VPS running cost |
+| **Cost** | Free (≤ 6 users) or paid | VPS running cost |
 | **Who can connect** | Tailscale tailnet members only | Anyone with the URL |
 | **Best for** | Internal teams | External collaborators, public demos |
 
@@ -102,7 +102,7 @@ Traffic never leaves your infrastructure in plaintext. Even when Tailscale's DER
 **Prerequisites**: Install Tailscale on the relay Mac and on every browser machine that needs access.
 
 - [Download Tailscale →](https://tailscale.com/download) — macOS, Windows, Linux, iOS, Android
-- Free plan: up to 3 users · [Pricing →](https://tailscale.com/pricing)
+- Free plan: up to 6 users · [Pricing →](https://tailscale.com/pricing)
 
 1. Install and connect Tailscale on the relay Mac:
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -83,7 +83,7 @@ tapflow는 두 가지 터널 프로바이더를 지원합니다:
 | | Tailscale | VPS + rathole |
 |---|-----------|---------------|
 | **설정** | 앱 설치 + 로그인 | SSH 접근 가능한 VPS 필요 |
-| **비용** | 무료 (3인 이하) 또는 유료 | VPS 운영 비용 |
+| **비용** | 무료 (6인 이하) 또는 유료 | VPS 운영 비용 |
 | **접속 가능 대상** | Tailscale tailnet 멤버만 | URL을 아는 누구나 |
 | **적합한 경우** | 내부 팀 | 외부 협력사, 공개 데모 |
 
@@ -102,7 +102,7 @@ tapflow는 두 가지 터널 프로바이더를 지원합니다:
 **사전 조건**: 릴레이 Mac과 접속할 브라우저 머신 모두에 Tailscale을 설치해야 합니다.
 
 - [Tailscale 다운로드 →](https://tailscale.com/download) — macOS, Windows, Linux, iOS, Android
-- 무료 플랜: 최대 3인 · [요금제 →](https://tailscale.com/pricing)
+- 무료 플랜: 최대 6인 · [요금제 →](https://tailscale.com/pricing)
 
 1. 릴레이 Mac에서 Tailscale을 설치하고 연결합니다:
 


### PR DESCRIPTION
## Summary

- Tailscale Personal 플랜은 최대 **6명**까지 무료 (3명으로 잘못 기재됨)
- EN/KO 비교표와 사전 조건 설명 모두 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting documentation guides in both English and Korean to reflect Tailscale's increased free tier user limit of 6 users (up from 3). Updated in both the deployment comparison table and prerequisites section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->