### PR TITLE
chore: release v0.8.0-next.1 (prerelease, dist-tag next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,8 +14,10 @@
   },
   "changesets": [
     "doctor-json-flag",
+    "doctor-platform",
     "setup-android",
     "setup-homebrew-autoinstall",
-    "setup-ios-and-unify"
+    "setup-ios-and-unify",
+    "setup-redesign"
   ]
 }

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.0-next.1
+
 ## 0.8.0-next.0
 
 ## 0.7.0

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.8.0-next.0",
+  "version": "0.8.0-next.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.0-next.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.1
+
 ## 0.8.0-next.0
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.8.0-next.0",
+  "version": "0.8.0-next.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,32 @@
 # tapflow
 
+## 0.8.0-next.1
+
+### Minor Changes
+
+- 5bd3381: fix(cli): `doctor` shows Android even without adb, and adds `doctor [platform]`
+
+  `tapflow doctor` no longer hides the Android section when adb is not found — it surfaces an `adb not found → tapflow setup android` warning so people setting up an Android-only agent can still diagnose it. Added `tapflow doctor ios|android` to check a single platform (mirrors `tapflow setup [platform]`); omit the argument to check all.
+
+- 3b5b28e: feat(cli): setup completes in one run; doctor reflects on-demand boot
+
+  `tapflow setup` is now an end-to-end interactive wizard instead of stopping to print manual commands:
+
+  - runs sudo steps directly after confirmation (`xcode-select -s`, `xcodebuild -license accept`, `-runFirstLaunch`) — no more "run this and re-run setup" loop.
+  - iOS: downloads the simulator runtime when no device exists.
+  - Android: when no AVD exists, installs a `google_apis` system image once and creates a set of 4 AVDs across form factors (compact / phone / large / tablet) so the device list is comparable to iOS. Device ids are chosen per-environment from candidates; ABI matches the host arch.
+  - no longer boots devices — relay boots on-demand when a QA Session connects, so setup only ensures a bootable device/AVD exists.
+  - `tapflow setup` (no argument) offers to set up Android even when adb isn't found, and ends with a `SETUP COMPLETE` / `SETUP INCOMPLETE` summary banner (per-platform ready state).
+
+  `tapflow doctor` now passes when a simulator device or AVD _exists_ (any state) rather than requiring a _running_ one, matching the on-demand boot model.
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.1
+- @tapflowio/ios-agent@0.8.0-next.1
+- @tapflowio/android-agent@0.8.0-next.1
+- @tapflowio/relay@0.8.0-next.1
+
 ## 0.8.0-next.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.8.0-next.0",
+  "version": "0.8.0-next.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.8.0-next.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.1
+
 ## 0.8.0-next.0
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.8.0-next.0",
+  "version": "0.8.0-next.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.8.0-next.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.1
+
 ## 0.8.0-next.0
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.8.0-next.0",
+  "version": "0.8.0-next.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Second prerelease of the 0.8.0 line (`changeset` pre mode, dist-tag `next`), folding in feedback from testing `0.8.0-next.0` on another Mac. **`latest` stays at 0.7.0.**

## What changed since next.0

- doctor: `doctor [platform]`, Android shown even without adb, device/AVD existence checks (on-demand boot aware)
- setup: runs sudo steps directly, downloads iOS runtime, creates a 4-AVD set across form factors, no boot, summary banner

## Release mechanics

- `changeset version` (pre mode) → fixed group bumped to `0.8.0-next.1`.
- `mcp-server` unchanged (ignore list).
- build/typecheck clean, no lockfile change.

## After merge

Tag the merge commit `v0.8.0-next.1` and push → CI publishes to the `next` dist-tag. Then `npm i -g tapflow@next` on another Mac to re-test `tapflow doctor` and `tapflow setup`.

> Prerelease half of the cycle — not a normal release. `latest` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific checks with `doctor [platform]` command
  * Transformed setup flow into an interactive, end-to-end wizard with per-platform completion summaries

* **Bug Fixes**
  * `doctor` command now displays Android section even when `adb` is unavailable

* **Chores**
  * Released version `0.8.0-next.1` across agent-core, Android agent, CLI, iOS agent, and relay packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->