### PR TITLE
fix(relay): bind dual-stack so LAN agents can connect over IPv4

### DIFF
--- a/.changeset/relay-dual-stack-bind.md
+++ b/.changeset/relay-dual-stack-bind.md
@@ -1,0 +1,5 @@
+---
+"@tapflowio/relay": patch
+---
+
+relay: bind the server dual-stack (IPv4 + IPv6). A bare `listen(port)` bound IPv6-only on some macOS/node setups, so an agent on another Mac connecting over `ws://<ipv4>:4000` timed out (TCP/HTTP reached the host, but the WebSocket handshake never hit the server). The relay now binds with `{ host: '::', ipv6Only: false }`, so LAN agents connect over IPv4 without a workaround.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -235,7 +235,9 @@ export class RelayServer {
           reject(err)
         }
       })
-      this.httpServer.listen(this.options.port, resolve)
+      // Bind dual-stack (IPv4 + IPv6). A bare listen(port) binds IPv6-only on some
+      // macOS/node setups, so LAN agents connecting over IPv4 (ws://<ipv4>:port) time out.
+      this.httpServer.listen({ port: this.options.port, host: '::', ipv6Only: false }, resolve)
     })
   }
 


### PR DESCRIPTION
## Problem

When the relay and agent run on **different Macs**, the agent (`tapflow agent start --relay ws://<relay-ip>:4000`) could hang at "Connecting…" and time out — even though `nc`/`curl` to the same `<relay-ip>:4000` succeeded.

Root cause: `RelayServer.start()` called `httpServer.listen(port)` with **no host**. On some macOS/node combinations this binds **IPv6-only** (`::`), so:
- `localhost` (resolves to `::1`) works
- `127.0.0.1` and the LAN IPv4 address are **refused / time out**

TCP and plain HTTP appeared to work in spot checks, but the WebSocket handshake from a LAN agent (IPv4) never reached the server.

## Fix

Bind dual-stack explicitly:

```ts
this.httpServer.listen({ port: this.options.port, host: '::', ipv6Only: false }, resolve)
```

`ipv6Only: false` accepts IPv4-mapped connections, so both `127.0.0.1`/LAN IPv4 and `::1`/IPv6 work. (`0.0.0.0` was avoided because it would drop the `::1` localhost path the dashboard uses.)

## Verification

- `RelayServer.test.ts` — 43/43 pass (localhost connections still work under dual-stack).
- Reproduced in the field: bare bind → IPv4 `127.0.0.1` refused while `::1` worked; the LAN agent only connected through a temporary `socat` IPv4→IPv6 bridge. This fix removes the need for that workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relay server connectivity for IPv4 LAN agents on certain macOS and Node.js configurations, enabling proper dual-stack networking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->