### PR TITLE
fix(cli): doctor/setup consistency + self-contained Android SDK bootstrap

### DIFF
--- a/.changeset/doctor-adb-fail.md
+++ b/.changeset/doctor-adb-fail.md
@@ -1,0 +1,7 @@
+---
+"tapflow": patch
+---
+
+fix(cli): doctor reports missing adb as a failure, consistent with Xcode
+
+`tapflow doctor` now marks a missing adb as a failure (✗) — the same as a missing Xcode — instead of a warning, so a clean machine shows its checks uniformly. `tapflow setup android` resolves it.

--- a/.changeset/setup-android-self-contained-sdk.md
+++ b/.changeset/setup-android-self-contained-sdk.md
@@ -1,0 +1,14 @@
+---
+"tapflow": minor
+---
+
+feat(cli): setup android bootstraps a self-contained SDK (JDK + cmdline-tools), no Android Studio
+
+`tapflow setup android` no longer relies on Android Studio (whose `.app` install doesn't include the SDK, breaking unattended setup). Instead it builds a self-contained SDK at `~/Library/Android/sdk`:
+
+- installs a JDK via Temurin when missing (required by sdkmanager)
+- bootstraps `cmdline-tools;latest` + `platform-tools` + `emulator` + a `google_apis` system image into the SDK with `sdkmanager --sdk_root`, auto-accepting licenses
+- registers `ANDROID_HOME` and platform-tools/emulator on PATH
+- creates the form-factor AVD set with the SDK's own avdmanager
+
+Because cmdline-tools live inside the SDK, the avdmanager resolves the SDK root automatically — fixing the "Valid system image paths are: null" failure caused by a brew/SDK path split. Verified end-to-end on a clean Mac.

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -257,4 +257,36 @@ describe('runDoctorChecks', () => {
     const adbCheck = result.android?.find((c) => c.label.includes('not in PATH'))
     expect(adbCheck?.detail).toContain(customAdb)
   })
+
+  it('Android SDK(cmdline-tools)가 있으면 ok', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('ANDROID_HOME', '')
+    vi.stubEnv('ANDROID_SDK_ROOT', '')
+    const sdkmanager = join(homedir(), 'Android', 'Sdk', 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+    mockExistsSync.mockImplementation((p) => p === sdkmanager)
+    mockExecSync.mockImplementation((cmd) => {
+      if ((cmd as string) === 'which adb') return '/usr/local/bin/adb\n'
+      return ''
+    })
+
+    const result = await runDoctorChecks('android')
+    const sdk = result.android?.find((c) => c.label.includes('Android SDK'))
+    expect(sdk?.ok).toBe(true)
+  })
+
+  it('Android SDK가 없으면 fail(✗)', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('ANDROID_HOME', '')
+    vi.stubEnv('ANDROID_SDK_ROOT', '')
+    mockExistsSync.mockReturnValue(false)
+    mockExecSync.mockImplementation((cmd) => {
+      if ((cmd as string) === 'which adb') throw new Error('not found')
+      return ''
+    })
+
+    const result = await runDoctorChecks('android')
+    const sdk = result.android?.find((c) => c.label === 'Android SDK')
+    expect(sdk?.ok).toBe(false)
+    expect(sdk?.warn).toBeFalsy()
+  })
 })

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -76,7 +76,7 @@ describe('runDoctorChecks', () => {
     expect(result.android?.some((c) => c.label.includes('Pixel_8'))).toBe(true)
   })
 
-  it('adb 없어도 Android 섹션은 숨기지 않고 adb warn 표시', async () => {
+  it('adb 없으면 Android 섹션은 숨기지 않고 미설치를 fail로 표시', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     vi.stubEnv('ANDROID_HOME', '')
     vi.stubEnv('ANDROID_SDK_ROOT', '')
@@ -89,7 +89,8 @@ describe('runDoctorChecks', () => {
     const result = await runDoctorChecks()
     expect(result.android).not.toBeNull()
     const adbCheck = result.android?.find((c) => c.label === 'adb')
-    expect(adbCheck?.warn).toBe(true)
+    expect(adbCheck?.ok).toBe(false)
+    expect(adbCheck?.warn).toBeFalsy()
     expect(adbCheck?.detail).toContain('setup android')
   })
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -24,8 +24,11 @@ const mockConfirm = vi.mocked(confirm)
 const mockText = vi.mocked(text)
 const XCODE_APP = '/Applications/Xcode.app'
 
-const STUDIO_APP = '/Applications/Android Studio.app'
-const sdkAdb = join(homedir(), 'Library', 'Android', 'sdk', 'platform-tools', 'adb')
+const SDK_DIR = join(homedir(), 'Library', 'Android', 'sdk')
+const SDK_SDKMANAGER = join(SDK_DIR, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+const SDK_AVDMANAGER = join(SDK_DIR, 'cmdline-tools', 'latest', 'bin', 'avdmanager')
+const SDK_ADB = join(SDK_DIR, 'platform-tools', 'adb')
+const SDK_EMULATOR = join(SDK_DIR, 'emulator', 'emulator')
 const zshrc = join(homedir(), '.zshrc')
 
 const okSpawn = { status: 0, stdout: '', stderr: '', pid: 1, output: [], signal: null }
@@ -42,20 +45,24 @@ describe('runSetupAndroid', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.stubEnv('SHELL', '/bin/zsh')
-    vi.stubEnv('ANDROID_HOME', '')
-    vi.stubEnv('ANDROID_SDK_ROOT', '')
-    mockExistsSync.mockReturnValue(false)
     mockReadFileSync.mockReturnValue('')
-    mockSpawnSync.mockReturnValue(okSpawn as never)
     mockConfirm.mockResolvedValue(true as never)
-    // 기본: 완전히 구성된 머신 (각 테스트에서 필요한 부분만 override)
+    // 기본: 완전히 구성된 머신 (brew·JDK·자기완결 SDK·AVD 모두 존재)
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      if (c === 'emulator -list-avds') return 'Pixel_8\n'
+      if (c === '/usr/libexec/java_home') return '/Library/Java/.../Home\n'
+      if (c === 'which sdkmanager') return '/opt/homebrew/bin/sdkmanager\n'
       return ''
+    })
+    mockExistsSync.mockImplementation(
+      (p) => p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_AVDMANAGER || p === SDK_EMULATOR,
+    )
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      if (cmd === SDK_EMULATOR && Array.isArray(args) && args.includes('-list-avds')) {
+        return { ...okSpawn, stdout: 'tapflow-phone\n' } as never
+      }
+      return okSpawn as never
     })
   })
 
@@ -65,242 +72,116 @@ describe('runSetupAndroid', () => {
     setTTY(undefined)
   })
 
-  it('Homebrew 있으면 ok', async () => {
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'homebrew')?.ok).toBe(true)
-  })
-
-  it('Homebrew 없음 + 비대화형이면 confirm 없이 warn + 안내', async () => {
+  it('Homebrew 없음 + 비대화형이면 confirm 없이 warn', async () => {
     setTTY(false)
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') throw new Error('not found')
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c === '/usr/libexec/java_home') return '/x\n'
+      if (c === 'which sdkmanager') return '/opt/homebrew/bin/sdkmanager\n'
       return ''
     })
 
     const results = await runSetupAndroid()
-    const brew = findStep(results, 'homebrew')
-    expect(brew?.ok).toBe(false)
-    expect(brew?.warn).toBe(true)
-    expect(brew?.detail).toContain('brew.sh')
+    expect(findStep(results, 'homebrew')?.ok).toBe(false)
     expect(mockConfirm).not.toHaveBeenCalled()
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('/bin/bash', expect.any(Array), expect.anything())
   })
 
-  it('Homebrew 없음 + TTY + 수락 시 공식 스크립트 설치', async () => {
+  it('JDK 없음 + TTY + 수락 시 temurin 설치 시도', async () => {
     setTTY(true)
-    mockConfirm.mockResolvedValue(true as never)
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') throw new Error('not found')
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      return ''
-    })
-
-    const results = await runSetupAndroid()
-    expect(mockConfirm).toHaveBeenCalled()
-    expect(mockSpawnSync).toHaveBeenCalledWith(
-      '/bin/bash',
-      ['-c', expect.stringContaining('Homebrew/install')],
-      expect.anything(),
-    )
-    expect(findStep(results, 'homebrew')?.ok).toBe(true)
-  })
-
-  it('Homebrew 없음 + TTY + 거절 시 warn + 설치 미실행', async () => {
-    setTTY(true)
-    mockConfirm.mockResolvedValue(false as never)
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') throw new Error('not found')
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      return ''
-    })
-
-    const results = await runSetupAndroid()
-    const brew = findStep(results, 'homebrew')
-    expect(brew?.warn).toBe(true)
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('/bin/bash', expect.any(Array), expect.anything())
-  })
-
-  it('adb가 PATH에 있으면 ok, 설치/등록 미호출', async () => {
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'adb')?.ok).toBe(true)
-    expect(mockAppendFileSync).not.toHaveBeenCalled()
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
-  })
-
-  it('adb 부재 시 brew install android-platform-tools 실행', async () => {
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
+      if (c === '/usr/libexec/java_home') throw new Error('no java')
+      if (c === 'which sdkmanager') return '/opt/homebrew/bin/sdkmanager\n'
       return ''
     })
-    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    expect(mockSpawnSync).toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
-    expect(findStep(results, 'adb')?.ok).toBe(true)
-  })
-
-  it('adb가 SDK엔 있고 PATH 없으면 shell rc에 PATH 등록', async () => {
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    const adb = findStep(results, 'adb')
-    expect(adb?.ok).toBe(true)
-    expect(mockAppendFileSync).toHaveBeenCalledWith(zshrc, expect.stringContaining('platform-tools'))
-    expect(adb?.detail).toContain('.zshrc')
-    // brew install은 호출되지 않아야 (이미 SDK에 있음)
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', 'android-platform-tools'], expect.anything())
-  })
-
-  it('PATH 등록 멱등 — rc에 마커가 이미 있으면 append 안 함', async () => {
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP || p === zshrc)
-    mockReadFileSync.mockReturnValue(
-      '# >>> tapflow android sdk >>>\nexport PATH="x:$PATH"\n# <<< tapflow android sdk <<<\n',
-    )
-
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'adb')?.ok).toBe(true)
-    expect(mockAppendFileSync).not.toHaveBeenCalled()
-  })
-
-  it('bash 셸이면 .bashrc에 등록', async () => {
-    vi.stubEnv('SHELL', '/bin/bash')
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes('devices')) return 'List of devices attached\nemulator-5554\tdevice\n'
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
 
     await runSetupAndroid()
-    expect(mockAppendFileSync).toHaveBeenCalledWith(
-      join(homedir(), '.bashrc'),
-      expect.stringContaining('platform-tools'),
-    )
+    expect(mockSpawnSync).toHaveBeenCalledWith('brew', ['install', '--cask', 'temurin'], expect.anything())
   })
 
-  it('Android Studio 있으면 ok, cask 설치 미호출', async () => {
-    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'android studio')?.ok).toBe(true)
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
-  })
-
-  it('Android Studio 없고 확인 수락 시 cask 설치', async () => {
-    setTTY(true)
-    mockExistsSync.mockReturnValue(false) // Android Studio 없음
-    mockConfirm.mockResolvedValue(true as never)
-
-    const results = await runSetupAndroid()
-    expect(mockConfirm).toHaveBeenCalled()
-    expect(mockSpawnSync).toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
-    expect(findStep(results, 'android studio')?.ok).toBe(true)
-  })
-
-  it('Android Studio 확인 거절 시 warn + 설치 미실행', async () => {
-    setTTY(true)
-    mockExistsSync.mockReturnValue(false)
-    mockConfirm.mockResolvedValue(false as never)
-
-    const results = await runSetupAndroid()
-    const studio = findStep(results, 'android studio')
-    expect(studio?.warn).toBe(true)
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
-  })
-
-  it('비대화형(non-TTY)이면 cask 설치 skip + 안내', async () => {
+  it('JDK 없음 + 비대화형이면 warn (설치 안 함)', async () => {
     setTTY(false)
-    mockExistsSync.mockReturnValue(false)
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === '/usr/libexec/java_home') throw new Error('no java')
+      if (c === 'which sdkmanager') return '/opt/homebrew/bin/sdkmanager\n'
+      return ''
+    })
 
     const results = await runSetupAndroid()
-    expect(mockConfirm).not.toHaveBeenCalled()
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'android-studio'], expect.anything())
-    expect(findStep(results, 'android studio')?.warn).toBe(true)
+    expect(findStep(results, 'java')?.warn).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', ['install', '--cask', 'temurin'], expect.anything())
   })
 
-  it('AVD가 있으면 ok (부팅 안 함)', async () => {
+  it('자기완결 SDK가 있으면 ok + ANDROID_HOME 등록 (설치 안 함)', async () => {
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android sdk')?.ok).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      'brew',
+      ['install', '--cask', 'android-commandlinetools'],
+      expect.anything(),
+    )
+    expect(mockAppendFileSync).toHaveBeenCalledWith(zshrc, expect.stringContaining('ANDROID_HOME'))
+  })
+
+  it('SDK 자기완결 아니면 sdkmanager로 자기완결 부트스트랩(cmdline-tools;latest 포함)', async () => {
+    setTTY(true)
+    let installed = false
+    mockExistsSync.mockImplementation((p) => {
+      if (p === SDK_SDKMANAGER || p === SDK_ADB) return installed
+      if (p === SDK_AVDMANAGER || p === SDK_EMULATOR) return true
+      return false
+    })
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (typeof cmd === 'string' && cmd.includes('sdkmanager') && a.includes('cmdline-tools;latest')) {
+        installed = true
+        return okSpawn as never
+      }
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) {
+        return { ...okSpawn, stdout: 'tapflow-phone\n' } as never
+      }
+      return okSpawn as never
+    })
+
+    const results = await runSetupAndroid()
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/sdkmanager',
+      expect.arrayContaining([`--sdk_root=${SDK_DIR}`, 'cmdline-tools;latest', 'platform-tools', 'emulator']),
+      expect.anything(),
+    )
+    expect(findStep(results, 'android sdk')?.ok).toBe(true)
+  })
+
+  it('SDK 자기완결 아님 + 비대화형이면 warn', async () => {
+    setTTY(false)
+    mockExistsSync.mockImplementation((p) => p === SDK_EMULATOR)
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android sdk')?.warn).toBe(true)
+  })
+
+  it('AVD가 있으면 ok (생성 안 함)', async () => {
     const results = await runSetupAndroid()
     expect(findStep(results, 'avd')?.ok).toBe(true)
-  })
-
-  it('AVD가 없으면 비대화형에서 warn (생성 안 함)', async () => {
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c === 'emulator -list-avds') return ''
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    expect(findStep(results, 'avd')?.warn).toBe(true)
-    expect(mockSpawnSync).not.toHaveBeenCalled()
-  })
-
-  it('미지원 셸(fish 등)이면 자동 등록 대신 warn + 수동 export 안내', async () => {
-    vi.stubEnv('SHELL', '/usr/bin/fish')
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') throw new Error('not found')
-      if (c.includes('devices')) return 'List of devices attached\n'
-      return ''
-    })
-    mockExistsSync.mockImplementation((p) => p === sdkAdb || p === STUDIO_APP)
-
-    const results = await runSetupAndroid()
-    const adb = findStep(results, 'adb')
-    expect(adb?.warn).toBe(true)
-    expect(adb?.detail).toContain('export PATH')
-    expect(mockAppendFileSync).not.toHaveBeenCalled()
-  })
-
-  it('AVD 없음 + TTY + 수락 시 시스템 이미지 1회 설치 + 폼팩터별 AVD 4개 생성', async () => {
-    setTTY(true)
-    vi.stubEnv('ANDROID_HOME', '/opt/android-sdk')
-    mockConfirm.mockResolvedValue(true as never)
-    const sdkmanager = join('/opt/android-sdk', 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
-    const avdmanager = join('/opt/android-sdk', 'cmdline-tools', 'latest', 'bin', 'avdmanager')
-    mockExecSync.mockImplementation((cmd) => {
-      const c = cmd as string
-      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
-      if (c === 'which adb') return '/opt/homebrew/bin/adb\n'
-      if (c === 'emulator -list-avds') return ''
-      return ''
-    })
-    mockExistsSync.mockImplementation(
-      (p) => p === STUDIO_APP || p === '/opt/android-sdk' || p === sdkmanager || p === avdmanager,
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      SDK_AVDMANAGER,
+      expect.arrayContaining(['create']),
+      expect.anything(),
     )
-    // avdmanager list device → 폼팩터별 후보가 모두 가용하도록
+  })
+
+  it('AVD 없음 + TTY + 수락 시 폼팩터별 AVD 4개 생성', async () => {
+    setTTY(true)
     mockSpawnSync.mockImplementation((cmd, args) => {
-      if (cmd === avdmanager && Array.isArray(args) && args.includes('device')) {
+      const a = Array.isArray(args) ? args : []
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) {
+        return { ...okSpawn, stdout: '' } as never
+      }
+      if (cmd === SDK_AVDMANAGER && a.includes('device')) {
         return {
           ...okSpawn,
           stdout: 'id: 0 or "pixel_5"\nid: 1 or "pixel_7"\nid: 2 or "pixel_7_pro"\nid: 3 or "pixel_c"\n',
@@ -310,23 +191,60 @@ describe('runSetupAndroid', () => {
     })
 
     const results = await runSetupAndroid()
-    // 시스템 이미지 1회 설치
-    expect(mockSpawnSync).toHaveBeenCalledWith(sdkmanager, [expect.stringContaining('system-images')], expect.anything())
-    // AVD 4개 생성 (create avd 호출 횟수)
     const createCalls = mockSpawnSync.mock.calls.filter(
-      (c) => c[0] === avdmanager && Array.isArray(c[1]) && c[1].includes('create'),
+      (c) => c[0] === SDK_AVDMANAGER && Array.isArray(c[1]) && c[1].includes('create'),
     )
     expect(createCalls).toHaveLength(4)
     expect(findStep(results, 'avd')?.ok).toBe(true)
   })
 
-  it('멱등 — 완전히 구성된 머신은 전부 ok, 부작용 없음', async () => {
-    mockExistsSync.mockImplementation((p) => p === STUDIO_APP)
+  it('AVD 없음 + 비대화형이면 warn (생성 안 함)', async () => {
+    setTTY(false)
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) return { ...okSpawn, stdout: '' } as never
+      return okSpawn as never
+    })
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'avd')?.warn).toBe(true)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      SDK_AVDMANAGER,
+      expect.arrayContaining(['create']),
+      expect.anything(),
+    )
+  })
+
+  it('미지원 셸이면 ANDROID_HOME 자동 등록 안 함 (SDK는 ready)', async () => {
+    vi.stubEnv('SHELL', '/usr/bin/fish')
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android sdk')?.ok).toBe(true)
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
+  })
+
+  it('멱등 — 완전 구성 + env 등록됨이면 전부 ok, 설치/생성/append 없음', async () => {
+    mockReadFileSync.mockReturnValue(
+      '# >>> tapflow android sdk >>>\nexport ANDROID_HOME="x"\n# <<< tapflow android sdk <<<\n',
+    )
+    mockExistsSync.mockImplementation(
+      (p) =>
+        p === SDK_SDKMANAGER ||
+        p === SDK_ADB ||
+        p === SDK_AVDMANAGER ||
+        p === SDK_EMULATOR ||
+        p === zshrc,
+    )
 
     const results = await runSetupAndroid()
     expect(results.every((r) => r.ok)).toBe(true)
     expect(mockAppendFileSync).not.toHaveBeenCalled()
-    expect(mockSpawnSync).not.toHaveBeenCalled()
+    expect(mockSpawnSync).not.toHaveBeenCalledWith('brew', expect.anything(), expect.anything())
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      SDK_AVDMANAGER,
+      expect.arrayContaining(['create']),
+      expect.anything(),
+    )
   })
 })
 

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -37,29 +37,46 @@ function buildIosChecks(isMac: boolean): DoctorCheck[] {
 }
 
 // adb가 없어도 섹션을 숨기지 않고 진단을 노출한다(Android를 세팅하려는 사용자가 볼 수 있도록).
+// iOS(Xcode / simctl / Simulator)와 대칭: Android SDK / adb / AVD.
 function buildAndroidChecks(adb: AdbResolution | null): DoctorCheck[] {
+  return [checkAndroidSdk(), checkAdbStatus(adb), checkAvdAvailable()]
+}
+
+function androidSdkDir(): string | null {
+  const candidates = [
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+    join(homedir(), 'Library', 'Android', 'sdk'), // macOS
+    join(homedir(), 'Android', 'Sdk'), // Linux
+  ]
+  for (const c of candidates) {
+    if (c && existsSync(join(c, 'cmdline-tools', 'latest', 'bin', 'sdkmanager'))) return c
+  }
+  return null
+}
+
+function checkAndroidSdk(): DoctorCheck {
+  const dir = androidSdkDir()
+  if (dir) {
+    return { label: `Android SDK: ${dir}`, ok: true }
+  }
+  return { label: 'Android SDK', ok: false, detail: 'Android SDK not found. Run: tapflow setup android' }
+}
+
+function checkAdbStatus(adb: AdbResolution | null): DoctorCheck {
   if (!adb) {
     // 미설치는 iOS(Xcode)와 동일하게 fail(✗)로 — setup으로 해결 가능함을 안내.
-    return [
-      {
-        label: 'adb',
-        ok: false,
-        detail: 'adb not found. Run: tapflow setup android',
-      },
-    ]
+    return { label: 'adb', ok: false, detail: 'adb not found. Run: tapflow setup android' }
   }
   if (adb.inPath) {
-    return [checkAdb(adb.path), checkAvdAvailable()]
+    return checkAdb(adb.path)
   }
-  return [
-    {
-      label: 'adb (not in PATH)',
-      ok: false,
-      warn: true,
-      detail: `adb found at ${adb.path} but not in PATH. Run: tapflow setup android`,
-    },
-    checkAvdAvailable(),
-  ]
+  return {
+    label: 'adb (not in PATH)',
+    ok: false,
+    warn: true,
+    detail: `adb found at ${adb.path} but not in PATH. Run: tapflow setup android`,
+  }
 }
 
 function checkXcode(): DoctorCheck {

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -39,11 +39,11 @@ function buildIosChecks(isMac: boolean): DoctorCheck[] {
 // adb가 없어도 섹션을 숨기지 않고 진단을 노출한다(Android를 세팅하려는 사용자가 볼 수 있도록).
 function buildAndroidChecks(adb: AdbResolution | null): DoctorCheck[] {
   if (!adb) {
+    // 미설치는 iOS(Xcode)와 동일하게 fail(✗)로 — setup으로 해결 가능함을 안내.
     return [
       {
         label: 'adb',
         ok: false,
-        warn: true,
         detail: 'adb not found. Run: tapflow setup android',
       },
     ]

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1,10 +1,10 @@
 import { execSync, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync, appendFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { confirm, text, isCancel } from '@clack/prompts'
-import { resolveAdb, type DoctorCheck } from './doctor.js'
-import { createSpinner, step } from './print.js'
+import { type DoctorCheck } from './doctor.js'
+import { step } from './print.js'
 
 // setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓴다.
 // ok=true: 이미 OK이거나 방금 자동 수정함, warn=true: 수동 조치 필요(안내).
@@ -12,7 +12,8 @@ export type SetupStepResult = DoctorCheck
 
 const PATH_MARKER_START = '# >>> tapflow android sdk >>>'
 const PATH_MARKER_END = '# <<< tapflow android sdk <<<'
-const STUDIO_APP = '/Applications/Android Studio.app'
+// SDK를 표준 경로에 자기완결로 고정한다(cmdline-tools·platform-tools·emulator·system-image 모두 이 아래).
+const ANDROID_SDK_DIR = join(homedir(), 'Library', 'Android', 'sdk')
 const XCODE_APP = '/Applications/Xcode.app'
 const XCODE_APPSTORE = 'https://apps.apple.com/app/xcode/id497799835'
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer'
@@ -69,10 +70,42 @@ export async function runSetupAndroid(): Promise<SetupStepResult[]> {
   const results: SetupStepResult[] = []
   const brew = await checkAndFixHomebrew()
   results.push(brew)
-  results.push(checkAndFixAdb(brew.ok))
-  results.push(await checkAndFixAndroidStudio(brew.ok))
-  results.push(await checkAndFixAvd())
+  const jdk = await checkAndFixJdk(brew.ok)
+  results.push(jdk)
+  const sdk = await checkAndFixAndroidSdk(brew.ok, jdk.ok)
+  results.push(sdk)
+  results.push(await checkAndFixAvd(sdk.ok))
   return results
+}
+
+// sdkmanager/avdmanager는 SDK 위치를 ANDROID_HOME으로 알아야 한다(자기완결 SDK 기준).
+function androidEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, ANDROID_HOME: ANDROID_SDK_DIR, ANDROID_SDK_ROOT: ANDROID_SDK_DIR }
+}
+
+const SDK_CMDLINE_BIN = join(ANDROID_SDK_DIR, 'cmdline-tools', 'latest', 'bin')
+
+// cmdline-tools가 SDK 안에 있고 platform-tools(adb)까지 갖춘 자기완결 상태인지.
+function sdkSelfContained(): boolean {
+  return existsSync(join(SDK_CMDLINE_BIN, 'sdkmanager')) && existsSync(join(ANDROID_SDK_DIR, 'platform-tools', 'adb'))
+}
+
+function hasJava(): boolean {
+  try {
+    execSync('/usr/libexec/java_home', { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function whichSdkmanager(): string | null {
+  try {
+    const p = execSync('which sdkmanager', { encoding: 'utf8', stdio: 'pipe' }).trim()
+    return p || null
+  } catch {
+    return null
+  }
 }
 
 export async function runSetupIos(): Promise<SetupStepResult[]> {
@@ -238,122 +271,103 @@ async function checkAndFixHomebrew(): Promise<SetupStepResult> {
   }
 }
 
-function checkAndFixAdb(brewAvailable: boolean): SetupStepResult {
-  const adb = resolveAdb()
-
-  // 1. PATH에 있음
-  if (adb?.inPath) {
-    return { label: `adb in PATH: ${adb.path}`, ok: true }
-  }
-
-  // 2. 표준 SDK 위치엔 있지만 PATH에 없음 → shell rc에 등록
-  if (adb) {
-    const platformTools = dirname(adb.path)
-    const registered = registerPathInShellRc(platformTools)
-    if (!registered) {
-      return {
-        label: 'adb (not in PATH)',
-        ok: false,
-        warn: true,
-        detail: `adb found at ${adb.path} but your shell ($SHELL) isn't auto-configurable. Add to your shell config: export PATH="${platformTools}:$PATH"`,
-      }
-    }
-    if (registered.added) {
-      return {
-        label: 'adb added to PATH',
-        ok: true,
-        detail: `Added ${platformTools} to PATH in ${registered.file}. Restart your shell or run: source ${registered.file}`,
-      }
-    }
-    return {
-      label: 'adb PATH already configured',
-      ok: true,
-      detail: `${platformTools} already registered in ${registered.file}`,
-    }
-  }
-
-  // 3. 어디에도 없음 → brew 설치
-  if (!brewAvailable) {
-    return {
-      label: 'adb',
-      ok: false,
-      warn: true,
-      detail: 'Install Homebrew first, then: brew install android-platform-tools',
-    }
-  }
-  const spinner = createSpinner('Installing android-platform-tools via Homebrew…')
-  spinner.start()
-  const r = spawnSync('brew', ['install', 'android-platform-tools'], { stdio: 'pipe' })
-  spinner.stop(r.status === 0)
-  if (r.status === 0) {
-    return { label: 'adb installed via Homebrew', ok: true }
-  }
-  return {
-    label: 'adb',
-    ok: false,
-    warn: true,
-    detail: 'brew install android-platform-tools failed. Install manually.',
-  }
-}
-
-async function checkAndFixAndroidStudio(brewAvailable: boolean): Promise<SetupStepResult> {
-  if (existsSync(STUDIO_APP)) {
-    return { label: 'Android Studio installed', ok: true }
+// sdkmanager/avdmanager 실행에 JDK가 필요하다(없으면 'Unable to locate a Java Runtime').
+async function checkAndFixJdk(brewAvailable: boolean): Promise<SetupStepResult> {
+  if (hasJava()) {
+    return { label: 'Java (JDK)', ok: true }
   }
   if (!brewAvailable) {
-    return {
-      label: 'Android Studio',
-      ok: false,
-      warn: true,
-      detail: 'Install from https://developer.android.com/studio',
-    }
+    return { label: 'Java (JDK)', ok: false, detail: 'Install Homebrew first, then: brew install --cask temurin' }
   }
-  // 대용량(~1GB+)이라 확인 후 설치. 비대화형이면 안내만.
   if (!process.stdout.isTTY) {
-    return {
-      label: 'Android Studio',
-      ok: false,
-      warn: true,
-      detail: 'Run: brew install --cask android-studio (skipped in non-interactive mode)',
-    }
+    return { label: 'Java (JDK)', ok: false, warn: true, detail: 'Run: brew install --cask temurin (skipped in non-interactive mode)' }
   }
-  const proceed = await confirm({ message: 'Install Android Studio (~1GB) via Homebrew?' })
+  const proceed = await confirm({
+    message: 'A JDK is required for the Android SDK tools. Install Temurin now? (may prompt for sudo)',
+  })
   if (isCancel(proceed) || !proceed) {
+    return { label: 'Java (JDK)', ok: false, warn: true, detail: 'Skipped. Install: brew install --cask temurin' }
+  }
+  console.log()
+  const r = spawnSync('brew', ['install', '--cask', 'temurin'], { stdio: 'inherit' })
+  if (r.status === 0 && hasJava()) {
+    return { label: 'Java (JDK) installed', ok: true }
+  }
+  return { label: 'Java (JDK)', ok: false, detail: 'JDK install failed. Install manually: brew install --cask temurin' }
+}
+
+// Android SDK를 ~/Library/Android/sdk에 자기완결로 구성한다(Android Studio GUI 불필요).
+async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): Promise<SetupStepResult> {
+  if (sdkSelfContained()) {
+    const reg = registerAndroidEnv()
     return {
-      label: 'Android Studio',
-      ok: false,
-      warn: true,
-      detail: 'Skipped. Run: brew install --cask android-studio',
+      label: 'Android SDK ready',
+      ok: true,
+      detail: reg?.added ? `Registered ANDROID_HOME/PATH in ${reg.file}.` : undefined,
     }
   }
-  const spinner = createSpinner('Installing Android Studio via Homebrew…')
-  spinner.start()
-  const r = spawnSync('brew', ['install', '--cask', 'android-studio'], { stdio: 'pipe' })
-  spinner.stop(r.status === 0)
-  if (r.status === 0) {
-    return { label: 'Android Studio installed via Homebrew', ok: true }
+  if (!javaOk) {
+    return { label: 'Android SDK', ok: false, detail: 'Install a JDK first (Android SDK tools need Java).' }
   }
+
+  // 부트스트랩 sdkmanager 확보: SDK 내부 → PATH(brew) → brew 설치
+  let bootSdkmanager = existsSync(join(SDK_CMDLINE_BIN, 'sdkmanager'))
+    ? join(SDK_CMDLINE_BIN, 'sdkmanager')
+    : whichSdkmanager()
+  if (!bootSdkmanager) {
+    if (!brewAvailable) {
+      return { label: 'Android SDK', ok: false, detail: 'Install Homebrew first, then: brew install --cask android-commandlinetools' }
+    }
+    if (!process.stdout.isTTY) {
+      return { label: 'Android SDK', ok: false, warn: true, detail: 'Run: brew install --cask android-commandlinetools (skipped in non-interactive mode)' }
+    }
+    console.log()
+    const b = spawnSync('brew', ['install', '--cask', 'android-commandlinetools'], { stdio: 'inherit' })
+    if (b.status !== 0) {
+      return { label: 'Android SDK', ok: false, detail: 'Failed to install android-commandlinetools.' }
+    }
+    bootSdkmanager = whichSdkmanager() ?? 'sdkmanager'
+  }
+
+  if (!process.stdout.isTTY) {
+    return { label: 'Android SDK', ok: false, warn: true, detail: 'Android SDK not installed (skipped in non-interactive mode).' }
+  }
+
+  // 자기완결 SDK 구성: cmdline-tools를 SDK 안에 넣어 이후 SDK 내부 바이너리만 쓰게 한다.
+  console.log()
+  const root = `--sdk_root=${ANDROID_SDK_DIR}`
+  const licenseInput = 'y\n'.repeat(50)
+  spawnSync(bootSdkmanager, [root, '--licenses'], { stdio: ['pipe', 'inherit', 'inherit'], input: licenseInput })
+  const inst = spawnSync(
+    bootSdkmanager,
+    [root, 'cmdline-tools;latest', 'platform-tools', 'emulator', androidSystemImage()],
+    { stdio: ['pipe', 'inherit', 'inherit'], input: licenseInput },
+  )
+  if (inst.status !== 0 || !sdkSelfContained()) {
+    return { label: 'Android SDK', ok: false, detail: 'Failed to set up the Android SDK.' }
+  }
+  const reg = registerAndroidEnv()
   return {
-    label: 'Android Studio',
-    ok: false,
-    warn: true,
-    detail: 'brew install --cask android-studio failed. Install manually.',
+    label: 'Android SDK installed',
+    ok: true,
+    detail: `SDK at ${ANDROID_SDK_DIR}.${reg?.added ? ` Restart your shell to pick up ANDROID_HOME/PATH (${reg.file}).` : ''}`,
   }
 }
 
-// 부팅하지 않는다 — AVD가 하나라도 준비됐는지만 보장(없으면 시스템 이미지 + AVD 생성).
-async function checkAndFixAvd(): Promise<SetupStepResult> {
+// 부팅하지 않는다 — AVD가 준비됐는지만 보장(없으면 폼팩터별 AVD 생성). 시스템 이미지는 SDK 단계에서 설치됨.
+async function checkAndFixAvd(sdkOk: boolean): Promise<SetupStepResult> {
+  if (!sdkOk) {
+    return { label: 'AVD', ok: false, detail: 'Set up the Android SDK first.' }
+  }
   const avds = listAvds()
   if (avds.length > 0) {
-    return { label: `AVD ready: ${avds[0]}`, ok: true }
+    return { label: `AVD ready: ${avds.length} device(s)`, ok: true }
   }
-  const manualHint = 'Create an AVD in Android Studio > Device Manager.'
+  const manualHint = 'Create an AVD with avdmanager (see Android docs).'
   if (!process.stdout.isTTY) {
     return { label: 'AVD', ok: false, warn: true, detail: `No AVD found. ${manualHint}` }
   }
-  const proceed = await confirm({
-    message: 'No Android Virtual Device found. Create a set of AVDs now? (downloads a system image)',
-  })
+  const proceed = await confirm({ message: 'No Android Virtual Device found. Create a set of AVDs now?' })
   if (isCancel(proceed) || !proceed) {
     return { label: 'AVD', ok: false, warn: true, detail: `Skipped. ${manualHint}` }
   }
@@ -365,59 +379,34 @@ async function checkAndFixAvd(): Promise<SetupStepResult> {
 }
 
 function listAvds(): string[] {
+  const emulator = join(ANDROID_SDK_DIR, 'emulator', 'emulator')
+  if (!existsSync(emulator)) return []
   try {
-    const out = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' }).trim()
+    const r = spawnSync(emulator, ['-list-avds'], { encoding: 'utf8', env: androidEnv() })
+    const out = (r.stdout ?? '').trim()
     return out ? out.split('\n').map((l) => l.trim()).filter(Boolean) : []
   } catch {
     return []
   }
 }
 
-function resolveAndroidSdk(): string | null {
-  const candidates = [
-    process.env.ANDROID_HOME,
-    process.env.ANDROID_SDK_ROOT,
-    join(homedir(), 'Library', 'Android', 'sdk'), // macOS
-    join(homedir(), 'Android', 'Sdk'), // Linux
-  ]
-  for (const c of candidates) {
-    if (c && existsSync(c)) return c
-  }
-  return null
-}
-
 function createAvds(): { ok: boolean; created: string[]; detail?: string } {
-  const sdk = resolveAndroidSdk()
-  if (!sdk) {
-    return { ok: false, created: [], detail: 'Android SDK not found. Install it via Android Studio.' }
-  }
-  const bin = join(sdk, 'cmdline-tools', 'latest', 'bin')
-  const sdkmanager = join(bin, 'sdkmanager')
-  const avdmanager = join(bin, 'avdmanager')
-  if (!existsSync(sdkmanager) || !existsSync(avdmanager)) {
-    return {
-      ok: false,
-      created: [],
-      detail: 'Android command-line tools not found. Install "Android SDK Command-line Tools" in Android Studio > SDK Manager.',
-    }
+  const avdmanager = join(SDK_CMDLINE_BIN, 'avdmanager')
+  if (!existsSync(avdmanager)) {
+    return { ok: false, created: [], detail: 'Android cmdline-tools not found in the SDK.' }
   }
   const image = androidSystemImage()
-  console.log()
-  // 시스템 이미지 1회 설치 (모든 AVD가 공유). 라이선스는 'y'로 동의.
-  const img = spawnSync(sdkmanager, [image], { stdio: 'inherit', input: 'y\n' })
-  if (img.status !== 0) {
-    return { ok: false, created: [], detail: `Failed to install ${image}.` }
-  }
   // 폼팩터별로 가용한 device id를 골라 AVD 생성. ('custom hardware profile?'에 'no')
   const available = listDeviceIds(avdmanager)
   const created: string[] = []
+  console.log()
   for (const spec of AVD_SPECS) {
     const device = spec.deviceCandidates.find((d) => available.includes(d))
     if (!device) continue
     const r = spawnSync(
       avdmanager,
       ['create', 'avd', '-n', spec.name, '-k', image, '-d', device, '--force'],
-      { stdio: 'inherit', input: 'no\n' },
+      { stdio: ['pipe', 'inherit', 'inherit'], input: 'no\n', env: androidEnv() },
     )
     if (r.status === 0) created.push(spec.name)
   }
@@ -429,7 +418,7 @@ function createAvds(): { ok: boolean; created: string[]; detail?: string } {
 
 function listDeviceIds(avdmanager: string): string[] {
   try {
-    const r = spawnSync(avdmanager, ['list', 'device'], { encoding: 'utf8' })
+    const r = spawnSync(avdmanager, ['list', 'device'], { encoding: 'utf8', env: androidEnv() })
     const out = r.stdout ?? ''
     const ids: string[] = []
     for (const m of out.matchAll(/id:\s*\d+\s+or\s+"([^"]+)"/g)) {
@@ -450,14 +439,19 @@ function shellRcPath(): string | null {
   return null
 }
 
-function registerPathInShellRc(platformTools: string): { added: boolean; file: string } | null {
+// ANDROID_HOME + platform-tools/emulator PATH를 rc에 멱등 등록(마커 블록).
+function registerAndroidEnv(): { added: boolean; file: string } | null {
   const file = shellRcPath()
   if (!file) return null
   const existing = existsSync(file) ? readFileSync(file, 'utf8') : ''
   if (existing.includes(PATH_MARKER_START)) {
     return { added: false, file }
   }
-  const block = `\n${PATH_MARKER_START}\nexport PATH="${platformTools}:$PATH"\n${PATH_MARKER_END}\n`
+  const block =
+    `\n${PATH_MARKER_START}\n` +
+    `export ANDROID_HOME="${ANDROID_SDK_DIR}"\n` +
+    `export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"\n` +
+    `${PATH_MARKER_END}\n`
   appendFileSync(file, block)
   return { added: true, file }
 }


### PR DESCRIPTION
## Summary

Second round of `0.8.0-next` feedback, focused on consistency and a robust Android setup. Verified end-to-end on a clean Mac before coding (no guesses).

## doctor

- **Missing adb is now a failure (✗)**, consistent with a missing Xcode (was a warning) — a clean machine shows checks uniformly.
- Added **`tapflow doctor [platform]`** (`ios` | `android`; omit for all), mirroring `setup`.
- Android section is now **Android SDK / adb / AVD**, symmetric with iOS's **Xcode / simctl / Simulator**.
- Checks device/AVD **existence**, not a running one (boot is on-demand via relay).

## setup android — self-contained SDK (drops Android Studio)

`Android Studio.app` install doesn't include the SDK (GUI-only), so unattended setup broke at AVD creation (`SETUP INCOMPLETE — AVD`). Replaced with a self-contained SDK at `~/Library/Android/sdk`:

1. **JDK** via `brew --cask temurin` when missing (sdkmanager needs Java)
2. bootstrap `cmdline-tools;latest` + `platform-tools` + `emulator` + `google_apis` system image with `sdkmanager --sdk_root`, licenses auto-accepted
3. register `ANDROID_HOME` + platform-tools/emulator on PATH
4. create the form-factor AVD set with the SDK's own `avdmanager`

Putting cmdline-tools **inside** the SDK lets avdmanager resolve the SDK root automatically — fixing the `Valid system image paths are: null` failure caused by a brew/SDK path split. This was validated on a clean Mac (JDK → cmdline-tools → SDK → AVD all unattended).

### Why not Android Studio?
Industry tools (Flutter, React Native) lean on Android Studio + a one-time GUI step and don't fully automate. tapflow only needs the SDK/emulator, so the self-contained CLI path is both lighter and the only one that completes in one run.

## Testing

- `pnpm --filter tapflow test` — 197 passing (setup JDK/SDK-bootstrap/AVD-set + doctor SDK/platform/availability rewritten).
- typecheck + lint clean. All OS calls, prompts, fs mocked.
- Verified real `tapflow doctor android` (Android SDK / adb / AVD).

Targets the `0.8.0-next` prerelease line; `latest` (0.7.0) unaffected. Ships as `v0.8.0-next.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `tapflow setup android` now installs a self-contained Android SDK without requiring Android Studio
  * Automatic JDK, emulator, and system image configuration and setup
  * SDK environment variables and PATH are automatically registered

* **Bug Fixes**
  * `tapflow doctor` now reports missing Android Debug Bridge as a failure instead of a warning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->