### PR TITLE
fix: improve tapflow doctor UX for simulator and xcode-select

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -115,24 +115,45 @@ If `arm64-v8a` is missing, the app was built targeting 32-bit ARM or Intel emula
 
 The iOS agent only runs on macOS (Apple policy). You cannot start an iOS agent on Linux or Windows.
 
-### `Xcode not found` or `xcrun simctl not found`
+### `Xcode not found` — Xcode is not installed
 
-Xcode is installed but the command-line tools are not configured:
+Install Xcode from the Mac App Store or the Apple Developer site, then run:
 
 ```sh
-xcode-select --install
-# or
-sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### `Xcode not found` — Xcode is installed but `xcode-select` is not configured
+
+This commonly happens after installing Xcode from the Mac App Store. Xcode is present but the developer tools path is not registered:
+
+```sh
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+Run `tapflow doctor` again to confirm the check passes.
+
+### No simulator is running
+
+`tapflow doctor` shows a warning when no simulator is booted. This does not block `tapflow start` — the warning is informational.
+
+To boot a simulator before starting:
+
+```sh
+tapflow devices        # list available simulators
+tapflow boot "iPhone 16 Pro"
 ```
 
 ### `adb not found`
 
-The Android SDK's `platform-tools` are not in `$PATH`. Set `ANDROID_HOME`:
+Android Studio is installed but `adb` is not in `$PATH`. Add the Android SDK `platform-tools` directory to your shell profile:
 
 ```sh
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```
+
+Add these lines to `~/.zshrc` (or `~/.bashrc`) to make the change permanent, then run `source ~/.zshrc`.
 
 ## Session issues
 

--- a/docs/ko/guide/troubleshooting.md
+++ b/docs/ko/guide/troubleshooting.md
@@ -115,24 +115,45 @@ aapt dump badging your-app.apk | grep native-code
 
 iOS 에이전트는 macOS에서만 실행됩니다 (Apple 정책). Linux나 Windows에서는 iOS 에이전트를 시작할 수 없습니다.
 
-### `Xcode not found` 또는 `xcrun simctl not found`
+### `Xcode not found` — Xcode가 설치되어 있지 않은 경우
 
-Xcode가 설치되어 있어도 커맨드라인 도구가 설정되지 않으면 발생합니다:
+Mac App Store 또는 Apple Developer 사이트에서 Xcode를 설치한 뒤 아래 명령어를 실행합니다:
 
 ```sh
-xcode-select --install
-# 또는
-sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### `Xcode not found` — Xcode는 설치되어 있지만 `xcode-select`가 설정되지 않은 경우
+
+Mac App Store에서 Xcode를 설치한 후 흔히 발생합니다. Xcode는 있지만 개발자 도구 경로가 등록되지 않은 상태입니다:
+
+```sh
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+이후 `tapflow doctor`를 다시 실행해 체크가 통과되는지 확인합니다.
+
+### 실행 중인 시뮬레이터가 없는 경우
+
+부팅된 시뮬레이터가 없으면 `tapflow doctor`에서 경고를 표시합니다. 이 경고는 `tapflow start` 실행을 막지 않으며 참고용입니다.
+
+시작 전에 시뮬레이터를 미리 부팅하려면:
+
+```sh
+tapflow devices        # 사용 가능한 시뮬레이터 목록 확인
+tapflow boot "iPhone 16 Pro"
 ```
 
 ### `adb not found`
 
-Android SDK의 `platform-tools`가 `$PATH`에 없는 경우입니다. `ANDROID_HOME`을 설정합니다:
+Android Studio는 설치되어 있지만 `adb`가 `$PATH`에 없는 경우입니다. 셸 프로필에 Android SDK `platform-tools` 경로를 추가합니다:
 
 ```sh
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```
+
+`~/.zshrc`(또는 `~/.bashrc`)에 위 내용을 추가하면 영구적으로 적용됩니다. 추가 후 `source ~/.zshrc`를 실행합니다.
 
 ## 세션 관련
 

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('node:child_process')
+vi.mock('node:fs')
 
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { runDoctorChecks } from '../../lib/doctor.js'
+
+const mockExistsSync = vi.mocked(existsSync)
 
 const mockExecSync = vi.mocked(execSync)
 
@@ -23,7 +27,10 @@ const simctlNoneBooted = JSON.stringify({
 })
 
 describe('runDoctorChecks', () => {
-  beforeEach(() => vi.resetAllMocks())
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockExistsSync.mockReturnValue(false)
+  })
   afterEach(() => vi.restoreAllMocks())
 
   it('iOS 섹션은 macOS에서만 포함', async () => {
@@ -109,7 +116,7 @@ describe('runDoctorChecks', () => {
     expect(result.ios?.some((c) => c.label.includes('iPhone 16 Pro'))).toBe(true)
   })
 
-  it('booted 없으면 사용 가능한 시뮬레이터 이름으로 hint 생성', async () => {
+  it('booted 없으면 warn + 사용 가능한 시뮬레이터 이름으로 hint 생성', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
@@ -122,11 +129,13 @@ describe('runDoctorChecks', () => {
     const result = await runDoctorChecks()
     const simCheck = result.ios?.find((c) => c.label === 'Simulator')
     expect(simCheck?.ok).toBe(false)
+    expect(simCheck?.warn).toBe(true)
     expect(simCheck?.detail).toContain('iPhone 16 Pro')
   })
 
   it('Xcode 미설치 시 실패 + 링크 포함', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExistsSync.mockReturnValue(false)
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'xcodebuild -version') throw new Error('not found')
@@ -139,5 +148,22 @@ describe('runDoctorChecks', () => {
     const xcodeCheck = result.ios?.find((c) => c.label === 'Xcode')
     expect(xcodeCheck?.ok).toBe(false)
     expect(xcodeCheck?.detail).toContain('developer.apple.com')
+  })
+
+  it('Xcode.app 존재하지만 xcode-select 미설정 시 경로 설정 힌트 포함', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExistsSync.mockReturnValue(true)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'xcodebuild -version') throw new Error('not found')
+      if (c.startsWith('xcrun simctl')) return simctlBooted
+      if (c === 'which adb') throw new Error('not found')
+      return ''
+    })
+
+    const result = await runDoctorChecks()
+    const xcodeCheck = result.ios?.find((c) => c.label === 'Xcode')
+    expect(xcodeCheck?.ok).toBe(false)
+    expect(xcodeCheck?.detail).toContain('xcode-select -s')
   })
 })

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 
 export interface DoctorCheck {
   label: string
@@ -30,6 +31,13 @@ function checkXcode(): DoctorCheck {
     const version = out.split('\n')[0]?.replace('Xcode ', '') ?? ''
     return { label: `Xcode ${version}`, ok: true }
   } catch {
+    if (existsSync('/Applications/Xcode.app')) {
+      return {
+        label: 'Xcode',
+        ok: false,
+        detail: 'Xcode is installed but xcode-select is not configured. Run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer',
+      }
+    }
     return {
       label: 'Xcode',
       ok: false,
@@ -62,9 +70,9 @@ function checkBootedSimulator(): DoctorCheck {
     }
     const available = allDevices.find((d) => d.state === 'Shutdown')
     const hint = available
-      ? `Run: tapflow boot "${available.name}"`
-      : 'Run: tapflow devices  to see available simulators, then: tapflow boot "<name>"'
-    return { label: 'Simulator', ok: false, detail: hint }
+      ? `No simulator is running. Run: tapflow boot "${available.name}"`
+      : 'No simulator is running. Run: tapflow devices  to see available simulators, then: tapflow boot "<name>"'
+    return { label: 'Simulator', ok: false, warn: true, detail: hint }
   } catch {
     return { label: 'Simulator', ok: false, detail: 'Could not query simulators. Is Xcode installed?' }
   }


### PR DESCRIPTION
## Summary

- 시뮬레이터 미부팅 상태를 ✗ 에러가 아닌 ⚠ 경고로 표시 — 시뮬레이터가 없는 게 아니라 부팅만 안 된 것이므로 `SOME CHECKS FAILED`에서 제외
- Xcode 체크 시 `/Applications/Xcode.app` 존재 여부를 감지해 상황에 맞는 힌트 제공
  - App Store에서 설치했지만 `xcode-select`가 미설정된 경우: `sudo xcode-select -s ...` 안내
  - 미설치인 경우: 기존 설치 링크 그대로
- 테스트 케이스 추가: `warn` 플래그 검증, `xcode-select` 미설정 경로 검증

## Test plan

- [ ] `tapflow doctor` 실행 시 시뮬 미부팅이면 ⚠ 로 표시되고 `SOME CHECKS FAILED` 없이 통과
- [ ] Xcode 설치 후 `xcode-select` 미설정 상태에서 `sudo xcode-select -s ...` 힌트 노출
- [ ] Xcode 미설치 상태에서 설치 링크 힌트 노출 (기존 동작 유지)
- [ ] `vitest run` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced iOS diagnostics with more accurate Xcode and simulator detection and clearer, actionable guidance (including xcode-select and simulator boot instructions).
* **Documentation**
  * Expanded troubleshooting docs (EN and KO) with separate scenarios for Xcode/install/configuration, simulator availability, and adb/PATH guidance.
* **Tests**
  * Test suite updated to better validate warning details and guidance shown for Xcode and simulator cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->