### PR TITLE
refactor(tests): remove all `as any` casts from test code

### DIFF
--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -66,8 +66,32 @@ import { hasEnvelope, readEnvelopeFlags, CODEC_H264, CODEC_JPEG } from '@tapflow
 import { AndroidAgent } from '../AndroidAgent'
 import { AdbWrapper } from '../AdbWrapper'
 import { ScrcpySession } from '../scrcpy/ScrcpySession'
+import type { ScrcpyControl } from '../scrcpy/ScrcpyControl'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 import type { AdbRunner } from '../adb'
+
+// Test-only view of a per-device state entry (the real DeviceState is not exported).
+interface TestState {
+  restarting: boolean
+  scrcpySession: { control: ScrcpyControl } | null
+  streamWs: WebSocket | null
+}
+
+// Test-only view of AndroidAgent internals (device state + reconnect fields are private).
+interface AndroidAgentInternals {
+  ws: WebSocket | null
+  adb: AdbWrapper
+  deviceStates: Map<string, TestState>
+  _stopping: boolean
+  _reconnectTimer: ReturnType<typeof setTimeout> | null
+  _reconnectAttempt: number
+  _scheduleReconnect(): void
+  restartVideoStream(state: TestState): Promise<void>
+  cleanupDeviceState(state: TestState): void
+  handleRelayMessage(msg: unknown): void
+}
+const internals = (agent: AndroidAgent): AndroidAgentInternals =>
+  agent as unknown as AndroidAgentInternals
 
 function mockAdb(booted = false): AdbWrapper {
   const runner: AdbRunner = {
@@ -319,17 +343,11 @@ describe('AndroidAgent', () => {
   })
 
   describe('auto-restart', () => {
-    interface TestState {
-      restarting: boolean
-      scrcpySession: object | null
-      streamWs: WebSocket | null
-    }
-
     let agent: AndroidAgent
     let browser: WebSocket
 
     function getState(): TestState {
-      return (agent as any).deviceStates.values().next().value as TestState
+      return internals(agent).deviceStates.values().next().value!
     }
 
     beforeEach(async () => {
@@ -354,7 +372,7 @@ describe('AndroidAgent', () => {
     describe('pump exit guard', () => {
       it('calls restartVideoStream when stream ends unexpectedly', async () => {
         scrcpyCloseOnCreate = true
-        const restartSpy = vi.spyOn(agent as any, 'restartVideoStream').mockResolvedValue(undefined)
+        const restartSpy = vi.spyOn(internals(agent), 'restartVideoStream').mockResolvedValue(undefined)
 
         browser.send(JSON.stringify({
           type: 'device:boot',
@@ -367,7 +385,7 @@ describe('AndroidAgent', () => {
       })
 
       it('skips restartVideoStream when restarting flag is already set', async () => {
-        const restartSpy = vi.spyOn(agent as any, 'restartVideoStream').mockResolvedValue(undefined)
+        const restartSpy = vi.spyOn(internals(agent), 'restartVideoStream').mockResolvedValue(undefined)
 
         browser.send(JSON.stringify({
           type: 'device:boot',
@@ -385,7 +403,7 @@ describe('AndroidAgent', () => {
       })
 
       it('skips restartVideoStream when session was intentionally stopped', async () => {
-        const restartSpy = vi.spyOn(agent as any, 'restartVideoStream').mockResolvedValue(undefined)
+        const restartSpy = vi.spyOn(internals(agent), 'restartVideoStream').mockResolvedValue(undefined)
 
         browser.send(JSON.stringify({
           type: 'device:boot',
@@ -395,7 +413,7 @@ describe('AndroidAgent', () => {
         await waitForType(browser, 'device:ready')
 
         const state = getState()
-        ;(agent as any).cleanupDeviceState(state) // sets scrcpySession = null
+        internals(agent).cleanupDeviceState(state) // sets scrcpySession = null
         scrcpyStreamController?.close()
 
         await vi.waitFor(() => expect(restartSpy).not.toHaveBeenCalled(), { timeout: 200 })
@@ -437,11 +455,11 @@ describe('AndroidAgent', () => {
         }))
         await waitForType(browser, 'device:ready')
 
-        const control = (getState() as any).scrcpySession.control
+        const control = getState().scrcpySession!.control
         expect(control.resetVideo).not.toHaveBeenCalled()
 
         // Relay sends this agent-ward during drop-to-keyframe recovery.
-        ;(agent as any).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId })
+        internals(agent).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId })
 
         expect(control.resetVideo).toHaveBeenCalledOnce()
       })
@@ -449,7 +467,7 @@ describe('AndroidAgent', () => {
       it('ignores stream:request-idr when no scrcpy session is active', () => {
         // No device booted → no session; handler must not throw.
         expect(() =>
-          (agent as any).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId }),
+          internals(agent).handleRelayMessage({ type: 'stream:request-idr', sessionId: agent.sessionId }),
         ).not.toThrow()
       })
     })
@@ -466,11 +484,11 @@ describe('AndroidAgent', () => {
       })
 
       it('resets restarting flag when serial is not found', async () => {
-        vi.spyOn((agent as any).adb as AdbWrapper, 'getSerial').mockReturnValue(undefined)
+        vi.spyOn(internals(agent).adb, 'getSerial').mockReturnValue(undefined)
 
         const state = getState()
         state.restarting = true
-        await (agent as any).restartVideoStream(state)
+        await internals(agent).restartVideoStream(state)
 
         expect(state.restarting).toBe(false)
       })
@@ -480,7 +498,7 @@ describe('AndroidAgent', () => {
         state.streamWs = null
         state.restarting = true
 
-        await (agent as any).restartVideoStream(state)
+        await internals(agent).restartVideoStream(state)
 
         expect(state.restarting).toBe(false)
       })
@@ -493,7 +511,7 @@ describe('AndroidAgent', () => {
         state.restarting = true
 
         const bootErrPromise = waitForType(browser, 'device:boot-error')
-        const restartPromise = (agent as any).restartVideoStream(state)
+        const restartPromise = internals(agent).restartVideoStream(state)
         await vi.runAllTimersAsync()
         await restartPromise
 
@@ -508,7 +526,7 @@ describe('AndroidAgent', () => {
         const state = getState()
         state.restarting = true
 
-        const restartPromise = (agent as any).restartVideoStream(state)
+        const restartPromise = internals(agent).restartVideoStream(state)
         await vi.runAllTimersAsync()
         await restartPromise
 
@@ -524,23 +542,23 @@ describe('AndroidAgent', () => {
       const agent = new AndroidAgent({}, mockAdb())
       await agent.connect(`ws://localhost:${port}`)
 
-      ;(agent as any)._reconnectTimer = setTimeout(() => {}, 10000)
+      internals(agent)._reconnectTimer = setTimeout(() => {}, 10000)
 
       agent.disconnect()
 
-      expect((agent as any)._stopping).toBe(true)
-      expect((agent as any)._reconnectTimer).toBeNull()
+      expect(internals(agent)._stopping).toBe(true)
+      expect(internals(agent)._reconnectTimer).toBeNull()
     })
 
     it('_scheduleReconnect() is no-op when _stopping is true', async () => {
       const agent = new AndroidAgent({}, mockAdb())
       await agent.connect(`ws://localhost:${port}`)
 
-      ;(agent as any)._stopping = true
-      ;(agent as any)._scheduleReconnect()
+      internals(agent)._stopping = true
+      internals(agent)._scheduleReconnect()
 
-      expect((agent as any)._reconnectTimer).toBeNull()
-      expect((agent as any)._reconnectAttempt).toBe(0)
+      expect(internals(agent)._reconnectTimer).toBeNull()
+      expect(internals(agent)._reconnectAttempt).toBe(0)
 
       agent.disconnect()
     })
@@ -549,11 +567,11 @@ describe('AndroidAgent', () => {
       const agent = new AndroidAgent({ reconnectDelays: [0] }, mockAdb())
       await agent.connect(`ws://localhost:${port}`)
 
-      const oldWs = (agent as any).ws as WebSocket
+      const oldWs = internals(agent).ws!
       oldWs.terminate()
 
       await vi.waitFor(() => {
-        const ws = (agent as any).ws as WebSocket | null
+        const ws = internals(agent).ws
         expect(ws).not.toBeNull()
         expect(ws).not.toBe(oldWs)       // 새 연결 객체여야 함
         expect(ws!.readyState).toBe(WebSocket.OPEN)

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -39,10 +39,18 @@ import { RelayServer, initDb, closeDb } from '@tapflowio/relay'
 import { IOSAgent } from '../IOSAgent'
 import { ScreenCaptureStreamer } from '../ScreenCaptureStreamer'
 import { SimctlWrapper } from '../SimctlWrapper'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { TouchHelper } from '../TouchHelper'
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const MockTouchHelper = TouchHelper as any
+const MockTouchHelper = vi.mocked(TouchHelper)
+
+// Test-only view of IOSAgent internals (reconnect state lives behind private fields).
+interface IOSAgentInternals {
+  ws: WebSocket | null
+  _stopping: boolean
+  _reconnectTimer: ReturnType<typeof setTimeout> | null
+  _reconnectAttempt: number
+  _scheduleReconnect(): void
+}
+const internals = (agent: IOSAgent): IOSAgentInternals => agent as unknown as IOSAgentInternals
 
 // HID usage codes from KeyCodeMap (duplicated here so tests are self-contained)
 const HID_BACKSPACE = 0x2A
@@ -549,23 +557,23 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({}, mockSimctl())
       await agent.connect(`ws://localhost:${port}`)
 
-      ;(agent as any)._reconnectTimer = setTimeout(() => {}, 10000)
+      internals(agent)._reconnectTimer = setTimeout(() => {}, 10000)
 
       agent.disconnect()
 
-      expect((agent as any)._stopping).toBe(true)
-      expect((agent as any)._reconnectTimer).toBeNull()
+      expect(internals(agent)._stopping).toBe(true)
+      expect(internals(agent)._reconnectTimer).toBeNull()
     })
 
     it('_scheduleReconnect() is no-op when _stopping is true', async () => {
       const agent = new IOSAgent({}, mockSimctl())
       await agent.connect(`ws://localhost:${port}`)
 
-      ;(agent as any)._stopping = true
-      ;(agent as any)._scheduleReconnect()
+      internals(agent)._stopping = true
+      internals(agent)._scheduleReconnect()
 
-      expect((agent as any)._reconnectTimer).toBeNull()
-      expect((agent as any)._reconnectAttempt).toBe(0)
+      expect(internals(agent)._reconnectTimer).toBeNull()
+      expect(internals(agent)._reconnectAttempt).toBe(0)
 
       agent.disconnect()
     })
@@ -574,11 +582,11 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({ reconnectDelays: [0] }, mockSimctl())
       await agent.connect(`ws://localhost:${port}`)
 
-      const oldWs = (agent as any).ws as WebSocket
+      const oldWs = internals(agent).ws!
       oldWs.terminate()
 
       await vi.waitFor(() => {
-        const ws = (agent as any).ws as WebSocket | null
+        const ws = internals(agent).ws
         expect(ws).not.toBeNull()
         expect(ws).not.toBe(oldWs)       // 새 연결 객체여야 함
         expect(ws!.readyState).toBe(WebSocket.OPEN)
@@ -593,8 +601,7 @@ describe('IOSAgent', () => {
   // path (no intervalMs) and reads the codec arg the mocked streamer was constructed with.
   describe('codec negotiation', () => {
     const ORIG_CODEC = process.env.TAPFLOW_IOS_CODEC
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const MockCapture = ScreenCaptureStreamer as any
+    const MockCapture = vi.mocked(ScreenCaptureStreamer)
 
     afterEach(() => {
       if (ORIG_CODEC === undefined) delete process.env.TAPFLOW_IOS_CODEC

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -648,13 +648,12 @@ describe('RelayServer', () => {
       observer.send(JSON.stringify({ type: 'agents:list' }))
       const listed = await waitForMessage(observer)
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sessions = listed.sessions as any[]
+      const sessions = listed.sessions!
       expect(sessions).toHaveLength(2)
       const macA = sessions.find((s) => s.agentName === 'Mac-A')
       const macB = sessions.find((s) => s.agentName === 'Mac-B')
-      expect(macA.devices).toHaveLength(2)
-      expect(macB.devices).toHaveLength(1)
+      expect(macA?.devices).toHaveLength(2)
+      expect(macB?.devices).toHaveLength(1)
 
       agentA.close()
       agentB.close()
@@ -679,10 +678,9 @@ describe('RelayServer', () => {
       await vi.waitFor(async () => {
         observer.send(JSON.stringify({ type: 'agents:list' }))
         const listed = await waitForMessage(observer)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const sessions = listed.sessions as any[]
-        const macA = sessions.find((s: { agentName: string }) => s.agentName === 'Mac-A')
-        const macB = sessions.find((s: { agentName: string }) => s.agentName === 'Mac-B')
+        const sessions = listed.sessions!
+        const macA = sessions.find((s) => s.agentName === 'Mac-A')
+        const macB = sessions.find((s) => s.agentName === 'Mac-B')
         expect(macA?.resources?.cpuPercent).toBe(30)
         expect(macB?.resources?.cpuPercent).toBe(70)
       }, { timeout: 500 })
@@ -710,8 +708,7 @@ describe('RelayServer', () => {
       await vi.waitFor(async () => {
         observer.send(JSON.stringify({ type: 'agents:list' }))
         const listed = await waitForMessage(observer)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const sessions = listed.sessions as any[]
+        const sessions = listed.sessions!
         expect(sessions).toHaveLength(1)
         expect(sessions[0].agentName).toBe('Mac-B')
       }, { timeout: 2000 })
@@ -848,8 +845,7 @@ describe('RelayServer', () => {
     await vi.waitFor(async () => {
       tmpObs.send(JSON.stringify({ type: 'agents:list' }))
       const listed = await waitForMessage(tmpObs)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((listed.sessions as any[])[0].devices[0].busy).toBe(false)
+      expect(listed.sessions![0].devices[0].busy).toBe(false)
     }, { timeout: 2000 })
     tmpObs.close()
 


### PR DESCRIPTION
## What

테스트 코드의 실제 `as any` 캐스팅 37건을 전부 제거하고 타입 안전한 방식으로 교체했습니다.

> grep으로 함께 잡히던 `expect.any()` matcher·문자열/주석 속 "any"는 타입 `any`가 아니라 대상에서 제외했습니다.

## Changes

| 파일 | 처리 |
|------|------|
| `relay/.../RelayServer.test.ts` | `listed.sessions as any[]` → `listed.sessions!` (반환 타입 `RelayMessage.sessions`가 이미 `SessionInfo[]`). `find()` 결과의 `undefined` 가능성이 타입에 드러나 `macA?.devices`로 정리 |
| `ios-agent/.../IOSAgent.test.ts` | `TouchHelper as any` / `ScreenCaptureStreamer as any` → `vi.mocked(...)`. private 접근 9건은 `IOSAgentInternals` 인터페이스 + `internals()` 헬퍼로 |
| `android-agent/.../AndroidAgent.test.ts` | private 접근 22건을 `AndroidAgentInternals` 인터페이스 + `internals()` 헬퍼로. `TestState`를 전역으로 올리고 `scrcpySession`을 `{ control: ScrcpyControl }`로 구체화 |

불필요해진 `// eslint-disable-next-line @typescript-eslint/no-explicit-any` 주석도 함께 제거했습니다.

## Why

private 멤버 접근을 매 줄 `as any`로 뚫는 대신 테스트 전용 `*Internals` 인터페이스로 한 번만 캐스팅하면, 실제 필드 타입(`NodeJS.Timeout | null` 등)이 잡혀 이후 시그니처/필드 변경이 컴파일 타임에 걸립니다. 런타임 동작 변화는 없습니다.

## Verification

- ✅ 남은 `as any` 0건
- ✅ typecheck 통과 (pre-commit 훅 포함, 9개 패키지 전부)
- ✅ 테스트: relay 168 / ios 159 / android 73 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced internal test infrastructure with improved type safety and stronger assertion patterns across agent and relay server tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->