### PR TITLE
fix(android): keyframe-aware backpressure + on-demand IDR for LAN congestion

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -9,11 +9,13 @@ import {
   createRateLimitedDropWarn,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
+  CODEC_H264,
 } from '@tapflowio/agent-core/utils'
 import { AdbWrapper } from './AdbWrapper.js'
 import { EmulatorLauncher } from './EmulatorLauncher.js'
 import { AndroidTouchHelper } from './AndroidTouchHelper.js'
 import { ScrcpySession } from './scrcpy/ScrcpySession.js'
+import type { ScrcpyFrame } from './scrcpy/ScrcpyVideo.js'
 
 const logger = createLogger('android-agent')
 
@@ -336,14 +338,18 @@ export class AndroidAgent implements DeviceAgent {
           if (done) break
           // Detect video size changes via H.264 SPS so ScrcpyControl.screenSize always
           // matches what scrcpy server is actually encoding (landscape-aware vs portrait-locked).
-          const parsed = parseSpsFromNal(value)
+          // The SPS leads the keyframe access unit, so parsing value.payload finds it.
+          const parsed = parseSpsFromNal(value.payload)
           if (parsed && (parsed.width !== state.videoWidth || parsed.height !== state.videoHeight)) {
             state.videoWidth = parsed.width
             state.videoHeight = parsed.height
             state.scrcpySession?.control.updateScreenSize(parsed.width, parsed.height)
             logger.info(`video size → ${parsed.width}×${parsed.height}`)
           }
-          sendBinaryWithBackpressure(streamWs, writeEnvelopeHeader(value, Date.now()), threshold, onDrop)
+          // Mark codec=H.264 + per-AU keyframe so the relay's keyframe-aware backpressure
+          // preserves the reference chain (drops to the next IDR instead of tearing).
+          const frame = writeEnvelopeHeader(value.payload, Date.now(), { codec: CODEC_H264, keyframe: value.keyframe })
+          sendBinaryWithBackpressure(streamWs, frame, threshold, onDrop)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect
@@ -770,7 +776,11 @@ export class AndroidAgent implements DeviceAgent {
   stream(): ReadableStream<Buffer> {
     const state = this.deviceStates.values().next().value
     if (!state?.scrcpySession) throw new ValidationError('no active scrcpy session — call connect() first')
+    // DeviceAgent.stream() is the platform-neutral Buffer contract; unwrap ScrcpyFrame payloads.
     return state.scrcpySession.video.start()
+      .pipeThrough(new TransformStream<ScrcpyFrame, Buffer>({
+        transform(frame, controller) { controller.enqueue(frame.payload) },
+      }))
   }
 
   touchStart(x: number, y: number): void {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -641,6 +641,12 @@ export class AndroidAgent implements DeviceAgent {
         state.touchHelper.pressButton(name)
         break
       }
+      case 'stream:request-idr': {
+        // Relay drop-to-keyframe recovery: reset the encoder so it re-emits SPS/PPS + IDR,
+        // resyncing fast instead of waiting for the periodic IDR. Throttled by the relay.
+        this.deviceStates.get(msg.sessionId!)?.scrcpySession?.control.resetVideo()
+        break
+      }
       case 'open-url': {
         const { url } = msg.payload as { url: string }
         const sessionId = msg.sessionId

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -20,7 +20,7 @@ vi.mock('../AndroidTouchHelper', () => ({
 // Shared state for per-test stream control (captured by inner factory closure)
 let scrcpyCloseOnCreate = false
 let scrcpyStartError: Error | null = null
-let scrcpyStreamController: ReadableStreamDefaultController<Buffer> | null = null
+let scrcpyStreamController: ReadableStreamDefaultController<ScrcpyFrame> | null = null
 
 vi.mock('../scrcpy/ScrcpySession', () => ({
   ScrcpySession: vi.fn(() => ({
@@ -33,7 +33,7 @@ vi.mock('../scrcpy/ScrcpySession', () => ({
     }),
     stop: vi.fn(),
     video: {
-      start: vi.fn(() => new ReadableStream<Buffer>({
+      start: vi.fn(() => new ReadableStream<ScrcpyFrame>({
         start(c) {
           scrcpyStreamController = c
           if (scrcpyCloseOnCreate) c.close()
@@ -61,9 +61,11 @@ vi.mock('../EmulatorLauncher', () => ({
 
 import { WebSocket } from 'ws'
 import { RelayServer, initDb, closeDb } from '@tapflowio/relay'
+import { hasEnvelope, readEnvelopeFlags, CODEC_H264, CODEC_JPEG } from '@tapflowio/agent-core/utils'
 import { AndroidAgent } from '../AndroidAgent'
 import { AdbWrapper } from '../AdbWrapper'
 import { ScrcpySession } from '../scrcpy/ScrcpySession'
+import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 import type { AdbRunner } from '../adb'
 
 function mockAdb(booted = false): AdbWrapper {
@@ -385,6 +387,33 @@ describe('AndroidAgent', () => {
         scrcpyStreamController?.close()
 
         await vi.waitFor(() => expect(restartSpy).not.toHaveBeenCalled(), { timeout: 200 })
+      })
+    })
+
+    describe('envelope marking (B-2)', () => {
+      it('marks codec=H.264 + per-AU keyframe so the relay stays keyframe-aware', async () => {
+        browser.send(JSON.stringify({
+          type: 'device:boot',
+          sessionId: agent.sessionId,
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        await waitForType(browser, 'device:ready')
+
+        const flags: Array<{ codec: number; keyframe: boolean }> = []
+        browser.on('message', (d: Buffer) => {
+          if (Buffer.isBuffer(d) && hasEnvelope(d)) flags.push(readEnvelopeFlags(d))
+        })
+
+        // A keyframe access unit (SPS+PPS merged) followed by a P-frame access unit.
+        scrcpyStreamController!.enqueue({ payload: Buffer.from([0x67, 0x42, 0xc0, 0x1f, 0x65, 0x88]), keyframe: true })
+        scrcpyStreamController!.enqueue({ payload: Buffer.from([0x41, 0x9a, 0x00, 0x20]), keyframe: false })
+
+        await vi.waitFor(() => expect(flags).toHaveLength(2), { timeout: 1000 })
+        expect(flags[0]).toEqual({ codec: CODEC_H264, keyframe: true })
+        expect(flags[1]).toEqual({ codec: CODEC_H264, keyframe: false })
+        // Regression guard: the pre-fix bug marked H.264 frames as JPEG (→ relay treated
+        // every frame as a keyframe, degrading drop-to-keyframe into tearing drop-to-latest).
+        expect(flags[0].codec).not.toBe(CODEC_JPEG)
       })
     })
 

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -412,8 +412,7 @@ describe('AndroidAgent', () => {
         await vi.waitFor(() => expect(flags).toHaveLength(2), { timeout: 1000 })
         expect(flags[0]).toEqual({ codec: CODEC_H264, keyframe: true })
         expect(flags[1]).toEqual({ codec: CODEC_H264, keyframe: false })
-        // Regression guard: the pre-fix bug marked H.264 frames as JPEG (→ relay treated
-        // every frame as a keyframe, degrading drop-to-keyframe into tearing drop-to-latest).
+        // Regression guard: the pre-fix bug marked H.264 frames as JPEG → relay saw every frame as a keyframe, degrading drop-to-keyframe into tearing drop-to-latest.
         expect(flags[0].codec).not.toBe(CODEC_JPEG)
       })
     })

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -47,6 +47,7 @@ vi.mock('../scrcpy/ScrcpySession', () => ({
       pinchStart: vi.fn(),
       pinchMove: vi.fn(),
       pinchEnd: vi.fn(),
+      resetVideo: vi.fn(),
     },
   })),
 }))
@@ -414,6 +415,32 @@ describe('AndroidAgent', () => {
         // Regression guard: the pre-fix bug marked H.264 frames as JPEG (→ relay treated
         // every frame as a keyframe, degrading drop-to-keyframe into tearing drop-to-latest).
         expect(flags[0].codec).not.toBe(CODEC_JPEG)
+      })
+    })
+
+    describe('stream:request-idr (B-3)', () => {
+      it('resets the scrcpy video encoder to force an on-demand IDR', async () => {
+        browser.send(JSON.stringify({
+          type: 'device:boot',
+          sessionId: agent.sessionId,
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        await waitForType(browser, 'device:ready')
+
+        const control = (getState() as any).scrcpySession.control
+        expect(control.resetVideo).not.toHaveBeenCalled()
+
+        // Relay sends this agent-ward during drop-to-keyframe recovery.
+        ;(agent as any).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId })
+
+        expect(control.resetVideo).toHaveBeenCalledOnce()
+      })
+
+      it('ignores stream:request-idr when no scrcpy session is active', () => {
+        // No device booted → no session; handler must not throw.
+        expect(() =>
+          (agent as any).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId }),
+        ).not.toThrow()
       })
     })
 

--- a/packages/android-agent/src/__tests__/ScrcpyControl.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyControl.test.ts
@@ -113,4 +113,15 @@ describe('ScrcpyControl', () => {
       expect(buf.readInt32BE(2)).toBe(4)
     })
   })
+
+  describe('resetVideo', () => {
+    it('writes the single-byte TYPE_RESET_VIDEO control message', () => {
+      // scrcpy v3.3 control_msg.c: RESET_VIDEO (type 17) serializes to 1 byte, no payload.
+      ctrl.resetVideo()
+      expect(socket.write).toHaveBeenCalledOnce()
+      const buf: Buffer = (socket.write as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(buf.length).toBe(1)
+      expect(buf.readUInt8(0)).toBe(17)
+    })
+  })
 })

--- a/packages/android-agent/src/__tests__/ScrcpyVideo.perf.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyVideo.perf.test.ts
@@ -12,13 +12,13 @@ function makeHeader(name: string, width: number, height: number): Buffer {
   return header
 }
 
-// N개의 NAL 유닛을 포함하는 Annex B 스트림 생성
-function makeAnnexBStream(nalCount: number, nalSize: number): Buffer {
-  const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01])
-  const nalBody = Buffer.alloc(nalSize, 0x42) // 임의 NAL 바이트
+// N개의 frame-meta 패킷([12B 헤더][payload]) 스트림 생성. payload는 0x42로 채움.
+function makePacketStream(count: number, payloadSize: number): Buffer {
   const parts: Buffer[] = []
-  for (let i = 0; i < nalCount; i++) {
-    parts.push(startCode, nalBody)
+  for (let i = 0; i < count; i++) {
+    const header = Buffer.alloc(12) // pts_flags(8) + len(4), 플래그 없음 = P-frame
+    header.writeUInt32BE(payloadSize, 8)
+    parts.push(header, Buffer.alloc(payloadSize, 0x42))
   }
   return Buffer.concat(parts)
 }
@@ -35,43 +35,41 @@ function fakeSocket(header: Buffer, dataChunks: Buffer[], emitEnd = true): Socke
 }
 
 describe('ScrcpyVideo — 성능', () => {
-  it('NAL 유닛 1000개를 200ms 이내에 파싱', async () => {
-    const NAL_COUNT = 1000
-    const NAL_SIZE = 64
+  it('패킷 1000개를 200ms 이내에 파싱', async () => {
+    const PACKET_COUNT = 1000
+    const PAYLOAD_SIZE = 64
 
     const header = makeHeader('Pixel_8_Pro', 1080, 2400)
-    const stream = makeAnnexBStream(NAL_COUNT, NAL_SIZE)
+    const stream = makePacketStream(PACKET_COUNT, PAYLOAD_SIZE)
     const socket = fakeSocket(header, [stream])
 
     const video = new ScrcpyVideo(socket)
     await video.deviceInfo()
 
-    const readableStream = video.start()
-    const reader = readableStream.getReader()
-
+    const reader = video.start().getReader()
     const start = Date.now()
     let count = 0
     while (true) {
       const { value, done } = await reader.read()
       if (done) break
       count++
-      // 실제 NAL 바이트가 포함되어 있는지 검증 (Potemkin 방지)
-      expect(value[4]).toBe(0x42)
+      // 실제 payload 바이트가 포함되어 있는지 검증 (Potemkin 방지)
+      expect(value.payload[0]).toBe(0x42)
     }
     const elapsed = Date.now() - start
 
-    expect(count).toBe(NAL_COUNT)
+    expect(count).toBe(PACKET_COUNT)
     // 200ms는 로컬 기준 여유 있는 임계값 — 실제 측정값은 통상 10ms 미만
     expect(elapsed).toBeLessThan(200)
   })
 
-  it('NAL 유닛 1000개를 청크 단위(32바이트)로 분할 수신해도 손실 없음', async () => {
-    const NAL_COUNT = 1000
-    const NAL_SIZE = 32
+  it('패킷 1000개를 청크 단위(32바이트)로 분할 수신해도 손실 없음', async () => {
+    const PACKET_COUNT = 1000
+    const PAYLOAD_SIZE = 32
     const CHUNK_SIZE = 32
 
     const header = makeHeader('Pixel', 1080, 1920)
-    const stream = makeAnnexBStream(NAL_COUNT, NAL_SIZE)
+    const stream = makePacketStream(PACKET_COUNT, PAYLOAD_SIZE)
 
     // TCP 단편화 시뮬레이션: 32바이트 청크로 쪼갬
     const chunks: Buffer[] = []
@@ -83,8 +81,7 @@ describe('ScrcpyVideo — 성능', () => {
     const video = new ScrcpyVideo(socket)
     await video.deviceInfo()
 
-    const readableStream = video.start()
-    const reader = readableStream.getReader()
+    const reader = video.start().getReader()
     let count = 0
     while (true) {
       const { done } = await reader.read()
@@ -92,6 +89,6 @@ describe('ScrcpyVideo — 성능', () => {
       count++
     }
 
-    expect(count).toBe(NAL_COUNT)
+    expect(count).toBe(PACKET_COUNT)
   })
 })

--- a/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { EventEmitter } from 'events'
-import { ScrcpyVideo } from '../scrcpy/ScrcpyVideo'
+import { ScrcpyVideo, type ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 import type { Socket } from 'net'
 
-// Header layout: 64 bytes device name + 4 bytes codec ID + 4 bytes width + 4 bytes height = 76 bytes
+// Device meta header: 64 bytes device name + 4 bytes codec ID + 4 bytes width + 4 bytes height = 76 bytes
 function makeHeader(name: string, width: number, height: number): Buffer {
   const header = Buffer.alloc(76)
   header.write(name, 0, 'utf8')
@@ -13,10 +13,22 @@ function makeHeader(name: string, width: number, height: number): Buffer {
   return header
 }
 
-// Build a minimal Annex B stream from NAL unit payloads (without start code)
+// scrcpy send_frame_meta=true packet: [8B pts_flags BE][4B len BE][payload].
+// CONFIG flag = bit63 (top bit), KEY_FRAME flag = bit62.
+function makePacket(payload: Buffer, opts: { config?: boolean; keyframe?: boolean } = {}): Buffer {
+  const header = Buffer.alloc(12)
+  let hi = 0
+  if (opts.config) hi |= 0x80000000
+  if (opts.keyframe) hi |= 0x40000000
+  header.writeUInt32BE(hi >>> 0, 0) // top 32 bits of pts_flags (flags live here)
+  header.writeUInt32BE(0, 4)        // low 32 bits of PTS
+  header.writeUInt32BE(payload.length, 8)
+  return Buffer.concat([header, payload])
+}
+
+// Annex B NAL run (start code + body), for building realistic payloads.
 function annexB(...nals: Buffer[]): Buffer {
-  const parts = nals.flatMap((nal) => [Buffer.from([0x00, 0x00, 0x00, 0x01]), nal])
-  return Buffer.concat(parts)
+  return Buffer.concat(nals.flatMap((nal) => [Buffer.from([0x00, 0x00, 0x00, 0x01]), nal]))
 }
 
 function fakeSocket(header: Buffer, dataChunks: Buffer[], emitEnd = true): Socket {
@@ -30,10 +42,25 @@ function fakeSocket(header: Buffer, dataChunks: Buffer[], emitEnd = true): Socke
   return socket
 }
 
-describe('ScrcpyVideo', () => {
+async function collect(video: ScrcpyVideo): Promise<ScrcpyFrame[]> {
+  const reader = video.start().getReader()
+  const out: ScrcpyFrame[] = []
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out.push(value)
+  }
+  return out
+}
+
+const SPS = Buffer.from([0x67, 0x42, 0xc0, 0x32])
+const PPS = Buffer.from([0x68, 0xce, 0x01, 0xa8])
+const IDR = Buffer.from([0x65, 0x88, 0x80, 0x10])  // NAL type 5
+const PSLICE = Buffer.from([0x41, 0x9a, 0x00, 0x20]) // NAL type 1
+
+describe('ScrcpyVideo (send_frame_meta=true)', () => {
   it('parses device name, width and height from 76-byte header', async () => {
-    const header = makeHeader('Pixel_8', 1080, 2400)
-    const socket = fakeSocket(header, [])
+    const socket = fakeSocket(makeHeader('Pixel_8', 1080, 2400), [])
     const video = new ScrcpyVideo(socket)
     const info = await video.deviceInfo()
     expect(info.deviceName).toBe('Pixel_8')
@@ -41,50 +68,74 @@ describe('ScrcpyVideo', () => {
     expect(info.height).toBe(2400)
   })
 
-  it('extracts NAL units from Annex B stream', async () => {
-    const sps = Buffer.from([0x67, 0x42, 0xc0, 0x32])
-    const pps = Buffer.from([0x68, 0xce, 0x01, 0xa8])
-    const header = makeHeader('test', 576, 1280)
-    const socket = fakeSocket(header, [annexB(sps, pps)])
-
+  // B-2 #1 + #3: config packet (SPS/PPS) merges into the following IDR packet,
+  // emitted as ONE keyframe access unit (SPS+PPS+IDR together).
+  it('merges the config packet into the following keyframe as one access unit', async () => {
+    const config = annexB(SPS, PPS)
+    const idr = annexB(IDR)
+    const socket = fakeSocket(makeHeader('t', 576, 1280), [
+      makePacket(config, { config: true }),
+      makePacket(idr, { keyframe: true }),
+    ])
     const video = new ScrcpyVideo(socket)
     await video.deviceInfo()
 
-    const stream = video.start()
-    const reader = stream.getReader()
-    const results: Buffer[] = []
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      results.push(value)
-    }
-    // Each NAL unit includes its Annex B start code
-    expect(results).toHaveLength(2)
-    expect(results[0].subarray(4)).toEqual(sps)
-    expect(results[1].subarray(4)).toEqual(pps)
+    const frames = await collect(video)
+    expect(frames).toHaveLength(1)
+    expect(frames[0].keyframe).toBe(true)
+    expect(frames[0].payload).toEqual(Buffer.concat([config, idr]))
   })
 
-  it('handles fragmented TCP data correctly', async () => {
-    const sps = Buffer.from([0x67, 0x42, 0xc0, 0x32])
-    const pps = Buffer.from([0x68, 0xce, 0x01])
-    const stream = annexB(sps, pps)
-    const header = makeHeader('test', 576, 1280)
-
-    // Split data across two TCP segments mid-stream
-    const socket = fakeSocket(header, [stream.subarray(0, 5), stream.subarray(5)])
+  // B-2 #2: a non-IDR packet is a P-frame access unit (keyframe=false), no config prepended.
+  it('emits a P-frame packet as a non-keyframe access unit', async () => {
+    const p = annexB(PSLICE)
+    const socket = fakeSocket(makeHeader('t', 576, 1280), [makePacket(p)])
     const video = new ScrcpyVideo(socket)
     await video.deviceInfo()
 
-    const videoStream = video.start()
-    const reader = videoStream.getReader()
-    const results: Buffer[] = []
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      results.push(value)
-    }
-    expect(results).toHaveLength(2)
-    expect(results[0].subarray(4)).toEqual(sps)
-    expect(results[1].subarray(4)).toEqual(pps)
+    const frames = await collect(video)
+    expect(frames).toHaveLength(1)
+    expect(frames[0].keyframe).toBe(false)
+    expect(frames[0].payload).toEqual(p)
+  })
+
+  it('reassembles a packet fragmented across TCP segments', async () => {
+    const p = annexB(PSLICE)
+    const packet = makePacket(p, { keyframe: true })
+    // Split mid-header and mid-payload across three segments
+    const socket = fakeSocket(makeHeader('t', 576, 1280), [
+      packet.subarray(0, 5),
+      packet.subarray(5, 13),
+      packet.subarray(13),
+    ])
+    const video = new ScrcpyVideo(socket)
+    await video.deviceInfo()
+
+    const frames = await collect(video)
+    expect(frames).toHaveLength(1)
+    expect(frames[0].keyframe).toBe(true)
+    expect(frames[0].payload).toEqual(p)
+  })
+
+  it('drains multiple packets bundled in a single chunk', async () => {
+    const p1 = annexB(PSLICE)
+    const p2 = annexB(Buffer.from([0x41, 0x9b, 0x10, 0x20]))
+    const socket = fakeSocket(makeHeader('t', 576, 1280), [
+      Buffer.concat([makePacket(p1), makePacket(p2)]),
+    ])
+    const video = new ScrcpyVideo(socket)
+    await video.deviceInfo()
+
+    const frames = await collect(video)
+    expect(frames.map((f) => f.payload)).toEqual([p1, p2])
+    expect(frames.every((f) => f.keyframe === false)).toBe(true)
+  })
+
+  it('rejects deviceInfo when the server closes before the header arrives', async () => {
+    const emitter = new EventEmitter()
+    const socket = emitter as unknown as Socket
+    process.nextTick(() => emitter.emit('end'))
+    const video = new ScrcpyVideo(socket)
+    await expect(video.deviceInfo()).rejects.toThrow()
   })
 })

--- a/packages/android-agent/src/scrcpy/ScrcpyControl.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyControl.ts
@@ -2,6 +2,7 @@ import type { Socket } from 'net'
 
 const TYPE_INJECT_KEYCODE = 0
 const TYPE_INJECT_TOUCH_EVENT = 2
+const TYPE_RESET_VIDEO = 17
 
 const ACTION_DOWN = 0
 const ACTION_UP = 1
@@ -44,6 +45,13 @@ export class ScrcpyControl {
   pinchEnd(): void {
     this.touchUp(0)
     this.touchUp(1)
+  }
+
+  // Forces the scrcpy server to reset the video encoder, which re-emits codec config
+  // (SPS/PPS) + a keyframe (IDR). Used for relay drop-to-keyframe recovery so the stream
+  // resyncs fast instead of waiting for the periodic IDR. (scrcpy v3.3: 1-byte message.)
+  resetVideo(): void {
+    this.socket.write(Buffer.from([TYPE_RESET_VIDEO]))
   }
 
   keyEvent(keyCode: number): void {

--- a/packages/android-agent/src/scrcpy/ScrcpySession.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpySession.ts
@@ -92,7 +92,11 @@ export class ScrcpySession {
       // and scrcpy rotates that content into the locked portrait frame, which CSS undoes.
       'capture_orientation=@0',
       'send_device_meta=true',   // 64-byte name + codec-id + width + height header
-      'send_frame_meta=false',   // raw Annex B stream (no length prefix per frame)
+      // 12-byte frame header per packet (pts + config/keyframe flags + length). Gives
+      // authoritative keyframe/config boundaries so the agent marks the TFFE envelope
+      // (codec=H.264, keyframe) correctly → relay keyframe-aware backpressure works
+      // (no P-frame tearing under LAN congestion). See ScrcpyVideo packet framer.
+      'send_frame_meta=true',
       'send_dummy_byte=false',   // skip the 1-byte connection-check byte
       // profile=1 (AVCProfileBaseline): the browser WASM decoder (tinyh264) only
       // decodes (constrained-)baseline — force it so Android shares the HTTP→WASM path.

--- a/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
@@ -1,6 +1,6 @@
 import type { Socket } from 'net'
 
-// Header layout (send_device_meta=true, send_stream_meta=true default):
+// Device meta header (send_device_meta=true):
 //   [0..63]  device name, null-padded (64 bytes)
 //   [64..67] codec ID as ASCII ("h264")  (4 bytes)
 //   [68..71] width   uint32 BE           (4 bytes)
@@ -8,19 +8,41 @@ import type { Socket } from 'net'
 const HEADER_SIZE = 76
 const DEVICE_NAME_SIZE = 64
 
+// Frame meta header (send_frame_meta=true), one per packet:
+//   [0..7] pts_flags uint64 BE — bit63 = CONFIG (codec config / SPS+PPS),
+//                                bit62 = KEY_FRAME (IDR); low 62 bits = PTS
+//   [8..11] packet length uint32 BE
+// (Verified against scrcpy v3.3 app/src/demuxer.c: SC_PACKET_HEADER_SIZE 12,
+//  SC_PACKET_FLAG_CONFIG=1<<63, SC_PACKET_FLAG_KEY_FRAME=1<<62.)
+const PACKET_HEADER_SIZE = 12
+const FLAG_CONFIG = 0x80000000 // bit63, tested on the high 32 bits
+const FLAG_KEY_FRAME = 0x40000000 // bit62
+
 export interface ScrcpyDeviceInfo {
   deviceName: string
   width: number
   height: number
 }
 
+/** One H.264 access unit. Mirrors ios-agent's StreamFrame so the relay's
+ *  keyframe-aware backpressure can preserve the reference chain. */
+export interface ScrcpyFrame {
+  payload: Buffer
+  /** True for IDR access units (config packet merged in). */
+  keyframe: boolean
+}
+
 export class ScrcpyVideo {
   private headerBuf: Buffer | null = null
-  private readonly dataChunks: Buffer[] = []
+  private readonly dataFrames: ScrcpyFrame[] = []
   private headerResolve: ((info: ScrcpyDeviceInfo) => void) | null = null
   private headerReject: ((e: Error) => void) | null = null
-  private streamController: ReadableStreamDefaultController<Buffer> | null = null
+  private streamController: ReadableStreamDefaultController<ScrcpyFrame> | null = null
   private pending = Buffer.alloc(0)
+  // CONFIG packet (SPS+PPS) buffered until the next packet (the IDR) so the keyframe
+  // access unit carries its parameter sets — the relay then never forwards an IDR whose
+  // config was dropped, and the browser decoder can always (re)initialize.
+  private pendingConfig: Buffer | null = null
   private headerConsumed = false
   private endReceived = false
 
@@ -33,16 +55,7 @@ export class ScrcpyVideo {
         this.headerReject = null
         return
       }
-      // Flush the last NAL unit (Annex B: last unit has no following start code)
-      if (this.pending.length > 0) {
-        const last = Buffer.from(this.pending)
-        this.pending = Buffer.alloc(0)
-        if (this.streamController) {
-          this.streamController.enqueue(last)
-        } else {
-          this.dataChunks.push(last)
-        }
-      }
+      // Length-prefixed framing: a partial trailing packet is incomplete → discard.
       this.streamController?.close()
     })
     socket.on('close', () => {
@@ -66,13 +79,13 @@ export class ScrcpyVideo {
     })
   }
 
-  start(): ReadableStream<Buffer> {
-    return new ReadableStream<Buffer>({
+  start(): ReadableStream<ScrcpyFrame> {
+    return new ReadableStream<ScrcpyFrame>({
       start: (controller) => {
         this.streamController = controller
-        // Flush any NAL units that arrived before start() was called
-        for (const chunk of this.dataChunks) controller.enqueue(chunk)
-        this.dataChunks.length = 0
+        // Flush frames that arrived before start() was called
+        for (const frame of this.dataFrames) controller.enqueue(frame)
+        this.dataFrames.length = 0
         if (this.endReceived) controller.close()
       },
       cancel: () => {
@@ -96,20 +109,37 @@ export class ScrcpyVideo {
       this.headerReject = null
     }
 
-    this.drainNalUnits()
+    this.drainPackets()
   }
 
-  private drainNalUnits(): void {
-    // send_frame_meta=false → raw H.264 Annex B stream (no length prefix)
-    const { units, remaining } = extractAnnexBNals(this.pending)
-    this.pending = Buffer.from(remaining)
-    for (const nal of units) {
-      if (this.streamController) {
-        this.streamController.enqueue(nal)
-      } else {
-        this.dataChunks.push(nal)
+  private drainPackets(): void {
+    while (this.pending.length >= PACKET_HEADER_SIZE) {
+      const flagsHi = this.pending.readUInt32BE(0) // high 32 bits of pts_flags
+      const len = this.pending.readUInt32BE(8)
+      if (this.pending.length < PACKET_HEADER_SIZE + len) break // wait for the rest
+
+      const payload = Buffer.from(this.pending.subarray(PACKET_HEADER_SIZE, PACKET_HEADER_SIZE + len))
+      this.pending = this.pending.subarray(PACKET_HEADER_SIZE + len)
+
+      if ((flagsHi & FLAG_CONFIG) !== 0) {
+        // Hold SPS/PPS until the next (key)frame packet; do not emit alone.
+        this.pendingConfig = this.pendingConfig ? Buffer.concat([this.pendingConfig, payload]) : payload
+        continue
       }
+
+      const keyframe = (flagsHi & FLAG_KEY_FRAME) !== 0
+      let frame = payload
+      if (this.pendingConfig) {
+        frame = Buffer.concat([this.pendingConfig, payload])
+        this.pendingConfig = null
+      }
+      this.emit({ payload: frame, keyframe })
     }
+  }
+
+  private emit(frame: ScrcpyFrame): void {
+    if (this.streamController) this.streamController.enqueue(frame)
+    else this.dataFrames.push(frame)
   }
 
   private parseHeader(buf: Buffer): ScrcpyDeviceInfo {
@@ -122,30 +152,4 @@ export class ScrcpyVideo {
     const height = buf.readUInt32BE(72)
     return { deviceName, width, height }
   }
-}
-
-function findStartCode(buf: Buffer, from: number): { pos: number; len: number } | null {
-  for (let i = from; i + 2 < buf.length; i++) {
-    if (buf[i] === 0 && buf[i + 1] === 0) {
-      if (buf[i + 2] === 1) return { pos: i, len: 3 }
-      if (i + 3 < buf.length && buf[i + 2] === 0 && buf[i + 3] === 1) return { pos: i, len: 4 }
-    }
-  }
-  return null
-}
-
-function extractAnnexBNals(buf: Buffer): { units: Buffer[]; remaining: Buffer } {
-  const units: Buffer[] = []
-  const first = findStartCode(buf, 0)
-  if (!first) return { units, remaining: buf }
-  let nalStart = first.pos
-  let searchFrom = first.pos + first.len
-  while (true) {
-    const next = findStartCode(buf, searchFrom)
-    if (!next) break
-    units.push(Buffer.from(buf.subarray(nalStart, next.pos)))
-    nalStart = next.pos
-    searchFrom = next.pos + next.len
-  }
-  return { units, remaining: buf.subarray(nalStart) }
 }


### PR DESCRIPTION
## Problem

Android stream frames were written to the TFFE envelope **without codec/keyframe flags**, so the relay read them as JPEG and treated **every** frame as a keyframe. That degraded the relay's keyframe-aware backpressure sender into drop-to-latest: under LAN congestion it forwarded P-frames after a drop, **tearing until the next periodic IDR (~1s)**. iOS got proper drop-to-keyframe recovery; Android did not.

Root cause found by reading the pipeline end-to-end:
- `AndroidAgent` pump called `writeEnvelopeHeader(value, t)` with no `{ codec, keyframe }` → envelope byte5 = 0 → relay reads codec=JPEG, so `isKeyframe` is always true (`RelayServer` `flags.codec === CODEC_JPEG || flags.keyframe`).
- Frames were also emitted per-NAL (start-code splitting), so there was no access-unit boundary or keyframe flag to mark.

## Fix

### B-2 — correct envelope marking (the corruption fix)
- Switch scrcpy to `send_frame_meta=true` and reframe `ScrcpyVideo` around the **12-byte packet header** (verified against scrcpy v3.3 `app/src/demuxer.c`: `SC_PACKET_HEADER_SIZE 12`, `CONFIG = bit63`, `KEY_FRAME = bit62`).
- Merge the CONFIG (SPS/PPS) packet into the following keyframe so each IDR access unit carries its parameter sets — the relay then never forwards an IDR whose config was dropped.
- Pump marks `{ codec: H264, keyframe }` on the envelope. Public `stream()` unwraps `ScrcpyFrame → Buffer` via `TransformStream`, keeping the `DeviceAgent` contract (mirrors ios-agent).

### B-3 — on-demand IDR for fast recovery
- After B-2, the relay fires `onWantKeyframe` (→ `stream:request-idr`) for Android once the socket drains but no keyframe has arrived. Android had no handler, so recovery waited for the periodic IDR.
- Add `ScrcpyControl.resetVideo()` — the 1-byte `RESET_VIDEO` control message (type 17, verified against scrcpy v3.3 `control_msg.c`). The server resets the encoder, re-emitting SPS/PPS + a keyframe. Wire `AndroidAgent`'s `stream:request-idr` case to it. Throttled by the relay.

Together this brings Android congestion recovery to parity with iOS.

## Verification

**Unit/integration** (android-agent, 69 tests pass; lint+tsc clean across all packages):
- `ScrcpyVideo`: 12-byte framing, config→keyframe merge, P-frame marking, TCP fragmentation reassembly, multi-packet drain.
- `AndroidAgent` (through a real relay): keyframe AU → `{ H264, keyframe:true }`, P-frame → `{ H264, keyframe:false }`, plus a regression guard against the old JPEG mismarking.
- `ScrcpyControl`: `resetVideo()` emits the 1-byte `RESET_VIDEO`. Handler dispatch + no-session safety.

**Real device** (scrcpy 3.3 + emulator Pixel_9_tapflow, android-34 google_apis, 1080×2424):
- First emitted frame is a keyframe carrying SPS+PPS+IDR (config merge works).
- P-frames present (`keyframe=false`).
- `RESET_VIDEO` → fresh keyframe in **306ms** (vs the ~1s periodic IDR), confirming on-demand recovery. (306ms is the encoder full-reconfigure cost — heavier than a pure sync-frame, still a clear net win.)

## Scope / follow-ups
- Out of scope: static downscale (`max_size` / VideoToolbox) and the LAN HTTPS decode-tier discussion — tracked separately (downscale touches both iOS and Android, so it's its own job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video stream reset capability for faster encoder recovery
  * Per-frame codec and keyframe metadata exposed to the relay
  * Dynamic resolution sync so display/control size follows stream

* **Bug Fixes**
  * Reduced frame tearing and improved keyframe boundary handling under congestion
  * More reliable stream reassembly across fragmented network packets

* **Tests**
  * Expanded tests for keyframe detection, envelope metadata, and reset handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->