### PR TITLE
chore: release v0.5.1 — Android 15+ rotation capture fix

### DIFF
--- a/.changeset/android-rotation-newer-android.md
+++ b/.changeset/android-rotation-newer-android.md
@@ -1,5 +1,0 @@
----
-"@tapflowio/android-agent": patch
----
-
-Fix Android screen rotation on Android 15+ (API 35+). `AdbWrapper.setRotation` now uses `wm user-rotation lock` instead of the legacy `settings put system user_rotation`, which is silently ignored on newer Android (only a rotation suggestion appears). The bundled scrcpy server is upgraded 3.1 → 3.3, which fixes the locked capture-orientation direction (scrcpy #6010) that left the stream sideways after rotation on API 35+. Verified on API 34 and API 36 emulators.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -49,6 +49,7 @@ model: claude-opus-4-8
 
 - **mcp-server**: `.changeset` `ignore` 대상이라 자동 bump 안 됨 → `package.json` version을 **`X.Y.Z-experimental.1`** 로 수동 변경(experimental dist-tag, graduation 전까지 수동).
 - **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
+  - **하단 compare 링크도 함께 갱신**(놓치기 쉬움): `[Unreleased]`를 `vX.Y.Z...HEAD`로 바꾸고, `[X.Y.Z]: .../compare/v{직전}...vX.Y.Z` 링크를 새로 추가한다. 직전 릴리즈 링크가 빠져 있으면 이번에 함께 메운다.
 - **dashboard**: private + `ignore` → 건드리지 않는다.
 
 ## 8. 검증

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-06
+
+### Fixed
+
+- android: screen rotation on Android 15+ (API 35+). `AdbWrapper.setRotation` now uses `wm user-rotation lock` instead of the legacy `settings put system user_rotation`, which newer Android silently ignores (only a rotation suggestion appears). The bundled scrcpy server is upgraded 3.1 → 3.3, fixing the locked capture-orientation direction (scrcpy #6010) that left the stream sideways after rotation. Verified on API 34 and API 36 emulators.
+
 ## [0.5.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/jo-duchan/tapflow/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/jo-duchan/tapflow/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jo-duchan/tapflow/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jo-duchan/tapflow/compare/v0.3.1...v0.4.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.5.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/android-agent
 
+## 0.5.1
+
+### Patch Changes
+
+- c469362: Fix Android screen rotation on Android 15+ (API 35+). `AdbWrapper.setRotation` now uses `wm user-rotation lock` instead of the legacy `settings put system user_rotation`, which is silently ignored on newer Android (only a rotation suggestion appears). The bundled scrcpy server is upgraded 3.1 → 3.3, which fixes the locked capture-orientation direction (scrcpy #6010) that left the stream sideways after rotation on API 35+. Verified on API 34 and API 36 emulators.
+  - @tapflowio/agent-core@0.5.1
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # tapflow
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [c469362]
+  - @tapflowio/android-agent@0.5.1
+  - @tapflowio/agent-core@0.5.1
+  - @tapflowio/ios-agent@0.5.1
+  - @tapflowio/relay@0.5.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.5.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.5.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.5.0-experimental.1",
+  "version": "0.5.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.5.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.5.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.5.1

테마: **Android 15+ (API 35+) 화면 회전 캡처 수정**

### 버전 변경

| 패키지 | 변경 | 비고 |
|--------|------|------|
| \`tapflow\` · \`@tapflowio/agent-core\` · \`@tapflowio/ios-agent\` · \`@tapflowio/android-agent\` · \`@tapflowio/relay\` | \`0.5.0\` → \`0.5.1\` | fixed 그룹 동반 bump |
| \`@tapflowio/mcp-server\` | \`0.5.0-experimental.1\` → \`0.5.1-experimental.1\` | 수동 (experimental dist-tag) |
| \`@tapflowio/dashboard\` | \`0.1.1\` 유지 | private + ignore |

### 릴리즈 노트 (Fixed)

- **android**: Android 15+ (API 35+) 화면 회전 수정. \`AdbWrapper.setRotation\`이 신규 Android에서 무시되는 레거시 \`settings put system user_rotation\` 대신 \`wm user-rotation lock\`을 사용합니다. 번들 scrcpy 서버를 3.1 → 3.3으로 업그레이드해 회전 후 스트림이 옆으로 눕던 locked capture-orientation 방향 버그(scrcpy #6010)도 수정. API 34 / API 36 에뮬레이터에서 검증.

### 호환성

- 프로토콜/공개 API/CLI/DB 스키마 변경 **없음** — 버그픽스 전용 patch. backward-compat 유지.
- 내부 의존성 \`workspace:*\` — lockfile 변경 없음.

### 발행 절차 (머지 후)

\`.github/workflows/release.yml\`은 **\`v0.5.1\` 태그 push로만** 발동합니다. main 머지만으로는 npm 발행이 일어나지 않으므로, 머지 후 머지 커밋에 태그를 달아 push해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen rotation on Android 15+ (API 35+) devices.
  * Upgraded bundled scrcpy server (3.1 → 3.3) to resolve capture-orientation issues after rotation; verified on API 34 and API 36 emulators.

* **Chores**
  * Released version 0.5.1 and updated package versions/dependency references across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->