### PR TITLE
fix: remove double space in tapflow doctor simulator hint

### DIFF
--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -71,7 +71,7 @@ function checkBootedSimulator(): DoctorCheck {
     const available = allDevices.find((d) => d.state === 'Shutdown')
     const hint = available
       ? `No simulator is running. Run: tapflow boot "${available.name}"`
-      : 'No simulator is running. Run: tapflow devices  to see available simulators, then: tapflow boot "<name>"'
+      : 'No simulator is running. Run: tapflow devices to see available simulators, then: tapflow boot "<name>"'
     return { label: 'Simulator', ok: false, warn: true, detail: hint }
   } catch {
     return { label: 'Simulator', ok: false, detail: 'Could not query simulators. Is Xcode installed?' }


### PR DESCRIPTION
## Summary

- Fixes a double space between `tapflow devices` and `to see...` in the simulator hint message (caught by CodeRabbit on #176)

## Test plan

- [ ] `tapflow doctor` 실행 시 시뮬레이터 미부팅 상태에서 hint 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when no iOS simulator is running. Users now receive clearer, more specific guidance on how to list available simulators and boot them properly, replacing vague help text with actionable next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->