### PR TITLE
chore: English PR template + CONTRIBUTING language note

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
-## 변경 내용
+## Summary
 
-<!-- 무엇을 왜 변경했는지 간략히 -->
+<!-- What changed and why, briefly -->
 
-## 체크리스트
+## Checklist
 
-- [ ] 테스트 작성 및 통과 확인
-- [ ] `any` 미사용
-- [ ] 인터페이스 변경 시 `agent-core` 먼저 수정
-- [ ] 민감 정보(토큰, 경로, 자격증명) 미포함
+- [ ] Tests written and passing
+- [ ] No `any`
+- [ ] Interface changes land in `agent-core` first
+- [ ] No sensitive info (tokens, paths, credentials)
 
-## 관련 `.work/` 문서
+## Related `.work/` docs
 
-<!-- plan/review 파일 있으면 이름 기재 -->
+<!-- Name the plan/review file, if any -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,10 @@ Platform-specific implementation notes for contributors:
 - type: `feat` · `fix` · `test` · `refactor` · `docs` · `chore` · `perf`
 - scope: the changed package name (`agent-core` · `ios-agent` · `android-agent` · `relay` · `dashboard` · `cli` · `playground`)
 
+## Language
+
+Write PRs, issues, and commit messages in English (internal `.work/` and `CLAUDE.md` docs may be in any language).
+
 ## Reporting bugs
 
 Use the [Bug Report](https://github.com/jo-duchan/tapflow/issues/new?template=bug_report.yml) issue template. Include steps to reproduce, expected vs. actual behavior, and your environment (tapflow version, Node.js version, and Xcode version for iOS issues).


### PR DESCRIPTION
## Summary

Make English the convention for contributor-facing text:
- Translate `.github/pull_request_template.md` from Korean to English.
- Add a **Language** note in `CONTRIBUTING.md`: write PRs, issues, and commit messages in English (internal `.work/` and `CLAUDE.md` docs may be in any language).

## Checklist

- [x] Tests written and passing (docs-only change, no tests needed)
- [x] No `any`
- [x] Interface changes land in `agent-core` first (n/a)
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)