### PR TITLE
chore(release): drop dead NPM_TOKEN refs — publish via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,10 @@ jobs:
           node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('packages/mcp-server/package.json','utf8'));delete p.private;fs.writeFileSync('packages/mcp-server/package.json',JSON.stringify(p,null,2))"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish mcp-server (experimental)
         continue-on-error: true
         run: pnpm --filter @tapflowio/mcp-server exec npm publish --tag experimental --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## 왜

npm 발행이 **GitHub OIDC(npm trusted publishing)** 로 전환되며 `NPM_TOKEN` 시크릿은 폐기됐다. 그런데 `release.yml`에는 아직 두 곳에 `NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}` 참조가 남아 **빈 시크릿을 가리키는 dead config** 상태다.

## 근거 (evidence)

- 방금 v0.5.0 릴리즈가 **빈 NPM_TOKEN으로 성공적으로 발행**됐다 → 인증이 이미 OIDC로 동작 중이라는 직접 증거.
- npm 확인: \`tapflow@0.5.0\` 외 stable 5종 + \`mcp-server@0.5.0-experimental.1\` 모두 정상 발행됨.

## 변경

- stable publish step: `NODE_AUTH_TOKEN` 라인 제거 (`GITHUB_TOKEN`은 스코프 밖이라 유지).
- experimental publish step: `NODE_AUTH_TOKEN`만 있던 `env:` 블록 제거.
- OIDC 필수 요소인 `permissions.id-token: write`와 `setup-node`의 `registry-url`은 그대로 유지.

## 검증 / 주의

- YAML 구조 유지(들여쓰기 확인 완료).
- 이 변경의 최종 실증은 **다음 릴리즈 태그 push 시**다. 특히 experimental step은 `continue-on-error: true`라 실패해도 워크플로우가 success로 뜨므로, 다음 릴리즈 후 \`npm view @tapflowio/mcp-server dist-tags.experimental\`로 발행 여부를 확인할 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for experimental package publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->