### PR TITLE
Gate docs edits behind ai-tells via hooks

### DIFF
--- a/.claude/hooks/docs-aitells-gate.sh
+++ b/.claude/hooks/docs-aitells-gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Stop: 이번 세션에 docs/*.md를 편집했는데 /ai-tells detect를 한 번도 실행하지 않았으면
+# 마무리를 차단(block)하고 점검을 요구한다. ai-tells를 한 번이라도 돌리면 통과 → 무한루프 없음.
+set -euo pipefail
+
+input=$(cat)
+tx=$(printf '%s' "$input" | jq -r '.transcript_path // ""')
+[ -f "$tx" ] || exit 0
+
+# 안전망: Stop hook이 block으로 재진입한 상태(stop_hook_active)면 통과시켜
+# 사용자가 의도적으로 건너뛸 수 있게 한다(스크립트 오류로 인한 무한 block 방지).
+active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false')
+[ "$active" = "true" ] && exit 0
+
+# docs/*.md를 Edit/Write/MultiEdit 한 횟수 (file_path가 input 첫 필드)
+edited=$(grep -cE '"name":"(Edit|Write|MultiEdit)","input":\{"file_path":"[^"]*/docs/[^"]*\.md' "$tx" || true)
+# ai-tells 스킬을 호출한 횟수 (리마인더 텍스트와 겹치지 않는 정확한 키)
+ran=$(grep -cE '"skill":"ai-tells"' "$tx" || true)
+
+if [ "${edited:-0}" -gt 0 ] && [ "${ran:-0}" -eq 0 ]; then
+  jq -n '{
+    decision: "block",
+    reason: "이번 세션에서 docs를 편집했지만 /ai-tells detect를 실행하지 않았습니다. 마무리 전 docs 산문(KO 번역투·em dash 삽입구·어순)을 /ai-tells detect로 점검하세요. 의도적으로 건너뛰려면 그대로 다시 멈추면 통과됩니다."
+  }'
+fi
+exit 0

--- a/.claude/hooks/docs-aitells-reminder.sh
+++ b/.claude/hooks/docs-aitells-reminder.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write|MultiEdit): docs/*.md 산문을 편집하면 ai-tells detect 리마인더를 주입한다.
+# 강제가 아니라 유도. 실제 게이트는 Stop 단계(docs-aitells-gate.sh)가 담당한다.
+set -euo pipefail
+
+input=$(cat)
+fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+
+case "$fp" in
+  */docs/*.md)
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: "docs 산문을 변경했습니다. 마무리 전 /ai-tells detect로 점검하세요 (KO 번역투·em dash 삽입구 — … —·어순 주의). 이번 세션에 ai-tells를 실행하지 않으면 Stop 단계에서 마무리가 차단됩니다."
+      }
+    }'
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,28 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/docs-aitells-reminder.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/docs-aitells-gate.sh\""
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

Enforce the ai-tells detect gate on docs prose edits. KO translation-ese (em-dash asides, word order) can't be reliably caught by regex lint and needs LLM judgement.

## How it works

- **PostToolUse** (`docs-aitells-reminder.sh`): after editing any `docs/*.md`, injects a reminder to run `/ai-tells detect` before wrapping up.
- **Stop** (`docs-aitells-gate.sh`): if this session edited docs but never ran ai-tells, blocks the Stop event with a prompt to run it. Running ai-tells once lets the session end — no infinite loop (`stop_hook_active` is the safety valve).

Detection reads the transcript: `"name":"Edit|Write|MultiEdit"` with a `/docs/*.md` file_path, and `"skill":"ai-tells"` for the run.

## Why no regex lint

A pre-commit regex approach was evaluated and dropped: em-dash asides can't be distinguished from legitimate trailing em-dashes, and the clear-cut patterns (double passives, etc.) are already absent from the docs. The reliable signal is LLM judgement, so the gate routes to ai-tells instead.

## Activation

Hook config loads at session start — a restart is needed to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)