### PR TITLE
chore: release v0.7.0 — tier1 low-latency render pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-08
+
+### Added
+
+- android: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators (auto-detected, 30fps cap), with automatic scrcpy fallback; real devices continue to use scrcpy.
+- streaming: unified per-session downscale. Resolution is chosen from the viewer's connection context — native on a secure context, 1280px on LAN-HTTP, 1000px external — and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+- relay: request an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+
+### Changed
+
+- dashboard: iOS/Android decoding and perf telemetry are unified behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+- ios-agent: static-frame skip — unchanged H.264 frames are no longer re-sent.
+
+### Fixed
+
+- ios: tear-free framebuffer snapshots via a seed-stable copy, and keyframe-aware backpressure on the agent→relay stream.
+- android: keyframe-aware backpressure on the agent→relay stream, and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
 ## [0.6.1] - 2026-06-06
 
 ### Fixed
@@ -86,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/jo-duchan/tapflow/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/jo-duchan/tapflow/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/jo-duchan/tapflow/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jo-duchan/tapflow/compare/v0.5.0...v0.5.1

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @tapflowio/agent-core
 
+## 0.7.0
+
+### Minor Changes
+
+- Tier1 low-latency render pipeline.
+
+  - **Android host-encode**: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators, with a 30fps cap and automatic scrcpy fallback; real devices continue to use scrcpy.
+  - **Unified downscale**: per-session resolution is chosen from the viewer's connection context (native on a secure context, 1280px on LAN-HTTP, 1000px external) and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+  - **Relay IDR-on-rejoin**: the relay requests an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+  - **iOS**: static-frame skip, tear-free framebuffer snapshots, and keyframe-aware backpressure on the agent→relay stream.
+  - **Android**: keyframe-aware backpressure and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
+  The dashboard unifies iOS/Android decoding and perf telemetry behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+
 ## 0.6.1
 
 ## 0.6.0

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @tapflowio/android-agent
 
+## 0.7.0
+
+### Minor Changes
+
+- Tier1 low-latency render pipeline.
+
+  - **Android host-encode**: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators, with a 30fps cap and automatic scrcpy fallback; real devices continue to use scrcpy.
+  - **Unified downscale**: per-session resolution is chosen from the viewer's connection context (native on a secure context, 1280px on LAN-HTTP, 1000px external) and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+  - **Relay IDR-on-rejoin**: the relay requests an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+  - **iOS**: static-frame skip, tear-free framebuffer snapshots, and keyframe-aware backpressure on the agent→relay stream.
+  - **Android**: keyframe-aware backpressure and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
+  The dashboard unifies iOS/Android decoding and perf telemetry behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,27 @@
 # tapflow
 
+## 0.7.0
+
+### Minor Changes
+
+- Tier1 low-latency render pipeline.
+
+  - **Android host-encode**: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators, with a 30fps cap and automatic scrcpy fallback; real devices continue to use scrcpy.
+  - **Unified downscale**: per-session resolution is chosen from the viewer's connection context (native on a secure context, 1280px on LAN-HTTP, 1000px external) and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+  - **Relay IDR-on-rejoin**: the relay requests an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+  - **iOS**: static-frame skip, tear-free framebuffer snapshots, and keyframe-aware backpressure on the agent→relay stream.
+  - **Android**: keyframe-aware backpressure and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
+  The dashboard unifies iOS/Android decoding and perf telemetry behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.7.0
+  - @tapflowio/ios-agent@0.7.0
+  - @tapflowio/android-agent@0.7.0
+  - @tapflowio/relay@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @tapflowio/ios-agent
 
+## 0.7.0
+
+### Minor Changes
+
+- Tier1 low-latency render pipeline.
+
+  - **Android host-encode**: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators, with a 30fps cap and automatic scrcpy fallback; real devices continue to use scrcpy.
+  - **Unified downscale**: per-session resolution is chosen from the viewer's connection context (native on a secure context, 1280px on LAN-HTTP, 1000px external) and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+  - **Relay IDR-on-rejoin**: the relay requests an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+  - **iOS**: static-frame skip, tear-free framebuffer snapshots, and keyframe-aware backpressure on the agent→relay stream.
+  - **Android**: keyframe-aware backpressure and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
+  The dashboard unifies iOS/Android decoding and perf telemetry behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.6.1-experimental.1",
+  "version": "0.7.0-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @tapflowio/relay
 
+## 0.7.0
+
+### Minor Changes
+
+- Tier1 low-latency render pipeline.
+
+  - **Android host-encode**: emulators now capture over gRPC and encode H.264 on the Mac host (VideoToolbox). The gRPC backend is the default for emulators, with a 30fps cap and automatic scrcpy fallback; real devices continue to use scrcpy.
+  - **Unified downscale**: per-session resolution is chosen from the viewer's connection context (native on a secure context, 1280px on LAN-HTTP, 1000px external) and is tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
+  - **Relay IDR-on-rejoin**: the relay requests an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.
+  - **iOS**: static-frame skip, tear-free framebuffer snapshots, and keyframe-aware backpressure on the agent→relay stream.
+  - **Android**: keyframe-aware backpressure and 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.
+
+  The dashboard unifies iOS/Android decoding and perf telemetry behind a single `useDecoderStream` hook (hardware WebCodecs on a secure context, WASM fallback otherwise).
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/agent-core@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.7.0

Theme: **tier1 low-latency render pipeline**.

### Versions

| Package | From | To |
|---------|------|-----|
| `tapflow` | 0.6.1 | **0.7.0** |
| `@tapflowio/agent-core` | 0.6.1 | **0.7.0** |
| `@tapflowio/ios-agent` | 0.6.1 | **0.7.0** |
| `@tapflowio/android-agent` | 0.6.1 | **0.7.0** |
| `@tapflowio/relay` | 0.6.1 | **0.7.0** |
| `@tapflowio/mcp-server` | 0.6.1-experimental.1 | **0.7.0-experimental.1** (experimental dist-tag) |
| `@tapflowio/dashboard` | — | unchanged (private, ignored) |

### Release notes

**Added**
- android: emulators capture over gRPC and encode H.264 on the Mac host (VideoToolbox). gRPC backend is the default for emulators (auto-detected, 30fps cap), with automatic scrcpy fallback; real devices keep using scrcpy.
- streaming: unified per-session downscale — resolution chosen from the viewer's connection context (native on secure, 1280px on LAN-HTTP, 1000px external), tunable via `TAPFLOW_MAX_SIZE` and the per-platform / `_LAN` / `_EXTERNAL` overrides.
- relay: request an IDR keyframe when a browser (re)joins a booted device, so a late joiner paints immediately.

**Changed**
- dashboard: iOS/Android decoding + perf telemetry unified behind a single `useDecoderStream` hook (hardware WebCodecs on secure context, WASM fallback otherwise).
- ios-agent: static-frame skip — unchanged H.264 frames are no longer re-sent.

**Fixed**
- ios: tear-free framebuffer snapshots via a seed-stable copy; keyframe-aware backpressure on the agent→relay stream.
- android: keyframe-aware backpressure on the agent→relay stream; 16-aligned encode sizing to avoid macroblock padding on the WASM decoder.

### Compatibility

SemVer minor (0.x). All changes are additive and backward compatible:
- `TAPFLOW_MAX_SIZE` and friends are new env vars with built-in tier defaults.
- The Android gRPC backend is an internal implementation detail with scrcpy fallback; the public `stream()` contract is unchanged.
- relay IDR-on-rejoin is new behavior, not a protocol change.

No breaking changes to public API, CLI flags, DB schema, or the WebSocket envelope.

### Verification

- ✅ lockfile unchanged (workspace:* internal deps)
- ✅ lint + typecheck pass (pre-commit hook)

### After merge

npm publish is triggered **only by pushing the `vX.Y.Z` tag** — merging this PR alone does not publish. The tag will be pushed separately after merge (with confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Low-latency rendering pipeline with H.264 video capture on Mac
  * Unified per-session streaming downscale with configurable overrides
  * Relay IDR keyframe requests on browser rejoin
  * Unified decoder stream telemetry across platforms

* **Bug Fixes**
  * Tear-free framebuffer snapshots
  * Improved backpressure handling and keyframe awareness
  * Enhanced encode sizing for decoder compatibility

* **Chores**
  * Version bump to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->