### PR TITLE
feat(cli): install Homebrew after confirmation in `tapflow setup`

### DIFF
--- a/.changeset/setup-homebrew-autoinstall.md
+++ b/.changeset/setup-homebrew-autoinstall.md
@@ -1,0 +1,7 @@
+---
+"tapflow": minor
+---
+
+feat(cli): `tapflow setup` can install Homebrew after confirmation
+
+When Homebrew is missing, `tapflow setup android` (and upcoming `setup ios`) now offers to install it via the official script after an explicit confirmation prompt, instead of only printing the install URL. In non-interactive shells it still just prints guidance — no remote script runs without consent. This makes Homebrew the shared first step for all platform setups.

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -67,7 +67,8 @@ describe('runSetupAndroid', () => {
     expect(findStep(results, 'homebrew')?.ok).toBe(true)
   })
 
-  it('Homebrew 없으면 warn + 설치 URL, brew install 미호출', async () => {
+  it('Homebrew 없음 + 비대화형이면 confirm 없이 warn + 안내', async () => {
+    setTTY(false)
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') throw new Error('not found')
@@ -81,7 +82,46 @@ describe('runSetupAndroid', () => {
     expect(brew?.ok).toBe(false)
     expect(brew?.warn).toBe(true)
     expect(brew?.detail).toContain('brew.sh')
-    expect(mockSpawnSync).not.toHaveBeenCalled()
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('/bin/bash', expect.any(Array), expect.anything())
+  })
+
+  it('Homebrew 없음 + TTY + 수락 시 공식 스크립트 설치', async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(true as never)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') throw new Error('not found')
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+
+    const results = await runSetupAndroid()
+    expect(mockConfirm).toHaveBeenCalled()
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      '/bin/bash',
+      ['-c', expect.stringContaining('Homebrew/install')],
+      expect.anything(),
+    )
+    expect(findStep(results, 'homebrew')?.ok).toBe(true)
+  })
+
+  it('Homebrew 없음 + TTY + 거절 시 warn + 설치 미실행', async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(false as never)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') throw new Error('not found')
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
+      return ''
+    })
+
+    const results = await runSetupAndroid()
+    const brew = findStep(results, 'homebrew')
+    expect(brew?.warn).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('/bin/bash', expect.any(Array), expect.anything())
   })
 
   it('adb가 PATH에 있으면 ok, 설치/등록 미호출', async () => {

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -24,8 +24,9 @@ export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   return results
 }
 
+// eval "$(...)"로 감싸 명령 치환 결과(설치 스크립트)가 word splitting 없이 단일 평가되게 한다.
 const HOMEBREW_INSTALL =
-  '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'
+  'eval "$(/usr/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
 
 async function checkAndFixHomebrew(): Promise<SetupStepResult> {
   try {
@@ -52,7 +53,12 @@ async function checkAndFixHomebrew(): Promise<SetupStepResult> {
   console.log()
   const r = spawnSync('/bin/bash', ['-c', HOMEBREW_INSTALL], { stdio: 'inherit' })
   if (r.status === 0) {
-    return { label: 'Homebrew installed', ok: true }
+    // 방금 설치한 brew는 현재 프로세스 PATH에 아직 없을 수 있다(셸 재시작 전).
+    return {
+      label: 'Homebrew installed',
+      ok: true,
+      detail: "If later steps can't find brew, open a new terminal and re-run tapflow setup.",
+    }
   }
   return {
     label: 'Homebrew',

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -16,7 +16,7 @@ const STUDIO_APP = '/Applications/Android Studio.app'
 
 export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   const results: SetupStepResult[] = []
-  const brew = checkAndFixHomebrew()
+  const brew = await checkAndFixHomebrew()
   results.push(brew)
   results.push(checkAndFixAdb(brew.ok))
   results.push(await checkAndFixAndroidStudio(brew.ok))
@@ -24,17 +24,41 @@ export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   return results
 }
 
-function checkAndFixHomebrew(): SetupStepResult {
+const HOMEBREW_INSTALL =
+  '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'
+
+async function checkAndFixHomebrew(): Promise<SetupStepResult> {
   try {
     execSync('which brew', { stdio: 'pipe' })
     return { label: 'Homebrew installed', ok: true }
   } catch {
+    // 미설치 — 아래에서 확인 후 설치
+  }
+  // 원격 스크립트 자동 실행은 명시적 동의가 있을 때만. 비대화형이면 안내만.
+  if (!process.stdout.isTTY) {
     return {
       label: 'Homebrew',
       ok: false,
       warn: true,
-      detail: 'Install Homebrew first: https://brew.sh (cannot auto-install)',
+      detail: 'Install Homebrew: https://brew.sh (skipped in non-interactive mode)',
     }
+  }
+  const proceed = await confirm({
+    message: 'Homebrew not found. Install it now via the official script? (may prompt for sudo)',
+  })
+  if (isCancel(proceed) || !proceed) {
+    return { label: 'Homebrew', ok: false, warn: true, detail: 'Skipped. Install Homebrew: https://brew.sh' }
+  }
+  console.log()
+  const r = spawnSync('/bin/bash', ['-c', HOMEBREW_INSTALL], { stdio: 'inherit' })
+  if (r.status === 0) {
+    return { label: 'Homebrew installed', ok: true }
+  }
+  return {
+    label: 'Homebrew',
+    ok: false,
+    warn: true,
+    detail: 'Homebrew install failed. Install manually: https://brew.sh',
   }
 }
 


### PR DESCRIPTION
## Summary

Groundwork for `tapflow setup ios` (#144): makes the Homebrew step the shared first action across platform setups, and lets it install Homebrew when missing.

Previously `tapflow setup android` only printed the Homebrew install URL. Now `checkAndFixHomebrew()`:

- offers to run the **official install script** after an explicit `confirm` prompt (TTY only);
- in **non-interactive** shells, prints guidance only — no remote script runs without consent;
- on decline, prints guidance and continues.

The install runs with inherited stdio so Homebrew handles its own output and any sudo prompt directly.

## Why split this out

`setup ios` and `setup android` share Homebrew as their first step, so this lands as a small standalone change before the larger iOS PR (which adds `runSetupIos()` and unifies the `setup [platform]` interface with auto-detection).

## Testing

- `pnpm --filter tapflow test` — 181 passing. New cases: non-interactive (confirm skipped + guidance), TTY accept (official script runs), TTY decline (no install).
- All `execSync`/`spawnSync`/confirm mocked — no real install in tests.
- typecheck + lint clean.

Part of #142 / prep for #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `tapflow setup android` can now offer to install Homebrew when missing; in interactive mode users are prompted before running the official installer, while non-interactive shells show guidance instead.
* **Tests**
  * Test coverage added for interactive and non-interactive setup flows to validate prompt behavior and install outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->