### PR TITLE
feat(dashboard): rectangular auth submit button + 404 error page

### DIFF
--- a/packages/dashboard/DESIGN.md
+++ b/packages/dashboard/DESIGN.md
@@ -171,7 +171,7 @@ Apply via the `level` prop on the `Card` component:
 | `rounded-sm` | 4px | Badges, tight inset elements |
 | `rounded-md` | 6px | Form inputs, nav buttons, dropdowns |
 | `rounded-lg` | 8px | Cards (`--radius` default) |
-| `rounded-pill` | 100px | Marketing-scale CTA buttons (Login Sign in) |
+| `rounded-pill` | 100px | Marketing-scale CTA buttons |
 | `rounded-pill-sm` | 64px | Tab ghost pills |
 | `rounded-full` | 9999px | Icon buttons, avatars |
 
@@ -200,9 +200,9 @@ Apply via the `level` prop on the `Card` component:
 |------|--------|-----|
 | `default` | h-10 (40px) | General buttons |
 | `sm` | h-9 (36px) | Form submit, inline actions |
-| `lg` | h-11 (44px) | Emphasized buttons |
+| `lg` | h-11 (44px) | Emphasized buttons, auth form submit (Login, Setup) |
 | `icon` | h-10 w-10 | Square icon buttons |
-| `pill` | h-12 (48px) + `rounded-pill` | Marketing-scale CTA (Login, etc.) |
+| `pill` | h-12 (48px) + `rounded-pill` | Marketing-scale CTA |
 | `nav` | h-7 (28px) + `text-xs` | Table inline, navigation |
 
 ### Cards

--- a/packages/dashboard/components/ErrorPage.tsx
+++ b/packages/dashboard/components/ErrorPage.tsx
@@ -1,0 +1,17 @@
+interface ErrorPageProps {
+  code: string | number
+  message: string
+}
+
+/** Minimal full-screen error state: `code │ message`, centered. Token-only for dark mode. */
+export function ErrorPage({ code, message }: ErrorPageProps) {
+  return (
+    <div className="flex min-h-svh items-center justify-center bg-background p-4">
+      <div className="flex items-center gap-4">
+        <span className="text-lg font-semibold tracking-tight text-foreground">{code}</span>
+        <span className="h-6 w-px bg-border" aria-hidden="true" />
+        <span className="text-sm text-muted-foreground">{message}</span>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { MacResources } from './pages/MacResources'
 import { DefaultSettings } from './pages/settings/Default'
 import { TeamSettings } from './pages/settings/Team'
 import { TokenSettings } from './pages/settings/Tokens'
+import { NotFound } from './pages/NotFound'
 
 export function App() {
   const { resolvedTheme } = useTheme()
@@ -30,8 +31,8 @@ export function App() {
           <Route path="/settings/default" element={<DefaultSettings />} />
           <Route path="/settings/team" element={<TeamSettings />} />
           <Route path="/settings/tokens" element={<TokenSettings />} />
-          <Route path="*" element={<Navigate to="/app-center" replace />} />
         </Route>
+        <Route path="*" element={<NotFound />} />
       </Routes>
       <Toaster position="bottom-right" richColors theme={resolvedTheme as ToasterProps['theme']} />
     </BrowserRouter>

--- a/packages/dashboard/src/pages/Login.tsx
+++ b/packages/dashboard/src/pages/Login.tsx
@@ -79,7 +79,7 @@ export function Login() {
               {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
             </div>
             {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
-            <Button type="submit" size="pill" disabled={isSubmitting} className="w-full mt-1">
+            <Button type="submit" size="lg" disabled={isSubmitting} className="w-full mt-1">
               {isSubmitting ? 'Signing in…' : 'Sign in'}
             </Button>
           </form>

--- a/packages/dashboard/src/pages/NotFound.tsx
+++ b/packages/dashboard/src/pages/NotFound.tsx
@@ -1,0 +1,5 @@
+import { ErrorPage } from '@/components/ErrorPage'
+
+export function NotFound() {
+  return <ErrorPage code={404} message="page not found" />
+}

--- a/packages/dashboard/src/pages/Setup.tsx
+++ b/packages/dashboard/src/pages/Setup.tsx
@@ -99,7 +99,7 @@ export function Setup() {
                 {errors.confirm && <p className="text-sm text-destructive">{errors.confirm.message}</p>}
               </div>
               {errors.root && <p className="text-sm text-destructive">{errors.root.message}</p>}
-              <Button type="submit" size="pill" disabled={isSubmitting} className="w-full mt-1">
+              <Button type="submit" size="lg" disabled={isSubmitting} className="w-full mt-1">
                 {isSubmitting ? 'Creating account…' : 'Create admin account'}
               </Button>
             </form>


### PR DESCRIPTION
대시보드 두 가지 개선.

## 1. 로그인/셋업 submit 버튼

pill 스타일(`h-12` + `rounded-pill 100px`, 마케팅 스케일)이 대시보드 디자인과 안 어울려서, full-width 사각형 CTA로 변경.

- `Login.tsx` / `Setup.tsx`: `size="pill"` → `size="lg"` (`h-11 44px`, `rounded-md 6px`), `w-full` 유지
- `DESIGN.md`의 `pill`/`lg` 용도 설명을 정합성에 맞춰 수정 (pill은 마케팅용으로 유지)

## 2. 404 에러 페이지

대시보드에 에러 페이지가 없어, 모르는 경로가 조용히 `/app-center`로 redirect되던 동작을 개선.

- `components/ErrorPage.tsx` 신규 — `ErrorPage({ code, message })` 재사용 컴포넌트. `코드 │ 메시지` 중앙 정렬, `bg-background`/`text-foreground`/`text-muted-foreground`/`border` 토큰만 사용해 다크모드 자동 대응
- `src/pages/NotFound.tsx` 신규 — `404 / page not found`
- `App.tsx`: `DashboardLayout` 안쪽 catch-all redirect 제거 → 최상위 `*` → `<NotFound/>`. 인증 게이트와 무관하게 404 노출

> API 에러(401/403/500 등)는 기존대로 각 페이지에서 toast로 개별 처리. 런타임 크래시용 ErrorBoundary는 이번 범위에서 제외.

### 동작 변경
- 모르는 경로: 기존 `/app-center` redirect → 404 페이지 노출 (의도한 개선)

## 검증
- [x] `tsc --noEmit`, lint (변경 파일) 통과
- [x] vitest 174개 전부 통과
- [x] `pnpm build` 성공
- [ ] LAN(:4000)에서 버튼/404 라이트·다크 시각 확인 (리뷰어)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dedicated error page displayed when accessing non-existent pages.

* **UI Updates**
  * Button sizes updated in login and setup forms.

* **Documentation**
  * Design system documentation updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->