### PR TITLE
chore: release v0.8.0-next.0 (prerelease, dist-tag next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,21 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@tapflowio/docs": "0.0.0",
+    "@tapflowio/agent-core": "0.7.0",
+    "@tapflowio/android-agent": "0.7.0",
+    "tapflow": "0.7.0",
+    "@tapflowio/dashboard": "0.1.1",
+    "@tapflowio/ios-agent": "0.7.0",
+    "@tapflowio/mcp-server": "0.7.0-experimental.1",
+    "@tapflowio/relay": "0.7.0",
+    "@tapflowio/playground": "0.0.0"
+  },
+  "changesets": [
+    "doctor-json-flag",
+    "setup-android",
+    "setup-homebrew-autoinstall",
+    "setup-ios-and-unify"
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*' # prerelease tags (e.g. v0.8.0-next.0)
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- cli: `tapflow doctor --json` emits machine-readable `{ ok, common, ios, android }` for CI/automation; `doctor` also diagnoses adb that is installed in a standard SDK location but missing from PATH.
+- cli: `tapflow setup [platform]` guides iOS/Android environment setup — Homebrew, adb/Xcode, simulator/emulator — applying safe fixes. Run without an argument to auto-detect and set up every supported platform. Homebrew can be installed via the official script after confirmation.
+
 ## [0.7.0] - 2026-06-08
 
 ### Added

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.0-next.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.7.0",
+  "version": "0.8.0-next.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.0-next.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.7.0",
+  "version": "0.8.0-next.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,48 @@
 # tapflow
 
+## 0.8.0-next.0
+
+### Minor Changes
+
+- 2552e53: feat(cli): add `tapflow doctor --json` and diagnose adb installed-but-not-in-PATH
+
+  - `tapflow doctor --json` emits machine-readable `{ ok, common, ios, android }` with no ANSI color, exiting 1 on failure — usable from CI and automation without screen-scraping.
+  - `doctor` now detects adb present in a standard SDK location (`$ANDROID_HOME`, `$ANDROID_SDK_ROOT`, `~/Library/Android/sdk`, `~/Android/Sdk`) but missing from PATH, instead of silently dropping the entire Android section. It surfaces an `adb (not in PATH)` warning hinting `tapflow setup android`.
+
+- 78743d4: feat(cli): add `tapflow setup android` — guided Android environment setup
+
+  `tapflow doctor` diagnoses problems; `tapflow setup android` fixes them. It walks through the required Android dependencies and applies fixes where safe:
+
+  - **Homebrew** — checks `which brew`, prints the install URL if missing (cannot auto-install).
+  - **adb** — if present in PATH it passes; if found in a standard SDK location but missing from PATH it registers the `platform-tools` directory in your shell rc (`.zshrc`/`.bashrc`) inside an idempotent marker block; if absent it runs `brew install android-platform-tools`.
+  - **Android Studio** — checks `/Applications/Android Studio.app`; since the cask is large (~1GB+) it asks for confirmation before `brew install --cask android-studio`, and skips with guidance in non-interactive shells.
+  - **Emulator** — reports running emulators and hints how to start an AVD.
+
+  Each step is idempotent — re-running on a configured machine prints ✓ and makes no changes.
+
+- e21902e: feat(cli): `tapflow setup` can install Homebrew after confirmation
+
+  When Homebrew is missing, `tapflow setup android` (and upcoming `setup ios`) now offers to install it via the official script after an explicit confirmation prompt, instead of only printing the install URL. In non-interactive shells it still just prints guidance — no remote script runs without consent. This makes Homebrew the shared first step for all platform setups.
+
+- 64d9a59: feat(cli): add `tapflow setup ios` and unify the setup command
+
+  `tapflow setup ios` guides iOS environment setup: Homebrew → Xcode → Xcode activation → Simulator.
+
+  - **Xcode** — since Xcode is App-Store-only, an interactive flow opens the App Store and waits for you to finish installing, then re-checks. Non-interactive shells print the App Store link instead.
+  - **Xcode activation** — detects the "installed but not usable" case (active developer dir on CommandLineTools, missing license, or first-launch) and prints the exact `sudo xcode-select -s …` / `xcodebuild -license accept` / `-runFirstLaunch` commands (these need sudo, so setup guides rather than auto-runs them).
+  - **Simulator** — boots the first available simulator if none is running.
+
+  The `setup` command now takes an optional platform: `tapflow setup ios`, `tapflow setup android`, or `tapflow setup` to auto-detect and run every supported platform (iOS on macOS, Android when adb is found).
+
+  Closes #144 (and completes #142 together with `setup android`).
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.0
+- @tapflowio/ios-agent@0.8.0-next.0
+- @tapflowio/android-agent@0.8.0-next.0
+- @tapflowio/relay@0.8.0-next.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.7.0",
+  "version": "0.8.0-next.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.8.0-next.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.7.0",
+  "version": "0.8.0-next.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.8.0-next.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.7.0",
+  "version": "0.8.0-next.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Prerelease of **0.8.0-next.0** via changesets **pre mode** (dist-tag `next`). This lets us verify the new CLI work on another Mac **without touching `latest` (stays at 0.7.0)**.

## What's in 0.8.0 (vs 0.7.0)

- `tapflow doctor --json` — machine-readable health output; diagnoses adb installed-but-not-on-PATH (#140)
- `tapflow setup [platform]` — guided iOS/Android setup with auto-detection (#142 / #144 / #145), plus confirm-then-install Homebrew

## Release mechanics

- `changeset pre enter next` + `changeset version` → fixed group (`tapflow`, `agent-core`, `ios-agent`, `android-agent`, `relay`) bumped to `0.8.0-next.0`.
- `mcp-server` is in the changeset `ignore` list — unchanged (`0.7.0-experimental.1`).
- Pending changesets stay consumed-on-exit (pre mode); they are listed in `.changeset/pre.json`.

## Verification plan (after merge + tag)

1. Tag the merge commit `v0.8.0-next.0` and push → CI publishes to the **`next`** dist-tag (latest unaffected).
2. On another Mac: `npm i -g tapflow@next`, then `tapflow doctor --json` and `tapflow setup`.
3. If good: `changeset pre exit` → `changeset version` → `0.8.0` → tag `v0.8.0` → promotes to `latest`.

> ⚠️ Do not merge as a normal release yet — this is the prerelease half of the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tapflow doctor --json` flag for machine-readable diagnostic output
  * Added `tapflow setup` command with guided iOS/Android environment configuration and auto-detection
  * Enhanced adb diagnostics with improved error messaging

* **Documentation**
  * Updated changelogs across packages to document new features and version updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->