### PR TITLE
chore: release v0.8.1-next.0 — iOS zombie recovery + relay dual-stack

### DIFF
--- a/.changeset/ios-simulator-auto-recovery.md
+++ b/.changeset/ios-simulator-auto-recovery.md
@@ -1,5 +1,5 @@
 ---
-"@tapflowio/ios-agent": minor
+"@tapflowio/ios-agent": patch
 ---
 
 iOS: auto-recover a simulator whose data directory vanished from disk. When an Xcode/macOS update prunes a runtime, `boot` fails with "cannot be located on disk"; the agent now erases the device to regenerate its data and retries the boot once (guarded so a healthy device is never erased), so dashboard/MCP sessions no longer dead-end on a broken simulator.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,19 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@tapflowio/docs": "0.0.0",
+    "@tapflowio/agent-core": "0.8.0",
+    "@tapflowio/android-agent": "0.8.0",
+    "tapflow": "0.8.0",
+    "@tapflowio/dashboard": "0.1.2",
+    "@tapflowio/ios-agent": "0.8.0",
+    "@tapflowio/mcp-server": "0.8.0-experimental.1",
+    "@tapflowio/relay": "0.8.0",
+    "@tapflowio/playground": "0.0.0"
+  },
+  "changesets": [
+    "ios-simulator-auto-recovery",
+    "relay-dual-stack-bind"
+  ]
+}

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.8.1-next.0
+
 ## 0.8.0
 
 ## 0.8.0-next.4

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.8.1-next.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.8.1-next.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # tapflow
 
+## 0.8.1-next.0
+
+### Patch Changes
+
+- Updated dependencies [80f4d78]
+- Updated dependencies [129b5b1]
+  - @tapflowio/ios-agent@0.8.1-next.0
+  - @tapflowio/relay@0.8.1-next.0
+  - @tapflowio/android-agent@0.8.1-next.0
+  - @tapflowio/agent-core@0.8.1-next.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tapflowio/ios-agent
 
+## 0.8.1-next.0
+
+### Patch Changes
+
+- 80f4d78: iOS: auto-recover a simulator whose data directory vanished from disk. When an Xcode/macOS update prunes a runtime, `boot` fails with "cannot be located on disk"; the agent now erases the device to regenerate its data and retries the boot once (guarded so a healthy device is never erased), so dashboard/MCP sessions no longer dead-end on a broken simulator.
+
+  Pre-boot is removed: `tapflow start` no longer boots a guessed device on startup. The agent only registers devices and boots on demand via `device:boot` (parity with android-agent). As a result, `--device` is now a relay-exposure filter (which simulators are exposed, default: all), not a boot target.
+
+  - @tapflowio/agent-core@0.8.1-next.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.8.0-experimental.1",
+  "version": "0.8.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/relay
 
+## 0.8.1-next.0
+
+### Patch Changes
+
+- 129b5b1: relay: bind the server dual-stack (IPv4 + IPv6). A bare `listen(port)` bound IPv6-only on some macOS/node setups, so an agent on another Mac connecting over `ws://<ipv4>:4000` timed out (TCP/HTTP reached the host, but the WebSocket handshake never hit the server). The relay now binds with `{ host: '::', ipv6Only: false }`, so LAN agents connect over IPv4 without a workaround.
+  - @tapflowio/agent-core@0.8.1-next.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
**next channel prerelease.** Verify on `@next` before promoting to stable 0.8.1.

## Versions
| Package | Version |
|---------|---------|
| `tapflow`, `@tapflowio/{agent-core,ios-agent,android-agent,relay}` | `0.8.1-next.0` |
| `@tapflowio/mcp-server` | `0.8.1-experimental.1` |

## Changes (patch)
- **ios-agent** — auto-recover a simulator whose data dir vanished ("cannot be located on disk") via `erase` + retry boot; a healthy device is never erased. Pre-boot removed: `tapflow start` no longer boots a guessed device — booting is on-demand via `device:boot`. **`--device` is now a relay-exposure filter (default: all), not a boot target.**
- **relay** — bind dual-stack (`{ host: '::', ipv6Only: false }`) so LAN agents connect over IPv4 without a socat workaround.

## Compatibility
- No WebSocket protocol / message changes.
- `--device` semantics change (boot target → exposure filter) — the flag is **kept**, so not a breaking removal. Recorded in the package CHANGELOG.
- relay change is bind-only; no client change required.

## ⚠️ Verify before promoting to stable
The relay dual-stack fix is **not yet field-verified**. Once this publishes to `next`, confirm on the multi-Mac setup that an agent connects via `ws://<relay-ip>:4000` **without socat**. If good → promote to stable `0.8.1` (`changeset pre exit` + re-version).

## Release steps after merge
Tag the merge commit `v0.8.1-next.0` and push it — that triggers the publish workflow (npm `next` / `experimental` dist-tags via OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS simulators now auto-recover when data directories are missing by erasing the device and retrying boot.
  * Relay now uses dual-stack binding to prevent IPv6-only connectivity issues on macOS.

* **Changes**
  * `tapflow start` no longer auto-boots simulators; devices now boot on-demand via `device:boot`.
  * `--device` flag now controls which simulators are exposed rather than specifying boot targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->