### PR TITLE
chore: release v0.6.0 — robust Android LAN streaming + idle-throttle prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-06
+
+### Added
+
+- android: opt-in stream throughput metrics (`TAPFLOW_STREAM_METRICS=1`) logging fps / KB·s / drop every 5s, matching the iOS agent.
+- agents: hold a macOS power assertion (`caffeinate -i`) while connected so an unattended/idle Mac doesn't throttle the simulator/emulator. macOS-only; no-op elsewhere.
+
+### Changed
+
+- android: H.264 frames now carry the codec/keyframe flags in the stream envelope, so the relay's keyframe-aware backpressure drops to the next keyframe under LAN congestion instead of forwarding P-frames that tear. (scrcpy `send_frame_meta=true`; the public `stream()` contract is unchanged.)
+- android: on-demand IDR recovery — `stream:request-idr` now resets the scrcpy encoder (RESET_VIDEO), resyncing fast instead of waiting for the periodic IDR (parity with iOS).
+
+### Fixed
+
+- android: the scrcpy stream now terminates on socket close, so the agent's pump and its timers no longer leak after a device shuts down.
+
 ## [0.5.1] - 2026-06-06
 
 ### Fixed
@@ -64,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/jo-duchan/tapflow/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jo-duchan/tapflow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jo-duchan/tapflow/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jo-duchan/tapflow/compare/v0.4.0...v0.4.1

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tapflowio/agent-core
 
+## 0.6.0
+
+### Minor Changes
+
+- Robust Android LAN streaming — keyframe-aware backpressure, on-demand IDR recovery, and idle-throttle prevention.
+
+  - Android H.264 frames now carry the codec/keyframe flags in the stream envelope, so the relay's keyframe-aware backpressure preserves the reference chain under LAN congestion — it drops to the next keyframe instead of forwarding P-frames that tear. (`scrcpy send_frame_meta=true`; the public `stream()` contract is unchanged.)
+  - On-demand IDR recovery for Android: the relay's `stream:request-idr` now resets the scrcpy encoder (RESET_VIDEO), resyncing fast instead of waiting for the periodic IDR — bringing Android congestion recovery to parity with iOS.
+  - Agents hold a macOS power assertion (`caffeinate -i`) while connected so an unattended/idle Mac doesn't throttle the simulator/emulator. macOS-only; no-op elsewhere.
+  - Fixed: the Android scrcpy stream now terminates on socket close, so the agent's pump and its timers no longer leak after a device shuts down.
+  - Added: opt-in Android stream throughput metrics (`TAPFLOW_STREAM_METRICS=1`), matching the iOS agent.
+
 ## 0.5.1
 
 ## 0.5.0

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @tapflowio/android-agent
 
+## 0.6.0
+
+### Minor Changes
+
+- Robust Android LAN streaming — keyframe-aware backpressure, on-demand IDR recovery, and idle-throttle prevention.
+
+  - Android H.264 frames now carry the codec/keyframe flags in the stream envelope, so the relay's keyframe-aware backpressure preserves the reference chain under LAN congestion — it drops to the next keyframe instead of forwarding P-frames that tear. (`scrcpy send_frame_meta=true`; the public `stream()` contract is unchanged.)
+  - On-demand IDR recovery for Android: the relay's `stream:request-idr` now resets the scrcpy encoder (RESET_VIDEO), resyncing fast instead of waiting for the periodic IDR — bringing Android congestion recovery to parity with iOS.
+  - Agents hold a macOS power assertion (`caffeinate -i`) while connected so an unattended/idle Mac doesn't throttle the simulator/emulator. macOS-only; no-op elsewhere.
+  - Fixed: the Android scrcpy stream now terminates on socket close, so the agent's pump and its timers no longer leak after a device shuts down.
+  - Added: opt-in Android stream throughput metrics (`TAPFLOW_STREAM_METRICS=1`), matching the iOS agent.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.6.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # tapflow
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.6.0
+  - @tapflowio/android-agent@0.6.0
+  - @tapflowio/ios-agent@0.6.0
+  - @tapflowio/relay@0.6.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @tapflowio/ios-agent
 
+## 0.6.0
+
+### Minor Changes
+
+- Robust Android LAN streaming — keyframe-aware backpressure, on-demand IDR recovery, and idle-throttle prevention.
+
+  - Android H.264 frames now carry the codec/keyframe flags in the stream envelope, so the relay's keyframe-aware backpressure preserves the reference chain under LAN congestion — it drops to the next keyframe instead of forwarding P-frames that tear. (`scrcpy send_frame_meta=true`; the public `stream()` contract is unchanged.)
+  - On-demand IDR recovery for Android: the relay's `stream:request-idr` now resets the scrcpy encoder (RESET_VIDEO), resyncing fast instead of waiting for the periodic IDR — bringing Android congestion recovery to parity with iOS.
+  - Agents hold a macOS power assertion (`caffeinate -i`) while connected so an unattended/idle Mac doesn't throttle the simulator/emulator. macOS-only; no-op elsewhere.
+  - Fixed: the Android scrcpy stream now terminates on socket close, so the agent's pump and its timers no longer leak after a device shuts down.
+  - Added: opt-in Android stream throughput metrics (`TAPFLOW_STREAM_METRICS=1`), matching the iOS agent.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.6.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.5.1-experimental.1",
+  "version": "0.6.0-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/relay
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.6.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Release **v0.6.0** — Robust Android LAN streaming: keyframe-aware backpressure, on-demand IDR recovery, and idle-throttle prevention.

### Versions

| Package | Version |
|---|---|
| `tapflow` (cli) · `@tapflowio/agent-core` · `@tapflowio/ios-agent` · `@tapflowio/android-agent` · `@tapflowio/relay` | `0.6.0` (fixed group) |
| `@tapflowio/mcp-server` | `0.6.0-experimental.1` (experimental dist-tag) |
| `@tapflowio/dashboard` · `@tapflowio/playground` | unchanged (ignored/private) |

### Release notes

**Added**
- android: opt-in stream throughput metrics (`TAPFLOW_STREAM_METRICS=1`) — fps / KB·s / drop, matching the iOS agent.
- agents: hold a macOS power assertion (`caffeinate -i`) while connected so an unattended/idle Mac doesn't throttle the simulator/emulator. macOS-only; no-op elsewhere.

**Changed**
- android: H.264 frames now carry codec/keyframe flags in the stream envelope, so the relay's keyframe-aware backpressure drops to the next keyframe under LAN congestion instead of forwarding P-frames that tear. (scrcpy `send_frame_meta=true`; public `stream()` contract unchanged.)
- android: on-demand IDR recovery — `stream:request-idr` resets the scrcpy encoder (RESET_VIDEO), resyncing fast instead of waiting for the periodic IDR (parity with iOS).

**Fixed**
- android: the scrcpy stream now terminates on socket close, so the agent's pump and timers no longer leak after a device shuts down.

### Compatibility

No breaking changes — minor bump. The frame envelope structure is unchanged (Android now correctly *sets* flags the relay/browser already read; covered by `agent-core/envelope.test.ts` "backward compatible" case). `DeviceAgent.stream()` signature unchanged; new APIs (`createSleepBlocker`, optional `sleepBlocker` option) are additive.

### Release mechanics

- `changeset version` applied; changeset consumed; `mcp-server` bumped manually (experimental, changeset-ignored).
- Root `CHANGELOG.md` promoted to `[0.6.0] - 2026-06-06` with compare links.
- `pnpm-lock.yaml` unchanged (workspace deps); lint + typecheck pass.
- Publish is triggered by pushing the `v0.6.0` tag after merge (OIDC trusted publishing) — not by the merge itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version 0.6.0 released with Android LAN streaming enhancements, macOS power management updates, improved stream stability, and optional throughput metrics.

* **Chores**
  * Bumped all package versions to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->