### PR TITLE
fix(cli): doctor avoids the macOS Command Line Tools install popup

### DIFF
--- a/.changeset/doctor-no-clt-popup.md
+++ b/.changeset/doctor-no-clt-popup.md
@@ -1,0 +1,7 @@
+---
+"tapflow": patch
+---
+
+fix(cli): doctor no longer triggers the macOS "install Command Line Tools" popup
+
+On a Mac without Xcode, `tapflow doctor` called `xcodebuild`/`xcrun`, which makes macOS pop up the Command Line Tools installer. doctor now checks for `/Applications/Xcode.app` first (no popup) and only invokes those tools when Xcode is present — otherwise it reports "Install Xcode / run tapflow setup ios" directly.

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -125,6 +125,7 @@ describe('runDoctorChecks', () => {
 
   it('booted 시뮬레이터가 있으면 이름 포함', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExistsSync.mockImplementation((p) => p === '/Applications/Xcode.app')
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'xcodebuild -version') return 'Xcode 15.0\n'
@@ -139,6 +140,7 @@ describe('runDoctorChecks', () => {
 
   it('booted 안 됐어도 디바이스가 있으면 ok (부팅은 on-demand)', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExistsSync.mockImplementation((p) => p === '/Applications/Xcode.app')
     mockExecSync.mockImplementation((cmd) => {
       const c = cmd as string
       if (c === 'xcodebuild -version') return 'Xcode 15.0\n'

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -33,6 +33,16 @@ function buildIosChecks(isMac: boolean): DoctorCheck[] {
   if (!isMac) {
     return [{ label: 'iOS', ok: false, warn: true, detail: 'iOS testing requires macOS.' }]
   }
+  // Xcode.app이 없으면 xcodebuild/xcrun을 부르지 않는다 — 호출 시 macOS가 CLT 설치 팝업을 띄운다.
+  if (!existsSync('/Applications/Xcode.app')) {
+    return [
+      {
+        label: 'Xcode',
+        ok: false,
+        detail: 'Install Xcode from https://developer.apple.com/xcode/ or the Mac App Store. Or run: tapflow setup ios',
+      },
+    ]
+  }
   return [checkXcode(), checkSimctl(), checkBootedSimulator()]
 }
 


### PR DESCRIPTION
## Problem

On a Mac without Xcode, `tapflow doctor` triggered the macOS **"xcodebuild requires the command line developer tools — install now?"** popup. doctor is a *diagnostic*, but calling `xcodebuild`/`xcrun` makes macOS (via the `/usr/bin` stubs) pop up the CLT installer.

## Fix

Guard the iOS checks with `existsSync('/Applications/Xcode.app')` (no popup) before invoking `xcodebuild`/`xcrun`:
- Xcode.app **absent** → no command call; report "Install Xcode / run `tapflow setup ios`" directly → **no popup**
- Xcode.app **present** → call `xcodebuild`/`xcrun` (already installed, so no popup)

`setup ios` already had this guard; only doctor was missing it.

## Testing
- `pnpm --filter tapflow test` — 198 passing (two simulator tests updated to mock Xcode.app presence).
- typecheck + lint clean.

Targets `0.8.0-next`; ships as `v0.8.0-next.4`. `latest` (0.7.0) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `tapflow doctor` on macOS to no longer trigger the Command Line Tools installation popup when Xcode is not installed. The command now provides clear instructions for installing Xcode and running the iOS development setup process.

* **Tests**
  * Updated iOS-focused doctor checks to explicitly simulate Xcode presence verification across test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->