### PR TITLE
chore(commands): add /release command for the changesets release flow

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,68 @@
+---
+description: 릴리즈 절차 — 버전 추천부터 릴리즈 PR까지 (changesets, 가이드형)
+model: claude-opus-4-8
+---
+
+다음 npm 릴리즈를 준비한다. 인자로 bump 레벨(`major`/`minor`/`patch`)을 줄 수 있고, 없으면 근거를 모아 직접 추천한다: **$ARGUMENTS**
+
+**가이드형으로 진행한다** — 각 판단 지점에서 멈춰 사용자와 합의하고, 위험 단계 전에 확인받는다. 자동으로 push/merge/publish 하지 않는다.
+
+## 1. 현황 수집 (evidence-based)
+
+- 현재 버전: publish 패키지들의 `package.json`
+- `git log v{latest}..HEAD --oneline`(머지 포함/제외 각각) — feat / fix / perf / breaking 분류
+- 열린 PR: `gh pr list`
+- 대기 중인 changeset: `.changeset/*.md`
+- `.changeset/config.json`의 `fixed` / `ignore` 그룹 재확인
+
+## 2. bump 레벨 추천 → 사용자 합의
+
+- SemVer 0.x 기준: feat 추가 = **minor**, 버그픽스만 = **patch**, 1.0 승격은 별도 논의(안정성 선언이라 아껴둔다).
+- 이번 사이클의 **테마 한 줄**을 뽑는다(릴리즈노트 제목이 된다).
+- 프로토콜/인터페이스 변경 커밋이 있으면 → 3번 호환성 검증.
+- **추천 버전을 제시하고 합의를 받은 뒤** 진행한다.
+
+## 3. 호환성 검증 (프로토콜/인터페이스 변경 시에만)
+
+- 변경 범주: WebSocket envelope/메시지, 공개 API 시그니처, CLI 커맨드·플래그, DB 스키마.
+- 있으면 **새 e2e를 돌리지 말고**, 해당 PR의 기존 검증 + 단위테스트의 backward-compat 케이스를 코드로 확인한다.
+  (예: `agent-core/envelope.test.ts`의 `backward compatible` 케이스, `ios-agent` `codec negotiation`의 version-skew 폴백 케이스)
+- backward-compat면 minor로 충분 → 릴리즈노트에 "호환 유지" 근거 인용.
+- 아니면 사용자에게 보고하고 릴리즈노트 상단에 경고 + breaking 여부 재논의.
+
+## 4. 브랜치
+
+- `git checkout main && git pull origin main` — 항상 최신 main에서 시작.
+- `git checkout -b release/vX.Y.Z`
+
+## 5. changeset 작성/보완
+
+- 이번 테마를 담은 changeset이 없으면 추가한다(기본 changelog 생성기는 changeset 본문만 CHANGELOG에 넣으므로, 핵심 변경이 changeset에 없으면 누락된다).
+- **fixed 그룹**(`tapflow`·`agent-core`·`ios-agent`·`android-agent`·`relay`)은 멤버 하나만 명시해도 5개가 동반 bump되지만, CHANGELOG 본문은 명시된 패키지에만 들어간다 → 본문이 필요한 핵심 패키지를 모두 명시한다.
+
+## 6. 버전 적용
+
+- `pnpm changeset version`
+- fixed 그룹 5개가 함께 `X.Y.Z`로 올랐는지, changeset 파일이 소비됐는지 확인.
+
+## 7. 이 레포 전용 수동 단계 (놓치기 가장 쉬움)
+
+- **mcp-server**: `.changeset` `ignore` 대상이라 자동 bump 안 됨 → `package.json` version을 **`X.Y.Z-experimental.1`** 로 수동 변경(experimental dist-tag, graduation 전까지 수동).
+- **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
+- **dashboard**: private + `ignore` → 건드리지 않는다.
+
+## 8. 검증
+
+- lint / typecheck(pre-commit 훅이 잡지만 미리 확인 가능).
+- 내부 의존성이 `workspace:*`라 lockfile 변경은 없어야 정상 — 변경이 생겼으면 의심한다.
+
+## 9. 커밋 → STOP
+
+- `chore: release vX.Y.Z — {테마}` 로 커밋.
+- **여기서 멈추고 push/PR 진행 여부를 사용자에게 확인한다.**
+
+## 10. push + PR (확인 후에만)
+
+- `git push -u origin release/vX.Y.Z`
+- `gh pr create --base main` — 본문에 버전 표 + 릴리즈노트 + 호환성 근거.
+- **PR을 머지하지 않는다.** 머지는 사용자 몫. 머지 후 `changeset publish`가 npm publish + 태그를 처리한다(mcp-server는 experimental dist-tag로 별도 publish).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Work logs go in `.work/`. Conventions: [.work/CLAUDE.md](./.work/CLAUDE.md).
 3. **Review** — edge cases + real data validation → PR (`type: review`).
 4. **Compound** — extract repeating patterns into test + code + prompt bundles (`type: compound`).
 
-Custom commands: `/work-plan {topic}` · `/deep-research {problem}` · `/qa {target}` · `/doc-sync` · `/compound`.
+Custom commands: `/work-plan {topic}` · `/deep-research {problem}` · `/qa {target}` · `/doc-sync` · `/compound` · `/release {major|minor|patch}`.
 
 ### Design Principles (SOLID — priority subset)
 


### PR DESCRIPTION
## 요약

`/release` 슬래시 커맨드를 추가한다. v0.5.0 릴리즈를 진행하며 매번 반복되고 놓치기 쉬운 **이 레포만의 릴리즈 함정**을 가이드형 절차로 코드화했다.

## 왜

릴리즈 절차에 이 레포 특유의 수동 단계가 섞여 있어 매번 빠뜨리기 쉽다:
- **fixed 그룹** — changeset 하나로 `tapflow`·`agent-core`·`ios-agent`·`android-agent`·`relay` 5개가 동반 bump
- **mcp-server** — `.changeset` `ignore` 대상이라 자동 안 됨 → `X.Y.Z-experimental.1` 수동 bump (가장 놓치기 쉬움)
- **루트 `CHANGELOG.md`** — changeset 관리 밖(Keep a Changelog) → `[Unreleased]` → `[X.Y.Z]` 수동 승격
- **dashboard** — private + `ignore` → 손대지 않음

## 동작 방식 — 가이드형

`/release [major|minor|patch]`. 각 판단 지점에서 멈춰 합의하고, 위험 단계 전에 확인받는다. 자동으로 push/merge/publish 하지 않는다.

1. 현황 수집(버전·git log·열린 PR·대기 changeset·fixed/ignore 그룹)
2. bump 레벨 추천 → **사용자 합의**
3. 호환성 검증(프로토콜 변경 시 새 e2e 대신 기존 테스트 backward-compat 케이스 확인)
4. main 최신화 → `release/vX.Y.Z`
5. changeset 작성/보완
6. `changeset version`
7. **레포 전용 수동 단계**(mcp-server·루트 CHANGELOG·dashboard)
8. lint/typecheck·lockfile 검증
9. 커밋 → **STOP**
10. push + PR (머지·publish는 사용자)

## 동반 변경

- `CLAUDE.md`의 `Custom commands:` 줄에 `/release` 추가.

## 검증

- pre-commit 훅에서 9개 패키지 lint + typecheck 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/release` command enabling SemVer-based version management with major, minor, and patch bump options.

* **Documentation**
  * Added release procedure guide with structured workflow documentation.
  * Updated command reference to include the new `/release` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->