### PR TITLE
docs(guide): document stream quality tiers + downscale tuning

### DIFF
--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -72,7 +72,7 @@ When selecting the system image, note the following:
 Use a `google_apis/arm64-v8a` image — the tested and recommended configuration. The `google_apis_playstore` image is not tested and has shown H.264 encoder issues.
 :::
 
-The agent boots the emulator automatically, waits for `sys.boot_completed`, then begins streaming.
+The agent boots the emulator automatically, waits for `sys.boot_completed`, then begins streaming. For emulators on Apple Silicon, the agent encodes H.264 on the Mac host (VideoToolbox), capped at 30 fps — no GPU load on the emulator itself.
 
 ### Troubleshooting
 
@@ -87,3 +87,29 @@ tapflow doctor
 ```
 
 See [Troubleshooting](/guide/troubleshooting) for more detailed solutions.
+
+## Stream quality
+
+tapflow automatically picks a stream resolution based on your browser's connection context:
+
+| Connection | Resolution cap | Decoder |
+|------------|---------------|---------|
+| Secure (localhost / LAN HTTPS) | native | WebCodecs (hardware) |
+| LAN HTTP | 1280 px longest side | WASM |
+| External | 1000 px longest side | WASM |
+
+On a **secure context** (localhost or HTTPS), the browser uses WebCodecs to decode H.264 in hardware — full simulator resolution with minimal CPU cost. On a non-secure LAN HTTP connection, the stream falls back to a software WASM decoder; tapflow caps the resolution at 1280 px to keep decode overhead manageable.
+
+To get the sharpest stream on a shared LAN, **serve the relay over HTTPS** — see [Self-Hosting the Relay](/guide/self-hosting). Browsers on HTTPS switch to hardware decoding at native resolution automatically.
+
+### Override environment variables
+
+Set these on the Mac running the agent to override the defaults.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TAPFLOW_MAX_SIZE` | *(per tier)* | Cap for all platforms (px, longest side). `0` forces native resolution on all connections. |
+| `TAPFLOW_MAX_SIZE_LAN` | `1280` | LAN HTTP cap. |
+| `TAPFLOW_MAX_SIZE_EXTERNAL` | `1000` | External connection cap. |
+| `TAPFLOW_IOS_MAX_SIZE` | *(per tier)* | iOS-specific override. Takes precedence over `TAPFLOW_MAX_SIZE`. |
+| `TAPFLOW_ANDROID_MAX_SIZE` | *(per tier)* | Android-specific override. Takes precedence over `TAPFLOW_MAX_SIZE`. |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -199,6 +199,8 @@ Sessions auto-close after 30 minutes of inactivity. This timeout cannot be chang
 - Check CPU and RAM usage for the affected Mac in the **Mac Resources** tab.
 - Reduce the number of simulators running simultaneously on one Mac.
 
+**Blurry or low-resolution stream on LAN:** On non-secure HTTP connections, tapflow caps the stream at 1280 px (longest side) to keep WASM decoder load manageable. To stream at the simulator's native resolution, serve the relay over HTTPS — see [Self-Hosting the Relay](/guide/self-hosting). You can also raise the cap without HTTPS by setting `TAPFLOW_MAX_SIZE_LAN` on the agent; see [Stream quality](/guide/agent#stream-quality).
+
 ## Auth issues
 
 ### `tapflow init` fails (`ALREADY INITIALIZED`)

--- a/docs/ko/guide/agent.md
+++ b/docs/ko/guide/agent.md
@@ -72,7 +72,7 @@ AVD를 생성할 때 시스템 이미지 선택에 주의하세요:
 `google_apis/arm64-v8a` 이미지를 사용하세요. 이것이 테스트된 권장 구성입니다. `google_apis_playstore` 이미지는 테스트되지 않았으며 H.264 인코더 문제가 보고되었습니다.
 :::
 
-에이전트가 에뮬레이터를 자동으로 부팅하고, `sys.boot_completed`를 기다린 뒤 스트리밍을 시작합니다.
+에이전트가 에뮬레이터를 자동으로 부팅하고, `sys.boot_completed`를 기다린 뒤 스트리밍을 시작합니다. Apple Silicon Mac의 에뮬레이터는 Mac 호스트에서 H.264 인코딩(VideoToolbox)을 수행하며, 30fps로 제한됩니다. 에뮬레이터 자체에 GPU 부하가 없습니다.
 
 ### 트러블슈팅
 
@@ -87,3 +87,29 @@ tapflow doctor
 ```
 
 더 자세한 문제 해결 방법은 [문제 해결](/ko/guide/troubleshooting)을 참고하세요.
+
+## 스트림 품질
+
+tapflow는 브라우저의 연결 컨텍스트에 따라 스트리밍 해상도를 자동으로 선택합니다.
+
+| 연결 유형 | 해상도 제한 | 디코더 |
+|-----------|------------|--------|
+| Secure (localhost / LAN HTTPS) | 원본 해상도 | WebCodecs (하드웨어) |
+| LAN HTTP | 가장 긴 변 1280px | WASM |
+| 외부 연결 | 가장 긴 변 1000px | WASM |
+
+**Secure 컨텍스트**(localhost 또는 HTTPS)에서는 브라우저가 WebCodecs로 H.264를 하드웨어 디코딩하므로, 시뮬레이터 원본 해상도를 낮은 CPU 부하로 받을 수 있습니다. 비보안 LAN HTTP 연결에서는 WASM 소프트웨어 디코더로 전환되며, 디코딩 부하를 줄이기 위해 해상도를 1280px로 제한합니다.
+
+LAN에서 최고 화질을 원한다면 **릴레이를 HTTPS로 제공**하세요 — [릴레이 배포](/ko/guide/self-hosting) 참고. HTTPS 연결에서는 브라우저가 자동으로 하드웨어 디코딩과 원본 해상도로 전환됩니다.
+
+### 환경변수 오버라이드
+
+에이전트가 실행되는 Mac에서 아래 환경변수를 설정하면 기본값을 재정의할 수 있습니다.
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `TAPFLOW_MAX_SIZE` | *(티어별)* | 전 플랫폼 공통 해상도 제한 (px, 가장 긴 변). `0`으로 설정하면 모든 연결에서 원본 해상도를 강제합니다. |
+| `TAPFLOW_MAX_SIZE_LAN` | `1280` | LAN HTTP 연결 제한값 |
+| `TAPFLOW_MAX_SIZE_EXTERNAL` | `1000` | 외부 연결 제한값 |
+| `TAPFLOW_IOS_MAX_SIZE` | *(티어별)* | iOS 전용 오버라이드. `TAPFLOW_MAX_SIZE`보다 우선 적용됩니다. |
+| `TAPFLOW_ANDROID_MAX_SIZE` | *(티어별)* | Android 전용 오버라이드. `TAPFLOW_MAX_SIZE`보다 우선 적용됩니다. |

--- a/docs/ko/guide/troubleshooting.md
+++ b/docs/ko/guide/troubleshooting.md
@@ -199,6 +199,8 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 - 대시보드 **Mac Resources** 탭에서 해당 Mac의 CPU·RAM 사용량을 확인합니다.
 - 한 Mac에서 동시에 실행하는 디바이스 수를 줄입니다.
 
+**LAN에서 스트림이 흐릿하거나 해상도가 낮게 보이는 경우:** 비보안 HTTP 연결에서 tapflow는 WASM 디코더 부하를 줄이기 위해 스트림을 1280px(가장 긴 변)로 제한합니다. 시뮬레이터 원본 해상도로 스트리밍하려면 릴레이를 HTTPS로 제공하세요 — [릴레이 배포](/ko/guide/self-hosting) 참고. HTTPS 없이 제한값만 높이려면 에이전트에서 `TAPFLOW_MAX_SIZE_LAN` 환경변수를 설정합니다 — [스트림 품질](/ko/guide/agent#스트림-품질) 참고.
+
 ## 인증 관련
 
 ### `tapflow init` 실패 (`ALREADY INITIALIZED`)


### PR DESCRIPTION
## What

The tier1 render pipeline introduced per-session resolution downscaling, but the user guide never explained it. This surfaces what users need to tune the stream.

## Changes

- **`guide/agent`** — new `Stream quality` section
  - secure / LAN-HTTP / external resolution tier table
  - hardware (WebCodecs) vs WASM software decoder differences
  - documents the five `TAPFLOW_MAX_SIZE` env overrides
  - notes that the Android emulator now host-encodes H.264 on Mac VideoToolbox (30fps)
- **`guide/troubleshooting`** — the "Low FPS / stream stuttering" section now explains the LAN-HTTP 1280px cap as the cause of a blurry stream, with HTTPS or `TAPFLOW_MAX_SIZE_LAN` as the fix

Both EN and KO are updated.

## Verification

- ✅ `pnpm docs:build` passes
- ✅ pre-commit lint + typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)