### PR TITLE
fix(relay): log handler exceptions instead of swallowing them

### DIFF
--- a/.changeset/router-error-logging.md
+++ b/.changeset/router-error-logging.md
@@ -1,0 +1,6 @@
+---
+"tapflow": patch
+"@tapflowio/relay": patch
+---
+
+The relay now logs handler exceptions (method, path, stack) instead of silently swallowing them, so 5xx failures are diagnosable. Response bodies still return only a generic message, and PATs are masked in the logs.

--- a/packages/relay/src/__tests__/router.test.ts
+++ b/packages/relay/src/__tests__/router.test.ts
@@ -176,3 +176,39 @@ describe('readJson', () => {
     await expect(readJson(req)).rejects.toThrow(SyntaxError)
   })
 })
+
+// #11 — 라우터가 핸들러 예외 스택을 삼키지 않고 기록 (응답엔 상세 비노출, PAT 마스킹)
+describe('핸들러 예외 관측성', () => {
+  it('핸들러 throw → 500 + 본문엔 상세 없음 + logger.error 기록 + PAT 마스킹', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = new Router()
+    router.get('/boom', () => { throw new Error('failure leaking tflw_pat_secret123') })
+    const req = makeReq('GET', '/boom')
+    const res = makeRes()
+
+    const handled = await router.handle(req, res)
+    expect(handled).toBe(true)
+    expect(res._written[0]?.status).toBe(500)
+    expect(JSON.parse(res._written[0]?.body)).toEqual({ error: 'Internal server error' })
+
+    expect(errorSpy).toHaveBeenCalled()
+    const logged = errorSpy.mock.calls.flat().map(String).join(' ')
+    expect(logged).toContain('GET /boom')
+    expect(logged).not.toContain('tflw_pat_secret123') // 마스킹됨
+    expect(logged).toContain('tflw_pat_***')
+    errorSpy.mockRestore()
+  })
+
+  it('async 핸들러 reject도 500 + 로깅', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = new Router()
+    router.post('/boom', () => Promise.reject(new Error('async boom')))
+    const req = makeReq('POST', '/boom')
+    const res = makeRes()
+
+    await router.handle(req, res)
+    expect(res._written[0]?.status).toBe(500)
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/relay/src/__tests__/router.test.ts
+++ b/packages/relay/src/__tests__/router.test.ts
@@ -211,4 +211,32 @@ describe('핸들러 예외 관측성', () => {
     expect(errorSpy).toHaveBeenCalled()
     errorSpy.mockRestore()
   })
+
+  it('경로 파라미터에 섞인 PAT도 마스킹 (전체 로그 라인 redact)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = new Router()
+    router.get('/api/:x', () => { throw new Error('boom') })
+    const req = makeReq('GET', '/api/tflw_pat_inpath')
+    const res = makeRes()
+
+    await router.handle(req, res)
+    const logged = errorSpy.mock.calls.flat().map(String).join(' ')
+    expect(logged).not.toContain('tflw_pat_inpath')
+    expect(logged).toContain('tflw_pat_***')
+    errorSpy.mockRestore()
+  })
+
+  it('세션 JWT도 마스킹', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = new Router()
+    router.get('/x', () => { throw new Error('verify failed: eyJhbGciOiJIUzI1.eyJzdWIiOiIxIn0.s1gnatur3') })
+    const req = makeReq('GET', '/x')
+    const res = makeRes()
+
+    await router.handle(req, res)
+    const logged = errorSpy.mock.calls.flat().map(String).join(' ')
+    expect(logged).not.toContain('eyJhbGciOiJIUzI1.eyJzdWIiOiIxIn0.s1gnatur3')
+    expect(logged).toContain('[jwt]')
+    errorSpy.mockRestore()
+  })
 })

--- a/packages/relay/src/router.ts
+++ b/packages/relay/src/router.ts
@@ -1,4 +1,12 @@
 import type http from 'http'
+import { createLogger } from '@tapflowio/agent-core'
+
+const logger = createLogger('relay:router')
+
+// 로그에 PAT가 새지 않도록 마스킹 (에러 메시지/스택에 토큰이 섞여 들어온 경우 대비).
+function redactSecrets(s: string): string {
+  return s.replace(/tflw_pat_[A-Za-z0-9_-]+/g, 'tflw_pat_***')
+}
 
 type Handler = (req: http.IncomingMessage, res: http.ServerResponse, params: Record<string, string>) => void | Promise<void>
 
@@ -37,7 +45,10 @@ export class Router {
       route.paramNames.forEach((name, i) => { params[name] = match[i + 1] })
       try {
         await route.handler(req, res, params)
-      } catch (_err) {
+      } catch (err) {
+        // 관측성: 스택을 삼키지 말고 기록한다. 단 응답 본문에는 상세를 노출하지 않는다.
+        const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        logger.error(`${method} ${url} — handler error: ${redactSecrets(detail)}`)
         json(res, 500, { error: 'Internal server error' })
       }
       return true

--- a/packages/relay/src/router.ts
+++ b/packages/relay/src/router.ts
@@ -3,9 +3,12 @@ import { createLogger } from '@tapflowio/agent-core'
 
 const logger = createLogger('relay:router')
 
-// 로그에 PAT가 새지 않도록 마스킹 (에러 메시지/스택에 토큰이 섞여 들어온 경우 대비).
+// 로그에 토큰이 새지 않도록 마스킹: PAT(tflw_pat_…)와 세션 JWT(eyJ….….…).
+// 메시지·스택뿐 아니라 method/url(경로 파라미터에 토큰이 섞인 경우)까지 포함해 로그 라인 전체에 적용한다.
 function redactSecrets(s: string): string {
-  return s.replace(/tflw_pat_[A-Za-z0-9_-]+/g, 'tflw_pat_***')
+  return s
+    .replace(/tflw_pat_[A-Za-z0-9_-]+/g, 'tflw_pat_***')
+    .replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[jwt]')
 }
 
 type Handler = (req: http.IncomingMessage, res: http.ServerResponse, params: Record<string, string>) => void | Promise<void>
@@ -48,7 +51,7 @@ export class Router {
       } catch (err) {
         // 관측성: 스택을 삼키지 말고 기록한다. 단 응답 본문에는 상세를 노출하지 않는다.
         const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
-        logger.error(`${method} ${url} — handler error: ${redactSecrets(detail)}`)
+        logger.error(redactSecrets(`${method} ${url} — handler error: ${detail}`))
         json(res, 500, { error: 'Internal server error' })
       }
       return true


### PR DESCRIPTION
The router's catch block returned 500 without logging, discarding the handler's stack — 5xx failures were undiagnosable.

## Change

- Log `method path — handler error: <stack>` via the relay logger on a caught handler exception.
- PATs are masked (`tflw_pat_***`) in case a token leaks into an error message/stack.
- The response body is unchanged — still a generic `{ error: 'Internal server error' }` with no detail.

## Tests

router suite: 20 passing (added: throw → 500 + logged + masked; async reject → 500 + logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Handler exceptions are now logged with diagnostic details including request method and route, enabling better error diagnosis. Response bodies remain generic to prevent information leakage. Sensitive tokens are automatically masked in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->