### PR TITLE
chore(changeset): record iOS simulator auto-recovery and pre-boot removal

### DIFF
--- a/.changeset/ios-simulator-auto-recovery.md
+++ b/.changeset/ios-simulator-auto-recovery.md
@@ -1,0 +1,7 @@
+---
+"@tapflowio/ios-agent": minor
+---
+
+iOS: auto-recover a simulator whose data directory vanished from disk. When an Xcode/macOS update prunes a runtime, `boot` fails with "cannot be located on disk"; the agent now erases the device to regenerate its data and retries the boot once (guarded so a healthy device is never erased), so dashboard/MCP sessions no longer dead-end on a broken simulator.
+
+Pre-boot is removed: `tapflow start` no longer boots a guessed device on startup. The agent only registers devices and boots on demand via `device:boot` (parity with android-agent). As a result, `--device` is now a relay-exposure filter (which simulators are exposed, default: all), not a boot target.


### PR DESCRIPTION
Adds the changeset missing from #267 so the next release picks up these changes.

## What it records (minor)
- iOS simulator **auto-recovery** — erase + retry boot once when a device's data dir vanished ("cannot be located on disk")
- **pre-boot removal** — `tapflow start` no longer boots a guessed device on startup; booting is on-demand via `device:boot` (android-agent parity)
- **`--device` is now a relay-exposure filter**, not a boot target

## Version impact
`@tapflowio/ios-agent: minor`. Via the `fixed` group in `.changeset/config.json`, this carries `tapflow` (cli), `agent-core`, `android-agent`, and `relay` to the same version.

No code changes — changeset only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic recovery when simulator data directory is missing; device will be erased and boot retried once.

* **Changes**
  * `tapflow start` no longer auto-boots a device on startup; devices now boot on demand only.
  * `--device` parameter now filters exposed simulators instead of selecting a boot target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->