### PR TITLE
ci(release): mark prerelease tags as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,6 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # Tags with a prerelease identifier (e.g. v0.8.0-next.1) are marked as
+          # pre-release so GitHub keeps "Latest" on the newest stable release.
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
The Release workflow published every tag as a normal GitHub release, so v0.8.0-next.x grabbed the "Latest" badge even though npm latest stayed at 0.7.0.

Set the gh-release prerelease flag from the tag: prerelease = contains(github.ref_name, '-'). A v0.8.0-next.x tag (with a "-" identifier) becomes a pre-release; only a stable vX.Y.Z tag becomes Latest.

Existing next.0-next.4 releases were already corrected manually via gh release edit, and v0.7.0 is Latest again.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to automatically mark pre-releases based on version tag format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->