### PR TITLE
docs(readme): both iOS and Android stream H.264; note resolution adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Navigate to `http://localhost:4000` and sign in with the account you just create
 
 What's included:
 
-- **Browser streaming** — iOS & Android at ~30 fps, no extra app on the device. The iOS pipeline streams H.264 through a 2-tier decoder (WebCodecs on secure contexts, WASM/tinyh264 on plain HTTP), which removes the media-element buffer from the decode path.<sup>[1](#latency-note)</sup>
+- **Browser streaming** — iOS & Android at ~30 fps, no extra app on the device. Both stream H.264 through a 2-tier decoder (WebCodecs on secure contexts, WASM/tinyh264 on plain HTTP), which removes the media-element buffer from the decode path. Resolution adapts to the connection — native on a secure context, downscaled on plain-HTTP LAN.<sup>[1](#latency-note)</sup>
 - **Codec fallback** — the stream negotiates the codec per client and falls back to JPEG when a hardware or WASM decoder isn't available, so older browsers still work.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator or emulator.
 - **Deeplink toolbar** — open supported deeplinks directly from the QA toolbar.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -135,7 +135,7 @@ Navigate to `http://localhost:4000` and sign in with the account you just create
 
 What's included:
 
-- **Browser streaming** — iOS & Android at ~30 fps, no extra app on the device. The iOS pipeline streams H.264 through a 2-tier decoder (WebCodecs on secure contexts, WASM/tinyh264 on plain HTTP), which removes the media-element buffer from the decode path.<sup>[1](#latency-note)</sup>
+- **Browser streaming** — iOS & Android at ~30 fps, no extra app on the device. Both stream H.264 through a 2-tier decoder (WebCodecs on secure contexts, WASM/tinyh264 on plain HTTP), which removes the media-element buffer from the decode path. Resolution adapts to the connection — native on a secure context, downscaled on plain-HTTP LAN.<sup>[1](#latency-note)</sup>
 - **Codec fallback** — the stream negotiates the codec per client and falls back to JPEG when a hardware or WASM decoder isn't available, so older browsers still work.
 - **Touch, swipe & pinch** — real-time input forwarded to the simulator or emulator.
 - **Deeplink toolbar** — open supported deeplinks directly from the QA toolbar.


### PR DESCRIPTION
## What

v0.7.0 moved Android to host-encoded H.264 (gRPC capture + Mac VideoToolbox) on the **same 2-tier decoder path as iOS** (unified `useDecoderStream`). The README still said "The iOS pipeline streams H.264", which is now stale.

## Changes

- Root and cli `README.md` (kept in sync): "The iOS pipeline streams H.264..." → "Both stream H.264 through a 2-tier decoder...".
- Added a short note that resolution adapts to the connection — native on a secure context, downscaled on plain-HTTP LAN (the v0.7.0 per-session downscale).

The deeper env-var tuning (`TAPFLOW_MAX_SIZE` etc.) stays in the guide docs (`guide/agent` → Stream quality); the README only carries the high-level behavior.

## Verification

- ✅ lint + typecheck pass (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser streaming documentation to clarify ~30 fps frame rate support for both iOS and Android platforms.
  * Documented H.264 streaming codec implementation and adaptive resolution features based on connection type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->