### PR TITLE
feat(cli): add `tapflow setup android` — guided Android environment setup

### DIFF
--- a/.changeset/setup-android.md
+++ b/.changeset/setup-android.md
@@ -1,0 +1,14 @@
+---
+"tapflow": minor
+---
+
+feat(cli): add `tapflow setup android` — guided Android environment setup
+
+`tapflow doctor` diagnoses problems; `tapflow setup android` fixes them. It walks through the required Android dependencies and applies fixes where safe:
+
+- **Homebrew** — checks `which brew`, prints the install URL if missing (cannot auto-install).
+- **adb** — if present in PATH it passes; if found in a standard SDK location but missing from PATH it registers the `platform-tools` directory in your shell rc (`.zshrc`/`.bashrc`) inside an idempotent marker block; if absent it runs `brew install android-platform-tools`.
+- **Android Studio** — checks `/Applications/Android Studio.app`; since the cask is large (~1GB+) it asks for confirmation before `brew install --cask android-studio`, and skips with guidance in non-interactive shells.
+- **Emulator** — reports running emulators and hints how to start an AVD.
+
+Each step is idempotent — re-running on a configured machine prints ✓ and makes no changes.

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
+
+vi.mock('../../lib/setup.js', () => ({
+  runSetupAndroid: vi.fn(),
+}))
+
+import { runSetupAndroid } from '../../lib/setup.js'
+import { cmdSetup } from '../../commands/setup.js'
+
+const mockRunSetupAndroid = vi.mocked(runSetupAndroid)
+
+describe('cmdSetup', () => {
+  let logLines: string[]
+  let errLines: string[]
+  let exitSpy: MockInstance
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    logLines = []
+    errLines = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(args.join(' ')))
+    vi.spyOn(console, 'error').mockImplementation((...args) => errLines.push(args.join(' ')))
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('setup android는 runSetupAndroid 결과를 출력', async () => {
+    mockRunSetupAndroid.mockResolvedValue([
+      { label: 'Homebrew installed', ok: true },
+      { label: 'No running emulator', ok: false, warn: true, detail: 'Start an AVD' },
+    ])
+
+    await cmdSetup('android')
+    expect(mockRunSetupAndroid).toHaveBeenCalled()
+    const out = logLines.join('\n')
+    expect(out).toContain('Homebrew installed')
+    expect(out).toContain('No running emulator')
+  })
+
+  it('알 수 없는 platform이면 에러 + exit(1)', async () => {
+    await expect(cmdSetup('windows')).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errLines.join('\n')).toMatch(/platform/i)
+    expect(mockRunSetupAndroid).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -20,6 +20,7 @@ describe('cmdSetup', () => {
     errLines = []
     vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(args.join(' ')))
     vi.spyOn(console, 'error').mockImplementation((...args) => errLines.push(args.join(' ')))
+    vi.spyOn(console, 'warn').mockImplementation((...args) => errLines.push(args.join(' ')))
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
   })
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('node:child_process')
+vi.mock('node:fs')
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+}))
+
+import { execSync, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { confirm } from '@clack/prompts'
+import { runSetupAndroid } from '../../lib/setup.js'
+
+const mockExecSync = vi.mocked(execSync)
+const mockSpawnSync = vi.mocked(spawnSync)
+const mockExistsSync = vi.mocked(existsSync)
+const mockReadFileSync = vi.mocked(readFileSync)
+const mockAppendFileSync = vi.mocked(appendFileSync)
+const mockConfirm = vi.mocked(confirm)
+
+const STUDIO_APP = '/Applications/Android Studio.app'
+const sdkAdb = join(homedir(), 'Library', 'Android', 'sdk', 'platform-tools', 'adb')
+const zshrc = join(homedir(), '.zshrc')
+
+const okSpawn = { status: 0, stdout: '', stderr: '', pid: 1, output: [], signal: null }
+
+function findStep(results: { label: string }[], keyword: string) {
+  return results.find((r) => r.label.toLowerCase().includes(keyword.toLowerCase()))
+}
+
+function setTTY(value: boolean | undefined) {
+  Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+}
+
+describe('runSetupAndroid', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubEnv('SHELL', '/bin/zsh')
+    vi.stubEnv('ANDROID_HOME', '')
+    vi.stubEnv('ANDROID_SDK_ROOT', '')
+    mockExistsSync.mockReturnValue(false)
+    mockReadFileSync.mockReturnValue('')
+    mockSpawnSync.mockReturnValue(okSpawn as never)
+    mockConfirm.mockResolvedValue(true as never)
+    // 기본: 완전히 구성된 머신 (각 테스트에서 필요한 부분만 override)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c === 'emulator -list-avds') return 'Pixel_8\n'
+      return ''
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    setTTY(undefined)
+  })
+
+  it('Homebrew 있으면 ok', async () => {
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'homebrew')?.ok).toBe(true)
+  })
+
+  it('Homebrew 없으면 warn + 설치 URL, brew install 미호출', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') throw new Error('not found')
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+
+    const results = await runSetupAndroid()
+    const brew = findStep(results, 'homebrew')
+    expect(brew?.ok).toBe(false)
+    expect(brew?.warn).toBe(true)
+    expect(brew?.detail).toContain('brew.sh')
+    expect(mockSpawnSync).not.toHaveBeenCalled()
+  })
+
+  it('adb가 PATH에 있으면 ok, 설치/등록 미호출', async () => {
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'adb')?.ok).toBe(true)
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
+  })
+
+  it('adb 부재 시 brew install android-platform-tools 실행', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    expect(mockSpawnSync).toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
+    expect(findStep(results, 'adb')?.ok).toBe(true)
+  })
+
+  it('adb가 SDK엔 있고 PATH 없으면 shell rc에 PATH 등록', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    const adb = findStep(results, 'adb')
+    expect(adb?.ok).toBe(true)
+    expect(mockAppendFileSync).toHaveBeenCalledWith(zshrc, expect.stringContaining('platform-tools'))
+    expect(adb?.detail).toContain('.zshrc')
+    // brew install은 호출되지 않아야 (이미 SDK에 있음)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
+  })
+
+  it('PATH 등록 멱등 — rc에 마커가 이미 있으면 append 안 함', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP || p === zshrc)
+    mockReadFileSync.mockReturnValue(
+      '# >>> tapflow android sdk >>>\nexport PATH="x:$PATH"\n# <<< tapflow android sdk <<<\n',
+    )
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'adb')?.ok).toBe(true)
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
+  })
+
+  it('bash 셸이면 .bashrc에 등록', async () => {
+    vi.stubEnv('SHELL', '/bin/bash')
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
+
+    await runSetupAndroid()
+    expect(mockAppendFileSync).toHaveBeenCalledWith(
+      join(homedir(), '.bashrc'),
+      expect.stringContaining('platform-tools'),
+    )
+  })
+
+  it('Android Studio 있으면 ok, cask 설치 미호출', async () => {
+    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android studio')?.ok).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
+  })
+
+  it('Android Studio 없고 확인 수락 시 cask 설치', async () => {
+    setTTY(true)
+    mockExistsSync.mockReturnValue(false) // Android Studio 없음
+    mockConfirm.mockResolvedValue(true as never)
+
+    const results = await runSetupAndroid()
+    expect(mockConfirm).toHaveBeenCalled()
+    expect(mockSpawnSync).toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
+    expect(findStep(results, 'android studio')?.ok).toBe(true)
+  })
+
+  it('Android Studio 확인 거절 시 warn + 설치 미실행', async () => {
+    setTTY(true)
+    mockExistsSync.mockReturnValue(false)
+    mockConfirm.mockResolvedValue(false as never)
+
+    const results = await runSetupAndroid()
+    const studio = findStep(results, 'android studio')
+    expect(studio?.warn).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
+  })
+
+  it('비대화형(non-TTY)이면 cask 설치 skip + 안내', async () => {
+    setTTY(false)
+    mockExistsSync.mockReturnValue(false)
+
+    const results = await runSetupAndroid()
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
+    expect(findStep(results, 'android studio')?.warn).toBe(true)
+  })
+
+  it('실행 중 에뮬레이터 있으면 ok', async () => {
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'emulator')?.ok).toBe(true)
+  })
+
+  it('에뮬레이터 없으면 warn + AVD 힌트', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c === 'adb devices') return 'List of devices attached\n'
+      if (c === 'emulator -list-avds') return 'Pixel_8\n'
+      return ''
+    })
+
+    const results = await runSetupAndroid()
+    const emu = findStep(results, 'emulator')
+    expect(emu?.warn).toBe(true)
+    expect(emu?.detail).toContain('Pixel_8')
+  })
+
+  it('멱등 — 완전히 구성된 머신은 전부 ok, 부작용 없음', async () => {
+    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    expect(results.every((r) => r.ok)).toBe(true)
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -50,7 +50,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       if (c === 'emulator -list-avds') return 'Pixel_8\n'
       return ''
     })
@@ -72,7 +72,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') throw new Error('not found')
       if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       return ''
     })
 
@@ -96,7 +96,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') throw new Error('not found')
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       return ''
     })
     mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
@@ -111,7 +111,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') throw new Error('not found')
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       return ''
     })
     mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
@@ -130,7 +130,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') throw new Error('not found')
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       return ''
     })
     mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP || p === zshrc)
@@ -149,7 +149,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') throw new Error('not found')
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
       return ''
     })
     mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
@@ -211,7 +211,7 @@ describe('runSetupAndroid', () => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c === 'adb devices') return 'List of devices attached\n'
+      if (c.includes('devices')) return 'List of devices attached\n'
       if (c === 'emulator -list-avds') return 'Pixel_8\n'
       return ''
     })
@@ -220,6 +220,42 @@ describe('runSetupAndroid', () => {
     const emu = findStep(results, 'emulator')
     expect(emu?.warn).toBe(true)
     expect(emu?.detail).toContain('Pixel_8')
+  })
+
+  it('adb가 PATH엔 없어도 SDK 경로로 해석해 에뮬레이터 감지 (PATH 미반영 회피)', async () => {
+    // 같은 실행에서 방금 PATH 등록한 adb는 현재 프로세스 PATH에 없다 → 절대경로로 조회해야 ok
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c.includes(sdkAdb) && c.includes('devices')) {
+        return 'List of devices attached\nemulator-5554\tdevice\n'
+      }
+      if (c === 'adb devices') return 'List of devices attached\n' // PATH adb는 실패 시뮬
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'emulator')?.ok).toBe(true)
+  })
+
+  it('미지원 셸(fish 등)이면 자동 등록 대신 warn + 수동 export 안내', async () => {
+    vi.stubEnv('SHELL', '/usr/bin/fish')
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') throw new Error('not found')
+      if (c.includes('devices')) return 'List of devices attached\n'
+      return ''
+    })
+    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
+
+    const results = await runSetupAndroid()
+    const adb = findStep(results, 'adb')
+    expect(adb?.warn).toBe(true)
+    expect(adb?.detail).toContain('export PATH')
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
   })
 
   it('멱등 — 완전히 구성된 머신은 전부 ok, 부작용 없음', async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,0 +1,29 @@
+import { runSetupAndroid, type SetupStepResult } from '../lib/setup.js'
+import { GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+
+function printResults(results: SetupStepResult[]): void {
+  for (const r of results) {
+    if (r.ok) {
+      console.log(`  ${GREEN}✓${R}  ${r.label}`)
+      if (r.detail) console.log(`${DIM}       ${r.detail}${R}`)
+    } else if (r.warn) {
+      console.log(`  ${YELLOW}⚠${R}  ${r.label}`)
+      if (r.detail) console.log(`${DIM}       → ${r.detail}${R}`)
+    } else {
+      console.log(`  ${RED}✗${R}  ${r.label}`)
+      if (r.detail) console.log(`${DIM}       → ${r.detail}${R}`)
+    }
+  }
+}
+
+export async function cmdSetup(platform: string): Promise<void> {
+  if (platform === 'android') {
+    console.log('\ntapflow setup android\n')
+    printResults(await runSetupAndroid())
+    console.log()
+    return
+  }
+
+  console.error(`Unknown or unsupported platform: ${platform}. Supported: android`)
+  process.exit(1)
+}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,5 +1,5 @@
 import { runSetupAndroid, type SetupStepResult } from '../lib/setup.js'
-import { GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+import { warn, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
 
 function printResults(results: SetupStepResult[]): void {
   for (const r of results) {
@@ -24,6 +24,6 @@ export async function cmdSetup(platform: string): Promise<void> {
     return
   }
 
-  console.error(`Unknown or unsupported platform: ${platform}. Supported: android`)
+  warn(`Unknown or unsupported platform: ${platform}. Supported: android`)
   process.exit(1)
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ const { version } = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'
 import { cmdInitConfig } from './commands/init.js'
 import { cmdAdminInit } from './commands/admin-init.js'
 import { cmdDoctor } from './commands/doctor.js'
+import { cmdSetup } from './commands/setup.js'
 import { cmdDevices } from './commands/devices.js'
 import { cmdBoot } from './commands/boot.js'
 import { cmdStart } from './commands/start.js'
@@ -43,6 +44,10 @@ cli
   .command('doctor', 'Check system prerequisites')
   .option('--json', 'Output machine-readable JSON')
   .action((opts: { json?: boolean }) => cmdDoctor(opts))
+
+cli
+  .command('setup <platform>', 'Set up the environment for a platform (android)')
+  .action((platform: string) => cmdSetup(platform))
 
 cli
   .command('devices', 'List available iOS simulators and Android AVDs')

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -107,12 +107,12 @@ function checkNodeVersion(): DoctorCheck {
   }
 }
 
-interface AdbResolution {
+export interface AdbResolution {
   path: string
   inPath: boolean
 }
 
-function resolveAdb(): AdbResolution | null {
+export function resolveAdb(): AdbResolution | null {
   try {
     const found = execSync('which adb', { encoding: 'utf8', stdio: 'pipe' }).trim()
     if (found) return { path: found, inPath: true }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -50,6 +50,14 @@ function checkAndFixAdb(brewAvailable: boolean): SetupStepResult {
   if (adb) {
     const platformTools = dirname(adb.path)
     const registered = registerPathInShellRc(platformTools)
+    if (!registered) {
+      return {
+        label: 'adb (not in PATH)',
+        ok: false,
+        warn: true,
+        detail: `adb found at ${adb.path} but your shell ($SHELL) isn't auto-configurable. Add to your shell config: export PATH="${platformTools}:$PATH"`,
+      }
+    }
     if (registered.added) {
       return {
         label: 'adb added to PATH',
@@ -134,14 +142,25 @@ async function checkAndFixAndroidStudio(brewAvailable: boolean): Promise<SetupSt
 }
 
 function checkAndFixEmulator(): SetupStepResult {
+  // resolveAdb()로 해석한 경로를 쓴다. 직전 단계에서 PATH에 등록했어도 현재 프로세스
+  // PATH엔 반영되지 않으므로 'adb'를 그대로 부르면 오탐이 난다.
+  const adb = resolveAdb()
+  if (!adb) {
+    return {
+      label: 'No running emulator',
+      ok: false,
+      warn: true,
+      detail: 'adb not found. Install/configure adb first, then start an AVD.',
+    }
+  }
   try {
-    const out = execSync('adb devices', { encoding: 'utf8', stdio: 'pipe' })
+    const out = execSync(`"${adb.path}" devices`, { encoding: 'utf8', stdio: 'pipe' })
     const lines = out.trim().split('\n').slice(1).filter(Boolean)
     if (lines.some((l) => l.startsWith('emulator-'))) {
       return { label: 'Emulator running', ok: true }
     }
   } catch {
-    // adb 미설치/실패 — 아래 힌트로
+    // adb 실행 실패 — 아래 힌트로
   }
   let hint = 'Start an AVD from Android Studio > Device Manager'
   try {
@@ -156,15 +175,18 @@ function checkAndFixEmulator(): SetupStepResult {
   return { label: 'No running emulator', ok: false, warn: true, detail: hint }
 }
 
-function shellRcPath(): string {
+// 자동 등록을 지원하는 셸의 rc 경로. 그 외 셸은 null(수동 안내).
+function shellRcPath(): string | null {
   const shell = process.env.SHELL ?? ''
   const home = homedir()
+  if (shell.includes('zsh')) return join(home, '.zshrc')
   if (shell.includes('bash')) return join(home, '.bashrc')
-  return join(home, '.zshrc') // 기본 zsh
+  return null
 }
 
-function registerPathInShellRc(platformTools: string): { added: boolean; file: string } {
+function registerPathInShellRc(platformTools: string): { added: boolean; file: string } | null {
   const file = shellRcPath()
+  if (!file) return null
   const existing = existsSync(file) ? readFileSync(file, 'utf8') : ''
   if (existing.includes(PATH_MARKER_START)) {
     return { added: false, file }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1,0 +1,175 @@
+import { execSync, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { confirm, isCancel } from '@clack/prompts'
+import { resolveAdb, type DoctorCheck } from './doctor.js'
+import { createSpinner } from './print.js'
+
+// setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓴다.
+// ok=true: 이미 OK이거나 방금 자동 수정함, warn=true: 수동 조치 필요(안내).
+export type SetupStepResult = DoctorCheck
+
+const PATH_MARKER_START = '# >>> tapflow android sdk >>>'
+const PATH_MARKER_END = '# <<< tapflow android sdk <<<'
+const STUDIO_APP = '/Applications/Android Studio.app'
+
+export async function runSetupAndroid(): Promise<SetupStepResult[]> {
+  const results: SetupStepResult[] = []
+  const brew = checkAndFixHomebrew()
+  results.push(brew)
+  results.push(checkAndFixAdb(brew.ok))
+  results.push(await checkAndFixAndroidStudio(brew.ok))
+  results.push(checkAndFixEmulator())
+  return results
+}
+
+function checkAndFixHomebrew(): SetupStepResult {
+  try {
+    execSync('which brew', { stdio: 'pipe' })
+    return { label: 'Homebrew installed', ok: true }
+  } catch {
+    return {
+      label: 'Homebrew',
+      ok: false,
+      warn: true,
+      detail: 'Install Homebrew first: https://brew.sh (cannot auto-install)',
+    }
+  }
+}
+
+function checkAndFixAdb(brewAvailable: boolean): SetupStepResult {
+  const adb = resolveAdb()
+
+  // 1. PATH에 있음
+  if (adb?.inPath) {
+    return { label: `adb in PATH: ${adb.path}`, ok: true }
+  }
+
+  // 2. 표준 SDK 위치엔 있지만 PATH에 없음 → shell rc에 등록
+  if (adb) {
+    const platformTools = dirname(adb.path)
+    const registered = registerPathInShellRc(platformTools)
+    if (registered.added) {
+      return {
+        label: 'adb added to PATH',
+        ok: true,
+        detail: `Added ${platformTools} to PATH in ${registered.file}. Restart your shell or run: source ${registered.file}`,
+      }
+    }
+    return {
+      label: 'adb PATH already configured',
+      ok: true,
+      detail: `${platformTools} already registered in ${registered.file}`,
+    }
+  }
+
+  // 3. 어디에도 없음 → brew 설치
+  if (!brewAvailable) {
+    return {
+      label: 'adb',
+      ok: false,
+      warn: true,
+      detail: 'Install Homebrew first, then: brew install android-platform-tools',
+    }
+  }
+  const spinner = createSpinner('Installing android-platform-tools via Homebrew…')
+  spinner.start()
+  const r = spawnSync('brew', ['install', 'android-platform-tools'], { stdio: 'pipe' })
+  spinner.stop(r.status === 0)
+  if (r.status === 0) {
+    return { label: 'adb installed via Homebrew', ok: true }
+  }
+  return {
+    label: 'adb',
+    ok: false,
+    warn: true,
+    detail: 'brew install android-platform-tools failed. Install manually.',
+  }
+}
+
+async function checkAndFixAndroidStudio(brewAvailable: boolean): Promise<SetupStepResult> {
+  if (existsSync(STUDIO_APP)) {
+    return { label: 'Android Studio installed', ok: true }
+  }
+  if (!brewAvailable) {
+    return {
+      label: 'Android Studio',
+      ok: false,
+      warn: true,
+      detail: 'Install from https://developer.android.com/studio',
+    }
+  }
+  // 대용량(~1GB+)이라 확인 후 설치. 비대화형이면 안내만.
+  if (!process.stdout.isTTY) {
+    return {
+      label: 'Android Studio',
+      ok: false,
+      warn: true,
+      detail: 'Run: brew install --cask android-studio (skipped in non-interactive mode)',
+    }
+  }
+  const proceed = await confirm({ message: 'Install Android Studio (~1GB) via Homebrew?' })
+  if (isCancel(proceed) || !proceed) {
+    return {
+      label: 'Android Studio',
+      ok: false,
+      warn: true,
+      detail: 'Skipped. Run: brew install --cask android-studio',
+    }
+  }
+  const spinner = createSpinner('Installing Android Studio via Homebrew…')
+  spinner.start()
+  const r = spawnSync('brew', ['install', '--cask', 'android-studio'], { stdio: 'pipe' })
+  spinner.stop(r.status === 0)
+  if (r.status === 0) {
+    return { label: 'Android Studio installed via Homebrew', ok: true }
+  }
+  return {
+    label: 'Android Studio',
+    ok: false,
+    warn: true,
+    detail: 'brew install --cask android-studio failed. Install manually.',
+  }
+}
+
+function checkAndFixEmulator(): SetupStepResult {
+  try {
+    const out = execSync('adb devices', { encoding: 'utf8', stdio: 'pipe' })
+    const lines = out.trim().split('\n').slice(1).filter(Boolean)
+    if (lines.some((l) => l.startsWith('emulator-'))) {
+      return { label: 'Emulator running', ok: true }
+    }
+  } catch {
+    // adb 미설치/실패 — 아래 힌트로
+  }
+  let hint = 'Start an AVD from Android Studio > Device Manager'
+  try {
+    const first = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' })
+      .trim()
+      .split('\n')[0]
+      ?.trim()
+    if (first) hint = `Start an AVD: emulator @${first} (or Android Studio > Device Manager)`
+  } catch {
+    // emulator 미설치 — 일반 힌트 유지
+  }
+  return { label: 'No running emulator', ok: false, warn: true, detail: hint }
+}
+
+function shellRcPath(): string {
+  const shell = process.env.SHELL ?? ''
+  const home = homedir()
+  if (shell.includes('bash')) return join(home, '.bashrc')
+  return join(home, '.zshrc') // 기본 zsh
+}
+
+function registerPathInShellRc(platformTools: string): { added: boolean; file: string } {
+  const file = shellRcPath()
+  const existing = existsSync(file) ? readFileSync(file, 'utf8') : ''
+  if (existing.includes(PATH_MARKER_START)) {
+    return { added: false, file }
+  }
+  const block = `\n${PATH_MARKER_START}\nexport PATH="${platformTools}:$PATH"\n${PATH_MARKER_END}\n`
+  appendFileSync(file, block)
+  return { added: true, file }
+}


### PR DESCRIPTION
## Summary

Implements #145 (part of #142). `tapflow doctor` diagnoses; `tapflow setup android` fixes. The command walks the required Android dependencies and applies fixes where safe, complementing the adb PATH **diagnosis** added in #140 with the corresponding **fix**.

```sh
tapflow setup android
```

## Steps

| Step | Check | Action |
|------|-------|--------|
| Homebrew | `which brew` | Print install URL — cannot auto-install |
| adb | `resolveAdb()` (PATH → standard SDK locations) | In PATH: pass · In SDK but not PATH: register `platform-tools` in shell rc · Absent: `brew install android-platform-tools` |
| Android Studio | `/Applications/Android Studio.app` | `brew install --cask android-studio` (confirmed first — large cask) |
| Emulator | `adb devices` | Report running emulators / hint how to start an AVD |

## Design decisions (from plan)

- **PATH registration** — `$SHELL`-aware append to `~/.zshrc` / `~/.bashrc` inside an idempotent marker block (`# >>> tapflow android sdk >>>`). Re-running detects the marker and makes no changes; the modified file is reported so the user can `source` it.
- **Large installs** — `android-platform-tools` installs automatically; `android-studio` (~1GB+) asks for confirmation via `@clack/prompts`, and skips with guidance in non-interactive shells (no TTY).
- **Reuse** — adb resolution reuses `resolveAdb()` from the doctor module (exported in this PR); no duplicated path logic.
- **Type** — reuses `DoctorCheck` as `SetupStepResult`; "auto-fixed" is conveyed via `detail`, no extra field.

## Idempotency

Re-running on a configured machine prints all ✓ and performs no installs or file writes.

## Testing

- `pnpm --filter tapflow test` — 177 passing (18 new: 16 in `lib/setup.test.ts`, 2 in `commands/setup.test.ts`).
- typecheck + lint clean.
- All OS calls (`execSync`/`spawnSync`), fs, and the confirm prompt are mocked — no real installs or dotfile writes in tests.
- Verified real `node dist/index.js setup android` on a configured machine (idempotent ✓ output) and the unknown-platform error path (exit 1).

> The PATH-registration and brew-install branches are covered by unit tests only, since the dev machine already has adb on PATH (avoids real side effects).

Part of #142. Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new setup command: `tapflow setup android` — runs guided Android checks, offers safe fixes (Homebrew, adb, Android Studio), idempotently updates PATH, and reports emulator/AVD status with start hints. Interactive cask installs prompt in TTY; non-interactive runs skip prompts and return guidance.
* **Bug Fixes**
  * Improved error handling for unsupported platforms (reports platform error and exits).
* **Tests**
  * Added comprehensive tests covering setup flows and environment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->