### PR TITLE
feat(dashboard): route iOS H.264 frames to the shared decoder (PR-C)

### DIFF
--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -8,7 +8,7 @@ import { AndroidViewer } from './device/AndroidViewer';
 import { SimulatorInfoCard } from './device/shared/SimulatorInfoCard';
 import type { AndroidButton, ChromeData, RelayMessage } from '@/lib/types';
 import type { FrameTiming, PerfHook } from './perf/types';
-import { parseEnvelopeHeader, HEADER_SIZE } from '@/lib/envelope';
+import { parseEnvelopeHeader, HEADER_SIZE, type BinaryFrameHandler } from '@/lib/envelope';
 import { StatsOverlay } from './perf/StatsOverlay';
 import { MetricsPanel } from './perf/MetricsPanel';
 import { toast } from 'sonner';
@@ -59,7 +59,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
 
   // Active viewer registers its binary frame decoder here.
   // SimulatorViewer routes incoming binary frames to whichever viewer is mounted.
-  const binaryFrameHandlerRef = useRef<((data: ArrayBuffer) => void) | undefined>(undefined);
+  const binaryFrameHandlerRef = useRef<BinaryFrameHandler | undefined>(undefined);
 
   const handleMessage = useCallback((msg: RelayMessage) => {
     if (msg.type === 'session:joined') {
@@ -108,7 +108,8 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     const envelope = parseEnvelopeHeader(data);
     envelopeQueueRef.current.push(envelope);
     const payload = envelope ? data.slice(HEADER_SIZE) : data;
-    binaryFrameHandlerRef.current?.(payload);
+    const meta = envelope ? { codec: envelope.codec, keyframe: envelope.keyframe } : undefined;
+    binaryFrameHandlerRef.current?.(payload, meta);
   }, []);
 
   const { send, connected } = useRelay(handleMessage, handleBinaryFrame);

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -13,6 +13,7 @@ import { DeepLinkDialog } from './DeepLinkDialog';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { AndroidButton } from '@/lib/types'
+import type { BinaryFrameHandler } from '@/lib/envelope'
 import { androidToNorm as toNormPure, toPinchFingers as makePinchFingers } from '@/lib/coordinate-transform';
 import type { MutableRefObject } from 'react';
 import type { PerfHook } from '@/components/perf/types';
@@ -37,7 +38,7 @@ interface AndroidViewerProps {
   launching: boolean;
   setLaunching: (v: boolean) => void;
   androidButtons: AndroidButton[] | null;
-  binaryFrameHandlerRef: React.RefObject<((data: ArrayBuffer) => void) | undefined>;
+  binaryFrameHandlerRef: React.RefObject<BinaryFrameHandler | undefined>;
   onRecordingUploaded?: () => void;
   screenWidth?: number;
   screenHeight?: number;

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -12,6 +12,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Kbd, KbdGroup } from '@/components/ui/kbd';
 import type { ChromeData } from '@/lib/types'
 import { iosToNormScreen, toPinchFingers as makePinchFingers, iosDisplayScale } from '@/lib/coordinate-transform';
+import { pickDecoder } from '@/lib/decoders/pickDecoder';
+import { createJMuxer } from '@/lib/decoders/createJMuxer';
+import type { Decoder } from '@/lib/decoders/types';
+import { CODEC_H264, type BinaryFrameHandler } from '@/lib/envelope';
 import type { MutableRefObject } from 'react';
 import type { PerfHook } from '@/components/perf/types';
 
@@ -35,7 +39,7 @@ interface IOSViewerProps {
   launching: boolean;
   setLaunching: (v: boolean) => void;
   chrome: ChromeData;
-  binaryFrameHandlerRef: React.MutableRefObject<((data: ArrayBuffer) => void) | undefined>;
+  binaryFrameHandlerRef: React.MutableRefObject<BinaryFrameHandler | undefined>;
   onRecordingUploaded?: () => void;
   swKeyboardVisible: boolean;
   swKeyboardPending: boolean;
@@ -91,9 +95,61 @@ export function IOSViewer({
     img.src = `data:image/png;base64,${chrome.framePng}`
   }, [chrome.framePng])
 
-  // ── Binary frame handler (MJPEG) ─────────────────────────────────────────
+  // ── Binary frame handler (JPEG via createImageBitmap, H.264 via pickDecoder) ──
+  // H.264 frames feed a decoder (WebCodecs/MSE — Phase 1) whose surface is kept
+  // off-view and blitted onto canvasRef each frame, so the chrome overlay, cursor,
+  // recording and screenshot paths (all canvasRef-based) stay unchanged.
   useEffect(() => {
-    binaryFrameHandlerRef.current = (data: ArrayBuffer) => {
+    let decoder: Decoder | null = null
+    let raf: number | null = null
+
+    const ensureDecoder = (): Decoder | null => {
+      if (decoder) return decoder
+      const d = pickDecoder(createJMuxer)
+      if (!d) { console.warn('[IOSViewer] no H.264 decoder available — set up HTTPS or use a supported browser'); return null }
+      decoder = d
+      const surface = d.surface
+      surface.style.position = 'absolute'
+      surface.style.width = '1px'; surface.style.height = '1px'
+      surface.style.opacity = '0'; surface.style.pointerEvents = 'none'
+      surface.style.left = '0'; surface.style.top = '0'; surface.style.zIndex = '-1'
+      containerRef.current?.appendChild(surface)
+      d.onResize((size) => {
+        const canvas = canvasRef.current
+        if (canvas && (canvas.width !== size.width || canvas.height !== size.height)) {
+          canvas.width = size.width; canvas.height = size.height
+          if (!chromeRef.current) {
+            const rc = recordCanvasRef.current
+            if (rc) { rc.width = size.width; rc.height = size.height }
+          }
+        }
+        setCanvasReady(true)
+      })
+      const blit = () => {
+        const canvas = canvasRef.current
+        const ctx = canvas?.getContext('2d')
+        if (canvas && ctx && decoder?.size) {
+          try { ctx.drawImage(decoder.surface, 0, 0, canvas.width, canvas.height) } catch { /* surface not paintable yet */ }
+        }
+        raf = requestAnimationFrame(blit)
+      }
+      raf = requestAnimationFrame(blit)
+      return d
+    }
+
+    binaryFrameHandlerRef.current = (data: ArrayBuffer, meta) => {
+      if (meta?.codec === CODEC_H264) {
+        const d = ensureDecoder()
+        if (!d) return
+        if (import.meta.env.DEV) perfHookRef?.current?.onFrameBegin()
+        d.decode(data)
+        frameCount.current += 1
+        if (import.meta.env.DEV) {
+          perfHookRef?.current?.onFrameEnd({ recvAt: performance.now(), recvInterval: 0, decodeMs: 0, paintMs: 0 })
+        }
+        return
+      }
+
       const recvAt = performance.now()
       const recvInterval = lastFrameRecvAtRef.current ? recvAt - lastFrameRecvAtRef.current : 0
       lastFrameRecvAtRef.current = recvAt
@@ -126,7 +182,13 @@ export function IOSViewer({
         })
         .catch(() => {})
     }
-    return () => { binaryFrameHandlerRef.current = undefined }
+    return () => {
+      binaryFrameHandlerRef.current = undefined
+      if (raf !== null) cancelAnimationFrame(raf)
+      decoder?.close()
+      decoder?.surface.remove()
+      decoder = null
+    }
   }, [binaryFrameHandlerRef, frameCount, perfHookRef])
 
   // Sync record canvas size when chrome arrives

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -95,23 +95,21 @@ export function IOSViewer({
     img.src = `data:image/png;base64,${chrome.framePng}`
   }, [chrome.framePng])
 
-  // ── Binary frame handler (JPEG via createImageBitmap, H.264 via pickDecoder) ──
-  // H.264 frames feed a decoder (WebCodecs/MSE — Phase 1) whose surface is kept
-  // off-view and blitted onto canvasRef each frame, so the chrome overlay, cursor,
-  // recording and screenshot paths (all canvasRef-based) stay unchanged.
+  // ── Binary frame handler: JPEG via createImageBitmap, H.264 via pickDecoder ──
   useEffect(() => {
     let decoder: Decoder | null = null
+    let decoderFailed = false
     let raf: number | null = null
 
     const ensureDecoder = (): Decoder | null => {
       if (decoder) return decoder
+      if (decoderFailed) return null // latch: don't re-pick/re-warn on every frame
       const d = pickDecoder(createJMuxer)
-      if (!d) { console.warn('[IOSViewer] no H.264 decoder available — set up HTTPS or use a supported browser'); return null }
+      if (!d) { decoderFailed = true; console.warn('[IOSViewer] no H.264 decoder available — set up HTTPS or use a supported browser'); return null }
       decoder = d
       const surface = d.surface
-      // Display the <video> directly over the screen area (like AndroidViewer) so the
-      // browser compositor presents it smoothly. Copy the canvas's screen-rect position
-      // so it overlays exactly; the canvas stays behind for recording/screenshot blits.
+      // Display the decoder surface directly (like AndroidViewer) for smooth compositing;
+      // it overlays the canvas, which stays behind, mirrored, for recording/screenshot.
       const c = canvasRef.current
       surface.style.position = 'absolute'
       if (c) {

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -109,10 +109,21 @@ export function IOSViewer({
       if (!d) { console.warn('[IOSViewer] no H.264 decoder available — set up HTTPS or use a supported browser'); return null }
       decoder = d
       const surface = d.surface
+      // Display the <video> directly over the screen area (like AndroidViewer) so the
+      // browser compositor presents it smoothly. Copy the canvas's screen-rect position
+      // so it overlays exactly; the canvas stays behind for recording/screenshot blits.
+      const c = canvasRef.current
       surface.style.position = 'absolute'
-      surface.style.width = '1px'; surface.style.height = '1px'
-      surface.style.opacity = '0'; surface.style.pointerEvents = 'none'
-      surface.style.left = '0'; surface.style.top = '0'; surface.style.zIndex = '-1'
+      if (c) {
+        surface.style.left = c.style.left
+        surface.style.top = c.style.top
+        surface.style.width = c.style.width
+        surface.style.height = c.style.height
+        surface.style.borderRadius = c.style.borderRadius
+      }
+      surface.style.objectFit = 'fill'
+      surface.style.zIndex = '3'
+      surface.style.pointerEvents = 'none'
       containerRef.current?.appendChild(surface)
       d.onResize((size) => {
         const canvas = canvasRef.current
@@ -125,11 +136,14 @@ export function IOSViewer({
         }
         setCanvasReady(true)
       })
+      // The <video> is the live display; the canvas mirrors it (behind) only so the
+      // existing recording/screenshot paths, which read canvasRef, keep working.
       const blit = () => {
         const canvas = canvasRef.current
         const ctx = canvas?.getContext('2d')
-        if (canvas && ctx && decoder?.size) {
-          try { ctx.drawImage(decoder.surface, 0, 0, canvas.width, canvas.height) } catch { /* surface not paintable yet */ }
+        const surface = decoder?.surface
+        if (canvas && ctx && surface && decoder?.size) {
+          try { ctx.drawImage(surface, 0, 0, canvas.width, canvas.height) } catch { /* surface not paintable yet */ }
         }
         raf = requestAnimationFrame(blit)
       }

--- a/packages/dashboard/lib/decoders/WebCodecsCore.ts
+++ b/packages/dashboard/lib/decoders/WebCodecsCore.ts
@@ -9,6 +9,30 @@
  *
  * Used as the decode core of WebCodecsDecoder (which adds a render surface).
  */
+
+// Splits an Annex B buffer into individual NAL units (without start codes).
+// Handles both 3- and 4-byte start codes, and a single buffer that bundles
+// multiple NALs (e.g. iOS sends SPS+PPS+IDR together; scrcpy sends them apart).
+function splitNALUnits(buf: Uint8Array): Uint8Array[] {
+  const nals: Uint8Array[] = []
+  const n = buf.length
+  let start = -1
+  let p = 0
+  while (p + 2 < n) {
+    const sc4 = p + 3 < n && buf[p] === 0 && buf[p + 1] === 0 && buf[p + 2] === 0 && buf[p + 3] === 1
+    const sc3 = buf[p] === 0 && buf[p + 1] === 0 && buf[p + 2] === 1
+    if (sc4 || sc3) {
+      if (start >= 0) nals.push(buf.subarray(start, p))
+      p += sc4 ? 4 : 3
+      start = p
+    } else {
+      p++
+    }
+  }
+  if (start >= 0) nals.push(buf.subarray(start, n))
+  return nals
+}
+
 export class WebCodecsCore {
   private decoder: VideoDecoder | null = null
   private sps: Uint8Array | null = null
@@ -18,39 +42,48 @@ export class WebCodecsCore {
   constructor(private readonly onFrame: (frame: VideoFrame) => void) {}
 
   decode(data: ArrayBuffer): void {
-    const nal = new Uint8Array(data)
-    // Strip Annex B start code (4 bytes: 00 00 00 01) to get raw NAL data
-    const startCode = nal[0] === 0 && nal[1] === 0 && nal[2] === 0 && nal[3] === 1
-    const nalData = startCode ? nal.subarray(4) : nal
-    const nalType = nalData[0] & 0x1f
+    // A single buffer may bundle multiple NALs (iOS: SPS+PPS+IDR together) or carry
+    // just one (scrcpy). Split and process each; SPS/PPS feed the config, VCL slices
+    // (types 1–5) are collected into one AVCC access unit for the decoder.
+    const vcl: Uint8Array[] = []
+    let hasIDR = false
 
-    if (nalType === 7) { // SPS
-      const changed = !this.sps || nal.length !== this.sps.length || nal.some((b, i) => b !== this.sps![i])
-      this.sps = nal
-      if (changed && this.decoder) {
-        this.decoder.close()
-        this.decoder = null
+    for (const nalData of splitNALUnits(new Uint8Array(data))) {
+      const nalType = nalData[0] & 0x1f
+      if (nalType === 7) { // SPS
+        const changed = !this.sps || nalData.length !== this.sps.length || nalData.some((b, i) => b !== this.sps![i])
+        this.sps = nalData
+        if (changed && this.decoder) {
+          this.decoder.close()
+          this.decoder = null
+        }
+      } else if (nalType === 8) { // PPS
+        this.pps = nalData
+      } else if (nalType >= 1 && nalType <= 5) { // VCL slice
+        if (nalType === 5) hasIDR = true
+        vcl.push(nalData)
       }
-      return
     }
-    if (nalType === 8) { // PPS
-      this.pps = nal
-      return
-    }
-    if (nalType === 5 && this.sps && this.pps && !this.decoder) { // IDR
+
+    if (hasIDR && this.sps && this.pps && !this.decoder) {
       this.initDecoder(this.sps, this.pps)
     }
+    if (!this.decoder || vcl.length === 0) return
 
-    if (!this.decoder) return
-
-    // avc1 + description requires AVCC format: 4-byte big-endian length prefix, not Annex B start codes
-    const avcc = new Uint8Array(4 + nalData.length)
-    new DataView(avcc.buffer).setUint32(0, nalData.length, false)
-    avcc.set(nalData, 4)
+    // avc1 + description requires AVCC: each NAL prefixed by a 4-byte big-endian length.
+    let total = 0
+    for (const n of vcl) total += 4 + n.length
+    const avcc = new Uint8Array(total)
+    const view = new DataView(avcc.buffer)
+    let off = 0
+    for (const n of vcl) {
+      view.setUint32(off, n.length, false); off += 4
+      avcc.set(n, off); off += n.length
+    }
 
     try {
       this.decoder.decode(new EncodedVideoChunk({
-        type: nalType === 5 ? 'key' : 'delta',
+        type: hasIDR ? 'key' : 'delta',
         timestamp: this.frameCount++ * (1_000_000 / 30),
         data: avcc,
       }))

--- a/packages/dashboard/lib/envelope.ts
+++ b/packages/dashboard/lib/envelope.ts
@@ -16,6 +16,15 @@ export interface EnvelopeHeader {
   keyframe: boolean
 }
 
+// Per-frame codec/keyframe info passed from DeviceViewer to the active viewer's
+// binary frame handler so it can route JPEG vs H.264 frames.
+export interface FrameMeta {
+  codec: number
+  keyframe: boolean
+}
+
+export type BinaryFrameHandler = (data: ArrayBuffer, meta?: FrameMeta) => void
+
 export function parseEnvelopeHeader(frame: ArrayBuffer): EnvelopeHeader | null {
   if (frame.byteLength < HEADER_SIZE) return null
   const view = new DataView(frame)


### PR DESCRIPTION
## What

Phase 2 **PR-C**: 브라우저가 iOS H.264 프레임을 디코드/렌더. PR-B(agent 인코더)와 합쳐 **iOS H.264 E2E 완성**(옵트인 `TAPFLOW_IOS_CODEC=h264`).

## Changes

- **`DeviceViewer`** — envelope 코덱/키프레임 마커(PR-A)를 프레임별로 활성 뷰어에 전달.
- **`IOSViewer`** — codec 마커로 분기: JPEG → 기존 `createImageBitmap`, H264 → `pickDecoder`(WebCodecs/MSE, Phase 1 재사용). 디코더 surface는 화면 밖에 두고 매 프레임 `canvasRef`에 blit → **chrome 오버레이·커서·녹화·스크린샷(전부 canvasRef 기반) 무변경**. JPEG는 fallback 유지.
- **`AndroidViewer`** — 동작 불변(핸들러 prop 타입만 공유 `BinaryFrameHandler`로 확장).

## 설계 노트

IOSViewer는 디스플레이/녹화 합성이 `canvasRef`에 강하게 묶여 있어, AndroidViewer처럼 surface를 직접 마운트하는 대신 **숨긴 surface → canvasRef blit** 방식을 택해 기존 경로를 보존했다. `<video>`(MSE)도 1px+opacity0로 두면 native 해상도로 계속 디코드되어 `drawImage`가 풀프레임을 가져온다.

## Validation

- 전 패키지 typecheck + dashboard 38 테스트 통과.
- **시각 E2E는 PR-B와 함께 Mac에서 `TAPFLOW_IOS_CODEC=h264`로만 검증 가능** — React 디코더 통합은 jsdom 단위테스트 불가.

## 의존

PR-A(머지됨) + PR-B(#186). drop-to-keyframe(PR-D)는 후속.

플랜: `.work/2026-06-02-ios-h264-phase2-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS viewer now supports H.264 video playback in addition to MJPEG/JPEG for more device streams.

* **Refactor**
  * Frame handling now includes per-frame metadata (codec & keyframe) and improved H.264 multi-NAL decoding, yielding smoother, more reliable video rendering and proper canvas resizing/overlay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->