### PR TITLE
chore: release v0.8.0-next.4 (prerelease, dist-tag next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,6 +16,7 @@
     "doctor-adb-fail",
     "doctor-avd-fail-consistency",
     "doctor-json-flag",
+    "doctor-no-clt-popup",
     "doctor-platform",
     "setup-android-self-contained-sdk",
     "setup-android",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.0-next.4
+
 ## 0.8.0-next.3
 
 ## 0.8.0-next.2

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.8.0-next.3",
+  "version": "0.8.0-next.4",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.0-next.4
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.4
+
 ## 0.8.0-next.3
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.8.0-next.3",
+  "version": "0.8.0-next.4",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # tapflow
 
+## 0.8.0-next.4
+
+### Patch Changes
+
+- a593b9a: fix(cli): doctor no longer triggers the macOS "install Command Line Tools" popup
+
+  On a Mac without Xcode, `tapflow doctor` called `xcodebuild`/`xcrun`, which makes macOS pop up the Command Line Tools installer. doctor now checks for `/Applications/Xcode.app` first (no popup) and only invokes those tools when Xcode is present — otherwise it reports "Install Xcode / run tapflow setup ios" directly.
+
+  - @tapflowio/agent-core@0.8.0-next.4
+  - @tapflowio/ios-agent@0.8.0-next.4
+  - @tapflowio/android-agent@0.8.0-next.4
+  - @tapflowio/relay@0.8.0-next.4
+
 ## 0.8.0-next.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.8.0-next.3",
+  "version": "0.8.0-next.4",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.8.0-next.4
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.4
+
 ## 0.8.0-next.3
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.8.0-next.3",
+  "version": "0.8.0-next.4",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.8.0-next.4
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.0-next.4
+
 ## 0.8.0-next.3
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.8.0-next.3",
+  "version": "0.8.0-next.4",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
Fifth prerelease of the 0.8.0 line (changeset pre mode, dist-tag next). latest stays at 0.7.0.

Since next.3:
- doctor no longer triggers the macOS "install Command Line Tools" popup on a Mac without Xcode (checks /Applications/Xcode.app before calling xcodebuild/xcrun)

Mechanics:
- changeset version (pre mode) bumps the fixed group to 0.8.0-next.4; mcp-server unchanged (ignore).
- build/typecheck clean, no lockfile change.

After merge: tag the merge commit v0.8.0-next.4 and push to publish to next.

Generated with Claude Code