### PR TITLE
chore: release v0.5.0 — H.264 streaming pipeline

### DIFF
--- a/.changeset/start-tunnel-banner.md
+++ b/.changeset/start-tunnel-banner.md
@@ -1,7 +1,0 @@
----
-"tapflow": minor
----
-
-feat(cli): `tapflow start`가 `tapflow.config.json`의 tunnel 설정을 읽어 공개 URL을 배너에 출력합니다.
-
-기존에는 `tapflow relay start`에서만 터널(Tailscale/rathole)을 기동했습니다. 이제 로컬 올인원 명령인 `tapflow start`도 동일하게 터널을 띄우고, Tailscale MagicDNS 호스트명(또는 tailnet IP)을 자동 감지해 배너에 `Public :` URL을 표시합니다. 터널 기동 로직은 `lib/tunnel-runner.ts`로 공통화했습니다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-04
+
+### Added
+
+- H.264 streaming pipeline: iOS streams H.264 by default via a VideoToolbox encoder, cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
+- Automatic codec negotiation: the browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG — no black screens on older browsers. Opt out with `TAPFLOW_IOS_CODEC=jpeg`.
+- Tiered browser decoders: HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
+- cli: `tapflow start` prints the public tunnel URL banner (Tailscale MagicDNS host / tailnet IP auto-detected); a missing rathole token now falls back to local-only instead of exiting.
+- dashboard: 404 error page and rectangular auth submit button.
+
 ### Changed
 
+- envelope: codec/keyframe marker added to the frame header (byte5 flags). Backward compatible — older clients read frames as JPEG and the relay forwards payloads untouched; agents without `acceptH264` (version skew) default to JPEG.
 - ios-agent: lower the default JPEG stream quality `0.95` → `0.8`, cutting iOS frame bandwidth ~40% on idle/simple screens to reduce relay→browser frame drops on LAN. Tune with the `TAPFLOW_JPEG_QUALITY` env var (`0`–`1`).
+
+### Fixed
+
+- android: landscape rotation and recording via a locked stream + local intent.
 
 ## [0.4.1] - 2026-06-01
 

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tapflowio/agent-core
 
+## 0.5.0
+
+### Minor Changes
+
+- H.264 streaming pipeline with automatic codec negotiation.
+
+  - iOS streams H.264 by default (VideoToolbox encoder), cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
+  - The browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG — no black screens on older browsers.
+  - Tiered browser decoders: HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
+
+  Backward compatible: the envelope codec/keyframe marker reuses a previously zero flag byte, so older clients read frames as JPEG and the relay forwards payloads untouched. Agents without `acceptH264` (version skew) default to JPEG. Opt out of H.264 anytime with `TAPFLOW_IOS_CODEC=jpeg`.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- 7e4023a: fix(android): landscape rotation and recording via a locked stream + local intent.
 - Updated dependencies
   - @tapflowio/agent-core@0.5.0
 

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/android-agent
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.5.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,9 +12,9 @@
 
   Backward compatible: the envelope codec/keyframe marker reuses a previously zero flag byte, so older clients read frames as JPEG and the relay forwards payloads untouched. Agents without `acceptH264` (version skew) default to JPEG. Opt out of H.264 anytime with `TAPFLOW_IOS_CODEC=jpeg`.
 
-- 267447c: feat(cli): `tapflow start`가 `tapflow.config.json`의 tunnel 설정을 읽어 공개 URL을 배너에 출력합니다.
+- 267447c: feat(cli): `tapflow start` now reads the tunnel config from `tapflow.config.json` and prints the public URL in the startup banner.
 
-  기존에는 `tapflow relay start`에서만 터널(Tailscale/rathole)을 기동했습니다. 이제 로컬 올인원 명령인 `tapflow start`도 동일하게 터널을 띄우고, Tailscale MagicDNS 호스트명(또는 tailnet IP)을 자동 감지해 배너에 `Public :` URL을 표시합니다. 터널 기동 로직은 `lib/tunnel-runner.ts`로 공통화했습니다.
+  Previously only `tapflow relay start` brought up the tunnel (Tailscale/rathole). Now the local all-in-one `tapflow start` starts the tunnel too, auto-detecting the Tailscale MagicDNS hostname (or tailnet IP) and showing a `Public :` URL in the banner. Tunnel startup logic was consolidated into `lib/tunnel-runner.ts`.
 
 ### Patch Changes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,29 @@
 # tapflow
 
+## 0.5.0
+
+### Minor Changes
+
+- H.264 streaming pipeline with automatic codec negotiation.
+
+  - iOS streams H.264 by default (VideoToolbox encoder), cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
+  - The browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG — no black screens on older browsers.
+  - Tiered browser decoders: HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
+
+  Backward compatible: the envelope codec/keyframe marker reuses a previously zero flag byte, so older clients read frames as JPEG and the relay forwards payloads untouched. Agents without `acceptH264` (version skew) default to JPEG. Opt out of H.264 anytime with `TAPFLOW_IOS_CODEC=jpeg`.
+
+- 267447c: feat(cli): `tapflow start`가 `tapflow.config.json`의 tunnel 설정을 읽어 공개 URL을 배너에 출력합니다.
+
+  기존에는 `tapflow relay start`에서만 터널(Tailscale/rathole)을 기동했습니다. 이제 로컬 올인원 명령인 `tapflow start`도 동일하게 터널을 띄우고, Tailscale MagicDNS 호스트명(또는 tailnet IP)을 자동 감지해 배너에 `Public :` URL을 표시합니다. 터널 기동 로직은 `lib/tunnel-runner.ts`로 공통화했습니다.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.5.0
+  - @tapflowio/ios-agent@0.5.0
+  - @tapflowio/relay@0.5.0
+  - @tapflowio/android-agent@0.5.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @tapflowio/ios-agent
 
+## 0.5.0
+
+### Minor Changes
+
+- H.264 streaming pipeline with automatic codec negotiation.
+
+  - iOS streams H.264 by default (VideoToolbox encoder), cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
+  - The browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG — no black screens on older browsers.
+  - Tiered browser decoders: HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
+
+  Backward compatible: the envelope codec/keyframe marker reuses a previously zero flag byte, so older clients read frames as JPEG and the relay forwards payloads untouched. Agents without `acceptH264` (version skew) default to JPEG. Opt out of H.264 anytime with `TAPFLOW_IOS_CODEC=jpeg`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.5.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.4.1-experimental.1",
+  "version": "0.5.0-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @tapflowio/relay
 
+## 0.5.0
+
+### Minor Changes
+
+- H.264 streaming pipeline with automatic codec negotiation.
+
+  - iOS streams H.264 by default (VideoToolbox encoder), cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
+  - The browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG — no black screens on older browsers.
+  - Tiered browser decoders: HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
+
+  Backward compatible: the envelope codec/keyframe marker reuses a previously zero flag byte, so older clients read frames as JPEG and the relay forwards payloads untouched. Agents without `acceptH264` (version skew) default to JPEG. Opt out of H.264 anytime with `TAPFLOW_IOS_CODEC=jpeg`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.5.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## 요약

npm 버전을 `v0.4.1` → **`v0.5.0`** 으로 올린다. 이번 사이클의 핵심은 **스트리밍 파이프라인을 JPEG → H.264로 전환**한 것이라, SemVer 0.x 관례상 minor bump가 맞다.

## 버전 변경

| 대상 | 변경 |
|---|---|
| fixed 그룹 (`tapflow`, `@tapflowio/agent-core`, `@tapflowio/ios-agent`, `@tapflowio/android-agent`, `@tapflowio/relay`) | `0.4.1` → **`0.5.0`** |
| `@tapflowio/mcp-server` (experimental, 수동) | `0.4.1-experimental.1` → **`0.5.0-experimental.1`** |
| `@tapflowio/dashboard` | `0.1.1` 유지 (private, changeset `ignore`) |

## 릴리즈 노트

### Added
- **H.264 streaming pipeline** — iOS streams H.264 by default (VideoToolbox encoder), cutting bandwidth ~10× vs JPEG (~16–27 KB/frame vs ~235 KB) for noticeably lower latency. Android streaming moves to a runtime decoder layer.
- **Automatic codec negotiation** — the browser advertises its decode capability (`acceptH264`) at boot; the agent picks H.264 only when the client can decode it, otherwise falls back to JPEG. No black screens on older browsers. Opt out with `TAPFLOW_IOS_CODEC=jpeg`.
- **Tiered browser decoders** — HTTPS → WebCodecs, plain-HTTP LAN → WASM (tinyh264), both WebGL2-rendered.
- **Tunnel public URL banner** — `tapflow start` prints the public tunnel URL; missing rathole token falls back to local-only instead of exiting.
- dashboard: 404 error page + rectangular auth submit button.

### Changed
- envelope: codec/keyframe marker added to the frame header (byte5 flags).
- ios-agent: default JPEG stream quality `0.95` → `0.8` (~40% idle bandwidth cut).

### Fixed
- android: landscape rotation + recording via locked stream + local intent.

## 호환성 — Backward compatible ✅

프로토콜이 바뀌었지만 **breaking change가 아니다.** 근거(PR #196 수동 e2e + 단위테스트로 입증):
- envelope 마커는 기존 0 플래그 바이트를 재사용 → 구버전 클라이언트는 프레임을 JPEG로 해석.
- relay는 `payload`를 `unknown`으로 그대로 forward (변경 0).
- agent는 `acceptH264` 필드 누락(버전 스큐) 시 JPEG로 안전 폴백 — `IOSAgent.test.ts` `describe('codec negotiation')`의 `defaults to JPEG when acceptH264 is absent (old browser / version skew)`로 회귀 방어됨.
- agent-core `envelope.test.ts`: `reads JPEG / non-keyframe from a default header (backward compatible)`.

**권장:** publish 패키지는 버전을 공유하므로 함께 업그레이드.

## 검증
- pre-commit 훅에서 9개 패키지 lint + typecheck 전부 통과.
- changeset 2개(`start-tunnel-banner`, `h264-streaming-pipeline`) 소비, `workspace:*` 표기라 lockfile 변경 없음.

## 머지 후
머지하면 `changeset publish`가 npm publish + 태그를 처리한다. (이 PR은 직접 머지해 주세요.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * H.264 streaming pipeline with automatic codec negotiation and JPEG fallback for older browsers
  * CLI start command now honors tunnel configuration and shows a public URL banner
  * Tiered browser decoders (WebCodecs → WASM) and improved decoder negotiation
  * New frame header codec/keyframe marker with backward-compatible handling
  * Option to opt out of H.264 on iOS

* **Bug Fixes**
  * Fixed Android landscape rotation/recording issue
<!-- end of auto-generated comment: release notes by coderabbit.ai -->