### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-01
+
 ### Breaking Changes
 
 - `tapflow init` no longer creates an admin account. It now scaffolds `tapflow.config.json`.
@@ -28,4 +30,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jo-duchan/tapflow/compare/v0.3.1...v0.4.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/agent-core
 
+## 0.4.0
+
+### Minor Changes
+
+- feat!: tapflow init redesign, Tailscale tunnel, web onboarding, and UX improvements
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tapflowio/android-agent
 
+## 0.4.0
+
+### Minor Changes
+
+- feat!: tapflow init redesign, Tailscale tunnel, web onboarding, and UX improvements
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # tapflow
 
+## 0.4.0
+
+### Minor Changes
+
+- feat!: tapflow init redesign, Tailscale tunnel, web onboarding, and UX improvements
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.4.0
+  - @tapflowio/ios-agent@0.4.0
+  - @tapflowio/android-agent@0.4.0
+  - @tapflowio/relay@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tapflowio/ios-agent
 
+## 0.4.0
+
+### Minor Changes
+
+- feat!: tapflow init redesign, Tailscale tunnel, web onboarding, and UX improvements
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tapflowio/relay
 
+## 0.4.0
+
+### Minor Changes
+
+- feat!: tapflow init redesign, Tailscale tunnel, web onboarding, and UX improvements
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.4.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.4.0

### Breaking Changes
- `tapflow init` 재설계 — config 스캐폴딩으로 변경 (admin 계정 생성 역할 제거)
- `tapflow start` / `tapflow relay start`에서 `tapflow.config.json` 자동 생성 제거

### Added
- `tapflow init` — `tapflow.config.json` 인터랙티브 생성, `.gitignore` 자동 추가
- `tapflow admin init` — CLI에서 최초 관리자 계정 생성 (헤드리스 환경 폴백)
- Dashboard `/setup` 페이지 — 웹 기반 최초 관리자 계정 생성
- Tailscale 터널 프로바이더 (`tunnel.provider: "tailscale"`)
- config 미존재 시 노란색 경고 출력 (`warn()` 유틸)

### Removed
- `tapflow start` / `tapflow relay start`의 config 자동 생성 사이드 이펙트

## 머지 후 할 일

```sh
git tag v0.4.0
git push origin v0.4.0
```

→ GitHub Actions가 자동으로 npm publish + GitHub Release 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

Release 0.4.0 with significant improvements to initialization and onboarding.

* **New Features**
  * Completely redesigned tapflow initialization workflow for improved usability and streamlined setup
  * Tailscale tunnel integration for enhanced secure connectivity
  * New web-based onboarding experience for faster first-time user setup
  * Overall user experience enhancements across the platform

* **Chores**
  * Released version 0.4.0 across all packages and components
  * Updated changelogs documenting all changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->