### PR TITLE
docs(commands): fix /release publish step — tag push is the real trigger

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -65,4 +65,16 @@ model: claude-opus-4-8
 
 - `git push -u origin release/vX.Y.Z`
 - `gh pr create --base main` — 본문에 버전 표 + 릴리즈노트 + 호환성 근거.
-- **PR을 머지하지 않는다.** 머지는 사용자 몫. 머지 후 `changeset publish`가 npm publish + 태그를 처리한다(mcp-server는 experimental dist-tag로 별도 publish).
+- **PR을 머지하지 않는다.** 머지는 사용자 몫.
+
+## 11. 머지 후 — 태그 push로 발행 트리거 (놓치면 발행이 안 됨)
+
+`.github/workflows/release.yml`은 **`vX.Y.Z` 태그 push로만** 발동한다. **main 머지만으로는 npm 발행이 일어나지 않는다** — 머지 후 태그를 직접 달아야 한다.
+
+- PR 머지를 확인한 뒤, **머지 커밋에** 태그를 단다(이전 릴리즈와 동일한 방식):
+  `git fetch origin main && git tag vX.Y.Z <머지 커밋 SHA>`
+- **STOP** — 태그 push는 즉시 npm 발행을 유발하는 되돌리기 어려운 작업이다. 사용자 확인 후 진행한다.
+- `git push origin vX.Y.Z`
+- 워크플로우가 처리하는 것: `pnpm build` → `changeset publish`(stable 5종) → `mcp-server`는 experimental dist-tag로 별도 publish → GitHub Release 생성.
+- npm 인증은 **GitHub OIDC(trusted publishing)** 로 동작한다 — NPM_TOKEN 등 별도 토큰이 필요 없다.
+- 발행 확인: Actions의 Release 워크플로우 `success`, `npm view tapflow version`, GitHub Releases 페이지.


### PR DESCRIPTION
## 왜

v0.5.0 릴리즈에서 드러난 문제를 `/release` 커맨드에 반영한다. 기존 10단계는 "머지 후 \`changeset publish\`가 npm publish + 태그를 처리한다"고 적었는데 **사실과 다르다.**

`.github/workflows/release.yml`은 **\`vX.Y.Z\` 태그 push로만** 발동한다 — main 머지만으로는 발행이 안 된다. 실제로 #207을 머지했지만 태그를 안 달아 발행이 멈춰 있었고, 머지 커밋에 \`v0.5.0\` 태그를 push하고 나서야 발행됐다(워크플로우 success 확인).

## 변경

- 10단계의 잘못된 설명 제거.
- **11단계 신설** — 머지 후 머지 커밋에 \`vX.Y.Z\` 태그를 달고(STOP 후) push해 Release 워크플로우를 발동. 발행 인증은 **GitHub OIDC(trusted publishing)**, NPM_TOKEN 불필요로 명시.

## 검증

- v0.5.0 실제 릴리즈에서 이 절차대로 동작 확인(Actions Release `success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release process documentation improved with clearer guidance on PR merge procedures, post-merge release workflows, version tag management, and verification of successful releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->