### PR TITLE
Harden relay: cross-origin, CSRF, invite links, and upload handling

### DIFF
--- a/.changeset/relay-exposure-hardening-p1.md
+++ b/.changeset/relay-exposure-hardening-p1.md
@@ -1,0 +1,11 @@
+---
+"tapflow": patch
+"@tapflowio/relay": patch
+---
+
+Further harden the relay for public exposure:
+
+- CORS is restricted to the configured origins (public URL + loopback) instead of `*`, so an `Authorization` token can't be used from an unlisted cross-origin script.
+- Cookie-authenticated state-changing requests must come from a same-origin or allowlisted origin (lightweight CSRF guard); PAT-authenticated requests are exempt.
+- Invite links are built from the configured base URL (tunnel public URL / relay URL) instead of the request `Host` header.
+- Uploads that exceed the size limit are rejected and their partial files removed (builds and comment attachments). Limits are configurable via `TAPFLOW_MAX_BUILD_BYTES` / `TAPFLOW_MAX_COMMENT_BYTES`.

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -64,6 +64,8 @@ openssl rand -hex 32
 
 ::: warning 리버스 프록시 뒤에서는 TAPFLOW_TRUSTED_PROXIES를 설정하세요
 릴레이를 같은 호스트의 리버스 프록시(nginx, Caddy) 뒤에서 운영하면서 `TAPFLOW_TRUSTED_PROXIES`를 비워 두면, 프록시의 loopback 주소 때문에 **모든 원격 클라이언트가 localhost로 취급**됩니다. localhost는 무인증이므로 외부에 그대로 노출됩니다. 프록시 주소(예: `127.0.0.1,::1`)를 `TAPFLOW_TRUSTED_PROXIES`에 설정하고, 프록시가 `X-Forwarded-For`를 전달하도록 구성하세요.
+
+프록시나 터널로 노출하는 경우 공개 URL(`tunnel.publicUrl` 또는 `relay.url`)도 함께 설정하세요. 설정하지 않으면 CORS/CSRF 허용 목록이 loopback만 남아, 대시보드의 cross-origin 요청이 차단될 수 있습니다.
 :::
 
 ## 데이터 디렉토리

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,8 @@ openssl rand -hex 32
 
 ::: warning Behind a reverse proxy, set TAPFLOW_TRUSTED_PROXIES
 If the relay runs behind a same-host reverse proxy (nginx, Caddy) and `TAPFLOW_TRUSTED_PROXIES` is left unset, the proxy's loopback address makes **every remote client look like localhost** — and localhost is unauthenticated. Set `TAPFLOW_TRUSTED_PROXIES` to the proxy's address (e.g. `127.0.0.1,::1`) and configure the proxy to forward `X-Forwarded-For`.
+
+For proxied or tunneled deployments, also set a public URL (`tunnel.publicUrl` or `relay.url`). Otherwise the CORS/CSRF allowlist is loopback-only and the dashboard's cross-origin requests can be blocked.
 :::
 
 ## Data directory

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -10,6 +10,8 @@ import { Router, json } from './router.js'
 import { requireViewAuth, requireAuth, getAuth, verifyPat } from './middleware/auth.js'
 import { classifyConnection } from './lib/connectionAuth.js'
 import { resolveClientAddress } from './lib/clientAddress.js'
+import { resolveCorsHeaders } from './lib/cors.js'
+import { isCsrfBlocked } from './lib/csrf.js'
 import { pickLanAddress } from './lib/lanAddress.js'
 import { getDb } from './db.js'
 import { handleLogin, handleLogout, handleMe, handleChangePassword, handleInit, handleAuthStatus } from './api/auth.js'
@@ -110,6 +112,7 @@ export class RelayServer {
   private wsExternal = new Map<WebSocket, boolean>()
   private readonly backpressureBytes: number
   private readonly screenshotTimeoutMs: number
+  private readonly corsAllowed: Set<string>
   // One-shot warning when XFF arrives on a loopback socket but TAPFLOW_TRUSTED_PROXIES is unset.
   private warnedProxyMisconfig = false
   private pendingScreenshots = new Map<string, {
@@ -119,9 +122,10 @@ export class RelayServer {
     timer: ReturnType<typeof setTimeout>
   }>()
 
-  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number; wsBackpressureBytes?: number; screenshotTimeoutMs?: number; trustedProxies?: string[] }) {
+  constructor(private readonly options: { port: number; publicDir?: string; uploadsDir?: string; idleTimeoutMs?: number; wsBackpressureBytes?: number; screenshotTimeoutMs?: number; trustedProxies?: string[]; corsOrigins?: string[] }) {
     this.backpressureBytes = options.wsBackpressureBytes ?? DEFAULT_BACKPRESSURE_BYTES
     this.screenshotTimeoutMs = options.screenshotTimeoutMs ?? 10_000
+    this.corsAllowed = new Set(options.corsOrigins ?? [])
     this.sessions = new SessionManager({ idleTimeoutMs: options.idleTimeoutMs })
     this.publicDir = options.publicDir ?? path.join(import.meta.dirname, '../public')
     this.uploadsDir = options.uploadsDir ?? path.join(import.meta.dirname, '../uploads')
@@ -787,8 +791,10 @@ export class RelayServer {
   }
 
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    const corsHeaders = resolveCorsHeaders(req.headers.origin, this.corsAllowed)
+    if (corsHeaders) {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v)
+    }
 
     if (req.method === 'OPTIONS') {
       res.writeHead(204)
@@ -801,6 +807,10 @@ export class RelayServer {
 
     if (url.startsWith('/api/')) {
       res.setHeader('Cache-Control', 'no-store')
+      if (isCsrfBlocked(req.method, req.headers, this.corsAllowed)) {
+        json(res, 403, { error: 'Cross-origin state-changing request blocked (CSRF protection)' })
+        return
+      }
     }
     if (url.startsWith('/uploads/')) {
       if (!requireViewAuth(req, res)) return

--- a/packages/relay/src/__tests__/cors.test.ts
+++ b/packages/relay/src/__tests__/cors.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCorsHeaders } from '../lib/cors'
+
+// #4 — CORS 출처 제한: 허용 목록에 든 origin만 에코, PAT의 cross-origin 사용 차단
+describe('resolveCorsHeaders', () => {
+  const allowed = new Set(['https://vps.example.com', 'http://localhost:4000'])
+
+  it('Origin 헤더 없음(same-origin/CLI) → CORS 헤더 없음', () => {
+    expect(resolveCorsHeaders(undefined, allowed)).toBeNull()
+  })
+
+  it('허용 목록에 든 origin → 그 origin을 에코', () => {
+    const h = resolveCorsHeaders('https://vps.example.com', allowed)
+    expect(h?.['Access-Control-Allow-Origin']).toBe('https://vps.example.com')
+    expect(h?.['Vary']).toBe('Origin')
+  })
+
+  it('허용 목록 밖의 origin → null (CORS 헤더 미부여 → 브라우저 차단)', () => {
+    expect(resolveCorsHeaders('https://evil.example.com', allowed)).toBeNull()
+  })
+
+  it('와일드카드(*)를 절대 반환하지 않는다 (PAT cross-origin 차단)', () => {
+    const h = resolveCorsHeaders('http://localhost:4000', allowed)
+    expect(h?.['Access-Control-Allow-Origin']).not.toBe('*')
+    expect(h?.['Access-Control-Allow-Origin']).toBe('http://localhost:4000')
+  })
+
+  it('빈 allowlist → 모든 origin 거부', () => {
+    expect(resolveCorsHeaders('https://vps.example.com', new Set())).toBeNull()
+  })
+})

--- a/packages/relay/src/__tests__/csrf.test.ts
+++ b/packages/relay/src/__tests__/csrf.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { isCsrfBlocked } from '../lib/csrf'
+
+// #5 — CSRF: 쿠키 인증 상태변경은 same-origin 또는 신뢰 allowlist만 허용
+describe('isCsrfBlocked', () => {
+  const allowed = new Set(['https://vps.example.com'])
+  const cookie = 'tapflow_token=abc'
+
+  it('안전 메서드(GET/HEAD/OPTIONS)는 항상 통과', () => {
+    expect(isCsrfBlocked('GET', { cookie, origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(false)
+    expect(isCsrfBlocked('HEAD', { cookie }, allowed)).toBe(false)
+    expect(isCsrfBlocked('OPTIONS', { cookie }, allowed)).toBe(false)
+  })
+
+  it('쿠키 + 상태변경 + same-origin(Origin host == Host) → 통과 (LAN/프록시 대시보드)', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'http://192.168.0.9:4000', host: '192.168.0.9:4000' }, allowed)).toBe(false)
+  })
+
+  it('쿠키 + 상태변경 + cross-origin → 차단', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'https://evil.com', host: '192.168.0.9:4000' }, allowed)).toBe(true)
+    expect(isCsrfBlocked('PATCH', { cookie, origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(true)
+    expect(isCsrfBlocked('DELETE', { cookie, origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(true)
+  })
+
+  it('Origin이 신뢰 allowlist에 있으면 통과 (프록시가 Host를 바꿔도)', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'https://vps.example.com', host: 'localhost:4000' }, allowed)).toBe(false)
+  })
+
+  it('PAT(Authorization) 인증은 면제', () => {
+    expect(isCsrfBlocked('POST', { authorization: 'Bearer tflw_pat_x', origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(false)
+  })
+
+  it('쿠키 없음(미인증/login/init) → 차단하지 않음', () => {
+    expect(isCsrfBlocked('POST', { origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(false)
+    expect(isCsrfBlocked('POST', { cookie: 'other=1', origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(false)
+  })
+
+  it('Origin 헤더 없음(비-브라우저) → 차단하지 않음', () => {
+    expect(isCsrfBlocked('POST', { cookie, host: 'x:4000' }, allowed)).toBe(false)
+  })
+
+  it('malformed Origin → cross-origin으로 간주, 차단', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'not-a-url', host: 'x:4000' }, allowed)).toBe(true)
+  })
+})

--- a/packages/relay/src/__tests__/publicUrl.test.ts
+++ b/packages/relay/src/__tests__/publicUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { buildInviteBaseUrl } from '../lib/publicUrl'
+
+// #6 — Host 인젝션 차단: 초대 링크 base를 Host 헤더가 아닌 설정값에서만 도출
+describe('buildInviteBaseUrl', () => {
+  const local = { port: 4000, dataDir: '.tapflow-data', wsBackpressureBytes: 1, trustedProxies: [] }
+
+  it('터널 공개 URL이 있으면 그것을 사용 (trailing slash 제거)', () => {
+    expect(buildInviteBaseUrl({ tunnel: { provider: 'tailscale', publicUrl: 'https://mac.ts.net:4000/' }, relay: { url: null }, local }))
+      .toBe('https://mac.ts.net:4000')
+  })
+
+  it('relay.url ws:// → http:// 변환', () => {
+    expect(buildInviteBaseUrl({ tunnel: null, relay: { url: 'ws://192.168.0.9:4000' }, local }))
+      .toBe('http://192.168.0.9:4000')
+  })
+
+  it('relay.url wss:// → https:// 변환', () => {
+    expect(buildInviteBaseUrl({ tunnel: null, relay: { url: 'wss://relay.example.com' }, local }))
+      .toBe('https://relay.example.com')
+  })
+
+  it('설정이 없으면 localhost:port 폴백', () => {
+    expect(buildInviteBaseUrl({ tunnel: null, relay: { url: null }, local }))
+      .toBe('http://localhost:4000')
+  })
+
+  it('터널 공개 URL이 relay.url보다 우선', () => {
+    expect(buildInviteBaseUrl({ tunnel: { provider: 'rathole', serverAddr: 'x:2333', publicUrl: 'https://vps.example.com', ssh: null }, relay: { url: 'ws://localhost:4000' }, local }))
+      .toBe('https://vps.example.com')
+  })
+
+  it('tailscale 터널이지만 publicUrl 미설정이면 relay.url로 폴백', () => {
+    expect(buildInviteBaseUrl({ tunnel: { provider: 'tailscale', publicUrl: undefined }, relay: { url: 'wss://relay.example.com' }, local }))
+      .toBe('https://relay.example.com')
+  })
+})

--- a/packages/relay/src/__tests__/upload-limits.test.ts
+++ b/packages/relay/src/__tests__/upload-limits.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { RelayServer } from '../RelayServer'
+import { initDb, getDb, closeDb } from '../db'
+import { makePasswordHash } from '../api/auth'
+import { signJwt } from '../middleware/auth'
+
+// multipart/form-data 바디를 직접 구성한다 (busboy 파싱용).
+function multipartBody(boundary: string, parts: { name: string; filename?: string; contentType?: string; data: Buffer | string }[]): Buffer {
+  const chunks: Buffer[] = []
+  for (const p of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`))
+    let disp = `Content-Disposition: form-data; name="${p.name}"`
+    if (p.filename) disp += `; filename="${p.filename}"`
+    chunks.push(Buffer.from(disp + '\r\n'))
+    if (p.contentType) chunks.push(Buffer.from(`Content-Type: ${p.contentType}\r\n`))
+    chunks.push(Buffer.from('\r\n'))
+    chunks.push(Buffer.isBuffer(p.data) ? p.data : Buffer.from(p.data))
+    chunks.push(Buffer.from('\r\n'))
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`))
+  return Buffer.concat(chunks)
+}
+
+function httpPostMultipart(port: number, urlPath: string, body: Buffer, boundary: string, cookie: string): Promise<{ status: number; body: { error?: string } }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: urlPath, method: 'POST', headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}`, 'Content-Length': body.length, Cookie: cookie } },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => resolve({ status: res.statusCode!, body: JSON.parse(Buffer.concat(chunks).toString() || '{}') }))
+      },
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+// #7 — 업로드 크기 초과 시 truncate된 파일을 저장하지 않고 거부 + orphan 정리
+describe('upload size-limit handling', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+  let uploadsDir: string
+  let cookie: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-upload-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+    getDb().prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    cookie = `tapflow_token=${signJwt({ userId: 1, email: 'admin@example.com', role: 'Admin' })}`
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-uploads-'))
+    server = new RelayServer({ port: 0, uploadsDir })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => {
+    await server.stop()
+    fs.rmSync(uploadsDir, { recursive: true, force: true })
+    delete process.env.TAPFLOW_MAX_BUILD_BYTES
+    delete process.env.TAPFLOW_MAX_COMMENT_BYTES
+  })
+
+  it('빌드: 크기 상한 초과 → 400 + uploads/builds에 잔존 파일 없음', async () => {
+    process.env.TAPFLOW_MAX_BUILD_BYTES = '100'
+    const boundary = 'X1'
+    const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: Buffer.alloc(500, 0x41) }])
+    const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
+    expect(r.status).toBe(400)
+    const buildsDir = path.join(uploadsDir, 'builds')
+    const leftover = fs.existsSync(buildsDir) ? fs.readdirSync(buildsDir) : []
+    expect(leftover).toEqual([])
+  })
+
+  it('빌드: 상한 이내 정상 업로드는 거부되지 않음 (size 한도 통과)', async () => {
+    process.env.TAPFLOW_MAX_BUILD_BYTES = String(10 * 1024)
+    const boundary = 'X2'
+    // 유효 zip이 아니므로 메타추출에서 다른 에러가 날 수 있지만, size 초과(400 exceeds)로는 거부되지 않아야 한다.
+    const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: Buffer.alloc(200, 0x41) }])
+    const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
+    expect(r.body.error).not.toBe('File exceeds the upload size limit')
+  })
+
+  it('댓글 첨부: 크기 상한 초과 → 400 + uploads/comments에 잔존 파일 없음', async () => {
+    process.env.TAPFLOW_MAX_COMMENT_BYTES = '100'
+    const boundary = 'Y1'
+    const body = multipartBody(boundary, [
+      { name: 'build_id', data: '1' },
+      { name: 'body', data: 'hi' },
+      { name: 'file', filename: 'a.png', contentType: 'image/png', data: Buffer.alloc(500, 0x42) },
+    ])
+    const r = await httpPostMultipart(port, '/api/v1/comments', body, boundary, cookie)
+    expect(r.status).toBe(400)
+    const commentsDir = path.join(uploadsDir, 'comments')
+    const leftover = fs.existsSync(commentsDir) ? fs.readdirSync(commentsDir) : []
+    expect(leftover).toEqual([])
+  })
+})

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -8,6 +8,7 @@ import busboy from 'busboy'
 import { getDb } from '../db.js'
 import { requireAuth, requireBuildAuth } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
+import { unlinkSafe } from '../lib/uploads.js'
 
 // ── zip / plist helpers ────────────────────────────────────────────────────
 
@@ -432,15 +433,6 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
   return chunks
 }
 
-function unlinkSafe(filePath: string, label: string): void {
-  try {
-    fs.unlinkSync(filePath)
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.warn(`[tapflow] purge: failed to delete ${label}`, (err as Error).message)
-    }
-  }
-}
 
 export function purgeExpiredBuilds(recordingsDir: string): void {
   const db = getDb()

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -276,6 +276,12 @@ export async function handleUpdateBuild(
   json(res, 200, { ok: true })
 }
 
+// 업로드 크기 상한(바이트). 기본 500 MB, TAPFLOW_MAX_BUILD_BYTES로 조정 가능.
+function maxBuildUploadBytes(): number {
+  const v = Number(process.env.TAPFLOW_MAX_BUILD_BYTES)
+  return Number.isFinite(v) && v > 0 ? v : 500 * 1024 * 1024
+}
+
 export function handleUploadBuild(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -284,7 +290,7 @@ export function handleUploadBuild(
   const auth = requireBuildAuth(req, res)
   if (!auth) return
 
-  const bb = busboy({ headers: req.headers, limits: { fileSize: 500 * 1024 * 1024 } })
+  const bb = busboy({ headers: req.headers, limits: { fileSize: maxBuildUploadBytes() } })
   const fields: Record<string, string> = {}
   let savedPath = ''
   let originalName = ''
@@ -316,14 +322,18 @@ export function handleUploadBuild(
       ws.on('finish', resolve)
       ws.on('error', reject)
     })
+    // 크기 상한 초과 시 busboy가 스트림을 잘라('limit') 보내므로, 잘린 파일을 유효 빌드로 저장하면 안 된다.
+    stream.on('limit', () => { fileError = 'File exceeds the upload size limit' })
     stream.pipe(ws)
   })
 
   bb.on('finish', async () => {
-    if (fileError) return json(res, 400, { error: fileError })
-    if (!savedPath) return json(res, 400, { error: 'File required' })
-
     await writePromise
+    if (fileError) {
+      if (savedPath) unlinkSafe(savedPath, 'rejected upload')
+      return json(res, 400, { error: fileError })
+    }
+    if (!savedPath) return json(res, 400, { error: 'File required' })
 
     const ext = path.extname(originalName).toLowerCase()
     const isIos = ext === '.zip'

--- a/packages/relay/src/api/comments.ts
+++ b/packages/relay/src/api/comments.ts
@@ -50,6 +50,12 @@ export function handleListComments(req: http.IncomingMessage, res: http.ServerRe
   json(res, 200, result)
 }
 
+// 첨부 크기 상한(바이트). 기본 5 MB, TAPFLOW_MAX_COMMENT_BYTES로 조정 가능.
+function maxCommentAttachmentBytes(): number {
+  const v = Number(process.env.TAPFLOW_MAX_COMMENT_BYTES)
+  return Number.isFinite(v) && v > 0 ? v : 5 * 1024 * 1024
+}
+
 export function handleCreateComment(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -58,11 +64,12 @@ export function handleCreateComment(
   const auth = requireAuth(req, res)
   if (!auth) return
 
-  const bb = busboy({ headers: req.headers, limits: { fileSize: 5 * 1024 * 1024 } })
+  const bb = busboy({ headers: req.headers, limits: { fileSize: maxCommentAttachmentBytes() } })
   const fields: Record<string, string> = {}
   let attachmentPath = ''
   let attachmentMime = ''
   let sizeError = false
+  let writePromise: Promise<void> = Promise.resolve()
 
   bb.on('field', (name, val) => { fields[name] = val })
 
@@ -75,16 +82,23 @@ export function handleCreateComment(
     attachmentMime = info.mimeType
     fs.mkdirSync(path.dirname(attachmentPath), { recursive: true })
 
-    let size = 0
-    stream.on('data', (chunk: Buffer) => {
-      size += chunk.length
-      if (size > 5 * 1024 * 1024) sizeError = true
+    const ws = fs.createWriteStream(attachmentPath)
+    writePromise = new Promise((resolve, reject) => {
+      ws.on('finish', resolve)
+      ws.on('error', reject)
     })
-    stream.pipe(fs.createWriteStream(attachmentPath))
+    // 크기 상한 초과 시 busboy가 스트림을 잘라 보내므로, 잘린 첨부를 저장하면 안 된다.
+    stream.on('limit', () => { sizeError = true })
+    stream.pipe(ws)
   })
 
-  bb.on('finish', () => {
-    if (sizeError) return json(res, 400, { error: 'Max 5MB per attachment' })
+  bb.on('finish', async () => {
+    // 쓰기 완료를 기다린 뒤 삭제해야 잘린 파일이 디스크에 남지 않는다.
+    await writePromise.catch(() => {})
+    if (sizeError) {
+      if (attachmentPath) { try { fs.unlinkSync(attachmentPath) } catch { /* already gone */ } }
+      return json(res, 400, { error: 'Max 5MB per attachment' })
+    }
     if (!fields.build_id || !fields.body?.trim()) {
       return json(res, 400, { error: 'build_id and body required' })
     }

--- a/packages/relay/src/api/comments.ts
+++ b/packages/relay/src/api/comments.ts
@@ -5,6 +5,7 @@ import busboy from 'busboy'
 import { getDb } from '../db.js'
 import { requireAuth } from '../middleware/auth.js'
 import { json } from '../router.js'
+import { unlinkSafe } from '../lib/uploads.js'
 
 export function handleListComments(req: http.IncomingMessage, res: http.ServerResponse): void {
   const auth = requireAuth(req, res)
@@ -96,8 +97,8 @@ export function handleCreateComment(
     // 쓰기 완료를 기다린 뒤 삭제해야 잘린 파일이 디스크에 남지 않는다.
     await writePromise.catch(() => {})
     if (sizeError) {
-      if (attachmentPath) { try { fs.unlinkSync(attachmentPath) } catch { /* already gone */ } }
-      return json(res, 400, { error: 'Max 5MB per attachment' })
+      if (attachmentPath) unlinkSafe(attachmentPath, 'rejected attachment')
+      return json(res, 400, { error: 'Attachment exceeds the upload size limit' })
     }
     if (!fields.build_id || !fields.body?.trim()) {
       return json(res, 400, { error: 'build_id and body required' })

--- a/packages/relay/src/api/team.ts
+++ b/packages/relay/src/api/team.ts
@@ -4,6 +4,8 @@ import { getDb } from '../db.js'
 import { requireRole } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
 import { sendMail } from '../lib/mailer.js'
+import { config } from '../lib/config.js'
+import { buildInviteBaseUrl } from '../lib/publicUrl.js'
 
 export function handleListMembers(req: http.IncomingMessage, res: http.ServerResponse): void {
   const auth = requireRole(req, res, ['Admin'])
@@ -34,8 +36,8 @@ export async function handleInvite(req: http.IncomingMessage, res: http.ServerRe
 
   let emailSent = false
   if (body.email) {
-    const proto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http'
-    const inviteUrl = `${proto}://${req.headers.host}/invite?token=${token}`
+    // Host 헤더는 조작 가능하므로 신뢰 base URL(설정값)에서 링크를 만든다 (#6 Host 인젝션 차단).
+    const inviteUrl = `${buildInviteBaseUrl(config)}/invite?token=${token}`
     const html = `<p>You've been invited to join tapflow as <strong>${role}</strong>.</p>
 <p><a href="${inviteUrl}">Accept invitation</a></p>
 <p>This link expires in 7 days.</p>`

--- a/packages/relay/src/lib/cors.ts
+++ b/packages/relay/src/lib/cors.ts
@@ -1,0 +1,18 @@
+// #4 — CORS 출처 제한.
+// 기존엔 모든 응답에 `Access-Control-Allow-Origin: *` + `Allow-Headers: Authorization`을 줘서,
+// PAT(Authorization 헤더)를 cross-origin 스크립트에서 사용할 수 있었다. 허용 출처 allowlist에
+// 든 origin만 에코하고, 그 외에는 CORS 헤더를 부여하지 않는다(브라우저가 cross-origin을 차단).
+// same-origin 요청과 비-브라우저(CLI/서버-서버, Origin 헤더 없음)는 CORS와 무관하게 그대로 동작한다.
+export function resolveCorsHeaders(
+  origin: string | undefined,
+  allowedOrigins: Set<string>,
+): Record<string, string> | null {
+  if (!origin) return null
+  if (!allowedOrigins.has(origin)) return null
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Vary': 'Origin',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+  }
+}

--- a/packages/relay/src/lib/csrf.ts
+++ b/packages/relay/src/lib/csrf.ts
@@ -1,0 +1,34 @@
+import type http from 'http'
+
+// #5 — CSRF 경량 가드.
+// 상태 변경 API가 `SameSite=Lax` 쿠키에만 의존하면 일부 cross-site 요청이 통과할 수 있다.
+// 쿠키로 인증된 상태 변경 요청은 Origin이 same-origin(Host 일치)이거나 신뢰 allowlist에 있을 때만
+// 허용하고, 그 외 cross-origin은 차단한다. 브라우저는 상태 변경 요청에 Origin을 강제로 붙이므로
+// 대시보드(same-origin)는 그대로 통과하고, 공격자 origin은 막힌다.
+// 면제: 안전 메서드(GET/HEAD/OPTIONS), PAT 인증(Authorization — 쿠키 자동 전송이 아님),
+//       쿠키 없는 요청(미인증/login/init), Origin 없는 요청(비-브라우저; 브라우저는 cross-site에 Origin을 생략하지 못한다).
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+export function isCsrfBlocked(
+  method: string | undefined,
+  headers: http.IncomingHttpHeaders,
+  allowedOrigins: Set<string>,
+): boolean {
+  if (SAFE_METHODS.has((method ?? 'GET').toUpperCase())) return false
+  if (headers['authorization']) return false
+  const cookie = headers['cookie']
+  const hasCookieAuth = typeof cookie === 'string' && cookie.includes('tapflow_token=')
+  if (!hasCookieAuth) return false
+
+  const origin = headers['origin']
+  if (!origin) return false
+  if (allowedOrigins.has(origin)) return false
+
+  const host = headers['host']
+  try {
+    if (host && new URL(origin).host === host) return false
+  } catch {
+    // malformed Origin → treat as cross-origin (blocked below)
+  }
+  return true
+}

--- a/packages/relay/src/lib/publicUrl.ts
+++ b/packages/relay/src/lib/publicUrl.ts
@@ -1,0 +1,18 @@
+import type { TapflowConfig } from './config.js'
+
+// #6 — 초대/공개 링크의 신뢰 base URL.
+// `req.headers.host`/`x-forwarded-proto`는 클라이언트가 조작할 수 있어(Host 인젝션) 피싱 링크가
+// 정상 메일로 발송될 수 있다. 따라서 Host 헤더 대신 설정값에서만 base를 도출한다.
+// 우선순위: 터널 공개 URL → 설정된 relay URL(ws→http 변환) → localhost 폴백.
+export function buildInviteBaseUrl(cfg: Pick<TapflowConfig, 'tunnel' | 'relay' | 'local'>): string {
+  if (cfg.tunnel?.publicUrl) return stripTrailingSlash(cfg.tunnel.publicUrl)
+  if (cfg.relay.url) {
+    const http = cfg.relay.url.replace(/^ws:\/\//i, 'http://').replace(/^wss:\/\//i, 'https://')
+    return stripTrailingSlash(http)
+  }
+  return `http://localhost:${cfg.local.port}`
+}
+
+function stripTrailingSlash(u: string): string {
+  return u.replace(/\/+$/, '')
+}

--- a/packages/relay/src/lib/uploads.ts
+++ b/packages/relay/src/lib/uploads.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+
+// 업로드 정리: 파일을 삭제하되 이미 없으면(ENOENT) 조용히 넘기고, 그 외 에러만 경고한다.
+// builds/comments 업로드 핸들러가 거부·만료된 파일을 정리할 때 공유한다.
+export function unlinkSafe(filePath: string, label: string): void {
+  try {
+    fs.unlinkSync(filePath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(`[tapflow] failed to delete ${label}`, (err as Error).message)
+    }
+  }
+}

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { initDb } from './db.js'
 import { RelayServer } from './RelayServer.js'
 import { config } from './lib/config.js'
+import { buildInviteBaseUrl } from './lib/publicUrl.js'
 import { createLogger } from '@tapflowio/agent-core'
 
 const logger = createLogger('relay')
@@ -12,7 +13,11 @@ const uploadsDir = path.join(dataDir, 'uploads')
 
 initDb(dbPath)
 
-const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.local.wsBackpressureBytes, trustedProxies: config.local.trustedProxies })
+// CORS allowlist: the configured public URL + loopback (dev). LAN access is same-origin, so
+// dynamic LAN IPs need not be listed; cross-origin browser use of a PAT is what we're restricting.
+const corsOrigins = [buildInviteBaseUrl(config), `http://localhost:${port}`, `http://127.0.0.1:${port}`]
+
+const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.local.wsBackpressureBytes, trustedProxies: config.local.trustedProxies, corsOrigins })
 
 void server.start().then(() => {
   logger.info(`tapflow relay running on port ${port}`)

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -15,7 +15,22 @@ initDb(dbPath)
 
 // CORS allowlist: the configured public URL + loopback (dev). LAN access is same-origin, so
 // dynamic LAN IPs need not be listed; cross-origin browser use of a PAT is what we're restricting.
-const corsOrigins = [buildInviteBaseUrl(config), `http://localhost:${port}`, `http://127.0.0.1:${port}`]
+// Entries must be origins (scheme+host+port, no path) to match the browser's Origin header, so
+// normalize the configured public URL via URL().origin.
+const configuredOrigin = (() => {
+  try { return new URL(buildInviteBaseUrl(config)).origin } catch { return null }
+})()
+const corsOrigins = [configuredOrigin, `http://localhost:${port}`, `http://127.0.0.1:${port}`]
+  .filter((o): o is string => o !== null)
+
+// Proxied/tunneled exposure needs a public URL so the dashboard's cross-origin requests survive the
+// CORS/CSRF guards. Without it the allowlist is loopback-only and proxied POSTs can be blocked silently.
+if (config.local.trustedProxies.length > 0 && !config.tunnel?.publicUrl && !config.relay.url) {
+  logger.warn(
+    'TAPFLOW_TRUSTED_PROXIES is set but no public URL (tunnel.publicUrl / relay.url) is configured. ' +
+    'Cross-origin dashboard requests may be blocked by the CSRF guard — set the public URL for proxied deployments.'
+  )
+}
 
 const server = new RelayServer({ port, uploadsDir, wsBackpressureBytes: config.local.wsBackpressureBytes, trustedProxies: config.local.trustedProxies, corsOrigins })
 


### PR DESCRIPTION
## Summary

Follow-up hardening for public and proxied relay exposure (P1). No protocol, public API, CLI, or DB schema changes.

## Changes

- **CORS**: restrict `Access-Control-Allow-Origin` to a configured allowlist (public URL + loopback) instead of `*`. An `Authorization` token can no longer be used from an unlisted cross-origin script.
- **CSRF**: cookie-authenticated state-changing requests must come from a same-origin or allowlisted `Origin`; PAT-authenticated requests are exempt. No dashboard changes needed — the browser sets `Origin` automatically and same-origin (incl. LAN/proxy) passes.
- **Invite links**: built from the configured base URL (tunnel/relay URL) instead of the request `Host` header.
- **Uploads**: reject files that exceed the size limit (truncated by busboy) and remove the partial file — builds and comment attachments. Limits configurable via `TAPFLOW_MAX_BUILD_BYTES` / `TAPFLOW_MAX_COMMENT_BYTES`.

## Compatibility

No breaking changes. CORS/CSRF only affect cross-origin browser requests; the dashboard is same-origin. New handler/option parameters are optional with defaults.

## Tests

New: cors (5), csrf (8), publicUrl (6), upload-limits (3). Full relay suite: 266 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable upload size limits for builds and comments with environment variable overrides.
  * CSRF protection for API state-changing requests from unauthorized origins.

* **Bug Fixes**
  * Restricted CORS origins to configured public URLs and loopback to prevent unauthorized cross-origin access.
  * Fixed invite link generation to use configured base URLs instead of request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->