### PR TITLE
fix(android): don't double-close the scrcpy stream after reader cancel

### DIFF
--- a/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
+++ b/packages/android-agent/src/__tests__/ScrcpyVideo.test.ts
@@ -156,4 +156,26 @@ describe('ScrcpyVideo (send_frame_meta=true)', () => {
     const video = new ScrcpyVideo(socket)
     await expect(video.deviceInfo()).rejects.toThrow()
   })
+
+  // Regression: cancelling the reader closes the stream; cancel() then runs socket.destroy()
+  // which emits 'close' → finish() must NOT call controller.close()/error() on the already-
+  // closed controller (throws ERR_INVALID_STATE in the socket event handler otherwise).
+  it.each(['close', 'error'] as const)(
+    'does not throw when the socket emits %s after the reader is cancelled',
+    async (event) => {
+      const emitter = new EventEmitter() as EventEmitter & { destroy: () => void }
+      emitter.destroy = () => emitter.emit(event) // scrcpy's cancel path: socket.destroy()
+      const socket = emitter as unknown as Socket
+      const video = new ScrcpyVideo(socket)
+      process.nextTick(() => {
+        emitter.emit('data', makeHeader('t', 576, 1280))
+        emitter.emit('data', makePacket(annexB(PSLICE)))
+      })
+      await video.deviceInfo()
+      const reader = video.start().getReader()
+      await reader.read()
+      // With the bug, cancel()'s destroy → finish() → controller.close() throws → cancel rejects.
+      await expect(reader.cancel()).resolves.toBeUndefined()
+    },
+  )
 })

--- a/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
+++ b/packages/android-agent/src/scrcpy/ScrcpyVideo.ts
@@ -70,8 +70,12 @@ export class ScrcpyVideo {
       return
     }
     if (!this.streamController) return // start() will close once it observes endReceived
-    if (err) this.streamController.error(err)
-    else this.streamController.close()
+    // The controller may already be closed (e.g. a late socket event after another
+    // settle path) — closing/erroring twice throws, so swallow it.
+    try {
+      if (err) this.streamController.error(err)
+      else this.streamController.close()
+    } catch { /* already closed */ }
   }
 
   deviceInfo(): Promise<ScrcpyDeviceInfo> {
@@ -92,6 +96,9 @@ export class ScrcpyVideo {
         if (this.endReceived) controller.close()
       },
       cancel: () => {
+        // The consumer cancelled — the stream is already settled by the ReadableStream
+        // itself, so the socket 'close'/'error' that destroy() triggers must not re-close it.
+        this.streamSettled = true
         this.socket.destroy()
       },
     })


### PR DESCRIPTION
## Summary

Fixes a latent crash shipped in v0.6.0 (the socket-close cleanup).

When a consumer of `ScrcpyVideo`'s stream cancels the reader, the ReadableStream closes the controller and *then* runs the cancel callback (`socket.destroy()`), which emits `'close'` → `finish()` called `controller.close()` on the already-closed controller. That throws `ERR_INVALID_STATE` **inside the socket event handler** — an unhandled throw that can crash the agent. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close), `close()` throws when the stream is already closed, cancelled, or errored.

The pump path (which never cancels) was unaffected; the public `DeviceAgent.stream()` + cancel path is the trigger.

### Fix

- Mark the stream settled in the cancel callback, so the follow-up `'close'`/`'error'` from `destroy()` is a no-op.
- Guard `finish()`'s `close`/`error` with `try/catch` for any other late double-settle path (belt-and-suspenders).

## Checklist

- [x] Tests written and passing (android-agent 73; lint + tsc clean) — new regression tests: cancel-then-close and cancel-then-error no longer throw
- [x] No `any`
- [x] Interface changes land in `agent-core` first (n/a — android-agent only)
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

None. (Found during Job A encoder re-verification; see `.work/2026-06-05-lan-render-pipe-latency-plan.md` context.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream finalization to defensively handle cases where streams are already closed or errored, preventing potential crashes.
  * Enhanced stream cancellation handling to prevent duplicate settlement attempts when socket events occur after cancellation.

* **Tests**
  * Added regression test suite ensuring stream cancellation path stability and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->