### PR TITLE
feat(dashboard): WASM H.264 decoder (tinyh264) for low-latency plain-HTTP LAN

### DIFF
--- a/contributing/streaming-latency-campaign.md
+++ b/contributing/streaming-latency-campaign.md
@@ -50,7 +50,7 @@
 | tier | 환경 | 디코더 | 특성 |
 |------|------|--------|------|
 | 2 | HTTPS / localhost | WebCodecs | HW, 최저지연 |
-| **1** | **LAN-HTTP** | **WASM (tinyh264)** ⬅️ 목표 | CPU, 저지연·버퍼0 (secure 불필요) |
+| **1** | **LAN-HTTP** | **WASM (tinyh264)** ✅ 측정 PASS | CPU, 저지연·버퍼0 (secure 불필요) |
 | fallback | 그 외 | MSE | 버퍼(지연) |
 
 WASM이 매력적인 이유: **secure context 불필요 + 미디어버퍼 없음** = JPEG의 즉시성 + H.264의 저대역폭을 LAN-HTTP에서 동시에. 대가는 **소프트웨어(CPU) 디코드** — 해상도×fps가 높으면 CPU 한계. 완화: **인코딩 해상도 다운스케일**(표시는 작음 → 대역폭·CPU·지연 삼중↓). 선례: ws-scrcpy가 tinyh264로 폰 해상도 baseline H.264 디코드.
@@ -100,8 +100,12 @@ WASM이 매력적인 이유: **secure context 불필요 + 미디어버퍼 없음
 | **H.264 WebCodecs 스크롤 (수정 후)** | **2.1 / 3.9** | **3.4 / 7.9** | 0–1 | |
 | **H.264 MSE 정지** | **239 / 254** | **240 / 255** | 0–1 | reorder=0 받아도 `<video>` 버퍼 잔존 |
 | **H.264 MSE 스크롤** | **229 / 244** | **230 / 245** | 0–1 | jmuxer `flushingTime:0`에도 구조적 |
+| **H.264 WASM 정지** | **8.7 / 30.4** | **9.6 / 31.5** | 0–1 | tinyh264, 미디어버퍼 없음 — JPEG급 |
+| **H.264 WASM 스크롤** | **14.3 / 37.9** | **16 / 40.3** | 1–2 | localhost-JPEG급 반응성 |
 
 → **WebCodecs는 수정으로 decode→present 267→2.5ms (~100x↓), 북극성(localhost-JPEG급) 도달.** 그러나 **MSE는 같은 reorder=0 스트림에도 ~235ms** — SPS 수정이 닿지 않는 **미디어-엘리먼트(`<video>`) 버퍼**(이미 `flushingTime:0` 튜닝됨, 더 못 깎음). → **tier1 LAN-HTTP(비-secure, MSE)엔 WASM(tinyh264) 필요**가 측정으로 확정. (`?decoder=mse` dev 오버라이드로 localhost 단일클럭 측정 — MSE는 드롭 대신 버퍼링이라 FIFO tracker가 정확.)
+
+→ **2단계 WASM 실측(2026-06-02, `?decoder=wasm`): 게이트 PASS.** tinyh264가 MSE의 `<video>` 버퍼를 완전히 회피 → decode→present **정지 8.7ms / 스크롤 14.3ms**(MSE 239/229 대비 **~27x·~16x↓**), glass→glass 9.6/16ms. **localhost-JPEG(북극성 12.4/9.4) 동급** — 정지는 JPEG보다 빠름. 색·체감 양호, CPU 여유(localhost는 인코더+디코더 한 Mac = 워스트케이스라 실 LAN은 더 여유). → **비-secure 경로로 북극성 도달 확정, 다운스케일(3단계) 현재 불필요.** 다음: pickDecoder 티어 flip(비-secure→WASM 우선).
 
 > \* JPEG glass→glass는 패널 미산출(`null`) — H.264 tracker 경로에서만 계산. decode(~10ms)+agent→relay(~1ms)로 ≈11–13ms.
 > **clock 유효성:** glass→glass = present(epoch) − capturedAt → **localhost 단일 클럭에서만**. decode→present(델타)·agent→relay(둘 다 Mac)는 모든 환경 유효.
@@ -117,7 +121,7 @@ WASM이 매력적인 이유: **secure context 불필요 + 미디어버퍼 없음
 |---|------|------|------|
 | **0** | per-stage 지연 계측 (capture→display, 인코더 시간) | 병목 수치 랭킹. localhost-WebCodecs-H.264 부검 | ✅ 완료 — 범인=SPS reorder 미선언 |
 | **1** | SPS reorder=0 주입으로 디코더 DPB 버퍼 제거 | WebCodecs를 localhost-JPEG급으로 | ✅ 완료 — 브라우저 검증(267→2.5ms) + **인코더 이전**(ios-agent가 SPS 재작성 → 전 디코더 혜택, localhost e2e 확인 `bitstreamRestriction:true`) |
-| 2 | **WASM 디코더(tinyh264)** → LAN-HTTP MSE 대체 | 버퍼0·secure불필요 → LAN 저지연 | 🔄 **정당화 확정**(MSE 실측 ~235ms 구조적) — WASM 구현 착수 |
+| 2 | **WASM 디코더** → LAN-HTTP MSE 대체 (tinyh264 첫 후보, 교체 가능) | 버퍼0·secure불필요 → LAN 저지연 | ✅ **구현+측정 PASS** — decode→present 정지 8.7/스크롤 14.3ms(MSE 대비 ~27x·~16x↓), localhost-JPEG급. pickDecoder flip(PR#2) 대기 |
 | 3 | 인코딩 해상도 다운스케일 | 대역폭·CPU·지연 삼중↓ | ☐ |
 | 4 | 캡처 이벤트화/고fps, 터치 경로 최적화 | 바닥 더 깎기 | ☐ |
 
@@ -170,10 +174,12 @@ http://localhost:3001?perf=1&decoder=mse     # MSE 강제 (LAN tier 측정)
 
 ## 7. 결정 로그 (시간순 누적)
 
+- **2026-06-02 — 2단계 WASM 구현 완료 + 측정 게이트 PASS (북극성 도달):** PR#1(R1~R3+R5 오버라이드) 구현 — `tinyh264@0.0.7`(baseline·I/P only, wasm는 data-URI 인라인=별도 에셋 불필요) + `WASMDecoder`(worker 캡슐화, AU 그대로 transfer) + 신규 `YUVWebGLRenderer`(I420 3-텍스처 BT.709 limited) + IOSViewer `?decoder=wasm` 오버라이드. 단위테스트 17개, 전체 183 통과, `vite build` worker 청크 173KB 검증. **localhost `?perf=1&decoder=wasm` 실측: decode→present 정지 8.7/p95 30.4, 스크롤 14.3/p95 37.9; glass→glass 정지 9.6, 스크롤 16ms.** MSE(239/229) 대비 **~27x·~16x↓**, localhost-JPEG(12.4/9.4) 동급 — **비-secure 경로로 북극성 달성.** 색·체감 양호, CPU 여유(localhost=워스트케이스). → **Q4: 다운스케일 불필요 확정.** 다음: pickDecoder flip(R4=PR#2)로 비-secure 기본을 WASM으로.
 - **2026-06-02 — H.264 마이그레이션 (Phase 2):** JPEG 풀프레임 대역폭 문제 확정(정지 3.3MB/s, LAN 스크롤 드롭 16–27/s) → VideoToolbox H.264 도입. 대역폭은 ~140x(정지)/~5x(스크롤) 해결, 드롭 거의 제거.
 - **2026-06-02 — 그러나 지연 발견:** H.264는 코덱 파이프라인 + LAN MSE 버퍼로 **JPEG보다 반응 느림**. localhost-JPEG가 "직접 조작 대등" 기준임을 확립. → "H.264로 갈아타기"가 아니라 **"저지연 디코드/전송 경로"가 진짜 과제**로 재정의.
 - **2026-06-02 — 캠페인 시작:** 측정 기반으로 병목을 하나씩. WASM 디코더(tier1 LAN-HTTP)를 핵심 레버로. PR-D(drop-to-keyframe)는 MSE 이탈 가능성으로 보류.
-- **2026-06-02 — MSE 실측 → WASM 정당화(2단계 진입):** reorder=0 수정이 모든 디코더에 적용된 뒤 MSE 경로를 `?decoder=mse` dev 오버라이드로 localhost(단일클럭) 측정 → decode→present p50 **~235ms**(WebCodecs ~2.5ms 대비). jmuxer `flushingTime:0`이 이미 적용된 상태라 이건 `<video>` 미디어-엘리먼트 버퍼 = **구조적·MSE 고유**(SPS·reorder와 무관). MSE는 드롭이 아니라 버퍼링이라 FIFO tracker가 정확(드리프트 없음). → **tier1 LAN-HTTP는 MSE로 북극성 불가**가 데이터로 확정 → **WASM(tinyh264, 미디어엘리먼트·버퍼 없음, secure 불필요) 착수**. dev 디코더 강제: IOSViewer `?decoder=mse|webcodecs`(WASM 추가 시 `wasm`도 동일 지점).
+- **2026-06-02 — 2단계 WASM plan 확정(설계 결정):** 구현 plan 작성(`.work/2026-06-02-wasm-tinyh264-decoder-plan.md`, 로컬). 핵심 결정 ① **디코더-불가지 경계** — `WASMDecoder`(Decoder 구현) + 신규 `YUVWebGLRenderer` 뒤에 구체 디코더를 캡슐화. **tinyh264 첫 후보지만 락인 아님**: 우리가 인코더=VideoToolbox baseline 소유 → baseline-only 디코더 제약이 무의미하고, full-res CPU 한계 시 렌더러/pickDecoder 불변 상태로 SIMD 빌드(ffmpeg.wasm·OpenH264)로 디코더만 교체. ② **기존 `WebGLVideoRenderer` 재사용 불가** — `texImage2D(VideoFrame)`은 WebCodecs=secure 전용인데 WASM 티어는 비-secure가 존재 이유 + tinyh264는 I420 YUV 출력 → **Y/U/V 3-텍스처 BT.709 셰이더 렌더러 신규 필요**(저지연 이득은 디코더 내부가 아니라 `<video>` 버퍼 부재에서 옴 → 디코더 무관 구조적). ③ **PR=옵션 A(2 PR)** — PR#1=구현 전부를 `?decoder=wasm` dev 오버라이드 뒤에만(pickDecoder 불변=프로덕션 0영향, 여기서 게이트 측정), PR#2=pickDecoder flip(비-secure→WASM 우선)은 **게이트 통과 후에만**. R1(Vite .wasm+worker 에셋 배선) 막히면 선행 분리. ④ Q4(full-res CPU 시퀀싱: 다운스케일/SIMD교체/롤백)=**R5 게이트 측정 보고 결정**. → **다음: R1 착수.**
+- **2026-06-02 — MSE 실측 → WASM 정당화(2단계 진입):** reorder=0 수정이 모든 디코더에 적용된 뒤 MSE 경로를 `?decoder=mse` dev 오버라이드로 localhost(단일클럭) 측정 → decode→present p50 **~235ms**(WebCodecs ~2.5ms 대비). jmuxer `flushingTime:0`이 이미 적용된 상태라 이건 `<video>` 미디어-엘리먼트 버퍼 = **구조적·MSE 고유**(SPS·reorder와 무관). MSE는 드롭이 아니라 버퍼링이라 FIFO tracker가 정확(드리프트 없음). → **tier1 LAN-HTTP는 MSE로 북극성 불가**가 데이터로 확정 → **WASM(미디어엘리먼트·버퍼 없음, secure 불필요) 착수**. dev 디코더 강제: IOSViewer `?decoder=mse|webcodecs`(WASM 추가 시 `wasm`도 동일 지점).
 - **2026-06-02 — 1단계 인코더 이전 완료:** SPS reorder=0 재작성을 **ios-agent로 이전**(`agent-core/utils/sps.ts` canonical, 키프레임 SPS만 `rewriteLowLatencySpsInFrame`). 인코더가 소스에서 reorder=0을 선언해 **WebCodecs·MSE·향후 WASM 전 경로**가 혜택. localhost e2e 확인: 브라우저 `[sps-vui]`가 `bitstreamRestriction:true, maxNumReorderFrames:0`(agent 재작성본 수신), decode→present p50 2.2ms 유지. 브라우저 사본은 방어선(no-op). **다음(2단계 진입): MSE 잔여 지연 실측** — `pnpm --filter @tapflowio/dashboard dev --host` 후 mac에서 `http://<mac-LAN-IP>:3001?perf=1`(비-secure→MSE, 같은 기기→단일클럭)로 MSE 미디어버퍼가 얼마 남는지 측정 → WASM 투자 판단.
 - **2026-06-02 — 0단계 부검 완료 + 1단계 검증 (핵심 돌파):** localhost-WebCodecs-H.264 지연 ~267ms의 범인 확정 — 전송/relay(~1ms)·입력 백로그(queueSize=0) 모두 무죄, **디코더가 max DPB(~8프레임) 버퍼링**. SPS VUI 파싱으로 `bitstreamRestriction:false`(Level 5.0) 확인 → 인코더가 "리오더 0"을 안 알려줘 디코더가 최악 가정. baseline이라 실제 리오더는 0인 **순수 신호 누락**. **수정:** WebCodecsCore가 configure 직전 SPS에 `max_num_reorder_frames=0`/`max_dec_frame_buffering=num_ref` 주입(`rewriteSpsLowLatency`). **결과: decode→present 267→2.5ms(~100x), glass→glass 235→3.5ms, 체감 localhost-JPEG급 도달.** (이 시점엔 WebCodecs 경로만 — 이후 인코더 이전으로 전 경로 확대, 위 항목 참조.)
 - **2026-06-02 — 0단계 계측 착수:** 기존 `perf` 시스템(`?perf=1`, FrameTiming, trace export)을 **재활용**(신규 샘플러 폐기). 핵심 공백은 H.264 경로가 `decodeMs/paintMs=0`으로 찍히던 것 — 디코더 surface로 fire-and-forget이라 부검 대상이 사각지대였음. 해결: Decoder에 `onDecodedFrame`(WebCodecs=output 콜백, MSE=`requestVideoFrameCallback`) 추가 + `FrameLatencyTracker`(submit↔present FIFO 상관, **baseline·B-frame OFF라 재정렬 없음→정확**)로 decode→present·glass→glass 복원. glass→glass는 epoch present−capturedAt이라 **localhost 단일 클럭에서만** 산출. 프로토콜/envelope 불변, 인터페이스 변경은 dashboard 내부(비 breaking). 측정 수치는 §4에 누적.

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -15,6 +15,7 @@ import { iosToNormScreen, toPinchFingers as makePinchFingers, iosDisplayScale } 
 import { pickDecoder, detectCapabilities } from '@/lib/decoders/pickDecoder';
 import { createJMuxer } from '@/lib/decoders/createJMuxer';
 import type { Decoder } from '@/lib/decoders/types';
+import { WASMDecoder } from '@/lib/decoders/WASMDecoder';
 import { CODEC_H264, type BinaryFrameHandler } from '@/lib/envelope';
 import { FrameLatencyTracker } from '@/components/perf/FrameLatencyTracker';
 import type { MutableRefObject } from 'react';
@@ -111,16 +112,19 @@ export function IOSViewer({
     const ensureDecoder = (): Decoder | null => {
       if (decoder) return decoder
       if (decoderFailed) return null // latch: don't re-pick/re-warn on every frame
-      // Dev override: ?decoder=mse forces the MSE tier on localhost (drop secure
-      // context + WebCodecs) so it can be measured without a non-secure LAN context.
+      // Dev override: ?decoder=mse|wasm forces a tier on localhost (single clock,
+      // perf panel) so it can be measured without a non-secure LAN context. wasm is
+      // built directly (pickDecoder priority is unchanged until the tier flip lands).
       const forced = import.meta.env.DEV ? new URLSearchParams(location.search).get('decoder') : null
-      const d = forced === 'mse'
+      const d = forced === 'wasm'
+        ? new WASMDecoder()
+        : forced === 'mse'
         ? pickDecoder(createJMuxer, { ...detectCapabilities(), secureContext: false, webCodecs: false })
         : pickDecoder(createJMuxer)
       if (!d) { decoderFailed = true; console.warn('[IOSViewer] no H.264 decoder available — set up HTTPS or use a supported browser'); return null }
       decoder = d
       if (import.meta.env.DEV) {
-        console.log(`[decoder] using ${d.surface instanceof HTMLVideoElement ? 'MSE' : 'WebCodecs'}${forced ? ` (forced: ${forced})` : ''}`)
+        console.log(`[decoder] using ${d instanceof WASMDecoder ? 'WASM' : d.surface instanceof HTMLVideoElement ? 'MSE' : 'WebCodecs'}${forced ? ` (forced: ${forced})` : ''}`)
         let diagN = 0
         d.onDecodedFrame?.((presentTime, sample) => {
           const timing = tracker.onPresented(

--- a/packages/dashboard/lib/YUVWebGLRenderer.ts
+++ b/packages/dashboard/lib/YUVWebGLRenderer.ts
@@ -1,0 +1,170 @@
+// Vertex shader: maps NDC [-1,1] quad to UV [0,1], Y-flipped so row-0 (top of the
+// decoded image) lands at the top of the canvas (matches WebGLVideoRenderer).
+const VERT = `#version 300 es
+in vec2 a_pos;
+out vec2 v_uv;
+void main() {
+  v_uv = vec2(a_pos.x * 0.5 + 0.5, 0.5 - a_pos.y * 0.5);
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}`
+
+// Fragment shader: samples the Y/U/V planes and converts BT.709 *limited* range to
+// RGB. The iOS encoder signals BT.709 limited (Y∈[16,235], C∈[16,240]); matching it
+// here keeps color fidelity (see project_android_color_fidelity — do not over-saturate).
+// Texture .r returns byte/255, so the offsets/scales below fold the 255 factor in.
+const FRAG = `#version 300 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_texY;
+uniform sampler2D u_texU;
+uniform sampler2D u_texV;
+out vec4 out_color;
+void main() {
+  float Y = (texture(u_texY, v_uv).r - 0.0627451) * 1.1643836; // (y-16/255)*255/219
+  float U = (texture(u_texU, v_uv).r - 0.5019608) * 1.1383929; // (u-128/255)*255/224
+  float V = (texture(u_texV, v_uv).r - 0.5019608) * 1.1383929;
+  float r = Y + 1.5748 * V;
+  float g = Y - 0.1873 * U - 0.4681 * V;
+  float b = Y + 1.8556 * U;
+  out_color = vec4(r, g, b, 1.0);
+}`
+
+interface GLState {
+  gl: WebGL2RenderingContext
+  program: WebGLProgram
+  texY: WebGLTexture
+  texU: WebGLTexture
+  texV: WebGLTexture
+  vao: WebGLVertexArrayObject
+}
+
+function makePlaneTexture(gl: WebGL2RenderingContext, unit: number, uniform: string, program: WebGLProgram): WebGLTexture {
+  const tex = gl.createTexture()!
+  gl.activeTexture(gl.TEXTURE0 + unit)
+  gl.bindTexture(gl.TEXTURE_2D, tex)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.uniform1i(gl.getUniformLocation(program, uniform), unit)
+  return tex
+}
+
+function initGLState(canvas: HTMLCanvasElement): GLState | null {
+  const gl = canvas.getContext('webgl2', {
+    alpha: false,
+    antialias: false,
+    powerPreference: 'high-performance',
+    preserveDrawingBuffer: true, // required for captureStream() recording
+  })
+  if (!gl) return null
+
+  const mkShader = (type: number, src: string): WebGLShader => {
+    const s = gl.createShader(type)!
+    gl.shaderSource(s, src)
+    gl.compileShader(s)
+    return s
+  }
+
+  const prog = gl.createProgram()!
+  const vs = mkShader(gl.VERTEX_SHADER, VERT)
+  const fs = mkShader(gl.FRAGMENT_SHADER, FRAG)
+  gl.attachShader(prog, vs)
+  gl.attachShader(prog, fs)
+  gl.linkProgram(prog)
+  gl.deleteShader(vs)
+  gl.deleteShader(fs)
+  gl.useProgram(prog)
+
+  // Fullscreen quad: two triangles covering NDC [-1, 1]
+  const vao = gl.createVertexArray()!
+  gl.bindVertexArray(vao)
+  const buf = gl.createBuffer()!
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf)
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+    -1, -1,  1, -1, -1,  1,
+    -1,  1,  1, -1,  1,  1,
+  ]), gl.STATIC_DRAW)
+  const loc = gl.getAttribLocation(prog, 'a_pos')
+  gl.enableVertexAttribArray(loc)
+  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0)
+  gl.bindVertexArray(null)
+
+  // R8 single-channel textures, one per plane. UNPACK_ALIGNMENT=1 so rows whose
+  // width isn't a multiple of 4 upload without padding skew.
+  gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)
+  const texY = makePlaneTexture(gl, 0, 'u_texY', prog)
+  const texU = makePlaneTexture(gl, 1, 'u_texU', prog)
+  const texV = makePlaneTexture(gl, 2, 'u_texV', prog)
+
+  return { gl, program: prog, texY, texU, texV, vao }
+}
+
+/**
+ * Renders I420 (YUV420 planar) frames — as produced by the tinyh264 WASM decoder —
+ * to a canvas via WebGL2. Software decoders can't make a WebCodecs VideoFrame
+ * (secure-context only) and emit raw YUV, so this is the WASM tier's renderer,
+ * separate from WebGLVideoRenderer (which uploads VideoFrames directly).
+ *
+ * Owns its render surface so the viewer stays decoder-agnostic.
+ */
+export class YUVWebGLRenderer {
+  private state: GLState | null = null
+
+  constructor(private readonly canvas: HTMLCanvasElement) {}
+
+  init(): boolean {
+    this.state = initGLState(this.canvas)
+    return this.state !== null
+  }
+
+  /**
+   * Uploads one I420 frame (combined Y+U+V buffer) and renders it.
+   * Returns the frame dimensions on success so callers can track size.
+   */
+  drawI420(data: Uint8Array, width: number, height: number): { width: number; height: number } | null {
+    const s = this.state
+    if (!s) return null
+
+    const { gl } = s
+    const cw = (width + 1) >> 1
+    const ch = (height + 1) >> 1
+    const ySize = width * height
+    const cSize = cw * ch
+    const yPlane = data.subarray(0, ySize)
+    const uPlane = data.subarray(ySize, ySize + cSize)
+    const vPlane = data.subarray(ySize + cSize, ySize + 2 * cSize)
+
+    if (this.canvas.width !== width || this.canvas.height !== height) {
+      this.canvas.width = width
+      this.canvas.height = height
+      gl.viewport(0, 0, width, height)
+    }
+
+    const upload = (unit: number, tex: WebGLTexture, pw: number, ph: number, plane: Uint8Array) => {
+      gl.activeTexture(gl.TEXTURE0 + unit)
+      gl.bindTexture(gl.TEXTURE_2D, tex)
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, pw, ph, 0, gl.RED, gl.UNSIGNED_BYTE, plane)
+    }
+    upload(0, s.texY, width, height, yPlane)
+    upload(1, s.texU, cw, ch, uPlane)
+    upload(2, s.texV, cw, ch, vPlane)
+
+    gl.bindVertexArray(s.vao)
+    gl.drawArrays(gl.TRIANGLES, 0, 6)
+    gl.bindVertexArray(null)
+
+    return { width, height }
+  }
+
+  dispose(): void {
+    const s = this.state
+    if (!s) return
+    s.gl.deleteTexture(s.texY)
+    s.gl.deleteTexture(s.texU)
+    s.gl.deleteTexture(s.texV)
+    s.gl.deleteVertexArray(s.vao)
+    s.gl.deleteProgram(s.program)
+    this.state = null
+  }
+}

--- a/packages/dashboard/lib/decoders/WASMDecoder.ts
+++ b/packages/dashboard/lib/decoders/WASMDecoder.ts
@@ -1,0 +1,113 @@
+import type { Decoder, DecoderSize, DecodeSample } from './types'
+import { YUVWebGLRenderer } from '../YUVWebGLRenderer'
+
+/** Minimal renderer seam — satisfied by YUVWebGLRenderer, mockable in tests. */
+export interface YUVRenderer {
+  init(): boolean
+  /** Draws one combined I420 (YUV420 planar) buffer; returns frame size or null. */
+  drawI420(data: Uint8Array, width: number, height: number): { width: number; height: number } | null
+  dispose(): void
+}
+
+interface PictureReadyMsg {
+  type: 'pictureReady'
+  width: number
+  height: number
+  data: ArrayBuffer
+  renderStateId: number
+}
+type WorkerMsg = { type: 'decoderReady' } | PictureReadyMsg
+
+// Single logical stream per decoder instance.
+const RENDER_STATE_ID = 0
+
+function defaultRenderer(canvas: HTMLCanvasElement): YUVRenderer {
+  const r = new YUVWebGLRenderer(canvas)
+  r.init()
+  return r
+}
+
+function defaultWorker(): Worker {
+  // new URL(..., import.meta.url) lets Vite bundle the worker as its own chunk
+  // (type:'module' so its static `import 'tinyh264'` resolves; see vite.config worker.format).
+  return new Worker(new URL('./tinyh264.worker.ts', import.meta.url), { type: 'module' })
+}
+
+/**
+ * Software H.264 decoder via the tinyh264 (h264bsd) WASM module in a Web Worker.
+ *
+ * This is the tier-1 decoder for plain-HTTP LAN access: it needs no secure context
+ * (unlike WebCodecs) and has no media-element buffer (unlike MSE), so it can reach
+ * low latency over non-secure HTTP. The worker emits I420 (YUV420) frames, rendered
+ * by YUVWebGLRenderer to this decoder's own <canvas>.
+ *
+ * tinyh264 accepts a whole Annex B access unit per `decode` call (start codes kept,
+ * multiple NALs OK) — we forward each received frame as-is. Profile must be
+ * (constrained-)baseline with no B-frames, which matches the iOS VideoToolbox encoder.
+ *
+ * Owns its render surface so the viewer stays decoder-agnostic.
+ */
+export class WASMDecoder implements Decoder {
+  private readonly canvas: HTMLCanvasElement
+  private readonly renderer: YUVRenderer
+  private readonly worker: Worker
+  private ready = false
+  // Frames that arrived before the WASM module finished initializing.
+  private readonly pending: ArrayBuffer[] = []
+  private _size: DecoderSize | null = null
+  private resizeCb?: (size: DecoderSize) => void
+  private decodedCb?: (presentTime: number, sample?: DecodeSample) => void
+
+  constructor(
+    createRenderer: (canvas: HTMLCanvasElement) => YUVRenderer = defaultRenderer,
+    createWorker: () => Worker = defaultWorker,
+  ) {
+    this.canvas = document.createElement('canvas')
+    this.renderer = createRenderer(this.canvas)
+    this.worker = createWorker()
+    this.worker.onmessage = (e: MessageEvent<WorkerMsg>) => this.onMessage(e.data)
+  }
+
+  get surface(): HTMLCanvasElement { return this.canvas }
+  get size(): DecoderSize | null { return this._size }
+
+  onResize(cb: (size: DecoderSize) => void): void { this.resizeCb = cb }
+  onDecodedFrame(cb: (presentTime: number, sample?: DecodeSample) => void): void { this.decodedCb = cb }
+
+  decode(data: ArrayBuffer): void {
+    if (!this.ready) { this.pending.push(data); return }
+    this.post(data)
+  }
+
+  close(): void {
+    this.worker.terminate()
+    this.renderer.dispose()
+  }
+
+  private post(data: ArrayBuffer): void {
+    // Transfer the buffer (zero-copy); the caller does not reuse it after decode().
+    this.worker.postMessage(
+      { type: 'decode', data, offset: 0, length: data.byteLength, renderStateId: RENDER_STATE_ID },
+      [data],
+    )
+  }
+
+  private onMessage(msg: WorkerMsg): void {
+    if (msg.type === 'decoderReady') {
+      this.ready = true
+      for (const d of this.pending) this.post(d)
+      this.pending.length = 0
+      return
+    }
+    // pictureReady — render the decoded I420 frame.
+    const size = this.renderer.drawI420(new Uint8Array(msg.data), msg.width, msg.height)
+    if (!size) return
+    // No exact per-frame decodeMs (software path) — the viewer's FIFO tracker derives
+    // decode→present from submit↔present. Report present time only.
+    this.decodedCb?.(performance.now())
+    if (!this._size || this._size.width !== size.width || this._size.height !== size.height) {
+      this._size = size
+      this.resizeCb?.(size)
+    }
+  }
+}

--- a/packages/dashboard/lib/decoders/tinyh264.d.ts
+++ b/packages/dashboard/lib/decoders/tinyh264.d.ts
@@ -1,0 +1,7 @@
+// tinyh264 ships no type definitions (package.json has no "types").
+// Minimal ambient declaration for the worker entry we use. init() instantiates
+// the embedded WASM (inlined as a data-URI — no separate .wasm asset) and wires
+// the worker message protocol; see tinyh264.worker.ts for the message shapes.
+declare module 'tinyh264' {
+  export function init(): Promise<void>
+}

--- a/packages/dashboard/lib/decoders/tinyh264.worker.ts
+++ b/packages/dashboard/lib/decoders/tinyh264.worker.ts
@@ -1,0 +1,14 @@
+// Web Worker hosting the tinyh264 (h264bsd) software H.264 decoder.
+//
+// Why a worker: software decode is CPU-bound; running it off the main thread keeps
+// rendering / pointer / recording responsive. The decoder's WASM is inlined as a
+// data-URI inside tinyh264, so there is no separate .wasm asset to serve.
+//
+// Message protocol (handled inside tinyh264's init()):
+//   IN  { type:'decode',  renderStateId, data:ArrayBuffer, offset, length }      — one H.264 access unit (NALs)
+//   IN  { type:'release', renderStateId }
+//   OUT { type:'decoderReady' }                                                  — once, after WASM init
+//   OUT { type:'pictureReady', renderStateId, width, height, data:ArrayBuffer }  — decoded YUV420 (transferable)
+import { init } from 'tinyh264'
+
+init()

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -41,6 +41,7 @@
     "recharts": "2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.4",
+    "tinyh264": "^0.0.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/dashboard/src/__tests__/WASMDecoder.test.ts
+++ b/packages/dashboard/src/__tests__/WASMDecoder.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { WASMDecoder } from '@/lib/decoders/WASMDecoder'
+import type { YUVRenderer } from '@/lib/decoders/WASMDecoder'
+
+// Mock worker: records postMessage (+transfer list), exposes emit() to simulate
+// worker→main messages. Real tinyh264 Worker + WASM are never instantiated in tests.
+function mockWorker() {
+  return {
+    posted: [] as { msg: Record<string, unknown>; transfer?: Transferable[] }[],
+    terminated: false,
+    onmessage: null as ((e: MessageEvent) => void) | null,
+    postMessage(msg: Record<string, unknown>, transfer?: Transferable[]) {
+      this.posted.push({ msg, transfer })
+    },
+    terminate() { this.terminated = true },
+    emit(data: unknown) { this.onmessage?.({ data } as MessageEvent) },
+  }
+}
+
+function mockRenderer(): YUVRenderer & { drawn: { len: number; w: number; h: number }[]; disposed: boolean } {
+  return {
+    drawn: [],
+    disposed: false,
+    init() { return true },
+    drawI420(data: Uint8Array, w: number, h: number) {
+      this.drawn.push({ len: data.length, w, h })
+      return { width: w, height: h }
+    },
+    dispose() { this.disposed = true },
+  }
+}
+
+function setup() {
+  const worker = mockWorker()
+  const renderer = mockRenderer()
+  const d = new WASMDecoder(() => renderer, () => worker as unknown as Worker)
+  return { d, worker, renderer }
+}
+
+function picture(w: number, h: number) {
+  return { type: 'pictureReady', width: w, height: h, data: new Uint8Array(w * h * 3 / 2).buffer, renderStateId: 0 }
+}
+
+describe('WASMDecoder — decode buffering until decoderReady', () => {
+  it('decoderReady 전 decode는 버퍼링되고 worker로 안 보냄', () => {
+    const { d, worker } = setup()
+    d.decode(new Uint8Array([1, 2, 3]).buffer)
+    expect(worker.posted).toHaveLength(0)
+  })
+
+  it('decoderReady 수신 시 버퍼된 프레임을 flush한다', () => {
+    const { d, worker } = setup()
+    d.decode(new Uint8Array([1, 2, 3]).buffer)
+    d.decode(new Uint8Array([4, 5]).buffer)
+    worker.emit({ type: 'decoderReady' })
+    expect(worker.posted).toHaveLength(2)
+    expect(worker.posted[0].msg.type).toBe('decode')
+    expect(worker.posted[0].msg.length).toBe(3)
+    expect(worker.posted[1].msg.length).toBe(2)
+  })
+
+  it('ready 이후 decode는 즉시 전송 + 버퍼 transfer', () => {
+    const { d, worker } = setup()
+    worker.emit({ type: 'decoderReady' })
+    const buf = new Uint8Array([7, 8, 9, 10]).buffer
+    d.decode(buf)
+    expect(worker.posted).toHaveLength(1)
+    expect(worker.posted[0].msg).toMatchObject({ type: 'decode', offset: 0, length: 4, renderStateId: 0 })
+    expect(worker.posted[0].transfer).toEqual([buf]) // zero-copy 전송
+  })
+})
+
+describe('WASMDecoder — pictureReady 렌더', () => {
+  it('YUV 프레임을 렌더러로 그리고 size를 갱신한다', () => {
+    const { d, worker, renderer } = setup()
+    worker.emit({ type: 'decoderReady' })
+    worker.emit(picture(4, 2))
+    expect(renderer.drawn).toEqual([{ len: 12, w: 4, h: 2 }]) // 4*2*3/2=12
+    expect(d.size).toEqual({ width: 4, height: 2 })
+  })
+
+  it('첫 프레임/치수 변경 시 onResize 콜백을 1회 발화한다', () => {
+    const { d, worker } = setup()
+    const onResize = vi.fn()
+    d.onResize(onResize)
+    worker.emit({ type: 'decoderReady' })
+    worker.emit(picture(640, 480))
+    worker.emit(picture(640, 480)) // 동일 치수 → 추가 호출 없음
+    worker.emit(picture(480, 640)) // 회전 → 재발화
+    expect(onResize).toHaveBeenCalledTimes(2)
+    expect(onResize).toHaveBeenLastCalledWith({ width: 480, height: 640 })
+  })
+
+  it('pictureReady마다 onDecodedFrame(present 시각)을 발화한다', () => {
+    const { d, worker } = setup()
+    const onFrame = vi.fn()
+    d.onDecodedFrame(onFrame)
+    worker.emit({ type: 'decoderReady' })
+    worker.emit(picture(4, 2))
+    expect(onFrame).toHaveBeenCalledOnce()
+    expect(typeof onFrame.mock.calls[0][0]).toBe('number') // presentTime
+  })
+})
+
+describe('WASMDecoder — surface / close', () => {
+  it('surface는 canvas다', () => {
+    const { d } = setup()
+    expect(d.surface).toBeInstanceOf(HTMLCanvasElement)
+  })
+
+  it('close는 worker.terminate + renderer.dispose', () => {
+    const { d, worker, renderer } = setup()
+    d.close()
+    expect(worker.terminated).toBe(true)
+    expect(renderer.disposed).toBe(true)
+  })
+})

--- a/packages/dashboard/src/__tests__/YUVWebGLRenderer.test.ts
+++ b/packages/dashboard/src/__tests__/YUVWebGLRenderer.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { YUVWebGLRenderer } from '@/lib/YUVWebGLRenderer'
+
+// ── WebGL2 목 (jsdom은 webgl2 컨텍스트를 제공하지 않음) ──────────────────────
+// WebGLVideoRenderer.test.ts와 동일 패턴: Proxy로 gl.* 호출을 기록, 상수는 이름
+// 문자열로, create*는 truthy 객체로 반환. 실제 픽셀 색(BT.709 변환)은 GL이 없어
+// 검증 불가 → 브라우저 컬러피커 시각검증(캠페인 방법론). 여기선 배선·평면분할 검증.
+function mockGL(throwOn?: string) {
+  const calls: Record<string, unknown[][]> = {}
+  const gl = new Proxy({} as Record<string, unknown>, {
+    get(_t, prop) {
+      if (typeof prop !== 'string') return undefined
+      if (/^[A-Z0-9_]+$/.test(prop)) return prop // GL 상수
+      return (...args: unknown[]) => {
+        ;(calls[prop] ??= []).push(args)
+        if (prop === throwOn) throw new Error(`GL ${prop} threw`)
+        if (prop.startsWith('create')) return { tag: prop }
+        if (prop === 'getAttribLocation' || prop === 'getUniformLocation') return 0
+        return undefined
+      }
+    },
+  })
+  return { gl, calls }
+}
+
+function mockCanvas(gl: unknown | null): HTMLCanvasElement {
+  return {
+    width: 0,
+    height: 0,
+    getContext: (type: string) => (type === 'webgl2' ? gl : null),
+  } as unknown as HTMLCanvasElement
+}
+
+// Combined I420 buffer: Y(w*h) + U(cw*ch) + V(cw*ch), cw=ceil(w/2), ch=ceil(h/2).
+function i420(width: number, height: number): Uint8Array {
+  const cw = (width + 1) >> 1
+  const ch = (height + 1) >> 1
+  return new Uint8Array(width * height + 2 * cw * ch)
+}
+
+describe('YUVWebGLRenderer — init', () => {
+  it('WebGL2 미지원(getContext null)이면 init()=false', () => {
+    expect(new YUVWebGLRenderer(mockCanvas(null)).init()).toBe(false)
+  })
+
+  it('WebGL2 컨텍스트가 있으면 init()=true', () => {
+    expect(new YUVWebGLRenderer(mockCanvas(mockGL().gl)).init()).toBe(true)
+  })
+})
+
+describe('YUVWebGLRenderer — drawI420', () => {
+  it('프레임 크기를 반환한다', () => {
+    const r = new YUVWebGLRenderer(mockCanvas(mockGL().gl))
+    r.init()
+    expect(r.drawI420(i420(100, 200), 100, 200)).toEqual({ width: 100, height: 200 })
+  })
+
+  it('치수가 바뀌면 캔버스를 리사이즈한다', () => {
+    const canvas = mockCanvas(mockGL().gl)
+    const r = new YUVWebGLRenderer(canvas)
+    r.init()
+    r.drawI420(i420(640, 480), 640, 480)
+    expect(canvas.width).toBe(640)
+    expect(canvas.height).toBe(480)
+  })
+
+  it('Y/U/V 3개 평면을 올바른 치수·서브배열로 업로드한다', () => {
+    const { gl, calls } = mockGL()
+    const r = new YUVWebGLRenderer(mockCanvas(gl))
+    r.init()
+    const w = 4, h = 2 // ySize=8, chroma 2x1 → 각 2바이트
+    r.drawI420(i420(w, h), w, h)
+
+    expect(calls.texImage2D).toHaveLength(3)
+    // texImage2D(target, level, internalformat, width, height, border, format, type, pixels)
+    const [y, u, v] = calls.texImage2D
+    expect([y[3], y[4], (y[8] as Uint8Array).length]).toEqual([4, 2, 8]) // Y: w×h
+    expect([u[3], u[4], (u[8] as Uint8Array).length]).toEqual([2, 1, 2]) // U: cw×ch
+    expect([v[3], v[4], (v[8] as Uint8Array).length]).toEqual([2, 1, 2]) // V: cw×ch
+    expect(calls.drawArrays).toBeDefined()
+  })
+
+  it('홀수 치수에서 chroma는 ceil(w/2)·ceil(h/2)', () => {
+    const { gl, calls } = mockGL()
+    const r = new YUVWebGLRenderer(mockCanvas(gl))
+    r.init()
+    const w = 5, h = 3 // cw=3, ch=2
+    r.drawI420(i420(w, h), w, h)
+    const [, u] = calls.texImage2D
+    expect([u[3], u[4], (u[8] as Uint8Array).length]).toEqual([3, 2, 6])
+  })
+
+  it('init 전 drawI420은 null 반환(throw 안 함)', () => {
+    const r = new YUVWebGLRenderer(mockCanvas(mockGL().gl)) // init 미호출
+    expect(r.drawI420(i420(100, 200), 100, 200)).toBeNull()
+  })
+})
+
+describe('YUVWebGLRenderer — dispose', () => {
+  it('GPU 리소스를 해제한다(텍스처 3개/vao/program)', () => {
+    const { gl, calls } = mockGL()
+    const r = new YUVWebGLRenderer(mockCanvas(gl))
+    r.init()
+    r.dispose()
+    expect(calls.deleteTexture).toHaveLength(3)
+    expect(calls.deleteVertexArray).toBeDefined()
+    expect(calls.deleteProgram).toBeDefined()
+  })
+
+  it('init 안 된 상태에서 dispose는 throw 안 함', () => {
+    const r = new YUVWebGLRenderer(mockCanvas(null))
+    r.init()
+    expect(() => r.dispose()).not.toThrow()
+  })
+})

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   build: {
     outDir: 'dist',
   },
+  // ESM worker (tinyh264.worker imports tinyh264) — 'es' format so the worker chunk
+  // can code-split its static imports. Default 'iife' breaks on code-split workers.
+  worker: {
+    format: 'es',
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:4000',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.1
+      tinyh264:
+        specifier: ^0.0.7
+        version: 0.0.7
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4469,6 +4472,9 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyh264@0.0.7:
+    resolution: {integrity: sha512-etkBRgYkSFBdAi2Cqk4sZgi+xWs/vhzNgvjO3z2i4WILeEmORiNqxuQ4URJatrWQ9LPNV3WPWAtzsh/LA/XL/g==}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
@@ -9084,6 +9090,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyh264@0.0.7: {}
 
   tinypool@1.1.1: {}
 


### PR DESCRIPTION
## What

Adds a **software H.264 decode tier** (tinyh264/WASM) behind the existing `Decoder` interface, gated to a DEV `?decoder=wasm` override. **pickDecoder priority is unchanged → zero production impact.** This is the tier-1 LAN-HTTP path: no secure context (unlike WebCodecs) and no media-element buffer (unlike MSE), so it reaches low latency over **plain HTTP**.

This is **PR#1** of the campaign step-2 (WASM) work. The pickDecoder tier flip (make WASM the default for non-secure) is a deliberate follow-up (PR#2), gated on this measurement + an Android-regression guard.

## Why

Campaign measurement showed MSE has a structural ~235ms decode→present latency (the `<video>` media-element buffer), unreachable by the SPS reorder=0 fix. WebCodecs (2.5ms) needs a secure context, so plain-HTTP LAN was stuck on MSE. WASM has no media buffer and needs no secure context — the missing piece for tier-1.

## How

- **tinyh264@0.0.7** (h264bsd; (constrained-)baseline, I/P only — matches the iOS VideoToolbox baseline encoder). WASM is **data-URI inlined**, so there is no separate `.wasm` asset to serve.
- **`WASMDecoder`**: runs tinyh264 in a Web Worker, forwards each Annex B access unit as-is (transferred), renders the I420 output via the new renderer. The concrete decoder is encapsulated behind the worker so it can be swapped (e.g. SIMD build) without touching the renderer/viewer.
- **`YUVWebGLRenderer`**: I420 → 3 `R8` textures → BT.709 *limited*→RGB shader. New, because `WebGLVideoRenderer` uploads `VideoFrame`s (secure-context only).
- **IOSViewer** `?decoder=wasm` dev override; `vite worker.format: 'es'` for the ESM worker.

## Measurement (localhost, `?perf=1&decoder=wasm`)

| path | decode→present p50/p95 | glass→glass p50/p95 |
|------|------------------------|---------------------|
| **WASM static** | **8.7 / 30.4** | **9.6 / 31.5** |
| **WASM scroll** | **14.3 / 37.9** | **16 / 40.3** |
| MSE (static/scroll) | 239 / 229 | 240 / 230 |
| localhost-JPEG (north star) | 12.4 / 9.4 | ≈13 / ≈11 |

~27x / ~16x below MSE, **on par with the localhost-JPEG north star** — over a non-secure-compatible path. Color and feel verified good.

## Test plan

- Unit: **17 new** (`YUVWebGLRenderer` 9, `WASMDecoder` 8) — GL/worker/wasm mocked per the repo's existing pattern. **183 total pass.**
- `tsc --noEmit` clean, `vite build` emits the worker chunk (173KB, wasm inlined).
- Browser: measured via the dev override above (color + latency).

## Not in this PR
- pickDecoder flip (non-secure default → WASM) — **PR#2**, needs an Android profile guard (tinyh264 is baseline-only; scrcpy can emit High profile) + a real LAN-HTTP smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WASM-based H.264 decoder option as an alternative decoding pathway
  * Added WebGL2-based frame rendering capability for improved performance

* **Documentation**
  * Updated streaming latency campaign documentation with decoder tier model specifications, measurement results, and completion milestones

* **Tests**
  * Added comprehensive test coverage for new decoder and rendering implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->