### PR TITLE
chore: release v0.4.1 — security patch

### DIFF
--- a/.changeset/security-uploads-ws-auth.md
+++ b/.changeset/security-uploads-ws-auth.md
@@ -1,9 +1,0 @@
----
-"tapflow": patch
-"@tapflowio/agent-core": patch
-"@tapflowio/ios-agent": patch
-"@tapflowio/android-agent": patch
-"@tapflowio/relay": patch
----
-
-fix: path traversal in /uploads/ and unauthenticated WebSocket access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-01
+
+### Security
+
+- relay: fix path traversal in `/uploads/` — `serveUpload` now validates that the resolved file path stays within `uploadsDir`; requests that escape the directory return 403.
+- relay: `/uploads/` route now requires view authentication — unauthenticated requests return 401 before file serving.
+- relay: WebSocket connections from non-localhost clients without a valid JWT cookie or PAT are rejected with close code 1008.
+- relay: WebSocket role gating — browser-role sockets that send agent-only messages (`agent:register`, `agent:resources`, etc.) are disconnected immediately.
+
 ## [0.4.0] - 2026-06-01
 
 ### Breaking Changes
@@ -30,5 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/jo-duchan/tapflow/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jo-duchan/tapflow/compare/v0.3.1...v0.4.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/agent-core
 
+## 0.4.1
+
+### Patch Changes
+
+- 17b8615: fix: path traversal in /uploads/ and unauthenticated WebSocket access
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/android-agent
 
+## 0.4.1
+
+### Patch Changes
+
+- 17b8615: fix: path traversal in /uploads/ and unauthenticated WebSocket access
+- Updated dependencies [17b8615]
+  - @tapflowio/agent-core@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # tapflow
 
+## 0.4.1
+
+### Patch Changes
+
+- 17b8615: fix: path traversal in /uploads/ and unauthenticated WebSocket access
+- Updated dependencies [17b8615]
+  - @tapflowio/agent-core@0.4.1
+  - @tapflowio/ios-agent@0.4.1
+  - @tapflowio/android-agent@0.4.1
+  - @tapflowio/relay@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/ios-agent
 
+## 0.4.1
+
+### Patch Changes
+
+- 17b8615: fix: path traversal in /uploads/ and unauthenticated WebSocket access
+- Updated dependencies [17b8615]
+  - @tapflowio/agent-core@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.4.0-experimental.1",
+  "version": "0.4.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/relay
 
+## 0.4.1
+
+### Patch Changes
+
+- 17b8615: fix: path traversal in /uploads/ and unauthenticated WebSocket access
+- Updated dependencies [17b8615]
+  - @tapflowio/agent-core@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

- Bump all packages to **0.4.1** (security patch release)
- Bump `@tapflowio/mcp-server` to `0.4.1-experimental.1`
- Update root `CHANGELOG.md`

## What's in this release

Security fixes from PR #173:
- relay: path traversal fix in `/uploads/`
- relay: `/uploads/` now requires view auth
- relay: WebSocket connections from non-localhost require JWT cookie or PAT
- relay: WebSocket role gating (browser sockets cannot spoof agent messages)

## After merging

```sh
git tag v0.4.1 && git push origin v0.4.1
```

Then deprecate affected versions:
```sh
npm deprecate "tapflow@<0.4.1" "Security fix: upgrade to 0.4.1"
npm deprecate "@tapflowio/relay@<0.4.1" "Security fix: upgrade to 0.4.1"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path traversal vulnerability in the upload feature that could allow unauthorized directory access
  * Enhanced WebSocket connection security by implementing stricter authentication requirements for non-localhost clients
  * Added authentication requirement for accessing uploaded files

* **Chores**
  * Released version 0.4.1 with security updates across agent core, CLI, and relay packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->