### PR TITLE
chore: release v0.6.1 — fix scrcpy stream cancel crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-06
+
+### Fixed
+
+- android: fix a crash when the scrcpy video stream is cancelled. The v0.6.0 socket-close cleanup could call `close()`/`error()` on an already-closed stream controller, throwing inside the socket event handler.
+
 ## [0.6.0] - 2026-06-06
 
 ### Added
@@ -80,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/jo-duchan/tapflow/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/jo-duchan/tapflow/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jo-duchan/tapflow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jo-duchan/tapflow/compare/v0.4.1...v0.5.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/android-agent
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix a crash when the scrcpy video stream is cancelled. The v0.6.0 socket-close cleanup could call `close()`/`error()` on an already-closed ReadableStream controller (after the consumer cancelled the reader), throwing `ERR_INVALID_STATE` inside the socket event handler. The stream is now marked settled on cancel and the close/error is guarded.
+  - @tapflowio/agent-core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # tapflow
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/android-agent@0.6.1
+  - @tapflowio/agent-core@0.6.1
+  - @tapflowio/ios-agent@0.6.1
+  - @tapflowio/relay@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.6.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.6.0-experimental.1",
+  "version": "0.6.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.6.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Patch release **v0.6.1** — fixes a crash regression shipped in v0.6.0.

### Versions

| Package | Version |
|---|---|
| `tapflow` (cli) · `@tapflowio/agent-core` · `@tapflowio/ios-agent` · `@tapflowio/android-agent` · `@tapflowio/relay` | `0.6.1` (fixed group) |
| `@tapflowio/mcp-server` | `0.6.1-experimental.1` (experimental dist-tag) |
| `@tapflowio/dashboard` · `@tapflowio/playground` | unchanged (ignored/private) |

### Release notes

**Fixed**
- android: fix a crash when the scrcpy video stream is cancelled. The v0.6.0 socket-close cleanup could call `close()`/`error()` on an already-closed ReadableStream controller (after the consumer cancelled the reader), throwing `ERR_INVALID_STATE` inside the socket event handler ([#220](https://github.com/jo-duchan/tapflow/pull/220)).

### Compatibility

No breaking changes — patch. Internal `ScrcpyVideo` bug fix only; no protocol / interface / CLI changes.

### Release mechanics

- `changeset version` applied; changeset consumed; `mcp-server` bumped manually (experimental, changeset-ignored).
- Root `CHANGELOG.md` promoted to `[0.6.1] - 2026-06-06` with compare links.
- `pnpm-lock.yaml` unchanged; lint + typecheck pass.
- Publish is triggered by pushing the `v0.6.1` tag after merge (OIDC trusted publishing) — not by the merge itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an Android crash that occurred when the scrcpy video stream was cancelled during socket cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->