### PR TITLE
docs(android): correct the playstore/c2 encoder claims (re-verified)

### DIFF
--- a/contributing/android-video-streaming-diagnosis.md
+++ b/contributing/android-video-streaming-diagnosis.md
@@ -33,6 +33,19 @@ The scrcpy official FAQ documents the same error ("then try with another encoder
 
 Apple Silicon: use `system-images;android-34;google_apis;arm64-v8a`.
 
+### Re-verification (2026-06-06, scrcpy 3.3)
+
+Re-tested the 2×2 (encoder × image) on current emulators with scrcpy 3.3 at native 1080×2424:
+
+| Image | `c2.android.avc.encoder` | `OMX.google.h264.encoder` (pinned) |
+|---|---|---|
+| `google_apis_playstore` (android-36) | STREAMS | STREAMS |
+| `google_apis` (android-34) | STREAMS | STREAMS |
+
+All four stream with no crash. The original crash is the H.264 **even-width requirement** (`(src.width() & 1) == 0`) — a general encoder constraint triggered by an **odd capture width**, not a playstore-specific defect; it did not reproduce at native even width. `OMX.google` can itself fail MediaCodec config in some environments (scrcpy [#6275](https://github.com/genymobile/scrcpy/issues/6275)).
+
+**Takeaway**: `google_apis` stays the tested/recommended image (CI). Playstore isn't fundamentally broken on current images, but it's untested. The real risk to guard is **odd-width capture** (rotation / `max_size`) — keep capture dimensions even.
+
 ### Command to list available encoders
 
 ```bash

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -69,7 +69,7 @@ Create an AVD using Android Studio's AVD Manager. See [Create and manage virtual
 When selecting the system image, note the following:
 
 ::: warning AVD image matters
-Use `google_apis/arm64-v8a` — **not** `google_apis_playstore`. The Play Store image causes the H.264 encoder to crash silently.
+Use a `google_apis/arm64-v8a` image — the tested and recommended configuration. The `google_apis_playstore` image is not tested and has shown H.264 encoder issues.
 :::
 
 The agent boots the emulator automatically, waits for `sys.boot_completed`, then begins streaming.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -68,7 +68,7 @@ Install it from Xcode → Settings → Platforms.
 
 ### Stream does not start or encoder crashes
 
-Occurs when the AVD uses the `google_apis_playstore` image. Recreate the AVD with the `google_apis/arm64-v8a` image:
+Most often the AVD uses an untested `google_apis_playstore` image. Recreate the AVD with the tested `google_apis/arm64-v8a` image:
 
 ```sh
 sdkmanager "system-images;android-34;google_apis;arm64-v8a"

--- a/docs/ko/guide/agent.md
+++ b/docs/ko/guide/agent.md
@@ -69,7 +69,7 @@ Android Studio의 AVD Manager에서 AVD를 생성합니다. 자세한 방법은 
 AVD를 생성할 때 시스템 이미지 선택에 주의하세요:
 
 ::: warning AVD 이미지 선택이 중요합니다
-`google_apis/arm64-v8a`를 사용하세요. **`google_apis_playstore` 이미지는 사용하지 마세요.** Play Store 이미지는 H.264 인코더가 조용히 크래시합니다.
+`google_apis/arm64-v8a` 이미지를 사용하세요. 이것이 테스트된 권장 구성입니다. `google_apis_playstore` 이미지는 테스트되지 않았으며 H.264 인코더 문제가 보고되었습니다.
 :::
 
 에이전트가 에뮬레이터를 자동으로 부팅하고, `sys.boot_completed`를 기다린 뒤 스트리밍을 시작합니다.

--- a/docs/ko/guide/troubleshooting.md
+++ b/docs/ko/guide/troubleshooting.md
@@ -68,7 +68,7 @@ Xcode → Settings → Platforms에서 iOS 18+ 런타임을 설치합니다.
 
 ### 스트림이 시작되지 않거나 인코더 크래시
 
-AVD가 `google_apis_playstore` 이미지를 사용하고 있는 경우 발생합니다. `google_apis/arm64-v8a` 이미지로 AVD를 다시 생성하세요.
+대개 AVD가 테스트되지 않은 `google_apis_playstore` 이미지를 사용할 때 발생합니다. 테스트된 `google_apis/arm64-v8a` 이미지로 AVD를 다시 생성하세요.
 
 ```sh
 sdkmanager "system-images;android-34;google_apis;arm64-v8a"

--- a/packages/android-agent/AGENTS.md
+++ b/packages/android-agent/AGENTS.md
@@ -13,8 +13,8 @@ Runs alongside `ios-agent` on the same Mac.
 
 - ADB commands are isolated in `AdbWrapper`, swappable with an `AdbRunner` mock in tests.
 - On emulator boot: `EmulatorLauncher.waitForBoot(serial)` — polls `sys.boot_completed=1`.
-- Screen streaming: `ScrcpySession` → `ScrcpyVideo` — pushes the scrcpy server to the device, runs it, and receives an H.264 Annex B stream over a TCP socket. AVD image must be `google_apis/arm64-v8a` (android-34) — `google_apis_playstore` images crash the H.264 encoder.
-- **Encoder**: `OMX.google.h264.encoder` (pure software) is pinned. The default `c2.android.avc.encoder` (Codec 2.0) stalls silently when GPU processes such as Chrome are running under the virtualized GPU layer — neither the scrcpy server nor the pump loop can detect the stall. On emulators there is no performance difference since everything is software-emulated anyway.
+- Screen streaming: `ScrcpySession` → `ScrcpyVideo` — pushes the scrcpy server to the device, runs it, and receives an H.264 Annex B stream over a TCP socket. Use a `google_apis/arm64-v8a` (android-34) image — the tested/recommended config; `google_apis_playstore` is untested (see `contributing/android-video-streaming-diagnosis.md`).
+- **Encoder**: `OMX.google.h264.encoder` (pure software) is pinned — the tested encoder. The default `c2.android.avc.encoder` (Codec 2.0) has shown silent stalls / encoder errors under GPU load (e.g. Chrome) on the virtualized GPU layer that neither the scrcpy server nor the pump loop can detect; the software encoder avoids that, with no emulator perf difference since everything is software-emulated anyway. Encoder availability and config success vary by image/environment — `google_apis` is the verified one.
 - scrcpy protocol: two connections in order — video socket (1st) + control socket (2nd) — before the server begins streaming. `ScrcpyControl` keeps the control socket open and serves as the foundation for the binary touch protocol.
 - Touch: `ScrcpyControl.touchDown/touchMove/touchUp` takes priority when a scrcpy session is active (low-latency binary protocol). Falls back to `AndroidTouchHelper` (`adb input tap/swipe`) only when no scrcpy session is running.
 - AVD name is the stable key for `Device.id` (`"avd:<name>"`). ADB serial is kept only in the internal `serialMap`.
@@ -25,8 +25,8 @@ Runs alongside `ios-agent` on the same Mac.
 
 - Do not hardcode the ADB path — use `$ANDROID_HOME/platform-tools/adb` or `$ADB_PATH`.
 - Do not run ADB commands before confirming emulator boot is complete.
-- Do not use `google_apis_playstore` AVD images — H.264 encoder crashes.
-- Do not revert to `video_encoder=c2.android.avc.encoder` — stalls silently with Chrome and other GPU-heavy apps.
+- Don't switch to `google_apis_playstore` AVD images without testing — untested, with historical H.264 encoder crashes (odd-width capture). `google_apis` is the verified image.
+- Do not revert to `video_encoder=c2.android.avc.encoder` — it has shown silent stalls / encoder errors under GPU load; the pinned `OMX.google` software encoder is the tested one.
 - Do not open only the video socket in `ScrcpySession.start()` and skip the control socket — violates the scrcpy protocol and the server will not start streaming.
 - Do not break the `AndroidTouchHelper` interface to add low-latency touch — replace only the internal implementation.
 - Do not pollute the `agent-core` `DeviceAgent` interface with Android-specific methods.


### PR DESCRIPTION
## Summary

Re-verification (Job A) showed the "`google_apis_playstore` crashes the H.264 encoder" claim is over-broad. A 2×2 test (c2/OMX × playstore/google_apis, scrcpy 3.3, native 1080×2424) had **all four stream with no crash**:

| Image | `c2.android.avc.encoder` | `OMX.google.h264.encoder` (pinned) |
|---|---|---|
| `google_apis_playstore` (android-36) | STREAMS | STREAMS |
| `google_apis` (android-34) | STREAMS | STREAMS |

The documented crash is the general H.264 **even-width requirement** (`(src.width() & 1) == 0`) — triggered by odd capture width, not a playstore defect. And encoder config can fail by environment regardless ([scrcpy #6275](https://github.com/genymobile/scrcpy/issues/6275)).

So this corrects the absolute "crashes" wording to **"`google_apis` is the tested/recommended image; `google_apis_playstore` is untested"** — `google_apis` stays recommended (it's what CI uses). No behavior change.

### Files
- `packages/android-agent/AGENTS.md` — internal: accurate mechanism (even-width, env-dependent), c2/OMX wording.
- `contributing/android-video-streaming-diagnosis.md` — Issue 1: added the re-verification table + takeaway.
- `docs/guide/agent.md` + `docs/ko/guide/agent.md` — softened the user-facing warning.
- `docs/guide/troubleshooting.md` + `docs/ko/guide/troubleshooting.md` — softened "Occurs when…".

## Checklist

- [x] Tests written and passing (docs-only; `pnpm docs:build` passes, lint + tsc clean)
- [x] No `any`
- [x] Interface changes land in `agent-core` first (n/a)
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/2026-06-05-lan-render-pipe-latency-plan.md` (Job A context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android emulator configuration guidance across multiple languages to clearly recommend the `google_apis/arm64-v8a` image as the tested and supported configuration for video streaming.
  * Improved troubleshooting documentation with explicit steps for resolving Android emulator streaming issues, including image selection recommendations.
  * Added diagnostic notes verifying compatibility with current emulator images and documenting encoder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->