### PR TITLE
fix(agent): stream cleanup + Android metrics + macOS power assertion (idle-throttle fix)

### DIFF
--- a/packages/agent-core/src/__tests__/power.test.ts
+++ b/packages/agent-core/src/__tests__/power.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { createSleepBlocker } from '../utils/power'
+
+function fakeProc() {
+  const e = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }
+  e.kill = vi.fn()
+  e.unref = vi.fn()
+  return e
+}
+
+describe('createSleepBlocker', () => {
+  it('is a complete no-op off macOS', () => {
+    const spawnFn = vi.fn(() => fakeProc())
+    const b = createSleepBlocker('linux', spawnFn as never)
+    b.acquire()
+    b.release()
+    expect(spawnFn).not.toHaveBeenCalled()
+  })
+
+  it('spawns `caffeinate -i` on acquire (macOS)', () => {
+    const spawnFn = vi.fn(() => fakeProc())
+    const b = createSleepBlocker('darwin', spawnFn as never)
+    b.acquire()
+    expect(spawnFn).toHaveBeenCalledOnce()
+    expect(spawnFn).toHaveBeenCalledWith('caffeinate', ['-i'], { stdio: 'ignore' })
+  })
+
+  it('is idempotent — repeated acquire spawns once', () => {
+    const spawnFn = vi.fn(() => fakeProc())
+    const b = createSleepBlocker('darwin', spawnFn as never)
+    b.acquire()
+    b.acquire()
+    b.acquire()
+    expect(spawnFn).toHaveBeenCalledOnce()
+  })
+
+  it('kills the process on release and can re-acquire afterwards', () => {
+    const procs: ReturnType<typeof fakeProc>[] = []
+    const spawnFn = vi.fn(() => { const p = fakeProc(); procs.push(p); return p })
+    const b = createSleepBlocker('darwin', spawnFn as never)
+    b.acquire()
+    b.release()
+    expect(procs[0].kill).toHaveBeenCalledOnce()
+    b.acquire()
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-acquires after the process emits error (caffeinate missing)', () => {
+    const procs: ReturnType<typeof fakeProc>[] = []
+    const spawnFn = vi.fn(() => { const p = fakeProc(); procs.push(p); return p })
+    const b = createSleepBlocker('darwin', spawnFn as never)
+    b.acquire()
+    procs[0].emit('error', new Error('ENOENT')) // handle dropped
+    b.acquire()
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throw if spawn itself throws', () => {
+    const spawnFn = vi.fn(() => { throw new Error('boom') })
+    const b = createSleepBlocker('darwin', spawnFn as never)
+    expect(() => b.acquire()).not.toThrow()
+  })
+})

--- a/packages/agent-core/src/__tests__/power.test.ts
+++ b/packages/agent-core/src/__tests__/power.test.ts
@@ -46,13 +46,28 @@ describe('createSleepBlocker', () => {
     expect(spawnFn).toHaveBeenCalledTimes(2)
   })
 
-  it('re-acquires after the process emits error (caffeinate missing)', () => {
+  it.each(['error', 'close', 'exit'] as const)(
+    're-acquires after the process emits %s (caffeinate died externally)',
+    (event) => {
+      const procs: ReturnType<typeof fakeProc>[] = []
+      const spawnFn = vi.fn(() => { const p = fakeProc(); procs.push(p); return p })
+      const b = createSleepBlocker('darwin', spawnFn as never)
+      b.acquire()
+      procs[0].emit(event) // handle should be dropped
+      b.acquire()
+      expect(spawnFn).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it("a stale child's late termination does not clear a newer process", () => {
     const procs: ReturnType<typeof fakeProc>[] = []
     const spawnFn = vi.fn(() => { const p = fakeProc(); procs.push(p); return p })
     const b = createSleepBlocker('darwin', spawnFn as never)
-    b.acquire()
-    procs[0].emit('error', new Error('ENOENT')) // handle dropped
-    b.acquire()
+    b.acquire()           // procs[0] held
+    b.release()           // proc cleared
+    b.acquire()           // procs[1] now held
+    procs[0].emit('exit') // late event from the released child — must be ignored
+    b.acquire()           // should be a no-op: procs[1] is still current
     expect(spawnFn).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/agent-core/src/utils/index.ts
+++ b/packages/agent-core/src/utils/index.ts
@@ -20,6 +20,8 @@ export {
 export type { EnvelopeFlags } from './envelope.js'
 export { createThroughputSampler } from './throughput.js'
 export type { ThroughputSample } from './throughput.js'
+export { createSleepBlocker } from './power.js'
+export type { SleepBlocker } from './power.js'
 export {
   parseSpsVui,
   rewriteSpsLowLatency,

--- a/packages/agent-core/src/utils/power.ts
+++ b/packages/agent-core/src/utils/power.ts
@@ -1,0 +1,43 @@
+import { spawn } from 'child_process'
+import type { ChildProcess } from 'child_process'
+
+export interface SleepBlocker {
+  /** Start holding the power assertion (idempotent). No-op off macOS. */
+  acquire(): void
+  /** Release the assertion. Safe to call when not held. */
+  release(): void
+}
+
+/**
+ * macOS-only host power assertion via `caffeinate -i`, so the system doesn't
+ * idle-throttle (or sleep) the simulator/emulator while a session is active —
+ * the emulator's software H.264 encoder starves badly when the host idles
+ * (unattended/backgrounded Mac). Off macOS this is a complete no-op.
+ *
+ * `caffeinate -i` only prevents idle/system sleep; it does NOT override battery
+ * CPU scaling. Partial but meaningful mitigation. `platform`/`spawnFn` are
+ * injectable for tests.
+ */
+export function createSleepBlocker(
+  platform: NodeJS.Platform = process.platform,
+  spawnFn: typeof spawn = spawn,
+): SleepBlocker {
+  let proc: ChildProcess | null = null
+  return {
+    acquire(): void {
+      if (proc || platform !== 'darwin') return
+      try {
+        proc = spawnFn('caffeinate', ['-i'], { stdio: 'ignore' })
+        // caffeinate missing or failed — drop the handle so a later acquire retries.
+        proc.on('error', () => { proc = null })
+        proc.unref()
+      } catch {
+        proc = null
+      }
+    },
+    release(): void {
+      proc?.kill()
+      proc = null
+    },
+  }
+}

--- a/packages/agent-core/src/utils/power.ts
+++ b/packages/agent-core/src/utils/power.ts
@@ -27,10 +27,16 @@ export function createSleepBlocker(
     acquire(): void {
       if (proc || platform !== 'darwin') return
       try {
-        proc = spawnFn('caffeinate', ['-i'], { stdio: 'ignore' })
-        // caffeinate missing or failed — drop the handle so a later acquire retries.
-        proc.on('error', () => { proc = null })
-        proc.unref()
+        const child = spawnFn('caffeinate', ['-i'], { stdio: 'ignore' })
+        proc = child
+        // Drop the handle on any termination (missing binary, external kill, exit) so a
+        // later acquire() re-spawns. Guard on identity so a stale child's late event can't
+        // null out a newer one.
+        const clear = (): void => { if (proc === child) proc = null }
+        child.once('error', clear)
+        child.once('close', clear)
+        child.once('exit', clear)
+        child.unref()
       } catch {
         proc = null
       }

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -8,6 +8,8 @@ import {
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
   createThroughputSampler,
+  createSleepBlocker,
+  type SleepBlocker,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
   CODEC_H264,
@@ -128,6 +130,8 @@ export interface AndroidAgentOptions {
   /** AVD name or emulator serial to expose. Omit to expose all detected devices. */
   deviceFilter?: string
   reconnectDelays?: number[]
+  /** Injectable for tests; defaults to a real macOS power assertion (no-op under vitest). */
+  sleepBlocker?: SleepBlocker
 }
 
 export class AndroidAgent implements DeviceAgent {
@@ -135,6 +139,9 @@ export class AndroidAgent implements DeviceAgent {
   private readonly launcher: EmulatorLauncher
   private ws: WebSocket | null = null
   private deviceStates = new Map<string, DeviceState>()
+  // Holds a macOS power assertion while connected so the host doesn't idle-throttle the
+  // emulator (its software H.264 encoder starves badly when the Mac idles). No-op off macOS.
+  private readonly sleepBlocker: SleepBlocker
   private relayUrl: string | null = null
   private resourcesTimer: ReturnType<typeof setInterval> | null = null
   private readonly resources = createResourceSampler()
@@ -150,6 +157,8 @@ export class AndroidAgent implements DeviceAgent {
     this.launcher = new EmulatorLauncher()
     this.deviceFilter = options.deviceFilter
     this.reconnectDelays = options.reconnectDelays ?? [1000, 2000, 4000, 8000, 16000, 30000]
+    // No-op under vitest so the suite never spawns real `caffeinate` processes.
+    this.sleepBlocker = options.sleepBlocker ?? (process.env.VITEST ? { acquire() {}, release() {} } : createSleepBlocker())
   }
 
   get sessionId(): string | null {
@@ -188,6 +197,7 @@ export class AndroidAgent implements DeviceAgent {
         const msg = JSON.parse(data.toString())
         if (msg.type === 'agent:registered') {
           this.ws = ws
+          this.sleepBlocker.acquire() // idempotent across reconnects
           this.initDeviceStates(
             msg.registeredSessions as Array<{ deviceId: string; sessionId: string }>,
           )
@@ -237,6 +247,7 @@ export class AndroidAgent implements DeviceAgent {
       this.cleanupDeviceState(state)
     }
     this.deviceStates.clear()
+    this.sleepBlocker.release()
     this.ws?.close()
     this.ws = null
     this.relayUrl = null

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -7,6 +7,7 @@ import {
   registerStreamWs,
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
+  createThroughputSampler,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
   CODEC_H264,
@@ -329,7 +330,23 @@ export class AndroidAgent implements DeviceAgent {
     const reader = stream.getReader()
 
     const threshold = Number(process.env.TAPFLOW_WS_BACKPRESSURE_BYTES) || DEFAULT_BACKPRESSURE_BYTES
-    const onDrop = createRateLimitedDropWarn(logger, state.deviceId)
+    const warnDrop = createRateLimitedDropWarn(logger, state.deviceId)
+
+    // Opt-in throughput baseline (TAPFLOW_STREAM_METRICS=1): logs fps/KB·s/drop every 5s,
+    // so the Android source rate can be compared against the relay→browser drop logs and
+    // against the iOS agent (which already samples). Distinguishes source-bound (low fpsSent)
+    // from decode/LAN-bound (high fpsSent, high dropRate).
+    const metrics = process.env.TAPFLOW_STREAM_METRICS === '1' ? createThroughputSampler() : null
+    const metricsTimer = metrics
+      ? setInterval(() => {
+          const s = metrics.sample()
+          logger.info(
+            `stream metrics [${state.deviceId}] ${s.fpsSent}fps ${s.kbPerSec}KB/s avg=${s.avgFrameKB}KB drop=${(s.dropRate * 100).toFixed(1)}% (${s.droppedFrames}/${s.producedFrames})`,
+          )
+        }, 5000)
+      : undefined
+    metricsTimer?.unref()
+    const onDrop = metrics ? () => { metrics.recordDropped(); warnDrop() } : warnDrop
 
     const pump = async () => {
       try {
@@ -349,11 +366,13 @@ export class AndroidAgent implements DeviceAgent {
           // Mark codec=H.264 + per-AU keyframe so the relay's keyframe-aware backpressure
           // preserves the reference chain (drops to the next IDR instead of tearing).
           const frame = writeEnvelopeHeader(value.payload, Date.now(), { codec: CODEC_H264, keyframe: value.keyframe })
-          sendBinaryWithBackpressure(streamWs, frame, threshold, onDrop)
+          const sent = sendBinaryWithBackpressure(streamWs, frame, threshold, onDrop)
+          if (sent) metrics?.recordSent(value.payload.length)
         }
       } catch {
         // stream cancelled or ws closed — expected on disconnect
       }
+      if (metricsTimer) clearInterval(metricsTimer)
       if (state.scrcpySession === session && !state.restarting) {
         state.restarting = true
         void this.restartVideoStream(state)

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -158,6 +158,17 @@ describe('AndroidAgent', () => {
       expect(agent.sessionId).toBeTruthy()
       agent.disconnect()
     })
+
+    it('holds a power assertion while connected (acquire on connect, release on disconnect)', async () => {
+      const adb = mockAdb()
+      const sleepBlocker = { acquire: vi.fn(), release: vi.fn() }
+      const agent = new AndroidAgent({ sleepBlocker }, adb)
+      await agent.connect(`ws://localhost:${port}`)
+      expect(sleepBlocker.acquire).toHaveBeenCalled()
+      expect(sleepBlocker.release).not.toHaveBeenCalled()
+      agent.disconnect()
+      expect(sleepBlocker.release).toHaveBeenCalled()
+    })
   })
 
   describe('device:boot flow', () => {

--- a/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
@@ -131,6 +131,24 @@ describe('ScrcpyVideo (send_frame_meta=true)', () => {
     expect(frames.every((f) => f.keyframe === false)).toBe(true)
   })
 
+  // Regression: ScrcpySession.stop()/device shutdown does socket.destroy() → 'close' (no FIN).
+  // The stream must terminate so the agent pump (and its metrics timer) stop instead of
+  // blocking forever on reader.read().
+  it('terminates the stream when the socket closes without a FIN', async () => {
+    const emitter = new EventEmitter()
+    const socket = emitter as unknown as Socket
+    const video = new ScrcpyVideo(socket)
+    process.nextTick(() => {
+      emitter.emit('data', makeHeader('t', 576, 1280))
+      emitter.emit('data', makePacket(annexB(PSLICE)))
+      emitter.emit('close') // destroy() emits 'close', not 'end'
+    })
+    await video.deviceInfo()
+    // Must resolve (reader observes `done`), not hang.
+    const frames = await collect(video)
+    expect(frames).toHaveLength(1)
+  })
+
   it('rejects deviceInfo when the server closes before the header arrives', async () => {
     const emitter = new EventEmitter()
     const socket = emitter as unknown as Socket

--- a/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
@@ -45,30 +45,33 @@ export class ScrcpyVideo {
   private pendingConfig: Buffer | null = null
   private headerConsumed = false
   private endReceived = false
+  private streamSettled = false
 
   constructor(private readonly socket: Socket) {
     socket.on('data', (chunk: Buffer) => this.onData(chunk))
-    socket.on('end', () => {
-      this.endReceived = true
-      if (!this.headerConsumed) {
-        this.headerReject?.(new Error('scrcpy server closed before sending device info'))
-        this.headerReject = null
-        return
-      }
-      // Length-prefixed framing: a partial trailing packet is incomplete → discard.
-      this.streamController?.close()
-    })
-    socket.on('close', () => {
-      if (!this.headerConsumed) {
-        this.headerReject?.(new Error('scrcpy server connection closed'))
-        this.headerReject = null
-      }
-    })
-    socket.on('error', (e) => {
-      this.headerReject?.(e)
+    // 'end' = clean FIN; 'close' = socket torn down without a FIN (e.g. ScrcpySession.stop()
+    // → videoSocket.destroy(), or device shutdown). BOTH must terminate the stream, else the
+    // agent pump blocks forever on reader.read() and its metrics timer leaks.
+    socket.on('end', () => this.finish())
+    socket.on('close', () => this.finish())
+    socket.on('error', (e) => this.finish(e))
+  }
+
+  // Settles the stream exactly once: rejects deviceInfo() if the header never arrived,
+  // otherwise closes (or errors) the ReadableStream so the consumer's reader sees `done`.
+  // Length-prefixed framing means a partial trailing packet is incomplete → discarded.
+  private finish(err?: Error): void {
+    if (this.streamSettled) return
+    this.streamSettled = true
+    this.endReceived = true
+    if (!this.headerConsumed) {
+      this.headerReject?.(err ?? new Error('scrcpy server connection closed before sending device info'))
       this.headerReject = null
-      this.streamController?.error(e)
-    })
+      return
+    }
+    if (!this.streamController) return // start() will close once it observes endReceived
+    if (err) this.streamController.error(err)
+    else this.streamController.close()
   }
 
   deviceInfo(): Promise<ScrcpyDeviceInfo> {

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -15,6 +15,8 @@ import {
   sendBinaryWithBackpressure,
   createRateLimitedDropWarn,
   createThroughputSampler,
+  createSleepBlocker,
+  type SleepBlocker,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
   rewriteLowLatencySpsInFrame,
@@ -32,6 +34,8 @@ export interface IOSAgentOptions {
   fps?: number
   intervalMs?: number
   reconnectDelays?: number[]
+  /** Injectable for tests; defaults to a real macOS power assertion (no-op under vitest). */
+  sleepBlocker?: SleepBlocker
 }
 
 interface DeviceState {
@@ -63,6 +67,9 @@ export class IOSAgent implements DeviceAgent {
   private readonly chromeLoader: DeviceChromeLoader
   private ws: WebSocket | null = null
   private deviceStates = new Map<string, DeviceState>()
+  // Holds a macOS power assertion while connected so the host doesn't idle-throttle the
+  // simulator capture/encode when the Mac is unattended. No-op off macOS.
+  private readonly sleepBlocker: SleepBlocker
   private relayUrl: string | null = null
   private resourcesTimer: ReturnType<typeof setInterval> | null = null
   private readonly resources = createResourceSampler()
@@ -76,6 +83,8 @@ export class IOSAgent implements DeviceAgent {
     this.intervalMs = options.intervalMs
     this.reconnectDelays = options.reconnectDelays ?? [1000, 2000, 4000, 8000, 16000, 30000]
     this.chromeLoader = new DeviceChromeLoader()
+    // No-op under vitest so the suite never spawns real `caffeinate` processes.
+    this.sleepBlocker = options.sleepBlocker ?? (process.env.VITEST ? { acquire() {}, release() {} } : createSleepBlocker())
   }
 
   get sessionId(): string | null {
@@ -111,6 +120,7 @@ export class IOSAgent implements DeviceAgent {
         const msg = JSON.parse(data.toString())
         if (msg.type === 'agent:registered') {
           this.ws = ws
+          this.sleepBlocker.acquire() // idempotent across reconnects
           this.initDeviceStates(
             msg.registeredSessions as Array<{ deviceId: string; sessionId: string }>,
           )
@@ -158,6 +168,7 @@ export class IOSAgent implements DeviceAgent {
       this.cleanupDeviceState(state)
     }
     this.deviceStates.clear()
+    this.sleepBlocker.release()
     this.ws?.close()
     this.ws = null
     this.relayUrl = null

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -152,6 +152,18 @@ describe('IOSAgent', () => {
     })
   })
 
+  describe('power assertion', () => {
+    it('acquires on connect and releases on disconnect', async () => {
+      const sleepBlocker = { acquire: vi.fn(), release: vi.fn() }
+      const agent = new IOSAgent({ sleepBlocker }, mockSimctl())
+      await agent.connect(`ws://localhost:${port}`)
+      expect(sleepBlocker.acquire).toHaveBeenCalled()
+      expect(sleepBlocker.release).not.toHaveBeenCalled()
+      agent.disconnect()
+      expect(sleepBlocker.release).toHaveBeenCalled()
+    })
+  })
+
   describe('pinch relay messages', () => {
     beforeEach(() => { MockTouchHelper.mockClear() })
 


### PR DESCRIPTION
## Summary

Three issues found during QA, unrelated to B-2/B-3 (#215):

1. **ScrcpyVideo cleanup bug** — The stream wasn't closed on socket `'close'` (device shutdown → `videoSocket.destroy()` emits `'close'` without a FIN), so after a shutdown the agent pump blocked forever on `reader.read()` and its timers (e.g. stream metrics) leaked, logging 0fps for a device that no longer existed. Settle the stream exactly once via a single `finish()` wired to `'end'` / `'close'` / `'error'`.

2. **Android stream metrics** — `TAPFLOW_STREAM_METRICS=1` now logs fps / KB·s / drop every 5s (parity with ios-agent). Distinguishes a source-bound bottleneck (low fpsSent) from a relay→browser one (high fpsSent + relay drops). The Android pump was the only streaming path without this sample.

3. **macOS power assertion (caffeinate)** — An unattended / idle / backgrounded Mac throttles the emulator's software H.264 encoder, dropping Android to ~4-18fps (verified that `caffeinate -i pnpm dev` fixes it). Add agent-core `createSleepBlocker()` (`caffeinate -i`, idempotent, macOS-only, silently no-op if caffeinate is missing). Both agents hold it from connect to disconnect (kept across reconnects). Limit: prevents idle/sleep throttle only — it does not override battery CPU scaling.

## Checklist

- [x] Tests written and passing (agent-core 97 / android 71 / ios 159, lint + tsc clean)
- [x] No `any` (none in production code; injected via DI in tests)
- [x] Interface changes land in `agent-core` first (`createSleepBlocker` added to agent-core, then used by both agents)
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`2026-06-06-agent-keep-awake-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS devices now prevent system sleep while connections are active, avoiding performance throttling during relay sessions.
  * Optional per-stream metrics collection for video performance analysis.

* **Bug Fixes**
  * Improved video stream handling to properly terminate when underlying socket closes unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->