### PR TITLE
feat(cli): add `tapflow setup ios` and unify the setup command

### DIFF
--- a/.changeset/setup-ios-and-unify.md
+++ b/.changeset/setup-ios-and-unify.md
@@ -1,0 +1,15 @@
+---
+"tapflow": minor
+---
+
+feat(cli): add `tapflow setup ios` and unify the setup command
+
+`tapflow setup ios` guides iOS environment setup: Homebrew → Xcode → Xcode activation → Simulator.
+
+- **Xcode** — since Xcode is App-Store-only, an interactive flow opens the App Store and waits for you to finish installing, then re-checks. Non-interactive shells print the App Store link instead.
+- **Xcode activation** — detects the "installed but not usable" case (active developer dir on CommandLineTools, missing license, or first-launch) and prints the exact `sudo xcode-select -s …` / `xcodebuild -license accept` / `-runFirstLaunch` commands (these need sudo, so setup guides rather than auto-runs them).
+- **Simulator** — boots the first available simulator if none is running.
+
+The `setup` command now takes an optional platform: `tapflow setup ios`, `tapflow setup android`, or `tapflow setup` to auto-detect and run every supported platform (iOS on macOS, Android when adb is found).
+
+Closes #144 (and completes #142 together with `setup android`).

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -2,12 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } fr
 
 vi.mock('../../lib/setup.js', () => ({
   runSetupAndroid: vi.fn(),
+  runSetupIos: vi.fn(),
+}))
+vi.mock('../../lib/doctor.js', () => ({
+  resolveAdb: vi.fn(),
 }))
 
-import { runSetupAndroid } from '../../lib/setup.js'
+import { runSetupAndroid, runSetupIos } from '../../lib/setup.js'
+import { resolveAdb } from '../../lib/doctor.js'
 import { cmdSetup } from '../../commands/setup.js'
 
 const mockRunSetupAndroid = vi.mocked(runSetupAndroid)
+const mockRunSetupIos = vi.mocked(runSetupIos)
+const mockResolveAdb = vi.mocked(resolveAdb)
 
 describe('cmdSetup', () => {
   let logLines: string[]
@@ -22,27 +29,58 @@ describe('cmdSetup', () => {
     vi.spyOn(console, 'error').mockImplementation((...args) => errLines.push(args.join(' ')))
     vi.spyOn(console, 'warn').mockImplementation((...args) => errLines.push(args.join(' ')))
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
+    mockRunSetupAndroid.mockResolvedValue([{ label: 'Homebrew installed', ok: true }])
+    mockRunSetupIos.mockResolvedValue([{ label: 'Xcode installed', ok: true }])
   })
 
   afterEach(() => vi.restoreAllMocks())
 
-  it('setup android는 runSetupAndroid 결과를 출력', async () => {
-    mockRunSetupAndroid.mockResolvedValue([
-      { label: 'Homebrew installed', ok: true },
-      { label: 'No running emulator', ok: false, warn: true, detail: 'Start an AVD' },
-    ])
-
-    await cmdSetup('android')
-    expect(mockRunSetupAndroid).toHaveBeenCalled()
-    const out = logLines.join('\n')
-    expect(out).toContain('Homebrew installed')
-    expect(out).toContain('No running emulator')
+  it('setup ios → runSetupIos만 호출', async () => {
+    await cmdSetup('ios')
+    expect(mockRunSetupIos).toHaveBeenCalled()
+    expect(mockRunSetupAndroid).not.toHaveBeenCalled()
   })
 
-  it('알 수 없는 platform이면 에러 + exit(1)', async () => {
+  it('setup android → runSetupAndroid만 호출 (회귀)', async () => {
+    await cmdSetup('android')
+    expect(mockRunSetupAndroid).toHaveBeenCalled()
+    expect(mockRunSetupIos).not.toHaveBeenCalled()
+  })
+
+  it('인자 없음 + darwin + adb 있음 → ios와 android 둘 다', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockResolveAdb.mockReturnValue({ path: '/x/adb', inPath: true })
+
+    await cmdSetup()
+    expect(mockRunSetupIos).toHaveBeenCalled()
+    expect(mockRunSetupAndroid).toHaveBeenCalled()
+  })
+
+  it('인자 없음 + darwin + adb 없음 → ios만', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockResolveAdb.mockReturnValue(null)
+
+    await cmdSetup()
+    expect(mockRunSetupIos).toHaveBeenCalled()
+    expect(mockRunSetupAndroid).not.toHaveBeenCalled()
+  })
+
+  it('인자 없음 + 감지 0개 → 안내, exit 없음', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockResolveAdb.mockReturnValue(null)
+
+    await cmdSetup()
+    expect(mockRunSetupIos).not.toHaveBeenCalled()
+    expect(mockRunSetupAndroid).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(errLines.join('\n')).toMatch(/no supported platform/i)
+  })
+
+  it('알 수 없는 platform → warn + exit(1)', async () => {
     await expect(cmdSetup('windows')).rejects.toThrow('process.exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(errLines.join('\n')).toMatch(/platform/i)
+    expect(mockRunSetupIos).not.toHaveBeenCalled()
     expect(mockRunSetupAndroid).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -393,19 +393,18 @@ describe('runSetupIos', () => {
     expect(findStep(results, 'simulator')?.ok).toBe(true)
   })
 
-  it('Booted 없고 Shutdown 후보 있으면 simctl boot 실행', async () => {
+  it('Booted 없고 Shutdown 후보 있으면 simctl boot 실행 (spawnSync argv)', async () => {
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
       if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
       if (c.includes('simctl list devices')) return simctlShutdown
-      if (c.includes('simctl boot')) return ''
       return ''
     })
 
     const results = await runSetupIos()
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('simctl boot BBB'), expect.anything())
+    expect(mockSpawnSync).toHaveBeenCalledWith('xcrun', ['simctl', 'boot', 'BBB'], expect.anything())
     expect(findStep(results, 'simulator')?.ok).toBe(true)
   })
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -4,6 +4,7 @@ vi.mock('node:child_process')
 vi.mock('node:fs')
 vi.mock('@clack/prompts', () => ({
   confirm: vi.fn(),
+  text: vi.fn(),
   isCancel: vi.fn(() => false),
 }))
 
@@ -11,8 +12,8 @@ import { execSync, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync, appendFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { confirm } from '@clack/prompts'
-import { runSetupAndroid } from '../../lib/setup.js'
+import { confirm, text } from '@clack/prompts'
+import { runSetupAndroid, runSetupIos } from '../../lib/setup.js'
 
 const mockExecSync = vi.mocked(execSync)
 const mockSpawnSync = vi.mocked(spawnSync)
@@ -20,6 +21,8 @@ const mockExistsSync = vi.mocked(existsSync)
 const mockReadFileSync = vi.mocked(readFileSync)
 const mockAppendFileSync = vi.mocked(appendFileSync)
 const mockConfirm = vi.mocked(confirm)
+const mockText = vi.mocked(text)
+const XCODE_APP = '/Applications/Xcode.app'
 
 const STUDIO_APP = '/Applications/Android Studio.app'
 const sdkAdb = join(homedir(), 'Library', 'Android', 'sdk', 'platform-tools', 'adb')
@@ -304,6 +307,125 @@ describe('runSetupAndroid', () => {
     const results = await runSetupAndroid()
     expect(results.every((r) => r.ok)).toBe(true)
     expect(mockAppendFileSync).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('runSetupIos', () => {
+  const simctlBooted = JSON.stringify({
+    devices: { 'iOS-18': [{ udid: 'AAA', name: 'iPhone 16 Pro', state: 'Booted' }] },
+  })
+  const simctlShutdown = JSON.stringify({
+    devices: { 'iOS-18': [{ udid: 'BBB', name: 'iPhone 15', state: 'Shutdown' }] },
+  })
+  const simctlEmpty = JSON.stringify({ devices: {} })
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockSpawnSync.mockReturnValue(okSpawn as never)
+    mockConfirm.mockResolvedValue(true as never)
+    mockText.mockResolvedValue('' as never)
+    // 기본: 완전히 구성된 macOS (brew·Xcode·활성화·Booted 시뮬)
+    mockExistsSync.mockImplementation((p) => p === XCODE_APP)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlBooted
+      return ''
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    setTTY(undefined)
+  })
+
+  it('Xcode 설치돼 있으면 ok', async () => {
+    const results = await runSetupIos()
+    expect(findStep(results, 'xcode')?.ok).toBe(true)
+  })
+
+  it('Xcode 미설치 + 비대화형이면 warn + App Store 링크', async () => {
+    setTTY(false)
+    mockExistsSync.mockReturnValue(false)
+
+    const results = await runSetupIos()
+    const xcode = findStep(results, 'xcode')
+    expect(xcode?.warn).toBe(true)
+    expect(xcode?.detail).toContain('apps.apple.com')
+    expect(mockText).not.toHaveBeenCalled()
+  })
+
+  it('Xcode 미설치 + TTY → App Store 열고 재확인 후 설치되면 ok', async () => {
+    setTTY(true)
+    // 처음엔 미설치, 두 번째 호출(재확인)부터 설치됨
+    let calls = 0
+    mockExistsSync.mockImplementation((p) => {
+      if (p === XCODE_APP) return calls++ > 0
+      return false
+    })
+
+    const results = await runSetupIos()
+    expect(mockText).toHaveBeenCalled()
+    expect(mockSpawnSync).toHaveBeenCalledWith('open', [expect.stringContaining('apps.apple.com')], expect.anything())
+    expect(findStep(results, 'xcode')?.ok).toBe(true)
+  })
+
+  it('active dir이 CommandLineTools면 활성화 단계 warn + xcode-select 안내', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Library/Developer/CommandLineTools\n'
+      if (c.includes('simctl list devices')) return simctlBooted
+      return ''
+    })
+
+    const results = await runSetupIos()
+    const act = results.find((r) => r.detail?.includes('xcode-select -s'))
+    expect(act?.warn).toBe(true)
+  })
+
+  it('시뮬레이터 Booted면 ok', async () => {
+    const results = await runSetupIos()
+    expect(findStep(results, 'simulator')?.ok).toBe(true)
+  })
+
+  it('Booted 없고 Shutdown 후보 있으면 simctl boot 실행', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlShutdown
+      if (c.includes('simctl boot')) return ''
+      return ''
+    })
+
+    const results = await runSetupIos()
+    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('simctl boot BBB'), expect.anything())
+    expect(findStep(results, 'simulator')?.ok).toBe(true)
+  })
+
+  it('사용 가능한 시뮬레이터가 없으면 warn', async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlEmpty
+      return ''
+    })
+
+    const results = await runSetupIos()
+    expect(findStep(results, 'simulator')?.warn).toBe(true)
+  })
+
+  it('멱등 — 완전 구성 머신은 전부 ok, 부작용 없음', async () => {
+    const results = await runSetupIos()
+    expect(results.every((r) => r.ok)).toBe(true)
     expect(mockSpawnSync).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,5 +1,19 @@
-import { runSetupAndroid, type SetupStepResult } from '../lib/setup.js'
-import { warn, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+import { runSetupAndroid, runSetupIos, type SetupStepResult } from '../lib/setup.js'
+import { resolveAdb } from '../lib/doctor.js'
+import { warn, BOLD, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+
+const RUNNERS: Record<string, () => Promise<SetupStepResult[]>> = {
+  ios: runSetupIos,
+  android: runSetupAndroid,
+}
+
+// 인자 없이 실행 시 환경을 보고 가능한 플랫폼을 고른다.
+function detectPlatforms(): string[] {
+  const platforms: string[] = []
+  if (process.platform === 'darwin') platforms.push('ios')
+  if (resolveAdb() !== null) platforms.push('android')
+  return platforms
+}
 
 function printResults(results: SetupStepResult[]): void {
   for (const r of results) {
@@ -16,14 +30,25 @@ function printResults(results: SetupStepResult[]): void {
   }
 }
 
-export async function cmdSetup(platform: string): Promise<void> {
-  if (platform === 'android') {
-    console.log('\ntapflow setup android\n')
-    printResults(await runSetupAndroid())
-    console.log()
-    return
+export async function cmdSetup(platform?: string): Promise<void> {
+  let targets: string[]
+  if (platform) {
+    if (!RUNNERS[platform]) {
+      warn(`Unknown or unsupported platform: ${platform}. Supported: ios, android`)
+      process.exit(1)
+    }
+    targets = [platform]
+  } else {
+    targets = detectPlatforms()
+    if (targets.length === 0) {
+      warn('No supported platform detected. Run: tapflow setup ios | android')
+      return
+    }
   }
 
-  warn(`Unknown or unsupported platform: ${platform}. Supported: android`)
-  process.exit(1)
+  for (const t of targets) {
+    console.log(`\n${BOLD}tapflow setup ${t}${R}\n`)
+    printResults(await RUNNERS[t]())
+  }
+  console.log()
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,8 +46,8 @@ cli
   .action((opts: { json?: boolean }) => cmdDoctor(opts))
 
 cli
-  .command('setup <platform>', 'Set up the environment for a platform (android)')
-  .action((platform: string) => cmdSetup(platform))
+  .command('setup [platform]', 'Set up the environment (ios | android; omit to auto-detect)')
+  .action((platform?: string) => cmdSetup(platform))
 
 cli
   .command('devices', 'List available iOS simulators and Android AVDs')

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -2,9 +2,9 @@ import { execSync, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync, appendFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { confirm, isCancel } from '@clack/prompts'
+import { confirm, text, isCancel } from '@clack/prompts'
 import { resolveAdb, type DoctorCheck } from './doctor.js'
-import { createSpinner } from './print.js'
+import { createSpinner, step } from './print.js'
 
 // setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓴다.
 // ok=true: 이미 OK이거나 방금 자동 수정함, warn=true: 수동 조치 필요(안내).
@@ -13,6 +13,9 @@ export type SetupStepResult = DoctorCheck
 const PATH_MARKER_START = '# >>> tapflow android sdk >>>'
 const PATH_MARKER_END = '# <<< tapflow android sdk <<<'
 const STUDIO_APP = '/Applications/Android Studio.app'
+const XCODE_APP = '/Applications/Xcode.app'
+const XCODE_APPSTORE = 'https://apps.apple.com/app/xcode/id497799835'
+const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer'
 
 export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   const results: SetupStepResult[] = []
@@ -22,6 +25,108 @@ export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   results.push(await checkAndFixAndroidStudio(brew.ok))
   results.push(checkAndFixEmulator())
   return results
+}
+
+export async function runSetupIos(): Promise<SetupStepResult[]> {
+  const results: SetupStepResult[] = []
+  results.push(await checkAndFixHomebrew())
+  const xcode = await checkAndFixXcode()
+  results.push(xcode)
+  results.push(checkXcodeActivation(xcode.ok))
+  results.push(checkAndFixSimulator())
+  return results
+}
+
+async function checkAndFixXcode(): Promise<SetupStepResult> {
+  if (existsSync(XCODE_APP)) {
+    return { label: 'Xcode installed', ok: true }
+  }
+  // Xcode는 App Store에서만 설치 가능 — CLI가 직접 설치할 수 없다.
+  if (!process.stdout.isTTY) {
+    return {
+      label: 'Xcode',
+      ok: false,
+      warn: true,
+      detail: `Install Xcode from the App Store: ${XCODE_APPSTORE}`,
+    }
+  }
+  step('Xcode can only be installed from the App Store.')
+  await text({ message: 'Press Enter to open the App Store…' })
+  spawnSync('open', [`macappstores://apps.apple.com/app/xcode/id497799835`], { stdio: 'ignore' })
+  await text({ message: 'Install Xcode, then press Enter to continue…' })
+  if (existsSync(XCODE_APP)) {
+    return { label: 'Xcode installed', ok: true }
+  }
+  return {
+    label: 'Xcode',
+    ok: false,
+    warn: true,
+    detail: 'Xcode not detected yet. Re-run `tapflow setup ios` after installing.',
+  }
+}
+
+// 설치됨 ≠ 사용 가능: active developer dir / 라이선스 / first-launch를 점검(sudo 작업은 안내만).
+function checkXcodeActivation(xcodeInstalled: boolean): SetupStepResult {
+  if (!xcodeInstalled) {
+    return { label: 'Xcode activation', ok: false, warn: true, detail: 'Install Xcode first.' }
+  }
+  let dir = ''
+  try {
+    dir = execSync('xcode-select -p', { encoding: 'utf8', stdio: 'pipe' }).trim()
+  } catch {
+    // active dir 미설정 — 아래 안내
+  }
+  if (!dir.includes('Xcode.app')) {
+    return {
+      label: 'Xcode command-line tools',
+      ok: false,
+      warn: true,
+      detail: `Active developer dir points away from Xcode. Run: sudo xcode-select -s ${XCODE_DEVELOPER_DIR}`,
+    }
+  }
+  try {
+    execSync('xcodebuild -version', { stdio: 'pipe' })
+    return { label: 'Xcode ready', ok: true }
+  } catch {
+    return {
+      label: 'Xcode setup',
+      ok: false,
+      warn: true,
+      detail: 'Finish Xcode setup: sudo xcodebuild -license accept && xcodebuild -runFirstLaunch',
+    }
+  }
+}
+
+function checkAndFixSimulator(): SetupStepResult {
+  try {
+    const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+    const data = JSON.parse(raw) as {
+      devices: Record<string, Array<{ name: string; state: string; udid: string }>>
+    }
+    const all = Object.values(data.devices).flat()
+    const booted = all.find((d) => d.state === 'Booted')
+    if (booted) {
+      return { label: `Simulator booted: ${booted.name}`, ok: true }
+    }
+    const candidate = all.find((d) => d.state === 'Shutdown')
+    if (candidate) {
+      execSync(`xcrun simctl boot ${candidate.udid}`, { stdio: 'pipe' })
+      return { label: `Simulator booted: ${candidate.name}`, ok: true }
+    }
+    return {
+      label: 'Simulator',
+      ok: false,
+      warn: true,
+      detail: 'No simulators available. Open Xcode to install a simulator runtime.',
+    }
+  } catch {
+    return {
+      label: 'Simulator',
+      ok: false,
+      warn: true,
+      detail: 'Could not query simulators. Finish Xcode setup first.',
+    }
+  }
 }
 
 // eval "$(...)"로 감싸 명령 치환 결과(설치 스크립트)가 word splitting 없이 단일 평가되게 한다.

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -51,9 +51,25 @@ async function checkAndFixXcode(): Promise<SetupStepResult> {
     }
   }
   step('Xcode can only be installed from the App Store.')
-  await text({ message: 'Press Enter to open the App Store…' })
-  spawnSync('open', [`macappstores://apps.apple.com/app/xcode/id497799835`], { stdio: 'ignore' })
-  await text({ message: 'Install Xcode, then press Enter to continue…' })
+  const openPrompt = await text({ message: 'Press Enter to open the App Store…' })
+  if (isCancel(openPrompt)) {
+    return {
+      label: 'Xcode',
+      ok: false,
+      warn: true,
+      detail: 'Cancelled. Install Xcode from the App Store and re-run `tapflow setup ios`.',
+    }
+  }
+  spawnSync('open', ['macappstores://apps.apple.com/app/xcode/id497799835'], { stdio: 'ignore' })
+  const continuePrompt = await text({ message: 'Install Xcode, then press Enter to continue…' })
+  if (isCancel(continuePrompt)) {
+    return {
+      label: 'Xcode',
+      ok: false,
+      warn: true,
+      detail: 'Cancelled. Re-run `tapflow setup ios` after installing Xcode.',
+    }
+  }
   if (existsSync(XCODE_APP)) {
     return { label: 'Xcode installed', ok: true }
   }
@@ -92,7 +108,7 @@ function checkXcodeActivation(xcodeInstalled: boolean): SetupStepResult {
       label: 'Xcode setup',
       ok: false,
       warn: true,
-      detail: 'Finish Xcode setup: sudo xcodebuild -license accept && xcodebuild -runFirstLaunch',
+      detail: 'Finish Xcode setup: sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch',
     }
   }
 }
@@ -110,7 +126,8 @@ function checkAndFixSimulator(): SetupStepResult {
     }
     const candidate = all.find((d) => d.state === 'Shutdown')
     if (candidate) {
-      execSync(`xcrun simctl boot ${candidate.udid}`, { stdio: 'pipe' })
+      const boot = spawnSync('xcrun', ['simctl', 'boot', candidate.udid], { stdio: 'pipe' })
+      if (boot.status !== 0) throw new Error('simctl boot failed')
       return { label: `Simulator booted: ${candidate.name}`, ok: true }
     }
     return {


### PR DESCRIPTION
## Summary

Implements #144 and completes the `tapflow setup` feature (#142). Adds `runSetupIos()` and unifies the `setup` command with an optional platform + auto-detection.

```sh
tapflow setup ios       # iOS only
tapflow setup android   # Android only
tapflow setup           # auto-detect and run every supported platform
```

## iOS setup steps

| Step | Behavior |
|------|----------|
| Homebrew | shared step (offers install after confirmation, from #242) |
| Xcode | App-Store-only → interactive flow: open the App Store, wait for Enter, re-check. Non-TTY prints the App Store link |
| Xcode activation | detects "installed but not usable" — active developer dir on CommandLineTools, missing license, or first-launch — and prints the exact `sudo xcode-select -s …` / `xcodebuild -license accept` / `-runFirstLaunch` commands |
| Simulator | boots the first available simulator if none is running |

## Design decisions (from plan)

- **sudo = guide, not auto-run.** `xcode-select -s`, `-license accept`, `-runFirstLaunch` all need sudo, so the activation step prints the exact commands rather than running them (per the decision recorded in the plan). This addresses the "simulator won't boot" case whose root cause is the active developer directory, not PATH.
- **Unified interface.** `setup [platform]` (positional, optional). Omitting it auto-detects: iOS on macOS, Android when `resolveAdb()` finds adb. Reuses `resolveAdb()` from the doctor module.
- **Xcode "installed" vs "usable"** are split into two steps so a present-but-unconfigured Xcode is reported accurately.

## Testing

- `pnpm --filter tapflow test` — 193 passing. New: 8 `runSetupIos` cases (Xcode present / non-TTY link / interactive install + re-check / CommandLineTools activation warning / simulator booted / boot a shutdown sim / no sims / idempotent) and 6 `cmdSetup` routing + auto-detect cases.
- All OS calls, prompts, and fs mocked — no real installs or simulator boots in tests.
- Verified real `setup ios` and `setup` (auto-detect runs iOS + Android) on a configured machine, plus the unknown-platform exit path.

Closes #144. Completes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive `setup ios` flow for Homebrew, Xcode activation/first-launch, and Simulator handling.
  * `setup` now accepts an optional platform argument and auto-detects available platforms when omitted.

* **Tests**
  * Expanded test coverage for platform selection, auto-detection behavior, and the iOS setup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->