### PR TITLE
fix(deps): override shell-quote to ^1.8.4 (CVE-2026-9277)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,10 @@
     "globals": "^17.6.0",
     "lefthook": "^2.1.7",
     "typescript-eslint": "^8.59.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "shell-quote@<1.8.4": "^1.8.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  shell-quote@<1.8.4: ^1.8.4
+
 importers:
 
   .:
@@ -4318,8 +4321,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@2.5.0:
@@ -7253,7 +7256,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -8950,7 +8953,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@2.5.0:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#10](https://github.com/jo-duchan/tapflow/security/dependabot/10) — **shell-quote** command injection (GHSA-w7jw-789q-3m8p / CVE-2026-9277, **Critical**).

`shell-quote`'s `quote()` failed to escape line terminators in object-token `.op` values, allowing shell command injection. Patched in `1.8.4`.

## Context

- `shell-quote` is a **dev-only, transitive** dependency, pulled in via `concurrently` (root + `playground`).
- `concurrently@9.x` pins `shell-quote` **exactly at `1.8.3`** — there is no patched release in the 9.x line. Only `concurrently@10.x` depends on `1.8.4`.
- Real-world exploitability here is effectively nil (the vector requires feeding attacker-controlled object tokens into `quote()`, which `concurrently` does not do), but the patch is risk-free, so we close the alert.

## Change

Added a conditional `pnpm.overrides` entry:

```json
"pnpm": {
  "overrides": {
    "shell-quote@<1.8.4": "^1.8.4"
  }
}
```

- Chose an override over a `concurrently` major bump (9 → 10) to keep the change minimal and avoid major-version risk for a dev-only dependency.
- The `@<1.8.4` predicate means the override **self-deactivates** once `concurrently` is upgraded to 10.x, so no cleanup debt.

## Verification

- `pnpm why shell-quote -r` → resolves to `1.8.4` on all paths.
- `concurrently` smoke test (`concurrently -n a,b "echo hello" "echo world"`) passes.
- lint + typecheck pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure proper dependency resolution for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->