### PR TITLE
fix(cli): doctor AVD consistency + setup new-terminal hint

### DIFF
--- a/.changeset/doctor-avd-fail-consistency.md
+++ b/.changeset/doctor-avd-fail-consistency.md
@@ -1,0 +1,7 @@
+---
+"tapflow": patch
+---
+
+fix(cli): doctor AVD is a failure (not a warning) when the SDK/emulator is absent
+
+On a clean machine, `tapflow doctor` showed Android SDK/adb as ✗ but AVD as ⚠. AVD now mirrors iOS Simulator: a missing SDK/emulator is a failure (✗, `tapflow setup android`), while a present emulator with no AVD stays a warning (⚠). The emulator is resolved from the SDK directory.

--- a/.changeset/setup-new-shell-hint.md
+++ b/.changeset/setup-new-shell-hint.md
@@ -1,0 +1,7 @@
+---
+"tapflow": patch
+---
+
+feat(cli): setup highlights "open a new terminal" after registering ANDROID_HOME/PATH
+
+When `tapflow setup android` adds `ANDROID_HOME`/PATH to your shell rc, the current shell doesn't pick them up — so running `tapflow doctor` right away showed confusing adb/AVD warnings. setup now prints a clear "open a new terminal (or run `exec zsh`), then `tapflow doctor`" note after the summary banner, only when the env was just registered.

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -121,6 +121,15 @@ describe('cmdSetup', () => {
     expect(out).toContain('Simulator')
   })
 
+  it('env를 방금 등록(detail에 new terminal)하면 새 터미널 안내 출력', async () => {
+    mockRunSetupAndroid.mockResolvedValue([
+      { label: 'Android SDK installed', ok: true, detail: 'SDK at /x. Added ANDROID_HOME/PATH to ~/.zshrc — open a new terminal (or run: exec zsh) to use them.' },
+    ])
+
+    await cmdSetup('android')
+    expect(logLines.join('\n')).toMatch(/new terminal/i)
+  })
+
   it('인자 없음 + 감지 0개 → 안내, exit 없음', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     mockResolveAdb.mockReturnValue(null)

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 vi.mock('node:child_process')
 vi.mock('node:fs')
 
-import { execSync } from 'node:child_process'
+import { execSync, spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -12,6 +12,9 @@ import { runDoctorChecks } from '../../lib/doctor.js'
 const mockExistsSync = vi.mocked(existsSync)
 
 const mockExecSync = vi.mocked(execSync)
+const mockSpawnSync = vi.mocked(spawnSync)
+const sdkmanagerLinux = join(homedir(), 'Android', 'Sdk', 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+const emulatorLinux = join(homedir(), 'Android', 'Sdk', 'emulator', 'emulator')
 
 const simctlBooted = JSON.stringify({
   devices: {
@@ -60,15 +63,21 @@ describe('runDoctorChecks', () => {
     expect(result.ios).toBeNull()
   })
 
-  it('adb 있으면 Android 섹션 포함', async () => {
+  it('adb 있으면 Android 섹션 포함 (SDK·AVD 존재)', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('ANDROID_HOME', '')
+    vi.stubEnv('ANDROID_SDK_ROOT', '')
+    mockExistsSync.mockImplementation((p) => p === sdkmanagerLinux || p === emulatorLinux)
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'which adb') return '/usr/local/bin/adb\n'
-      if (c === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n'
-      if (c.startsWith('adb -s emulator-5554')) return 'Pixel_8\nOK\n'
-      if (c === 'emulator -list-avds') return 'Pixel_8\n'
       return ''
+    })
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      if (cmd === emulatorLinux && Array.isArray(args) && args.includes('-list-avds')) {
+        return { stdout: 'Pixel_8\n' } as never
+      }
+      return { stdout: '' } as never
     })
 
     const result = await runDoctorChecks()

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -74,6 +74,6 @@ export async function cmdSetup(platform?: string): Promise<void> {
 
   // env를 방금 등록했으면 현재 쉘엔 반영 안 됨 → 새 터미널 안내(doctor가 PATH 경고를 내지 않도록).
   if (needsNewShell) {
-    step('Open a new terminal (or run: exec zsh), then `tapflow doctor` to verify — ANDROID_HOME/PATH was just added to your shell config.')
+    step('Open a new terminal (or run: exec $SHELL), then `tapflow doctor` to verify — ANDROID_HOME/PATH was just added to your shell config.')
   }
 }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,7 +1,7 @@
 import { confirm, isCancel } from '@clack/prompts'
 import { runSetupAndroid, runSetupIos, type SetupStepResult } from '../lib/setup.js'
 import { resolveAdb } from '../lib/doctor.js'
-import { warn, banner, BOLD, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
+import { warn, banner, step, BOLD, GREEN, RED, YELLOW, DIM, R } from '../lib/print.js'
 
 const RUNNERS: Record<string, () => Promise<SetupStepResult[]>> = {
   ios: runSetupIos,
@@ -56,10 +56,12 @@ export async function cmdSetup(platform?: string): Promise<void> {
   // 각 플랫폼 실행 후, 마지막에 relay/agent READY 톤의 요약 배너로 준비 상태를 알린다.
   const summary: string[] = []
   let allReady = true
+  let needsNewShell = false
   for (const t of targets) {
     console.log(`\n${BOLD}tapflow setup ${t}${R}\n`)
     const results = await RUNNERS[t]()
     printResults(results)
+    if (results.some((r) => r.detail?.includes('new terminal'))) needsNewShell = true
     const pending = results.filter((r) => !r.ok)
     if (pending.length === 0) {
       summary.push(`${t}: ready`)
@@ -69,4 +71,9 @@ export async function cmdSetup(platform?: string): Promise<void> {
     }
   }
   banner(allReady ? 'success' : 'error', allReady ? 'SETUP COMPLETE' : 'SETUP INCOMPLETE', summary)
+
+  // env를 방금 등록했으면 현재 쉘엔 반영 안 됨 → 새 터미널 안내(doctor가 PATH 경고를 내지 않도록).
+  if (needsNewShell) {
+    step('Open a new terminal (or run: exec zsh), then `tapflow doctor` to verify — ANDROID_HOME/PATH was just added to your shell config.')
+  }
 }

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execSync, spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -176,15 +176,21 @@ function checkAdb(path: string): DoctorCheck {
 }
 
 // 부팅은 relay on-demand가 한다 — AVD가 하나라도 존재하면 ok.
+// iOS Simulator와 대칭: SDK/emulator 자체가 없으면 fail(✗), emulator는 있는데 AVD만 없으면 warn(⚠).
 function checkAvdAvailable(): DoctorCheck {
+  const dir = androidSdkDir()
+  const emulator = dir ? join(dir, 'emulator', 'emulator') : null
+  if (!emulator || !existsSync(emulator)) {
+    return { label: 'AVD', ok: false, detail: 'Android SDK/emulator not found. Run: tapflow setup android' }
+  }
   try {
-    const out = execSync('emulator -list-avds', { encoding: 'utf8', stdio: 'pipe' }).trim()
-    const avds = out ? out.split('\n').map((l) => l.trim()).filter(Boolean) : []
+    const out = spawnSync(emulator, ['-list-avds'], { encoding: 'utf8' }).stdout ?? ''
+    const avds = out.trim() ? out.trim().split('\n').map((l) => l.trim()).filter(Boolean) : []
     if (avds.length > 0) {
       return { label: `AVD available: ${avds[0]}`, ok: true }
     }
   } catch {
-    // emulator 미설치/조회 실패 — 아래 안내
+    // 조회 실패 — 아래 warn
   }
   return { label: 'AVD', ok: false, warn: true, detail: 'No AVD found. Run: tapflow setup android' }
 }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -303,7 +303,7 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
     return {
       label: 'Android SDK ready',
       ok: true,
-      detail: reg?.added ? `Registered ANDROID_HOME/PATH in ${reg.file}.` : undefined,
+      detail: reg?.added ? newShellHint(reg.file) : undefined,
     }
   }
   if (!javaOk) {
@@ -350,8 +350,13 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
   return {
     label: 'Android SDK installed',
     ok: true,
-    detail: `SDK at ${ANDROID_SDK_DIR}.${reg?.added ? ` Restart your shell to pick up ANDROID_HOME/PATH (${reg.file}).` : ''}`,
+    detail: `SDK at ${ANDROID_SDK_DIR}.${reg?.added ? ` ${newShellHint(reg.file)}` : ''}`,
   }
+}
+
+// env를 방금 rc에 등록한 경우의 안내. cmdSetup이 이 문구('new terminal')를 감지해 배너 뒤에 강조한다.
+function newShellHint(file: string): string {
+  return `Added ANDROID_HOME/PATH to ${file} — open a new terminal (or run: exec zsh) to use them.`
 }
 
 // 부팅하지 않는다 — AVD가 준비됐는지만 보장(없으면 폼팩터별 AVD 생성). 시스템 이미지는 SDK 단계에서 설치됨.

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -356,7 +356,8 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
 
 // env를 방금 rc에 등록한 경우의 안내. cmdSetup이 이 문구('new terminal')를 감지해 배너 뒤에 강조한다.
 function newShellHint(file: string): string {
-  return `Added ANDROID_HOME/PATH to ${file} — open a new terminal (or run: exec zsh) to use them.`
+  const shell = file.endsWith('.zshrc') ? 'zsh' : file.endsWith('.bashrc') ? 'bash' : '$SHELL'
+  return `Added ANDROID_HOME/PATH to ${file} — open a new terminal (or run: exec ${shell}) to use them.`
 }
 
 // 부팅하지 않는다 — AVD가 준비됐는지만 보장(없으면 폼팩터별 AVD 생성). 시스템 이미지는 SDK 단계에서 설치됨.


### PR DESCRIPTION
## Summary

Two small fixes from `0.8.0-next.2` testing on a clean Mac.

## doctor: AVD failure consistency

On a clean machine, doctor showed Android **SDK ✗ / adb ✗ / AVD ⚠** — inconsistent. AVD now mirrors iOS Simulator:
- missing SDK/emulator → **✗** (tool missing, `tapflow setup android`)
- emulator present but no AVD → **⚠** (device not created)

The emulator is resolved from the SDK dir, so the check no longer reports a stray warning when the SDK itself is absent.

## setup: "open a new terminal" hint

`tapflow setup android` adds `ANDROID_HOME`/PATH to the shell rc, which the current shell doesn't pick up — so an immediate `tapflow doctor` showed adb/AVD warnings (confusing right after a successful setup). setup now prints a clear note after the summary banner (only when env was just registered):

```
→ Open a new terminal (or run: exec zsh), then `tapflow doctor` to verify —
  ANDROID_HOME/PATH was just added to your shell config.
```

Confirmed on a clean Mac: `setup android` completes end-to-end (JDK → self-contained SDK → 4 AVDs), and `tapflow doctor` passes after opening a new shell.

## Testing
- `pnpm --filter tapflow test` — 198 passing. typecheck + lint clean.

Targets `0.8.0-next`; ships as `v0.8.0-next.3`. `latest` (0.7.0) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now prints a highlighted instruction to open a new terminal (or run your shell) after Android environment variables are registered, then re-run diagnostics.

* **Bug Fixes**
  * tapflow doctor now treats a missing Android emulator binary as a failure (✗) instead of a warning, while still warning (⚠) when an emulator exists but no AVDs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->