### PR TITLE
chore: release v0.8.0-next.3 (prerelease, dist-tag next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,12 +14,14 @@
   },
   "changesets": [
     "doctor-adb-fail",
+    "doctor-avd-fail-consistency",
     "doctor-json-flag",
     "doctor-platform",
     "setup-android-self-contained-sdk",
     "setup-android",
     "setup-homebrew-autoinstall",
     "setup-ios-and-unify",
+    "setup-new-shell-hint",
     "setup-redesign"
   ]
 }

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.0-next.3
+
 ## 0.8.0-next.2
 
 ## 0.8.0-next.1

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.8.0-next.2",
+  "version": "0.8.0-next.3",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.0-next.3
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.3
+
 ## 0.8.0-next.2
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.8.0-next.2",
+  "version": "0.8.0-next.3",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # tapflow
 
+## 0.8.0-next.3
+
+### Patch Changes
+
+- 629741f: fix(cli): doctor AVD is a failure (not a warning) when the SDK/emulator is absent
+
+  On a clean machine, `tapflow doctor` showed Android SDK/adb as ✗ but AVD as ⚠. AVD now mirrors iOS Simulator: a missing SDK/emulator is a failure (✗, `tapflow setup android`), while a present emulator with no AVD stays a warning (⚠). The emulator is resolved from the SDK directory.
+
+- fc98ebd: feat(cli): setup highlights "open a new terminal" after registering ANDROID_HOME/PATH
+
+  When `tapflow setup android` adds `ANDROID_HOME`/PATH to your shell rc, the current shell doesn't pick them up — so running `tapflow doctor` right away showed confusing adb/AVD warnings. setup now prints a clear "open a new terminal (or run `exec zsh`), then `tapflow doctor`" note after the summary banner, only when the env was just registered.
+
+  - @tapflowio/agent-core@0.8.0-next.3
+  - @tapflowio/ios-agent@0.8.0-next.3
+  - @tapflowio/android-agent@0.8.0-next.3
+  - @tapflowio/relay@0.8.0-next.3
+
 ## 0.8.0-next.2
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.8.0-next.2",
+  "version": "0.8.0-next.3",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.8.0-next.3
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.3
+
 ## 0.8.0-next.2
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.8.0-next.2",
+  "version": "0.8.0-next.3",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.8.0-next.3
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.3
+
 ## 0.8.0-next.2
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.8.0-next.2",
+  "version": "0.8.0-next.3",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Summary

Fourth prerelease of the 0.8.0 line (changeset pre mode, dist-tag `next`). **`latest` stays at 0.7.0.**

## Since next.2
- doctor: AVD is a failure (not a warning) when the SDK/emulator is absent — symmetric with iOS Simulator
- setup: shell-aware "open a new terminal" hint after registering ANDROID_HOME/PATH (zsh/bash)

## Mechanics
- `changeset version` (pre mode) → fixed group `0.8.0-next.3`; mcp-server unchanged (ignore).
- build/typecheck clean, no lockfile change.

## After merge
Tag the merge commit `v0.8.0-next.3` and push → CI publishes to `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational message in `tapflow setup android` prompting users to open a new terminal after environment setup.

* **Bug Fixes**
  * Updated `tapflow doctor` to treat missing Android SDK/emulator for AVD as a failure instead of a warning.

* **Chores**
  * Version bump to 0.8.0-next.3 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->