### PR TITLE
docs(roadmap): add #202 to Phase 4 UX

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,7 @@ drop-to-keyframe — and it continues here.
 
 - [#102](https://github.com/jo-duchan/tapflow/issues/102) — streaming performance improvements (encoding + transport)
 - [#195](https://github.com/jo-duchan/tapflow/issues/195) — optimize capture cadence + touch input path
+- [#202](https://github.com/jo-duchan/tapflow/issues/202) — iOS session recording at native resolution (match Android fidelity)
 - [#156](https://github.com/jo-duchan/tapflow/issues/156) — evaluate WebTransport for relay→browser streaming
 - [#153](https://github.com/jo-duchan/tapflow/issues/153) — app log viewer in the QA session
 


### PR DESCRIPTION
Adds #202 (iOS session recording at native resolution) to the **Phase 4 — Experience / UX — browser testing experience** list in ROADMAP.md, alongside the other capture/streaming-fidelity items.

Recording fidelity directly affects the QA/design review experience (the people who test), so it belongs under Phase 4 UX. Matches the `phase-4` label on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap with Phase 4 (v0.4.0) planned item: iOS session recording at native resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->