### PR TITLE
docs: sync README/AGENTS with remote agent token auth (v0.8.1)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -23,7 +23,7 @@ Common rules are in the root [AGENTS.md](./AGENTS.md).
 |-----------|-----------|---------|
 | playground | [playground/AGENTS.md](./playground/AGENTS.md) | Full-stack local run and integration testing |
 | .work | [.work/CLAUDE.md](./.work/CLAUDE.md) | Local work log conventions (plan/review/compound) |
-| .internal/marketing | [.internal/marketing/AGENTS.md](./.internal/marketing/AGENTS.md) | Marketing context — product positioning, copy bank, channel tone guide |
+| .internal/marketing | [.internal/marketing/CLAUDE.md](./.internal/marketing/CLAUDE.md) | Marketing context — product positioning, copy bank, channel tone guide |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ tapflow is self-hosted by design — build files, device streams, and session re
 | Third-party simulator cloud | Not required |
 
 - **LAN-first** — the agent ↔ relay leg is internal traffic; the device stream never transits a third party.
-- **PAT + roles** — Personal Access Tokens carry scopes (e.g. `builds:write` for CI uploads), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
+- **Authenticated by default off-host** — the relay accepts unauthenticated connections only from its own machine (`localhost`). Browsers reaching it from elsewhere sign in; agents on another machine present an `agent`-scope token.
+- **PAT + roles** — Personal Access Tokens carry scopes (`builds:write` for CI uploads, `agent` for remote agents), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
 
 Found a vulnerability? See [SECURITY.md](SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/guide/security).
 
@@ -200,9 +201,11 @@ pm2 save && pm2 startup
 **Each Mac agent:**
 
 ```sh
-tapflow agent start --relay wss://your-relay-url
+tapflow agent start --relay wss://your-relay-url --token <agent-token>
 ```
 
+> A relay on a different machine accepts an agent only with an `agent`-scope token — create one in **Settings → Tokens** (Admin only). Agents on the relay's own machine (`tapflow start`) need no token. See [Remote relay authentication](https://www.tapflow.dev/guide/agent#remote-relay-authentication).
+>
 > For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
@@ -211,7 +214,7 @@ tapflow agent start --relay wss://your-relay-url
 |---------|-------------|
 | `tapflow start` | Start relay + agent together (local mode) |
 | `tapflow relay start` | Start relay only |
-| `tapflow agent start --relay <url>` | Start agent and connect to a relay |
+| `tapflow agent start --relay <url> [--token <pat>]` | Start agent and connect to a relay (remote relays need an `agent`-scope token) |
 | `tapflow init` | Scaffold `tapflow.config.json` |
 | `tapflow admin init` | Create the first admin account (CLI fallback) |
 | `tapflow doctor [platform]` | Diagnose prerequisites (Node, iOS, Android) |

--- a/packages/agent-core/AGENTS.md
+++ b/packages/agent-core/AGENTS.md
@@ -12,7 +12,7 @@ The sole contract that platform implementations (ios-agent, android-agent) depen
 ## HOW
 
 - The interface contains only platform-neutral methods: `listDevices`, `boot`, `shutdown`, `installApp`, `launchApp`, `screenshot`, `stream`, `touchStart`, `touchMove`, `touchEnd`.
-- `AgentRegistry` exposes exactly two methods: `register(platform, AgentClass)` / `get(platform)`.
+- `AgentRegistry`: platforms self-register via `register(platform, AgentClass, opts?)` (with a `connect` hook and optional `canRun` gate); the CLI drives them through `available()` / `connect(platform, relayUrl, opts)`. `connect`'s `AgentConnectOpts` carries `deviceFilter` and an optional `token` (opaque credential the agent forwards to a remote relay as `Authorization: Bearer`).
 - Interface changes must pass all implementation package tests before merging.
 
 ## HOW NOT

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -15,7 +15,7 @@ Commands are registered in `src/index.ts`:
 | `admin init [--relay]` | Create the first admin account on the relay (CLI fallback for headless servers; web `/setup` is the default path) |
 | `start [--device, --platform]` | Local-only shortcut — starts relay + agent together (same Mac) |
 | `relay start [--port, --tunnel]` | Start relay only (for Docker/Linux server) |
-| `agent start [--relay, --device, --platform]` | Start agent only — connects to an existing relay |
+| `agent start [--relay, --device, --platform, --token]` | Start agent only — connects to an existing relay. `--token` (or `TAPFLOW_AGENT_TOKEN`) carries an `agent`-scope PAT, required when the relay is on a different machine; flag wins over env. |
 | `doctor [platform]` | Check system prerequisites (`ios` \| `android`; omit for all): iOS Xcode/simctl/Simulator, Android SDK/adb/AVD |
 | `setup [platform]` | Guided environment setup (`ios` \| `android`; omit to auto-detect): installs/repairs JDK, Android SDK (self-contained at `~/Library/Android/sdk`), simulator runtime / AVDs |
 | `devices` | List available simulators and AVDs |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -173,7 +173,8 @@ tapflow is self-hosted by design — build files, device streams, and session re
 | Third-party simulator cloud | Not required |
 
 - **LAN-first** — the agent ↔ relay leg is internal traffic; the device stream never transits a third party.
-- **PAT + roles** — Personal Access Tokens carry scopes (e.g. `builds:write` for CI uploads), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
+- **Authenticated by default off-host** — the relay accepts unauthenticated connections only from its own machine (`localhost`). Browsers reaching it from elsewhere sign in; agents on another machine present an `agent`-scope token.
+- **PAT + roles** — Personal Access Tokens carry scopes (`builds:write` for CI uploads, `agent` for remote agents), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
 
 Found a vulnerability? See [SECURITY.md](https://github.com/jo-duchan/tapflow/blob/main/SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/guide/security).
 
@@ -203,9 +204,11 @@ pm2 save && pm2 startup
 **Each Mac agent:**
 
 ```sh
-tapflow agent start --relay wss://your-relay-url
+tapflow agent start --relay wss://your-relay-url --token <agent-token>
 ```
 
+> A relay on a different machine accepts an agent only with an `agent`-scope token — create one in **Settings → Tokens** (Admin only). Agents on the relay's own machine (`tapflow start`) need no token. See [Remote relay authentication](https://www.tapflow.dev/guide/agent#remote-relay-authentication).
+>
 > For nginx / Caddy reverse proxy setup and external access, see [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting).
 
 ## CLI Reference
@@ -214,7 +217,7 @@ tapflow agent start --relay wss://your-relay-url
 |---------|-------------|
 | `tapflow start` | Start relay + agent together (local mode) |
 | `tapflow relay start` | Start relay only |
-| `tapflow agent start --relay <url>` | Start agent and connect to a relay |
+| `tapflow agent start --relay <url> [--token <pat>]` | Start agent and connect to a relay (remote relays need an `agent`-scope token) |
 | `tapflow init` | Scaffold `tapflow.config.json` |
 | `tapflow admin init` | Create the first admin account (CLI fallback) |
 | `tapflow doctor [platform]` | Diagnose prerequisites (Node, iOS, Android) |

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -26,6 +26,7 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 ## HOW
 
 - The agent connects to the relay via outbound WebSocket first (the key to NAT traversal).
+- **Auth boundary**: connections from `localhost` are unauthenticated; every other origin must authenticate — browsers by JWT cookie / PAT, agents by a PAT with the `agent` scope (`Authorization: Bearer`). The role (browser / agent / stream) is decided in `classifyConnection` (`lib/connectionAuth.ts`); a `browser`-role socket that sends an agent-only message (`AGENT_MSG_TYPES`, which includes `stream:register`) is closed with 1008.
 - JSON messages and binary frames share the same WebSocket connection, branched by the `isBinary` flag.
 - Control message protocol: `input:touch:*`, `input:pinch:*`, `input:button`, `input:key`, `input:type`, `input:rotate`, `input:keyboard:toggle`, `device:boot`, `device:shutdown`, `session:start`, `session:end`.
 - JWTs are issued based on team invite links.


### PR DESCRIPTION
Brings the context docs in line with the v0.8.1 remote-agent token auth (#271), plus a couple of stale references found along the way.

## Changed

- **README.md** (root) and **packages/cli/README.md** (npm mirror, kept in sync):
  - The remote `tapflow agent start` example now includes `--token <agent-token>`, with a note that a relay on a different machine requires an `agent`-scope token (Admin-issued) and that `localhost` agents need none.
  - CLI Reference table: `agent start` shows `[--token <pat>]`.
  - Security & Privacy: new bullet stating the off-host auth boundary (relay accepts unauthenticated connections only from its own machine; others authenticate — browsers sign in, agents present an `agent`-scope token), and the PAT scope list now includes `agent`.
- **packages/cli/AGENTS.md**: `agent start` documents `--token` / `TAPFLOW_AGENT_TOKEN` (flag wins; required for a remote relay).
- **packages/relay/AGENTS.md**: adds the **Auth boundary** rule — `classifyConnection` (`lib/connectionAuth.ts`) and the `AGENT_MSG_TYPES` guard (now including `stream:register`), referenced by symbol, not line number.

## Fixed (stale, pre-existing)

- **packages/agent-core/AGENTS.md**: "AgentRegistry exposes exactly two methods: register/get" was outdated — corrected to the actual surface (`register` / `available` / `connect`) and `AgentConnectOpts.token`.
- **INDEX.md**: the `.internal/marketing` row pointed at `AGENTS.md`; the actual file is `CLAUDE.md`.

## Notes

- Docs-only; lint + typecheck pass via pre-commit.
- root and cli READMEs are intentional mirrors (GitHub vs npmjs.com), so both were edited identically.
- One item left for later: relay/AGENTS.md's "JWTs are issued based on team invite links" is slightly imprecise (JWTs also issue on login) but unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `--token` parameter to `agent start` command for authenticating with remote relays using agent-scope tokens
  * Clarified relay authentication boundaries: localhost connections are unauthenticated, remote connections require token-based authentication
  * Updated self-hosting team setup instructions to include token configuration
  * Revised CLI reference and agent registry behavior documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->