### PR TITLE
chore: release v0.8.0-next.2 (prerelease, dist-tag next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,8 +13,10 @@
     "@tapflowio/playground": "0.0.0"
   },
   "changesets": [
+    "doctor-adb-fail",
     "doctor-json-flag",
     "doctor-platform",
+    "setup-android-self-contained-sdk",
     "setup-android",
     "setup-homebrew-autoinstall",
     "setup-ios-and-unify",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.0-next.2
+
 ## 0.8.0-next.1
 
 ## 0.8.0-next.0

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.8.0-next.1",
+  "version": "0.8.0-next.2",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.0-next.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.2
+
 ## 0.8.0-next.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.8.0-next.1",
+  "version": "0.8.0-next.2",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,31 @@
 # tapflow
 
+## 0.8.0-next.2
+
+### Minor Changes
+
+- 3991d68: feat(cli): setup android bootstraps a self-contained SDK (JDK + cmdline-tools), no Android Studio
+
+  `tapflow setup android` no longer relies on Android Studio (whose `.app` install doesn't include the SDK, breaking unattended setup). Instead it builds a self-contained SDK at `~/Library/Android/sdk`:
+
+  - installs a JDK via Temurin when missing (required by sdkmanager)
+  - bootstraps `cmdline-tools;latest` + `platform-tools` + `emulator` + a `google_apis` system image into the SDK with `sdkmanager --sdk_root`, auto-accepting licenses
+  - registers `ANDROID_HOME` and platform-tools/emulator on PATH
+  - creates the form-factor AVD set with the SDK's own avdmanager
+
+  Because cmdline-tools live inside the SDK, the avdmanager resolves the SDK root automatically — fixing the "Valid system image paths are: null" failure caused by a brew/SDK path split. Verified end-to-end on a clean Mac.
+
+### Patch Changes
+
+- 4f957e1: fix(cli): doctor reports missing adb as a failure, consistent with Xcode
+
+  `tapflow doctor` now marks a missing adb as a failure (✗) — the same as a missing Xcode — instead of a warning, so a clean machine shows its checks uniformly. `tapflow setup android` resolves it.
+
+  - @tapflowio/agent-core@0.8.0-next.2
+  - @tapflowio/ios-agent@0.8.0-next.2
+  - @tapflowio/android-agent@0.8.0-next.2
+  - @tapflowio/relay@0.8.0-next.2
+
 ## 0.8.0-next.1
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.8.0-next.1",
+  "version": "0.8.0-next.2",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.8.0-next.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.2
+
 ## 0.8.0-next.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.8.0-next.1",
+  "version": "0.8.0-next.2",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.8.0-next.2
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.2
+
 ## 0.8.0-next.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.8.0-next.1",
+  "version": "0.8.0-next.2",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Third prerelease of the 0.8.0 line (changeset pre mode, dist-tag `next`). **`latest` stays at 0.7.0.**

## Since next.1
- doctor: missing adb is a failure (consistent with Xcode), `doctor [platform]`, Android SDK/adb/AVD symmetric with iOS
- setup android: self-contained SDK bootstrap (JDK + cmdline-tools + SDK + AVD set), Android Studio no longer required

## Mechanics
- `changeset version` (pre mode) → fixed group `0.8.0-next.2`; mcp-server unchanged (ignore).
- build/typecheck clean, no lockfile change.

## After merge
Tag the merge commit `v0.8.0-next.2` and push → CI publishes to `next`. Then `npm i -g tapflow@next` on a clean Mac to verify the unattended `tapflow setup android` (JDK → SDK → AVD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `tapflow setup android` now bootstraps a fully self-contained SDK, automatically configuring JDK, platform tools, emulator, and virtual device images without requiring Android Studio.
  * `tapflow doctor` now reports missing Android debug bridge as a critical failure, improving diagnostic visibility.

* **Chores**
  * Version bumped to 0.8.0-next.2 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->