### PR TITLE
fix(cli): doctor/setup improvements from 0.8.0-next.0 testing

### DIFF
--- a/.changeset/doctor-platform.md
+++ b/.changeset/doctor-platform.md
@@ -1,0 +1,7 @@
+---
+"tapflow": minor
+---
+
+fix(cli): `doctor` shows Android even without adb, and adds `doctor [platform]`
+
+`tapflow doctor` no longer hides the Android section when adb is not found — it surfaces an `adb not found → tapflow setup android` warning so people setting up an Android-only agent can still diagnose it. Added `tapflow doctor ios|android` to check a single platform (mirrors `tapflow setup [platform]`); omit the argument to check all.

--- a/.changeset/setup-redesign.md
+++ b/.changeset/setup-redesign.md
@@ -8,7 +8,7 @@ feat(cli): setup completes in one run; doctor reflects on-demand boot
 
 - runs sudo steps directly after confirmation (`xcode-select -s`, `xcodebuild -license accept`, `-runFirstLaunch`) — no more "run this and re-run setup" loop.
 - iOS: downloads the simulator runtime when no device exists.
-- Android: creates a system image + AVD via `sdkmanager`/`avdmanager` when none exists.
+- Android: when no AVD exists, installs a `google_apis` system image once and creates a set of 4 AVDs across form factors (compact / phone / large / tablet) so the device list is comparable to iOS. Device ids are chosen per-environment from candidates; ABI matches the host arch.
 - no longer boots devices — relay boots on-demand when a QA Session connects, so setup only ensures a bootable device/AVD exists.
 - `tapflow setup` (no argument) offers to set up Android even when adb isn't found, and ends with a `SETUP COMPLETE` / `SETUP INCOMPLETE` summary banner (per-platform ready state).
 

--- a/.changeset/setup-redesign.md
+++ b/.changeset/setup-redesign.md
@@ -1,0 +1,15 @@
+---
+"tapflow": minor
+---
+
+feat(cli): setup completes in one run; doctor reflects on-demand boot
+
+`tapflow setup` is now an end-to-end interactive wizard instead of stopping to print manual commands:
+
+- runs sudo steps directly after confirmation (`xcode-select -s`, `xcodebuild -license accept`, `-runFirstLaunch`) — no more "run this and re-run setup" loop.
+- iOS: downloads the simulator runtime when no device exists.
+- Android: creates a system image + AVD via `sdkmanager`/`avdmanager` when none exists.
+- no longer boots devices — relay boots on-demand when a QA Session connects, so setup only ensures a bootable device/AVD exists.
+- `tapflow setup` (no argument) offers to set up Android even when adb isn't found, and ends with a `SETUP COMPLETE` / `SETUP INCOMPLETE` summary banner (per-platform ready state).
+
+`tapflow doctor` now passes when a simulator device or AVD *exists* (any state) rather than requiring a *running* one, matching the on-demand boot model.

--- a/packages/cli/src/__tests__/commands/doctor.test.ts
+++ b/packages/cli/src/__tests__/commands/doctor.test.ts
@@ -11,12 +11,15 @@ const mockRunDoctorChecks = vi.mocked(runDoctorChecks)
 
 describe('cmdDoctor', () => {
   let logLines: string[]
+  let errLines: string[]
   let exitSpy: MockInstance
 
   beforeEach(() => {
     vi.resetAllMocks()
     logLines = []
+    errLines = []
     vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(args.join(' ')))
+    vi.spyOn(console, 'warn').mockImplementation((...args) => errLines.push(args.join(' ')))
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit') })
   })
 
@@ -31,6 +34,24 @@ describe('cmdDoctor', () => {
 
     await cmdDoctor()
     expect(logLines.join('\n')).toContain('All checks passed')
+  })
+
+  it('platform 인자를 runDoctorChecks에 전달', async () => {
+    mockRunDoctorChecks.mockResolvedValue({
+      common: [{ label: 'Node v20.0.0', ok: true }],
+      ios: null,
+      android: [{ label: 'adb found: /x', ok: true }],
+    })
+
+    await cmdDoctor({ platform: 'android' })
+    expect(mockRunDoctorChecks).toHaveBeenCalledWith('android')
+  })
+
+  it('알 수 없는 platform이면 warn + exit(1), 진단 미실행', async () => {
+    await expect(cmdDoctor({ platform: 'windows' })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errLines.join('\n')).toMatch(/platform/i)
+    expect(mockRunDoctorChecks).not.toHaveBeenCalled()
   })
 
   it('실패 체크 있으면 "Some checks failed" 출력 후 exit(1)', async () => {

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -7,14 +7,24 @@ vi.mock('../../lib/setup.js', () => ({
 vi.mock('../../lib/doctor.js', () => ({
   resolveAdb: vi.fn(),
 }))
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+}))
 
 import { runSetupAndroid, runSetupIos } from '../../lib/setup.js'
 import { resolveAdb } from '../../lib/doctor.js'
+import { confirm } from '@clack/prompts'
 import { cmdSetup } from '../../commands/setup.js'
 
 const mockRunSetupAndroid = vi.mocked(runSetupAndroid)
 const mockRunSetupIos = vi.mocked(runSetupIos)
 const mockResolveAdb = vi.mocked(resolveAdb)
+const mockConfirm = vi.mocked(confirm)
+
+function setTTY(value: boolean | undefined) {
+  Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+}
 
 describe('cmdSetup', () => {
   let logLines: string[]
@@ -33,7 +43,10 @@ describe('cmdSetup', () => {
     mockRunSetupIos.mockResolvedValue([{ label: 'Xcode installed', ok: true }])
   })
 
-  afterEach(() => vi.restoreAllMocks())
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setTTY(undefined)
+  })
 
   it('setup ios → runSetupIos만 호출', async () => {
     await cmdSetup('ios')
@@ -56,13 +69,56 @@ describe('cmdSetup', () => {
     expect(mockRunSetupAndroid).toHaveBeenCalled()
   })
 
-  it('인자 없음 + darwin + adb 없음 → ios만', async () => {
+  it('인자 없음 + darwin + adb 없음 + 비대화형 → ios만 (Android 안 물음)', async () => {
+    setTTY(false)
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     mockResolveAdb.mockReturnValue(null)
 
     await cmdSetup()
     expect(mockRunSetupIos).toHaveBeenCalled()
     expect(mockRunSetupAndroid).not.toHaveBeenCalled()
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
+  it('인자 없음 + darwin + adb 없음 + TTY + Android 수락 → 둘 다', async () => {
+    setTTY(true)
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockResolveAdb.mockReturnValue(null)
+    mockConfirm.mockResolvedValue(true as never)
+
+    await cmdSetup()
+    expect(mockConfirm).toHaveBeenCalled()
+    expect(mockRunSetupIos).toHaveBeenCalled()
+    expect(mockRunSetupAndroid).toHaveBeenCalled()
+  })
+
+  it('인자 없음 + darwin + adb 없음 + TTY + Android 거절 → ios만', async () => {
+    setTTY(true)
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockResolveAdb.mockReturnValue(null)
+    mockConfirm.mockResolvedValue(false as never)
+
+    await cmdSetup()
+    expect(mockRunSetupAndroid).not.toHaveBeenCalled()
+  })
+
+  it('전부 ready면 SETUP COMPLETE 배너', async () => {
+    mockRunSetupIos.mockResolvedValue([{ label: 'Xcode ready', ok: true }])
+
+    await cmdSetup('ios')
+    expect(logLines.join('\n')).toContain('SETUP COMPLETE')
+  })
+
+  it('미완 step 있으면 SETUP INCOMPLETE 배너 + 사유', async () => {
+    mockRunSetupIos.mockResolvedValue([
+      { label: 'Xcode ready', ok: true },
+      { label: 'Simulator', ok: false, warn: true, detail: '...' },
+    ])
+
+    await cmdSetup('ios')
+    const out = logLines.join('\n')
+    expect(out).toContain('SETUP INCOMPLETE')
+    expect(out).toContain('Simulator')
   })
 
   it('인자 없음 + 감지 0개 → 안내, exit 없음', async () => {

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -76,15 +76,21 @@ describe('runDoctorChecks', () => {
     expect(result.android?.some((c) => c.label.includes('Pixel_8'))).toBe(true)
   })
 
-  it('adb 없으면 Android 섹션 null', async () => {
+  it('adb 없어도 Android 섹션은 숨기지 않고 adb warn 표시', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('ANDROID_HOME', '')
+    vi.stubEnv('ANDROID_SDK_ROOT', '')
+    mockExistsSync.mockReturnValue(false)
     mockExecSync.mockImplementation((cmd) => {
       if ((cmd as string) === 'which adb') throw new Error('not found')
       return ''
     })
 
     const result = await runDoctorChecks()
-    expect(result.android).toBeNull()
+    expect(result.android).not.toBeNull()
+    const adbCheck = result.android?.find((c) => c.label === 'adb')
+    expect(adbCheck?.warn).toBe(true)
+    expect(adbCheck?.detail).toContain('setup android')
   })
 
   it('Node 버전 >= 20이면 ok', async () => {
@@ -194,18 +200,43 @@ describe('runDoctorChecks', () => {
     expect(adbCheck?.detail).toContain(sdkAdb)
   })
 
-  it('adb가 PATH/표준 위치 모두 없으면 Android 섹션 null', async () => {
-    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
-    vi.stubEnv('ANDROID_HOME', '')
-    vi.stubEnv('ANDROID_SDK_ROOT', '')
-    mockExistsSync.mockReturnValue(false)
+  it("platform 'android' 지정 시 Android만 진단 (iOS null)", async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     mockExecSync.mockImplementation((cmd) => {
-      if ((cmd as string) === 'which adb') throw new Error('not found')
+      const c = cmd as string
+      if (c === 'which adb') return '/usr/local/bin/adb\n'
+      if (c === 'adb devices') return 'List of devices attached\n'
+      if (c === 'emulator -list-avds') return 'Pixel_8\n'
       return ''
     })
 
-    const result = await runDoctorChecks()
+    const result = await runDoctorChecks('android')
+    expect(result.ios).toBeNull()
+    expect(result.android).not.toBeNull()
+  })
+
+  it("platform 'ios' 지정 시 iOS만 진단 (Android null)", async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.startsWith('xcrun simctl')) return simctlBooted
+      return ''
+    })
+
+    const result = await runDoctorChecks('ios')
     expect(result.android).toBeNull()
+    expect(result.ios).not.toBeNull()
+  })
+
+  it("platform 'ios'를 non-macOS에서 지정하면 macOS 필요 warn", async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockExecSync.mockImplementation(() => { throw new Error('not found') })
+
+    const result = await runDoctorChecks('ios')
+    const iosCheck = result.ios?.[0]
+    expect(iosCheck?.warn).toBe(true)
+    expect(iosCheck?.detail).toContain('macOS')
   })
 
   it('ANDROID_HOME 지정 시 해당 경로의 adb로 진단', async () => {

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -127,7 +127,7 @@ describe('runDoctorChecks', () => {
     expect(result.ios?.some((c) => c.label.includes('iPhone 16 Pro'))).toBe(true)
   })
 
-  it('booted 없으면 warn + 사용 가능한 시뮬레이터 이름으로 hint 생성', async () => {
+  it('booted 안 됐어도 디바이스가 있으면 ok (부팅은 on-demand)', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
@@ -138,10 +138,8 @@ describe('runDoctorChecks', () => {
     })
 
     const result = await runDoctorChecks()
-    const simCheck = result.ios?.find((c) => c.label === 'Simulator')
-    expect(simCheck?.ok).toBe(false)
-    expect(simCheck?.warn).toBe(true)
-    expect(simCheck?.detail).toContain('iPhone 16 Pro')
+    const simCheck = result.ios?.find((c) => c.label.includes('Simulator'))
+    expect(simCheck?.ok).toBe(true)
   })
 
   it('Xcode 미설치 시 실패 + 링크 포함', async () => {

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -282,7 +282,7 @@ describe('runSetupAndroid', () => {
     expect(mockAppendFileSync).not.toHaveBeenCalled()
   })
 
-  it('AVD 없음 + TTY + 수락 시 sdkmanager + avdmanager로 생성', async () => {
+  it('AVD 없음 + TTY + 수락 시 시스템 이미지 1회 설치 + 폼팩터별 AVD 4개 생성', async () => {
     setTTY(true)
     vi.stubEnv('ANDROID_HOME', '/opt/android-sdk')
     mockConfirm.mockResolvedValue(true as never)
@@ -298,10 +298,25 @@ describe('runSetupAndroid', () => {
     mockExistsSync.mockImplementation(
       (p) => p === STUDIO_APP || p === '/opt/android-sdk' || p === sdkmanager || p === avdmanager,
     )
+    // avdmanager list device → 폼팩터별 후보가 모두 가용하도록
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      if (cmd === avdmanager && Array.isArray(args) && args.includes('device')) {
+        return {
+          ...okSpawn,
+          stdout: 'id: 0 or "pixel_5"\nid: 1 or "pixel_7"\nid: 2 or "pixel_7_pro"\nid: 3 or "pixel_c"\n',
+        } as never
+      }
+      return okSpawn as never
+    })
 
     const results = await runSetupAndroid()
+    // 시스템 이미지 1회 설치
     expect(mockSpawnSync).toHaveBeenCalledWith(sdkmanager, [expect.stringContaining('system-images')], expect.anything())
-    expect(mockSpawnSync).toHaveBeenCalledWith(avdmanager, expect.arrayContaining(['create', 'avd']), expect.anything())
+    // AVD 4개 생성 (create avd 호출 횟수)
+    const createCalls = mockSpawnSync.mock.calls.filter(
+      (c) => c[0] === avdmanager && Array.isArray(c[1]) && c[1].includes('create'),
+    )
+    expect(createCalls).toHaveLength(4)
     expect(findStep(results, 'avd')?.ok).toBe(true)
   })
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -244,43 +244,24 @@ describe('runSetupAndroid', () => {
     expect(findStep(results, 'android studio')?.warn).toBe(true)
   })
 
-  it('실행 중 에뮬레이터 있으면 ok', async () => {
+  it('AVD가 있으면 ok (부팅 안 함)', async () => {
     const results = await runSetupAndroid()
-    expect(findStep(results, 'emulator')?.ok).toBe(true)
+    expect(findStep(results, 'avd')?.ok).toBe(true)
   })
 
-  it('에뮬레이터 없으면 warn + AVD 힌트', async () => {
+  it('AVD가 없으면 비대화형에서 warn (생성 안 함)', async () => {
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c.includes('devices')) return 'List of devices attached\n'
-      if (c === 'emulator -list-avds') return 'Pixel_8\n'
+      if (c === 'emulator -list-avds') return ''
       return ''
     })
+    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
 
     const results = await runSetupAndroid()
-    const emu = findStep(results, 'emulator')
-    expect(emu?.warn).toBe(true)
-    expect(emu?.detail).toContain('Pixel_8')
-  })
-
-  it('adb가 PATH엔 없어도 SDK 경로로 해석해 에뮬레이터 감지 (PATH 미반영 회피)', async () => {
-    // 같은 실행에서 방금 PATH 등록한 adb는 현재 프로세스 PATH에 없다 → 절대경로로 조회해야 ok
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes(sdkAdb) && c.includes('devices')) {
-        return 'List of devices attached\nemulator-5554\tdevice\n'
-      }
-      if (c === 'adb devices') return 'List of devices attached\n' // PATH adb는 실패 시뮬
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'emulator')?.ok).toBe(true)
+    expect(findStep(results, 'avd')?.warn).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalled()
   })
 
   it('미지원 셸(fish 등)이면 자동 등록 대신 warn + 수동 export 안내', async () => {
@@ -299,6 +280,29 @@ describe('runSetupAndroid', () => {
     expect(adb?.warn).toBe(true)
     expect(adb?.detail).toContain('export PATH')
     expect(mockAppendFileSync).not.toHaveBeenCalled()
+  })
+
+  it('AVD 없음 + TTY + 수락 시 sdkmanager + avdmanager로 생성', async () => {
+    setTTY(true)
+    vi.stubEnv('ANDROID_HOME', '/opt/android-sdk')
+    mockConfirm.mockResolvedValue(true as never)
+    const sdkmanager = join('/opt/android-sdk', 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+    const avdmanager = join('/opt/android-sdk', 'cmdline-tools', 'latest', 'bin', 'avdmanager')
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
+      if (c === 'emulator -list-avds') return ''
+      return ''
+    })
+    mockExistsSync.mockImplementation(
+      (p) => p === STUDIO_APP || p === '/opt/android-sdk' || p === sdkmanager || p === avdmanager,
+    )
+
+    const results = await runSetupAndroid()
+    expect(mockSpawnSync).toHaveBeenCalledWith(sdkmanager, [expect.stringContaining('system-images')], expect.anything())
+    expect(mockSpawnSync).toHaveBeenCalledWith(avdmanager, expect.arrayContaining(['create', 'avd']), expect.anything())
+    expect(findStep(results, 'avd')?.ok).toBe(true)
   })
 
   it('멱등 — 완전히 구성된 머신은 전부 ok, 부작용 없음', async () => {
@@ -388,27 +392,22 @@ describe('runSetupIos', () => {
     expect(act?.warn).toBe(true)
   })
 
-  it('시뮬레이터 Booted면 ok', async () => {
-    const results = await runSetupIos()
-    expect(findStep(results, 'simulator')?.ok).toBe(true)
-  })
-
-  it('Booted 없고 Shutdown 후보 있으면 simctl boot 실행 (spawnSync argv)', async () => {
+  it('디바이스가 있으면 부팅하지 않고 ready', async () => {
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
       if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
       if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
-      if (c.includes('simctl list devices')) return simctlShutdown
+      if (c.includes('simctl list devices')) return simctlShutdown // 미부팅 디바이스 존재
       return ''
     })
 
     const results = await runSetupIos()
-    expect(mockSpawnSync).toHaveBeenCalledWith('xcrun', ['simctl', 'boot', 'BBB'], expect.anything())
     expect(findStep(results, 'simulator')?.ok).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('xcrun', expect.anything(), expect.anything())
   })
 
-  it('사용 가능한 시뮬레이터가 없으면 warn', async () => {
+  it('사용 가능한 시뮬레이터가 없으면 비대화형에서 warn', async () => {
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
@@ -420,6 +419,43 @@ describe('runSetupIos', () => {
 
     const results = await runSetupIos()
     expect(findStep(results, 'simulator')?.warn).toBe(true)
+  })
+
+  it('active dir이 CommandLineTools + TTY + 수락 시 sudo xcode-select 직접 실행', async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(true as never)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Library/Developer/CommandLineTools\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlBooted
+      return ''
+    })
+
+    const results = await runSetupIos()
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'sudo',
+      ['xcode-select', '-s', '/Applications/Xcode.app/Contents/Developer'],
+      expect.anything(),
+    )
+    expect(findStep(results, 'xcode ready')?.ok).toBe(true)
+  })
+
+  it('시뮬 디바이스 없음 + TTY + 수락 시 xcodebuild -downloadPlatform 실행', async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(true as never)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlEmpty
+      return ''
+    })
+
+    await runSetupIos()
+    expect(mockSpawnSync).toHaveBeenCalledWith('xcodebuild', ['-downloadPlatform', 'iOS'], expect.anything())
   })
 
   it('멱등 — 완전 구성 머신은 전부 ok, 부작용 없음', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { runDoctorChecks, type DoctorCheck, type DoctorResult } from '../lib/doctor.js'
-import { banner, step, GREEN, RED, YELLOW, BOLD, DIM, R } from '../lib/print.js'
+import { banner, step, warn, GREEN, RED, YELLOW, BOLD, DIM, R } from '../lib/print.js'
 
 function printChecks(checks: DoctorCheck[]): void {
   for (const check of checks) {
@@ -21,8 +21,12 @@ function hasFailures(result: DoctorResult): boolean {
   return all.some((c) => !c.ok && !c.warn)
 }
 
-export async function cmdDoctor(opts: { json?: boolean } = {}): Promise<void> {
-  const result = await runDoctorChecks()
+export async function cmdDoctor(opts: { json?: boolean; platform?: string } = {}): Promise<void> {
+  if (opts.platform && opts.platform !== 'ios' && opts.platform !== 'android') {
+    warn(`Unknown platform: ${opts.platform}. Supported: ios, android`)
+    process.exit(1)
+  }
+  const result = await runDoctorChecks(opts.platform)
 
   if (opts.json) {
     const ok = !hasFailures(result)

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,6 +1,7 @@
+import { confirm, isCancel } from '@clack/prompts'
 import { runSetupAndroid, runSetupIos, type SetupStepResult } from '../lib/setup.js'
 import { resolveAdb } from '../lib/doctor.js'
-import { warn, BOLD, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+import { warn, banner, BOLD, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
 
 const RUNNERS: Record<string, () => Promise<SetupStepResult[]>> = {
   ios: runSetupIos,
@@ -8,10 +9,16 @@ const RUNNERS: Record<string, () => Promise<SetupStepResult[]>> = {
 }
 
 // 인자 없이 실행 시 환경을 보고 가능한 플랫폼을 고른다.
-function detectPlatforms(): string[] {
+// macOS면 iOS, adb가 있으면 Android 자동. adb가 없어도 TTY면 Android 세팅 의향을 묻는다.
+async function detectPlatforms(): Promise<string[]> {
   const platforms: string[] = []
   if (process.platform === 'darwin') platforms.push('ios')
-  if (resolveAdb() !== null) platforms.push('android')
+  if (resolveAdb() !== null) {
+    platforms.push('android')
+  } else if (process.platform === 'darwin' && process.stdout.isTTY) {
+    const also = await confirm({ message: 'Also set up Android? (adb not found)' })
+    if (!isCancel(also) && also) platforms.push('android')
+  }
   return platforms
 }
 
@@ -39,16 +46,27 @@ export async function cmdSetup(platform?: string): Promise<void> {
     }
     targets = [platform]
   } else {
-    targets = detectPlatforms()
+    targets = await detectPlatforms()
     if (targets.length === 0) {
       warn('No supported platform detected. Run: tapflow setup ios | android')
       return
     }
   }
 
+  // 각 플랫폼 실행 후, 마지막에 relay/agent READY 톤의 요약 배너로 준비 상태를 알린다.
+  const summary: string[] = []
+  let allReady = true
   for (const t of targets) {
     console.log(`\n${BOLD}tapflow setup ${t}${R}\n`)
-    printResults(await RUNNERS[t]())
+    const results = await RUNNERS[t]()
+    printResults(results)
+    const pending = results.filter((r) => !r.ok)
+    if (pending.length === 0) {
+      summary.push(`${t}: ready`)
+    } else {
+      allReady = false
+      summary.push(`${t}: incomplete — ${pending.map((r) => r.label).join(', ')}`)
+    }
   }
-  console.log()
+  banner(allReady ? 'success' : 'error', allReady ? 'SETUP COMPLETE' : 'SETUP INCOMPLETE', summary)
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,9 +41,9 @@ cli
   })
 
 cli
-  .command('doctor', 'Check system prerequisites')
+  .command('doctor [platform]', 'Check system prerequisites (ios | android; omit for all)')
   .option('--json', 'Output machine-readable JSON')
-  .action((opts: { json?: boolean }) => cmdDoctor(opts))
+  .action((platform: string | undefined, opts: { json?: boolean }) => cmdDoctor({ ...opts, platform }))
 
 cli
   .command('setup [platform]', 'Set up the environment (ios | android; omit to auto-detect)')

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -16,18 +16,38 @@ export interface DoctorResult {
   android: DoctorCheck[] | null
 }
 
-export async function runDoctorChecks(): Promise<DoctorResult> {
+// platform: 'ios' | 'android' 지정 시 해당 플랫폼만. 없으면 자동(iOS는 macOS에서만, Android은 항상).
+export async function runDoctorChecks(platform?: string): Promise<DoctorResult> {
   const isMac = process.platform === 'darwin'
-  const adb = resolveAdb()
+  const wantIos = platform === 'ios' || (!platform && isMac)
+  const wantAndroid = platform === 'android' || !platform
 
   return {
     common: [checkNodeVersion()],
-    ios: isMac ? [checkXcode(), checkSimctl(), checkBootedSimulator()] : null,
-    android: adb !== null ? buildAndroidChecks(adb) : null,
+    ios: wantIos ? buildIosChecks(isMac) : null,
+    android: wantAndroid ? buildAndroidChecks(resolveAdb()) : null,
   }
 }
 
-function buildAndroidChecks(adb: AdbResolution): DoctorCheck[] {
+function buildIosChecks(isMac: boolean): DoctorCheck[] {
+  if (!isMac) {
+    return [{ label: 'iOS', ok: false, warn: true, detail: 'iOS testing requires macOS.' }]
+  }
+  return [checkXcode(), checkSimctl(), checkBootedSimulator()]
+}
+
+// adb가 없어도 섹션을 숨기지 않고 진단을 노출한다(Android를 세팅하려는 사용자가 볼 수 있도록).
+function buildAndroidChecks(adb: AdbResolution | null): DoctorCheck[] {
+  if (!adb) {
+    return [
+      {
+        label: 'adb',
+        ok: false,
+        warn: true,
+        detail: 'adb not found. Run: tapflow setup android',
+      },
+    ]
+  }
   // adb가 PATH에 있으면 명령은 그대로 'adb', 표준 위치 fallback이면 절대경로로 실행
   if (adb.inPath) {
     return [checkAdb(adb.path), checkBootedAvd('adb')]

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -48,9 +48,8 @@ function buildAndroidChecks(adb: AdbResolution | null): DoctorCheck[] {
       },
     ]
   }
-  // adb가 PATH에 있으면 명령은 그대로 'adb', 표준 위치 fallback이면 절대경로로 실행
   if (adb.inPath) {
-    return [checkAdb(adb.path), checkBootedAvd('adb')]
+    return [checkAdb(adb.path), checkAvdAvailable()]
   }
   return [
     {
@@ -59,7 +58,7 @@ function buildAndroidChecks(adb: AdbResolution | null): DoctorCheck[] {
       warn: true,
       detail: `adb found at ${adb.path} but not in PATH. Run: tapflow setup android`,
     },
-    checkBootedAvd(adb.path),
+    checkAvdAvailable(),
   ]
 }
 
@@ -97,20 +96,20 @@ function checkSimctl(): DoctorCheck {
   }
 }
 
+// 부팅은 QA Session 접속 시 relay가 on-demand로 한다 — 미부팅은 정상, 디바이스 존재만 확인.
 function checkBootedSimulator(): DoctorCheck {
   try {
     const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
     const data = JSON.parse(raw) as { devices: Record<string, Array<{ name: string; state: string; udid: string }>> }
     const allDevices = Object.values(data.devices).flat()
-    const booted = allDevices.find((d) => d.state === 'Booted')
-    if (booted) {
-      return { label: `Simulator booted: ${booted.name}`, ok: true }
+    if (allDevices.length === 0) {
+      return { label: 'Simulator', ok: false, warn: true, detail: 'No simulator available. Run: tapflow setup ios' }
     }
-    const available = allDevices.find((d) => d.state === 'Shutdown')
-    const hint = available
-      ? `No simulator is running. Run: tapflow boot "${available.name}"`
-      : 'No simulator is running. Run: tapflow devices to see available simulators, then: tapflow boot "<name>"'
-    return { label: 'Simulator', ok: false, warn: true, detail: hint }
+    const booted = allDevices.find((d) => d.state === 'Booted')
+    return {
+      label: booted ? `Simulator: ${booted.name} (booted)` : `Simulator available (${allDevices.length})`,
+      ok: true,
+    }
   } catch {
     return { label: 'Simulator', ok: false, detail: 'Could not query simulators. Is Xcode installed?' }
   }
@@ -159,42 +158,16 @@ function checkAdb(path: string): DoctorCheck {
   return { label: `adb found: ${path}`, ok: true }
 }
 
-function checkBootedAvd(adbCmd: string): DoctorCheck {
-  try {
-    const out = execSync(`${adbCmd} devices`, { encoding: 'utf8', stdio: 'pipe' })
-    const lines = out.trim().split('\n').slice(1).filter(Boolean)
-    const emulator = lines.find((l) => l.startsWith('emulator-'))
-    if (!emulator) {
-      const hint = listAvdHint()
-      return {
-        label: 'AVD',
-        ok: false,
-        warn: true,
-        detail: hint
-          ? `No running emulator. Run: emulator @${hint}`
-          : 'No running emulator. Start an AVD from Android Studio > Device Manager.',
-      }
-    }
-
-    const serial = emulator.split('\t')[0]?.trim() ?? ''
-    try {
-      const avdName = execSync(`${adbCmd} -s ${serial} emu avd name`, { encoding: 'utf8', stdio: 'pipe' })
-        .split('\n')[0]
-        ?.trim() ?? serial
-      return { label: `AVD: ${avdName}`, ok: true }
-    } catch {
-      return { label: `AVD: ${serial}`, ok: true }
-    }
-  } catch {
-    return { label: 'AVD', ok: false, detail: 'Could not query running emulators.' }
-  }
-}
-
-function listAvdHint(): string | null {
+// 부팅은 relay on-demand가 한다 — AVD가 하나라도 존재하면 ok.
+function checkAvdAvailable(): DoctorCheck {
   try {
     const out = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' }).trim()
-    return out.split('\n')[0]?.trim() || null
+    const avds = out ? out.split('\n').map((l) => l.trim()).filter(Boolean) : []
+    if (avds.length > 0) {
+      return { label: `AVD available: ${avds[0]}`, ok: true }
+    }
   } catch {
-    return null
+    // emulator 미설치/조회 실패 — 아래 안내
   }
+  return { label: 'AVD', ok: false, warn: true, detail: 'No AVD found. Run: tapflow setup android' }
 }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -16,9 +16,20 @@ const STUDIO_APP = '/Applications/Android Studio.app'
 const XCODE_APP = '/Applications/Xcode.app'
 const XCODE_APPSTORE = 'https://apps.apple.com/app/xcode/id497799835'
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer'
-const AVD_NAME = 'tapflow'
-const ANDROID_SYSTEM_IMAGE = 'system-images;android-35;google_apis;arm64-v8a'
-const AVD_DEVICE = 'pixel_7'
+// Play Store 이미지는 crash 이슈가 있어 google_apis(non-playstore)를 쓴다.
+const AVD_IMAGE_API = 'android-35'
+// 폼팩터별로 해상도가 골고루 분포하도록 4종. device id는 SDK마다 다르므로 후보 중 가용한 첫 id 선택.
+const AVD_SPECS: { name: string; deviceCandidates: string[] }[] = [
+  { name: 'tapflow-compact', deviceCandidates: ['pixel_5', 'pixel_4a', 'pixel_4'] },
+  { name: 'tapflow-phone', deviceCandidates: ['pixel_7', 'pixel_6', 'pixel'] },
+  { name: 'tapflow-large', deviceCandidates: ['pixel_7_pro', 'pixel_6_pro', 'pixel_4_xl'] },
+  { name: 'tapflow-tablet', deviceCandidates: ['pixel_tablet', 'pixel_c', 'Nexus 10'] },
+]
+
+function androidSystemImage(): string {
+  const abi = process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64'
+  return `system-images;${AVD_IMAGE_API};google_apis;${abi}`
+}
 
 // 디바이스 부팅은 하지 않는다 — QA Session 접속 시 relay가 on-demand로 부팅한다.
 // setup은 "부팅 가능한 디바이스/AVD가 준비된 상태"까지만 보장한다.
@@ -341,16 +352,16 @@ async function checkAndFixAvd(): Promise<SetupStepResult> {
     return { label: 'AVD', ok: false, warn: true, detail: `No AVD found. ${manualHint}` }
   }
   const proceed = await confirm({
-    message: 'No Android Virtual Device found. Create one now? (downloads a system image)',
+    message: 'No Android Virtual Device found. Create a set of AVDs now? (downloads a system image)',
   })
   if (isCancel(proceed) || !proceed) {
     return { label: 'AVD', ok: false, warn: true, detail: `Skipped. ${manualHint}` }
   }
-  const created = createAvd()
-  if (created.ok) {
-    return { label: `AVD created: ${created.name}`, ok: true }
+  const result = createAvds()
+  if (result.ok) {
+    return { label: `AVDs created: ${result.created.join(', ')}`, ok: true }
   }
-  return { label: 'AVD', ok: false, warn: true, detail: created.detail ?? manualHint }
+  return { label: 'AVD', ok: false, warn: true, detail: result.detail ?? manualHint }
 }
 
 function listAvds(): string[] {
@@ -375,10 +386,10 @@ function resolveAndroidSdk(): string | null {
   return null
 }
 
-function createAvd(): { ok: boolean; name?: string; detail?: string } {
+function createAvds(): { ok: boolean; created: string[]; detail?: string } {
   const sdk = resolveAndroidSdk()
   if (!sdk) {
-    return { ok: false, detail: 'Android SDK not found. Install it via Android Studio.' }
+    return { ok: false, created: [], detail: 'Android SDK not found. Install it via Android Studio.' }
   }
   const bin = join(sdk, 'cmdline-tools', 'latest', 'bin')
   const sdkmanager = join(bin, 'sdkmanager')
@@ -386,25 +397,48 @@ function createAvd(): { ok: boolean; name?: string; detail?: string } {
   if (!existsSync(sdkmanager) || !existsSync(avdmanager)) {
     return {
       ok: false,
+      created: [],
       detail: 'Android command-line tools not found. Install "Android SDK Command-line Tools" in Android Studio > SDK Manager.',
     }
   }
+  const image = androidSystemImage()
   console.log()
-  // 시스템 이미지 설치 (라이선스는 'y' 입력으로 동의)
-  const img = spawnSync(sdkmanager, [ANDROID_SYSTEM_IMAGE], { stdio: 'inherit', input: 'y\n' })
+  // 시스템 이미지 1회 설치 (모든 AVD가 공유). 라이선스는 'y'로 동의.
+  const img = spawnSync(sdkmanager, [image], { stdio: 'inherit', input: 'y\n' })
   if (img.status !== 0) {
-    return { ok: false, detail: `Failed to install ${ANDROID_SYSTEM_IMAGE}.` }
+    return { ok: false, created: [], detail: `Failed to install ${image}.` }
   }
-  // AVD 생성 ('custom hardware profile?'에 'no' 입력)
-  const create = spawnSync(
-    avdmanager,
-    ['create', 'avd', '-n', AVD_NAME, '-k', ANDROID_SYSTEM_IMAGE, '-d', AVD_DEVICE, '--force'],
-    { stdio: 'inherit', input: 'no\n' },
-  )
-  if (create.status !== 0) {
-    return { ok: false, detail: 'avdmanager create failed.' }
+  // 폼팩터별로 가용한 device id를 골라 AVD 생성. ('custom hardware profile?'에 'no')
+  const available = listDeviceIds(avdmanager)
+  const created: string[] = []
+  for (const spec of AVD_SPECS) {
+    const device = spec.deviceCandidates.find((d) => available.includes(d))
+    if (!device) continue
+    const r = spawnSync(
+      avdmanager,
+      ['create', 'avd', '-n', spec.name, '-k', image, '-d', device, '--force'],
+      { stdio: 'inherit', input: 'no\n' },
+    )
+    if (r.status === 0) created.push(spec.name)
   }
-  return { ok: true, name: AVD_NAME }
+  if (created.length === 0) {
+    return { ok: false, created, detail: 'Could not create any AVD.' }
+  }
+  return { ok: true, created }
+}
+
+function listDeviceIds(avdmanager: string): string[] {
+  try {
+    const r = spawnSync(avdmanager, ['list', 'device'], { encoding: 'utf8' })
+    const out = r.stdout ?? ''
+    const ids: string[] = []
+    for (const m of out.matchAll(/id:\s*\d+\s+or\s+"([^"]+)"/g)) {
+      if (m[1]) ids.push(m[1])
+    }
+    return ids
+  } catch {
+    return []
+  }
 }
 
 // 자동 등록을 지원하는 셸의 rc 경로. 그 외 셸은 null(수동 안내).

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -16,6 +16,43 @@ const STUDIO_APP = '/Applications/Android Studio.app'
 const XCODE_APP = '/Applications/Xcode.app'
 const XCODE_APPSTORE = 'https://apps.apple.com/app/xcode/id497799835'
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer'
+const AVD_NAME = 'tapflow'
+const ANDROID_SYSTEM_IMAGE = 'system-images;android-35;google_apis;arm64-v8a'
+const AVD_DEVICE = 'pixel_7'
+
+// 디바이스 부팅은 하지 않는다 — QA Session 접속 시 relay가 on-demand로 부팅한다.
+// setup은 "부팅 가능한 디바이스/AVD가 준비된 상태"까지만 보장한다.
+
+// confirm 후 sudo 명령들을 순차 실행(stdio 상속 → sudo가 비번 프롬프트를 직접 처리).
+async function runSudo(message: string, commands: string[][]): Promise<boolean> {
+  const proceed = await confirm({ message })
+  if (isCancel(proceed) || !proceed) return false
+  console.log()
+  for (const args of commands) {
+    const r = spawnSync('sudo', args, { stdio: 'inherit' })
+    if (r.status !== 0) return false
+  }
+  return true
+}
+
+function isXcodeReady(): boolean {
+  try {
+    execSync('xcodebuild -version', { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function hasIosDevice(): boolean {
+  try {
+    const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
+    const data = JSON.parse(raw) as { devices: Record<string, unknown[]> }
+    return Object.values(data.devices).some((arr) => arr.length > 0)
+  } catch {
+    return false
+  }
+}
 
 export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   const results: SetupStepResult[] = []
@@ -23,7 +60,7 @@ export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   results.push(brew)
   results.push(checkAndFixAdb(brew.ok))
   results.push(await checkAndFixAndroidStudio(brew.ok))
-  results.push(checkAndFixEmulator())
+  results.push(await checkAndFixAvd())
   return results
 }
 
@@ -32,8 +69,8 @@ export async function runSetupIos(): Promise<SetupStepResult[]> {
   results.push(await checkAndFixHomebrew())
   const xcode = await checkAndFixXcode()
   results.push(xcode)
-  results.push(checkXcodeActivation(xcode.ok))
-  results.push(checkAndFixSimulator())
+  results.push(await checkXcodeActivation(xcode.ok))
+  results.push(await checkAndFixSimulator())
   return results
 }
 
@@ -81,69 +118,69 @@ async function checkAndFixXcode(): Promise<SetupStepResult> {
   }
 }
 
-// 설치됨 ≠ 사용 가능: active developer dir / 라이선스 / first-launch를 점검(sudo 작업은 안내만).
-function checkXcodeActivation(xcodeInstalled: boolean): SetupStepResult {
+// 설치됨 ≠ 사용 가능: active developer dir / 라이선스 / first-launch. sudo 조치를 동의 후 직접 실행.
+async function checkXcodeActivation(xcodeInstalled: boolean): Promise<SetupStepResult> {
   if (!xcodeInstalled) {
     return { label: 'Xcode activation', ok: false, warn: true, detail: 'Install Xcode first.' }
   }
+  const selectHint = `Run: sudo xcode-select -s ${XCODE_DEVELOPER_DIR}`
+
+  // 1. active developer dir이 Xcode를 가리키게
   let dir = ''
   try {
     dir = execSync('xcode-select -p', { encoding: 'utf8', stdio: 'pipe' }).trim()
   } catch {
-    // active dir 미설정 — 아래 안내
+    // 미설정 — 아래에서 조치
   }
   if (!dir.includes('Xcode.app')) {
-    return {
-      label: 'Xcode command-line tools',
-      ok: false,
-      warn: true,
-      detail: `Active developer dir points away from Xcode. Run: sudo xcode-select -s ${XCODE_DEVELOPER_DIR}`,
+    if (!process.stdout.isTTY) {
+      return { label: 'Xcode command-line tools', ok: false, warn: true, detail: selectHint }
+    }
+    const ok = await runSudo('Set Xcode as the active developer directory (needs sudo)?', [
+      ['xcode-select', '-s', XCODE_DEVELOPER_DIR],
+    ])
+    if (!ok) {
+      return { label: 'Xcode command-line tools', ok: false, warn: true, detail: selectHint }
     }
   }
-  try {
-    execSync('xcodebuild -version', { stdio: 'pipe' })
+
+  // 2. license / first-launch
+  if (isXcodeReady()) {
     return { label: 'Xcode ready', ok: true }
-  } catch {
-    return {
-      label: 'Xcode setup',
-      ok: false,
-      warn: true,
-      detail: 'Finish Xcode setup: sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch',
-    }
   }
+  const finishHint = 'Finish Xcode setup: sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch'
+  if (!process.stdout.isTTY) {
+    return { label: 'Xcode setup', ok: false, warn: true, detail: finishHint }
+  }
+  const ok = await runSudo('Accept the Xcode license and run first launch (needs sudo)?', [
+    ['xcodebuild', '-license', 'accept'],
+    ['xcodebuild', '-runFirstLaunch'],
+  ])
+  if (ok && isXcodeReady()) {
+    return { label: 'Xcode ready', ok: true }
+  }
+  return { label: 'Xcode setup', ok: false, warn: true, detail: finishHint }
 }
 
-function checkAndFixSimulator(): SetupStepResult {
-  try {
-    const raw = execSync('xcrun simctl list devices --json', { encoding: 'utf8', stdio: 'pipe' })
-    const data = JSON.parse(raw) as {
-      devices: Record<string, Array<{ name: string; state: string; udid: string }>>
-    }
-    const all = Object.values(data.devices).flat()
-    const booted = all.find((d) => d.state === 'Booted')
-    if (booted) {
-      return { label: `Simulator booted: ${booted.name}`, ok: true }
-    }
-    const candidate = all.find((d) => d.state === 'Shutdown')
-    if (candidate) {
-      const boot = spawnSync('xcrun', ['simctl', 'boot', candidate.udid], { stdio: 'pipe' })
-      if (boot.status !== 0) throw new Error('simctl boot failed')
-      return { label: `Simulator booted: ${candidate.name}`, ok: true }
-    }
-    return {
-      label: 'Simulator',
-      ok: false,
-      warn: true,
-      detail: 'No simulators available. Open Xcode to install a simulator runtime.',
-    }
-  } catch {
-    return {
-      label: 'Simulator',
-      ok: false,
-      warn: true,
-      detail: 'Could not query simulators. Finish Xcode setup first.',
-    }
+// 부팅하지 않는다 — 시뮬 런타임/디바이스가 준비됐는지만 보장(없으면 런타임 설치).
+async function checkAndFixSimulator(): Promise<SetupStepResult> {
+  if (hasIosDevice()) {
+    return { label: 'Simulator ready', ok: true }
   }
+  const hint = 'No simulator runtime. Run: xcodebuild -downloadPlatform iOS (or install one in Xcode).'
+  if (!process.stdout.isTTY) {
+    return { label: 'Simulator', ok: false, warn: true, detail: hint }
+  }
+  const proceed = await confirm({ message: 'No iOS simulator found. Download the iOS simulator runtime?' })
+  if (isCancel(proceed) || !proceed) {
+    return { label: 'Simulator', ok: false, warn: true, detail: `Skipped. ${hint}` }
+  }
+  console.log()
+  const r = spawnSync('xcodebuild', ['-downloadPlatform', 'iOS'], { stdio: 'inherit' })
+  if (r.status === 0 && hasIosDevice()) {
+    return { label: 'Simulator runtime installed', ok: true }
+  }
+  return { label: 'Simulator', ok: false, warn: true, detail: 'Could not prepare a simulator. Open Xcode to install a runtime.' }
 }
 
 // eval "$(...)"로 감싸 명령 치환 결과(설치 스크립트)가 word splitting 없이 단일 평가되게 한다.
@@ -293,38 +330,81 @@ async function checkAndFixAndroidStudio(brewAvailable: boolean): Promise<SetupSt
   }
 }
 
-function checkAndFixEmulator(): SetupStepResult {
-  // resolveAdb()로 해석한 경로를 쓴다. 직전 단계에서 PATH에 등록했어도 현재 프로세스
-  // PATH엔 반영되지 않으므로 'adb'를 그대로 부르면 오탐이 난다.
-  const adb = resolveAdb()
-  if (!adb) {
+// 부팅하지 않는다 — AVD가 하나라도 준비됐는지만 보장(없으면 시스템 이미지 + AVD 생성).
+async function checkAndFixAvd(): Promise<SetupStepResult> {
+  const avds = listAvds()
+  if (avds.length > 0) {
+    return { label: `AVD ready: ${avds[0]}`, ok: true }
+  }
+  const manualHint = 'Create an AVD in Android Studio > Device Manager.'
+  if (!process.stdout.isTTY) {
+    return { label: 'AVD', ok: false, warn: true, detail: `No AVD found. ${manualHint}` }
+  }
+  const proceed = await confirm({
+    message: 'No Android Virtual Device found. Create one now? (downloads a system image)',
+  })
+  if (isCancel(proceed) || !proceed) {
+    return { label: 'AVD', ok: false, warn: true, detail: `Skipped. ${manualHint}` }
+  }
+  const created = createAvd()
+  if (created.ok) {
+    return { label: `AVD created: ${created.name}`, ok: true }
+  }
+  return { label: 'AVD', ok: false, warn: true, detail: created.detail ?? manualHint }
+}
+
+function listAvds(): string[] {
+  try {
+    const out = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' }).trim()
+    return out ? out.split('\n').map((l) => l.trim()).filter(Boolean) : []
+  } catch {
+    return []
+  }
+}
+
+function resolveAndroidSdk(): string | null {
+  const candidates = [
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+    join(homedir(), 'Library', 'Android', 'sdk'), // macOS
+    join(homedir(), 'Android', 'Sdk'), // Linux
+  ]
+  for (const c of candidates) {
+    if (c && existsSync(c)) return c
+  }
+  return null
+}
+
+function createAvd(): { ok: boolean; name?: string; detail?: string } {
+  const sdk = resolveAndroidSdk()
+  if (!sdk) {
+    return { ok: false, detail: 'Android SDK not found. Install it via Android Studio.' }
+  }
+  const bin = join(sdk, 'cmdline-tools', 'latest', 'bin')
+  const sdkmanager = join(bin, 'sdkmanager')
+  const avdmanager = join(bin, 'avdmanager')
+  if (!existsSync(sdkmanager) || !existsSync(avdmanager)) {
     return {
-      label: 'No running emulator',
       ok: false,
-      warn: true,
-      detail: 'adb not found. Install/configure adb first, then start an AVD.',
+      detail: 'Android command-line tools not found. Install "Android SDK Command-line Tools" in Android Studio > SDK Manager.',
     }
   }
-  try {
-    const out = execSync(`"${adb.path}" devices`, { encoding: 'utf8', stdio: 'pipe' })
-    const lines = out.trim().split('\n').slice(1).filter(Boolean)
-    if (lines.some((l) => l.startsWith('emulator-'))) {
-      return { label: 'Emulator running', ok: true }
-    }
-  } catch {
-    // adb 실행 실패 — 아래 힌트로
+  console.log()
+  // 시스템 이미지 설치 (라이선스는 'y' 입력으로 동의)
+  const img = spawnSync(sdkmanager, [ANDROID_SYSTEM_IMAGE], { stdio: 'inherit', input: 'y\n' })
+  if (img.status !== 0) {
+    return { ok: false, detail: `Failed to install ${ANDROID_SYSTEM_IMAGE}.` }
   }
-  let hint = 'Start an AVD from Android Studio > Device Manager'
-  try {
-    const first = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' })
-      .trim()
-      .split('\n')[0]
-      ?.trim()
-    if (first) hint = `Start an AVD: emulator @${first} (or Android Studio > Device Manager)`
-  } catch {
-    // emulator 미설치 — 일반 힌트 유지
+  // AVD 생성 ('custom hardware profile?'에 'no' 입력)
+  const create = spawnSync(
+    avdmanager,
+    ['create', 'avd', '-n', AVD_NAME, '-k', ANDROID_SYSTEM_IMAGE, '-d', AVD_DEVICE, '--force'],
+    { stdio: 'inherit', input: 'no\n' },
+  )
+  if (create.status !== 0) {
+    return { ok: false, detail: 'avdmanager create failed.' }
   }
-  return { label: 'No running emulator', ok: false, warn: true, detail: hint }
+  return { ok: true, name: AVD_NAME }
 }
 
 // 자동 등록을 지원하는 셸의 rc 경로. 그 외 셸은 null(수동 안내).


### PR DESCRIPTION
## Summary

Feedback fixes from testing `0.8.0-next.0` on another Mac. Focus: make `tapflow setup` a one-run wizard that needs no follow-up, and make `tapflow doctor` usable for an Android-only machine.

## doctor

- No longer hides the Android section when adb is missing — shows an `adb not found → tapflow setup android` warning so an Android-only setup is diagnosable.
- Added `tapflow doctor [platform]` (`ios` | `android`; omit for all), mirroring `setup`.
- Checks device/AVD **existence** instead of a **running** one — booting is on-demand (relay boots when a QA Session connects), so an un-booted simulator/emulator is normal.

## setup

- **Runs sudo steps directly** after confirmation (`xcode-select -s`, `xcodebuild -license accept`, `-runFirstLaunch`) instead of printing commands and exiting — removes the "do this, then re-run" loop. TTY only; non-interactive prints guidance.
- **iOS**: downloads the simulator runtime when no device exists (Xcode then provides the standard device set).
- **Android**: when no AVD exists, installs a `google_apis` system image once and creates **4 AVDs across form factors** (compact / phone / large / tablet) so the device list is comparable to iOS. Device ids are chosen per-environment (they vary by SDK); ABI matches the host arch.
- **No boot** — setup only ensures a bootable device/AVD exists.
- `tapflow setup` (no arg) offers Android even without adb, and ends with a `SETUP COMPLETE` / `SETUP INCOMPLETE` summary banner (relay/agent-style).

## Notes

- `google_apis` (not `google_apis_playstore`) is used intentionally — the Play Store image has a known crash issue in our setup.
- Targets the `0.8.0-next` prerelease line; `latest` (0.7.0) is unaffected. After merge, this ships as `v0.8.0-next.1` for re-testing.

## Testing

- `pnpm --filter tapflow test` — 202 passing (doctor platform/availability, setup sudo/runtime/AVD-set/auto-detect/summary).
- typecheck + lint clean. All OS calls, prompts, and fs mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tapflow doctor [platform]` support to check specific platforms (ios/android) or all if omitted
  * Enhanced `tapflow setup` with improved interactive wizard for one-run, end-to-end configuration
  * Setup now installs required iOS simulator runtime and creates multiple Android AVDs automatically
  * Setup can proceed with Android configuration even without adb initially found

* **Bug Fixes**
  * Doctor command now shows Android diagnostics with warnings even when adb is unavailable
  * Doctor passes when simulator/AVD exists in any state, not just when currently running

<!-- end of auto-generated comment: release notes by coderabbit.ai -->