### PR TITLE
fix(android): rotation via locked stream + local intent; fix landscape recording

### DIFF
--- a/packages/android-agent/src/AdbWrapper.ts
+++ b/packages/android-agent/src/AdbWrapper.ts
@@ -138,7 +138,8 @@ export class AdbWrapper {
     return this.runner.execBinary('-s', serial, 'exec-out', 'screencap', '-p')
   }
 
-  async setRotation(serial: string, rotation: 0 | 1): Promise<void> {
+  // rotation is an Android user_rotation value (0=portrait, 3=canonical landscape home-left/punch-right)
+  async setRotation(serial: string, rotation: 0 | 1 | 2 | 3): Promise<void> {
     await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'accelerometer_rotation', '0')
     await this.runner.exec('-s', serial, 'shell', 'settings', 'put', 'system', 'user_rotation', String(rotation))
   }

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -114,7 +114,7 @@ interface DeviceState {
   displayHeight: number
   videoWidth: number   // actual scrcpy video frame dimensions — used for touch coordinates
   videoHeight: number
-  deviceRotation: number
+  landscape: boolean   // rotation intent toggle — only to request device rotation on input:rotate
   lastTouchPx: { x: number; y: number }
   bootSeq: number
   restarting: boolean
@@ -218,7 +218,7 @@ export class AndroidAgent implements DeviceAgent {
         displayHeight: 0,
         videoWidth: 0,
         videoHeight: 0,
-        deviceRotation: 0,
+        landscape: false,
         lastTouchPx: { x: 0, y: 0 },
         bootSeq: 0,
         restarting: false,
@@ -314,9 +314,9 @@ export class AndroidAgent implements DeviceAgent {
     state.touchHelper = touchHelper
 
     const session = new ScrcpySession()
-    const info = await session.start(serial, (rotation) => this.handleRotationNotification(state, rotation))
+    const info = await session.start(serial)
     state.scrcpySession = session
-    state.deviceRotation = 0
+    state.landscape = false
 
     state.displayWidth = info.width
     state.displayHeight = info.height
@@ -390,30 +390,6 @@ export class AndroidAgent implements DeviceAgent {
     } finally {
       state.restarting = false
     }
-  }
-
-  private handleRotationNotification(state: DeviceState, rotation: number): void {
-    if (rotation === state.deviceRotation) return
-    const prevRotation = state.deviceRotation
-    state.deviceRotation = rotation
-
-    // Swap displayW/H when rotation changes by an odd number of 90° steps.
-    // Do NOT call control.updateScreenSize here — scrcpy screenWidth/Height must match
-    // the actual video frame dimensions set in the ScrcpyControl constructor, not the
-    // display orientation. Portrait-locked apps keep portrait video even on a landscape
-    // device; mismatching screenSize causes scrcpy to silently drop all touch events.
-    const quarters = ((rotation - prevRotation) + 4) % 4
-    if (quarters === 1 || quarters === 3) {
-      ;[state.displayWidth, state.displayHeight] = [state.displayHeight, state.displayWidth]
-    }
-
-    logger.info(`rotation ${prevRotation}→${rotation} displaySize=${state.displayWidth}×${state.displayHeight}`)
-
-    this.ws?.send(JSON.stringify({
-      type: 'device:rotate',
-      sessionId: state.sessionId,
-      payload: { rotation, displayWidth: state.displayWidth, displayHeight: state.displayHeight },
-    }))
   }
 
   private async openStreamWs(state: DeviceState): Promise<WebSocket> {
@@ -643,13 +619,13 @@ export class AndroidAgent implements DeviceAgent {
         if (!state) break
         const serial = this.adb.getSerial(state.deviceId)
         if (!serial) break
-        // Toggle portrait (0) ↔ landscape (1); optimistic update — roll back if ADB fails.
-        const prevRotation = state.deviceRotation
-        const targetRotation: 0 | 1 = prevRotation % 2 === 1 ? 0 : 1
-        this.handleRotationNotification(state, targetRotation)
-        this.adb.setRotation(serial, targetRotation).catch(() => {
-          this.handleRotationNotification(state, prevRotation)
-        })
+        // The viewer owns rotation intent locally (CSS); here we only ask the device to
+        // rotate so rotation-capable apps re-layout. user_rotation=3 = canonical landscape
+        // (home-left/punch-right). Portrait-locked apps ignore it — the viewer's CSS handles
+        // their cosmetic rotation, so we don't track or sync device rotation back.
+        const next = !state.landscape
+        state.landscape = next
+        this.adb.setRotation(serial, next ? 3 : 0).catch(() => { state.landscape = !next })
         break
       }
       case 'input:button': {

--- a/packages/android-agent/src/scrcpy/ScrcpyControl.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyControl.ts
@@ -7,24 +7,12 @@ const ACTION_DOWN = 0
 const ACTION_UP = 1
 const ACTION_MOVE = 2
 
-// Server → client device message types
-const DEVICE_MSG_CLIPBOARD = 0
-const DEVICE_MSG_ACK_CLIPBOARD = 1
-const DEVICE_MSG_ROTATION_NOTIFICATION = 4
-
 export class ScrcpyControl {
-  private parseBuf = Buffer.alloc(0)
-
   constructor(
     private readonly socket: Socket,
     private screenWidth: number,
     private screenHeight: number,
-    private readonly onRotation?: (rotation: number) => void,
-  ) {
-    if (onRotation) {
-      socket.on('data', (data: Buffer) => this.handleServerMessage(data))
-    }
-  }
+  ) {}
 
   updateScreenSize(width: number, height: number): void {
     this.screenWidth = width
@@ -66,34 +54,6 @@ export class ScrcpyControl {
     buf.writeInt32BE(0, 6)        // repeat
     buf.writeInt32BE(0, 10)       // metaState
     this.socket.write(buf)
-  }
-
-  private handleServerMessage(data: Buffer): void {
-    this.parseBuf = Buffer.concat([this.parseBuf, data])
-    while (this.parseBuf.length > 0) {
-      const type = this.parseBuf[0]
-      if (type === DEVICE_MSG_ROTATION_NOTIFICATION) {
-        // [type(1), rotation(1)] — total 2 bytes
-        if (this.parseBuf.length < 2) return
-        const rotation = this.parseBuf[1]
-        this.parseBuf = Buffer.from(this.parseBuf.subarray(2))
-        this.onRotation!(rotation)
-      } else if (type === DEVICE_MSG_CLIPBOARD) {
-        // [type(1), seq(8), clip_len(4), clip(N)]
-        if (this.parseBuf.length < 13) return
-        const clipLen = this.parseBuf.readUInt32BE(9)
-        if (this.parseBuf.length < 13 + clipLen) return
-        this.parseBuf = Buffer.from(this.parseBuf.subarray(13 + clipLen))
-      } else if (type === DEVICE_MSG_ACK_CLIPBOARD) {
-        // [type(1), seq(8)] — total 9 bytes
-        if (this.parseBuf.length < 9) return
-        this.parseBuf = Buffer.from(this.parseBuf.subarray(9))
-      } else {
-        // Unknown type — discard buffer to avoid getting stuck
-        this.parseBuf = Buffer.alloc(0)
-        return
-      }
-    }
   }
 
   private writeTouchEvent(action: number, pointerId: number, x: number, y: number): void {

--- a/packages/android-agent/src/scrcpy/ScrcpySession.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpySession.ts
@@ -63,7 +63,7 @@ export class ScrcpySession {
     return this._control
   }
 
-  async start(serial: string, onRotation?: (rotation: number) => void): Promise<ScrcpyDeviceInfo> {
+  async start(serial: string): Promise<ScrcpyDeviceInfo> {
     const adb = getAdbPath()
     const port = allocatePort()
     this.port = port
@@ -83,6 +83,11 @@ export class ScrcpySession {
       'max_fps=30',
       'audio=false',
       'stay_awake=true',         // prevent device display from sleeping during capture
+      // Lock the captured stream to portrait so device rotation never resizes it (no SPS
+      // re-init → no decoder reset / black flash). Rotation is shown client-side via CSS,
+      // matching the iOS viewer; rotation-capable apps still re-layout (we set user_rotation)
+      // and scrcpy rotates that content into the locked portrait frame, which CSS undoes.
+      'capture_orientation=@0',
       'send_device_meta=true',   // 64-byte name + codec-id + width + height header
       'send_frame_meta=false',   // raw Annex B stream (no length prefix per frame)
       'send_dummy_byte=false',   // skip the 1-byte connection-check byte
@@ -114,7 +119,7 @@ export class ScrcpySession {
       this._video = new ScrcpyVideo(this.videoSocket)
       const info = await this._video.deviceInfo()
 
-      this._control = new ScrcpyControl(this.controlSocket, info.width, info.height, onRotation)
+      this._control = new ScrcpyControl(this.controlSocket, info.width, info.height)
       logger.info(`ready — ${info.deviceName} ${info.width}×${info.height}`)
       return info
     } catch (e) {

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -54,7 +54,6 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   const [installError, setInstallError] = useState<string | null>(null);
   const [bootError, setBootError] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
-  const [deviceRotation, setDeviceRotation] = useState(0);
   const [swKeyboardVisible, setSwKeyboardVisible] = useState(false);
   const [swKeyboardPending, setSwKeyboardPending] = useState(false);
 
@@ -79,10 +78,6 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       setInstallError(null);
       setBootError(null);
       setChrome(null); // causes active viewer to unmount → cleanup
-      setDeviceRotation(0);
-    }
-    if (msg.type === 'device:rotate') {
-      setDeviceRotation(msg.payload.rotation);
     }
     if (msg.type === 'device:ready') {
       setDeviceReady(true);
@@ -179,7 +174,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   return (
     <>
       {iosChrome && <IOSViewer {...commonProps} chrome={iosChrome} perfHookRef={devPerfHookRef} />}
-      {androidChrome && <AndroidViewer {...commonProps} androidButtons={androidChrome.buttons} screenWidth={androidChrome.screenWidth} screenHeight={androidChrome.screenHeight} deviceRotation={deviceRotation} perfHookRef={devPerfHookRef} />}
+      {androidChrome && <AndroidViewer {...commonProps} androidButtons={androidChrome.buttons} screenWidth={androidChrome.screenWidth} screenHeight={androidChrome.screenHeight} perfHookRef={devPerfHookRef} />}
       {import.meta.env.DEV && perfMode && perfVisible && (
         <>
           <StatsOverlay perfHookRef={statsRef} />

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -41,7 +41,6 @@ interface AndroidViewerProps {
   onRecordingUploaded?: () => void;
   screenWidth?: number;
   screenHeight?: number;
-  deviceRotation?: number;
   perfHookRef?: MutableRefObject<PerfHook>;
 }
 
@@ -50,7 +49,7 @@ export function AndroidViewer({
   deviceReady, installing, installed, installError, bootError,
   launching, setLaunching, androidButtons,
   binaryFrameHandlerRef, onRecordingUploaded,
-  screenWidth, screenHeight, deviceRotation = 0,
+  screenWidth, screenHeight,
   perfHookRef,
 }: AndroidViewerProps) {
   const surfaceHostRef = useRef<HTMLDivElement>(null);
@@ -64,6 +63,9 @@ export function AndroidViewer({
   const [decoderUnsupported, setDecoderUnsupported] = useState(false);
   const videoSizeRef = useRef<{ width: number; height: number } | null>(null);
   const [videoSize, setVideoSize] = useState<{ width: number; height: number } | null>(null);
+  // Rotation intent is owned locally (iOS IOSViewer pattern). It only drives CSS shell
+  // rotation for portrait-locked apps; rotation-capable apps follow the actual stream.
+  const [userWantsLandscape, setUserWantsLandscape] = useState(false);
 
   const [keyboardActive, setKeyboardActive] = useState(false);
   const [pinchActive, setPinchActive] = useState(false);
@@ -123,55 +125,63 @@ export function AndroidViewer({
   // ── Recording (composeFrame only — state/refs/lifecycle in useClientRecording) ──
   const composeFrame = useCallback(() => {
     const rc = recordCanvasRef.current; const fc = decoderRef.current?.surface
-    if (!rc || !fc) return
+    const size = videoSizeRef.current
+    if (!rc || !fc || !size) return
     const ctx = rc.getContext('2d')
     if (!ctx) return
 
-    ctx.drawImage(fc, 0, 0, rc.width, rc.height)
+    // rc was sized to the displayed orientation at record start (handleRecordToggle; MediaRecorder
+    // fixed the dimensions then). If rc's orientation differs from the frame's, the shell was
+    // CSS-rotated — bake the same rotation so the recording is landscape too; otherwise draw 1:1.
+    const fw = size.width; const fh = size.height
+    const css = (rc.width > rc.height) !== (fw > fh)
 
-    // Draw overlays in CSS pixel space so coordinates/radii match the display
-    const dpr = window.devicePixelRatio || 1
-    const cssW = rc.width / dpr; const cssH = rc.height / dpr
     ctx.save()
-    ctx.scale(dpr, dpr)
+    if (css) { ctx.translate(rc.width, 0); ctx.rotate(Math.PI / 2) } // CSS rotate(90deg) = clockwise
+    ctx.drawImage(fc, 0, 0, fw, fh)
+
+    // Overlays in normalized × frame space; radii scaled CSS-px → native-px to match the live view.
+    const longSide = Math.max(fw, fh)
+    const s = longSide > MAX_ANDROID_LONG ? longSide / MAX_ANDROID_LONG : 1
+    const ringR = CURSOR_RING_R * s; const dotR = CURSOR_DOT_R * s
 
     const ph = pinchHintRef.current
     if (ph) {
       for (const f of [ph.f0, ph.f1]) {
-        const cx = f.x * cssW; const cy = f.y * cssH
+        const cx = f.x * fw; const cy = f.y * fh
         if (isPinchMode.current) {
-          ctx.beginPath(); ctx.arc(cx, cy, CURSOR_DOT_R, 0, Math.PI * 2)
+          ctx.beginPath(); ctx.arc(cx, cy, dotR, 0, Math.PI * 2)
           ctx.fillStyle = 'rgba(255,255,255,0.92)'; ctx.fill()
-          ctx.strokeStyle = 'rgba(0,0,0,0.2)'; ctx.lineWidth = 1; ctx.stroke()
+          ctx.strokeStyle = 'rgba(0,0,0,0.2)'; ctx.lineWidth = s; ctx.stroke()
         } else {
-          ctx.beginPath(); ctx.arc(cx, cy, CURSOR_RING_R, 0, Math.PI * 2)
-          ctx.strokeStyle = 'rgba(0,0,0,0.3)'; ctx.lineWidth = 3; ctx.stroke()
-          ctx.beginPath(); ctx.arc(cx, cy, CURSOR_RING_R, 0, Math.PI * 2)
-          ctx.strokeStyle = 'rgba(255,255,255,0.65)'; ctx.lineWidth = 1.5; ctx.stroke()
+          ctx.beginPath(); ctx.arc(cx, cy, ringR, 0, Math.PI * 2)
+          ctx.strokeStyle = 'rgba(0,0,0,0.3)'; ctx.lineWidth = 3 * s; ctx.stroke()
+          ctx.beginPath(); ctx.arc(cx, cy, ringR, 0, Math.PI * 2)
+          ctx.strokeStyle = 'rgba(255,255,255,0.65)'; ctx.lineWidth = 1.5 * s; ctx.stroke()
         }
       }
     }
 
     const cp = cursorPosRef.current
     if (cp) {
+      const cx = cp.x * fw; const cy = cp.y * fh
       const state = cursorStateRef.current; const ra = releaseAnimRef.current
       if (state === 'down') {
-        ctx.beginPath(); ctx.arc(cp.x, cp.y, CURSOR_DOT_R, 0, Math.PI * 2)
+        ctx.beginPath(); ctx.arc(cx, cy, dotR, 0, Math.PI * 2)
         ctx.fillStyle = 'rgba(255,255,255,0.92)'; ctx.fill()
-        ctx.strokeStyle = 'rgba(0,0,0,0.2)'; ctx.lineWidth = 1; ctx.stroke()
+        ctx.strokeStyle = 'rgba(0,0,0,0.2)'; ctx.lineWidth = s; ctx.stroke()
       } else if (state === 'release' && ra) {
         const t = Math.min((performance.now() - ra.startTime) / 350, 1)
-        ctx.beginPath(); ctx.arc(cp.x, cp.y, CURSOR_DOT_R + 26 * t, 0, Math.PI * 2)
-        ctx.strokeStyle = `rgba(255,255,255,${(1 - t) * 0.55})`; ctx.lineWidth = 1.5; ctx.stroke()
+        ctx.beginPath(); ctx.arc(cx, cy, dotR + 26 * s * t, 0, Math.PI * 2)
+        ctx.strokeStyle = `rgba(255,255,255,${(1 - t) * 0.55})`; ctx.lineWidth = 1.5 * s; ctx.stroke()
         if (t >= 1) { cursorStateRef.current = 'idle'; releaseAnimRef.current = null }
       } else {
-        ctx.beginPath(); ctx.arc(cp.x, cp.y, CURSOR_RING_R, 0, Math.PI * 2)
-        ctx.strokeStyle = 'rgba(0,0,0,0.3)'; ctx.lineWidth = 3; ctx.stroke()
-        ctx.beginPath(); ctx.arc(cp.x, cp.y, CURSOR_RING_R, 0, Math.PI * 2)
-        ctx.strokeStyle = 'rgba(255,255,255,0.65)'; ctx.lineWidth = 1.5; ctx.stroke()
+        ctx.beginPath(); ctx.arc(cx, cy, ringR, 0, Math.PI * 2)
+        ctx.strokeStyle = 'rgba(0,0,0,0.3)'; ctx.lineWidth = 3 * s; ctx.stroke()
+        ctx.beginPath(); ctx.arc(cx, cy, ringR, 0, Math.PI * 2)
+        ctx.strokeStyle = 'rgba(255,255,255,0.65)'; ctx.lineWidth = 1.5 * s; ctx.stroke()
       }
     }
-
     ctx.restore()
   }, [])
 
@@ -191,10 +201,12 @@ export function AndroidViewer({
   const handleRecordToggle = useCallback(() => {
     if (recordState === 'idle') {
       const rc = recordCanvasRef.current; if (!rc) return
-      const dpr = window.devicePixelRatio || 1
-      const container = containerRef.current
-      if (container && container.clientWidth > 0) { rc.width = container.clientWidth * dpr; rc.height = container.clientHeight * dpr }
-      else { const size = videoSizeRef.current; if (size) { rc.width = size.width; rc.height = size.height } else return }
+      // Size the record canvas to the displayed orientation (frame-native, swapped when the
+      // shell is CSS-rotated) so the recording keeps aspect AND matches what's on screen (#179).
+      const size = videoSizeRef.current; if (!size) return
+      const css = needsCSSRotationRef.current
+      rc.width = css ? size.height : size.width
+      rc.height = css ? size.width : size.height
       startClientRecording(composeFrame)
     } else if (recordState === 'recording') {
       stopClientRecording()
@@ -203,7 +215,16 @@ export function AndroidViewer({
 
   const handleRotate = useCallback(() => {
     send({ type: 'input:rotate', sessionId })
+    setUserWantsLandscape((prev) => !prev)
   }, [send, sessionId])
+
+  // Reset device orientation to portrait on unmount if we left it in landscape (iOS pattern).
+  const userWantsLandscapeRef = useRef(userWantsLandscape)
+  useEffect(() => { userWantsLandscapeRef.current = userWantsLandscape }, [userWantsLandscape])
+  useEffect(() => {
+    return () => { if (userWantsLandscapeRef.current) send({ type: 'input:rotate', sessionId }) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // ── Keyboard forwarding ───────────────────────────────────────────────────
   useEffect(() => {
@@ -286,7 +307,7 @@ export function AndroidViewer({
     touchStartPos.current = pos
     ;(e.target as Element).setPointerCapture(e.pointerId)
     const _rect = (e.currentTarget as Element).getBoundingClientRect()
-    cursorPosRef.current = { x: e.clientX - _rect.left, y: e.clientY - _rect.top }
+    cursorPosRef.current = pos // normalized — composeFrame maps to record-canvas (native) space
     cursorStateRef.current = 'down'; releaseAnimRef.current = null
     const _lc = liveCursorRef.current
     if (_lc) {
@@ -310,7 +331,7 @@ export function AndroidViewer({
       const _r = (e.currentTarget as Element).getBoundingClientRect()
       const _lc = liveCursorRef.current
       if (norm) {
-        cursorPosRef.current = { x: e.clientX - _r.left, y: e.clientY - _r.top }
+        cursorPosRef.current = norm // normalized — see composeFrame
         if (cursorStateRef.current !== 'down') cursorStateRef.current = 'idle'
         if (_lc) {
           _lc.style.display = 'block'
@@ -343,7 +364,7 @@ export function AndroidViewer({
     if (now - lastMoveSentAt.current < MOVE_THROTTLE_MS) return
     lastMoveSentAt.current = now
     const _r = (e.currentTarget as Element).getBoundingClientRect()
-    cursorPosRef.current = { x: e.clientX - _r.left, y: e.clientY - _r.top }
+    cursorPosRef.current = pos // normalized — see composeFrame
     const _lc = liveCursorRef.current
     if (_lc && _lc.style.display !== 'none') {
       _lc.style.left = `${e.clientX - _r.left}px`; _lc.style.top = `${e.clientY - _r.top}px`
@@ -393,11 +414,12 @@ export function AndroidViewer({
   const androidDisplayW = effectiveSize ? Math.round(effectiveSize.width * androidScale) : 324;
   const androidDisplayH = effectiveSize ? Math.round(effectiveSize.height * androidScale) : 720;
 
-  // CSS rotation: applied when device is landscape but video content is portrait (portrait-locked app).
-  // Matches native Android emulator behavior — chrome rotates even when app content stays portrait.
-  const isLandscapeDevice = deviceRotation === 1 || deviceRotation === 3;
+  // CSS rotation: applied when the user requested landscape but the video content is still
+  // portrait (portrait-locked app). Matches native Android emulator — the shell rotates even
+  // when app content stays portrait. Rotation-capable apps make the stream landscape, so they
+  // display naturally (any landscape direction stays upright — scrcpy mirrors the real display).
   const isLandscapeContent = effectiveSize ? effectiveSize.width > effectiveSize.height : false;
-  const needsCSSRotation = isLandscapeDevice && !isLandscapeContent;
+  const needsCSSRotation = userWantsLandscape && !isLandscapeContent;
   useLayoutEffect(() => { needsCSSRotationRef.current = needsCSSRotation }, [needsCSSRotation])
   // Container uses landscape dims; canvas inside rotated 90° to show portrait content in landscape shell
   const containerW = needsCSSRotation ? androidDisplayH : androidDisplayW;

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -138,7 +138,6 @@ export type RelayMessage =
   | { type: 'device:booting' }
   | { type: 'device:ready'; payload: { deviceId: string } }
   | { type: 'device:boot-error'; message: string }
-  | { type: 'device:rotate'; payload: { rotation: number; displayWidth: number; displayHeight: number } }
   | { type: 'device:shutdown'; sessionId: string; payload: { deviceId: string } }
   | { type: 'device:shutdown-done'; payload: { deviceId: string } }
   | { type: 'input:touch:start'; sessionId: string; payload: { x: number; y: number } }

--- a/packages/relay/CLAUDE.md
+++ b/packages/relay/CLAUDE.md
@@ -27,7 +27,7 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 
 - The agent connects to the relay via outbound WebSocket first (the key to NAT traversal).
 - JSON messages and binary frames share the same WebSocket connection, branched by the `isBinary` flag.
-- Control message protocol: `input:touch:*`, `input:pinch:*`, `input:button`, `input:key`, `input:type`, `input:rotate`, `input:keyboard:toggle`, `device:boot`, `device:rotate`, `device:shutdown`, `session:start`, `session:end`.
+- Control message protocol: `input:touch:*`, `input:pinch:*`, `input:button`, `input:key`, `input:type`, `input:rotate`, `input:keyboard:toggle`, `device:boot`, `device:shutdown`, `session:start`, `session:end`.
 - JWTs are issued based on team invite links.
 - Serves the `public/` directory as HTTP static files (dashboard build output).
 - The relay does not buffer stream data — it forwards immediately on arrival.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -60,7 +60,7 @@ const RESOURCE_THRESHOLD = Number.isFinite(_parsedThreshold) ? _parsedThreshold 
 const AGENT_MSG_TYPES = new Set([
   'agent:register', 'agent:resources', 'screenshot:done', 'screenshot:error',
   'device:booting', 'device:boot-error', 'device:shutdown-done', 'device:ready',
-  'device:rotate', 'session:chrome', 'session:deviceInfo',
+  'session:chrome', 'session:deviceInfo',
   'app:install-done', 'app:install-error', 'app:launch-done', 'app:launch-error',
   'open-url:done', 'open-url:error', 'keyboard:toggled',
 ])
@@ -460,13 +460,6 @@ export class RelayServer {
         if (!session) break
         this.sessions.updateDeviceStatus(session.id, 'booted')
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
-          session.browserSocket.send(JSON.stringify(msg))
-        }
-        break
-      }
-      case 'device:rotate': {
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
         break

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -16,7 +16,6 @@ export type MessageType =
   | 'device:booting'
   | 'device:ready'
   | 'device:boot-error'
-  | 'device:rotate'
   | 'device:shutdown'
   | 'device:shutdown-done'
   | 'app:install'


### PR DESCRIPTION
## What

Fixes Android live-viewer rotation desync (#178) and landscape recording distortion (#179).

## Root cause

`deviceRotation` was an **optimistic agent toggle** (never reconciled with reality), tangled with a **dead scrcpy rotation notification** (`DEVICE_MSG` type 4 doesn't exist in scrcpy 3.1 — it never fired) and the video-size signal. The current state was a regression: a prior `#110` revert removed the `capture_orientation=@0` stream lock from the coherent rotation design, leaving an incoherent mix.

## Changes

**agent (`android-agent`)**
- Lock the scrcpy stream to portrait (`capture_orientation=@0`) — device rotation no longer resizes the stream (no SPS re-init / decoder reset, no black flash).
- Remove dead `ROTATION_NOTIFICATION` parsing, `onRotation` plumbing, optimistic `deviceRotation` tracking, and `device:rotate` emission.
- `input:rotate` now just toggles `user_rotation` 0↔3 (canonical landscape = home-left/punch-right) so rotation-capable apps re-layout; portrait-locked apps are handled client-side by CSS.

**relay**
- Drop the `device:rotate` message (union type, route case, agent allowlist, protocol doc). Forward-only message, relay co-serves the dashboard → not a meaningful breaking change.

**dashboard**
- Own rotation intent locally (`userWantsLandscape`), mirroring the iOS viewer. `needsCSSRotation = userWantsLandscape && !isLandscapeContent`. Reset device orientation on unmount.
- **Recording (#179):** record at the displayed orientation (bake CSS rotation when the shell is rotated), draw the frame 1:1 at native resolution, map cursor/pinch overlays in normalized × record-canvas space — fixes the landscape distortion / portrait-only recording.

## Verification

- `pnpm typecheck` (9/9), `pnpm lint` (7/7), tests green (relay 168, dashboard 174, android-agent 59).
- Manually verified on emulator: rotation-capable apps + portrait-locked apps rotate correctly, touch aligned, no stuck state, landscape recording correct (rotate-then-record).

## Known follow-ups (not blocking)

- Brief black frame on rotation for apps that re-layout (app-level redraw, deprioritized).
- `record-then-rotate` keeps the start orientation (MediaRecorder fixes canvas dimensions at capture start) — rotate before recording for landscape output.

Closes #178
Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extended device rotation values, enabling broader orientation handling for Android devices.

* **Refactor**
  * Improved internal device rotation and orientation state management system for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->