### PR TITLE
docs(requirements): pin iOS support to the Xcode/macOS 26 line

### DIFF
--- a/docs/guide/requirements.md
+++ b/docs/guide/requirements.md
@@ -15,8 +15,12 @@ The agent runs on macOS. iOS and Android can run together on the same Mac.
 
 ### iOS
 
-- macOS 26 or later
-- Xcode 26 or later with iOS Simulator Runtime installed
+- macOS 26 (26.x)
+- Xcode 26 (26.x) with iOS Simulator Runtime installed
+
+::: tip Newer versions
+When a new major version (e.g. Xcode 27) is released, supporting it is our top priority. Until that support lands, please stay on the verified versions above.
+:::
 
 ### Android
 

--- a/docs/ko/guide/requirements.md
+++ b/docs/ko/guide/requirements.md
@@ -15,8 +15,12 @@
 
 ### iOS
 
-- macOS 26 이상
-- iOS Simulator Runtime이 설치된 Xcode 26 이상
+- macOS 26 (26.x)
+- iOS Simulator Runtime이 설치된 Xcode 26 (26.x)
+
+::: tip 새 버전 지원
+새로운 메이저 버전(예: Xcode 27)이 출시되면 버전 지원을 최우선으로 작업합니다. 지원이 추가되기 전까지는 위 검증된 버전을 사용해 주세요.
+:::
 
 ### Android
 


### PR DESCRIPTION
## What

Close the open-ended "Xcode/macOS 26 or later" in the iOS requirements to the verified 26.x line, and add a forward-looking note (EN/KO).

## Why

iOS simulator control (touch / capture / keyboard / rotation) calls private framework symbols directly (IndigoHIDMessage*, SimDeviceLegacyHIDClient, SimulatorKit IOSurface). These signatures can change between major OS/Xcode versions — e.g. IndigoHIDMessageForMouseNSEvent went 5-arg to 9-arg in iOS 26. So "or later" was an implicit promise to support untested future majors.

This closes the matrix honestly and frames newer majors (e.g. Xcode 27) as prioritized when released, rather than warning users away.

## Changes

- docs/guide/requirements.md, docs/ko/guide/requirements.md
  - 26 or later -> 26 (26.x)
  - Added a tip note: new majors are top priority to support; stay on verified versions until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)