### PR TITLE
chore(hooks): block Korean in gh pr/issue create/edit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "input=$(cat); if echo \"$input\" | jq -r '.tool_input.command // \"\"' | grep -qE 'gh pr (merge|review)'; then echo '{\"continue\": false, \"stopReason\": \"PR merge/approve는 직접 수행해주세요.\"}'; else echo \"$input\" | jq -r '.tool_input.command // \"\"' > /dev/null; fi"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); printf '%s' \"$cmd\" | perl -CSD -e 'local $/; my $c=<>; if ($c =~ /gh\\s+(pr|issue)\\s+(create|edit)/ && $c =~ /\\p{Hangul}/) { print STDERR \"Blocked: the gh pr/issue command contains Korean. Rewrite the PR/Issue title and body in English, then re-run.\\n\"; exit 2 }'"
           }
         ]
       }


### PR DESCRIPTION
## What

Adds a `PreToolUse` / `Bash` hook that blocks `gh pr create|edit` and `gh issue create|edit` commands when they contain Korean (Hangul), so PR/issue bodies are written in English. On a match it exits 2 with a message asking for an English rewrite, which the agent then acts on.

It sits alongside the existing `gh pr merge|review` guard in the same matcher group.

## Notes

- Korean detection uses `perl \p{Hangul}` because macOS BSD `grep` does not support `-P` (PCRE).
- Scope is limited to `gh pr|issue create|edit` — other `gh`/bash commands are unaffected (e.g. `gh pr merge`, `git commit` with Korean are not blocked).

## Known limitations

- `--body-file <path>` is not detected (no Korean in the command string itself).
- PRs/issues authored directly in the GitHub web UI are out of scope (hooks only see tool calls).

## Verification

Pipe-tested against 5 cases (Korean create → exit 2; English → exit 0; Korean `git commit` → exit 0; Korean `gh issue edit` → exit 2; Korean `gh pr merge` → exit 0). Confirmed live: the hook fired and blocked a test command during setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command validation to restrict GitHub CLI commands containing Korean characters from executing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->