### PR TITLE
fix(dashboard): align side-button pressed image Y with normal button

### DIFF
--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -720,7 +720,7 @@ export function IOSViewer({
                     <img src={`data:image/png;base64,${btn.pressedPng}`} style={{
                       position: 'absolute', zIndex: btn.onTop ? 3 : 1,
                       left: `${isTopAnchor ? rolloverLeftPct : isHovered ? hoverLeftPct : rolloverLeftPct}%`,
-                      top: `${isTopAnchor ? (isHovered ? hoverTopPct : imgTopPct) : (btn.pressedRect.y / chrome.compositeHeight) * 100}%`,
+                      top: `${isTopAnchor ? (isHovered ? hoverTopPct : imgTopPct) : imgTopPct}%`,
                       width: `${(btn.pressedRect.width / chrome.compositeWidth) * 100}%`,
                       height: `${(btn.pressedRect.height / chrome.compositeHeight) * 100}%`,
                       pointerEvents: 'none', userSelect: 'none',


### PR DESCRIPTION
## 문제

iOS 뷰어에서 Sleep/Wake 같은 **좌/우 side 버튼**을 클릭하면, 눌림 이미지가 정상 버튼보다 `buttonH/2`만큼 아래로 내려앉아 "버튼 아래 버튼이 생기는" 현상이 있었습니다. 원래는 hover의 X 시프트로 누름 모션이 표현되고 눌림 이미지는 같은 자리에서 텍스처만 교체돼야 합니다.

| 정상(hover) | 버그(click) |
|---|---|
| 버튼이 올바른 물리 위치 | 눌림 이미지가 ~58.5px(=buttonH/2) 아래로 떨어짐 |

## 원인

커밋 `149b952`가 side 버튼의 `buttonPng`·tooltip top을 `normalOffset.y` → `normalOffset.y - buttonH/2`로 올렸지만, 눌림 이미지의 top(`pressedRect.y`)은 같이 올리지 않았습니다. 그래서 normal/hover는 정상인데 클릭 시에만 눌림 이미지가 옛 위치(아래)에 남아 어긋났습니다.

실제 기기 데이터(`phone13`, Sleep/Wake)로 확인:
- `anchor: right`, 에셋 `16×117`, `normal.y == rollover.y == 262`
- 정상 버튼 top = `262 - 58.5 = 203.5`, 눌림 이미지 top = `262` → 정확히 `buttonH/2` 차이

## 수정

`IOSViewer.tsx`의 side-button 눌림 이미지 `top`을 정상 버튼과 동일한 `imgTopPct`로 정렬:

\`\`\`diff
- top: \`\${isTopAnchor ? (isHovered ? hoverTopPct : imgTopPct) : (btn.pressedRect.y / chrome.compositeHeight) * 100}%\`,
+ top: \`\${isTopAnchor ? (isHovered ? hoverTopPct : imgTopPct) : imgTopPct}%\`,
\`\`\`

- `image`/`imageDown`은 동일 크기 + `imageDownDrawMode: replace` → 같은 슬롯 텍스처 교체 구조라 같은 rect가 맞음
- bottom 앵커는 `imgTopPct == pressedRect.y`라 영향 없음 → 스코프가 side 버튼에 한정

## 검증

- [x] `tsc --noEmit` 통과
- [x] pre-commit lint/typecheck 통과
- [x] `pnpm build` 성공
- [ ] LAN(:4000)에서 Sleep/Wake 클릭 시 가로(X) 모션만 확인 (리뷰어 수동 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the positioning of pressed-button visual feedback in the iOS device viewer to ensure consistent alignment with hover and anchor positioning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->