### PR TITLE
refactor(relay): namespace DNS/ACME credential env vars under TAPFLOW_ (#232)

### DIFF
--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -146,7 +146,7 @@ describe('cmdInitConfig', () => {
 
     const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tapflow.config.json'), 'utf-8'))
     expect(cfg.tls).toEqual({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'cloudflare' })
-    expect(output.join('\n')).toContain('CLOUDFLARE_API_TOKEN')
+    expect(output.join('\n')).toContain('TAPFLOW_CLOUDFLARE_TOKEN')
   })
 
   it('none + High + Vercel → byo-api-token(vercel) tls 생성', async () => {
@@ -158,7 +158,7 @@ describe('cmdInitConfig', () => {
 
     const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tapflow.config.json'), 'utf-8'))
     expect(cfg.tls).toEqual({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'vercel' })
-    expect(output.join('\n')).toContain('VERCEL_TOKEN')
+    expect(output.join('\n')).toContain('TAPFLOW_VERCEL_TOKEN')
   })
 
   it('none + High + Import → import-cert tls 생성', async () => {

--- a/packages/relay/src/__tests__/acmeStaging.integration.test.ts
+++ b/packages/relay/src/__tests__/acmeStaging.integration.test.ts
@@ -7,11 +7,11 @@ import type { DnsProvider } from '../lib/cert/DnsProvider.js'
 import { parseCertNotAfter } from '../lib/cert/parseCert.js'
 
 // 실제 Let's Encrypt STAGING 발급 통합 테스트. 비밀과 네트워크가 필요하므로 기본 OFF.
-// DNS provider는 env로 선택: VERCEL_TOKEN 있으면 Vercel, 없으면 CLOUDFLARE_API_TOKEN으로 Cloudflare.
+// DNS provider는 env로 선택: TAPFLOW_VERCEL_TOKEN 있으면 Vercel, 없으면 TAPFLOW_CLOUDFLARE_TOKEN으로 Cloudflare.
 //
 // 실행:
-//   export VERCEL_TOKEN=...           # 또는 CLOUDFLARE_API_TOKEN. 셸 env로만(채팅/명령줄 인라인 금지)
-//   # (Vercel 팀 도메인이면) export VERCEL_TEAM_ID=team_xxx
+//   export TAPFLOW_VERCEL_TOKEN=...           # 또는 TAPFLOW_CLOUDFLARE_TOKEN. 셸 env로만(채팅/명령줄 인라인 금지)
+//   # (Vercel 팀 도메인이면) export TAPFLOW_VERCEL_TEAM_ID=team_xxx
 //   TAPFLOW_ACME_SMOKE=1 TAPFLOW_ACME_DOMAIN=tap.your-domain.com \
 //     pnpm --filter @tapflowio/relay exec vitest run src/__tests__/acmeStaging.integration.test.ts
 //
@@ -19,17 +19,17 @@ import { parseCertNotAfter } from '../lib/cert/parseCert.js'
 
 const RUN = process.env.TAPFLOW_ACME_SMOKE === '1'
 const domain = process.env.TAPFLOW_ACME_DOMAIN ?? ''
-const email = process.env.ACME_EMAIL ?? ''
-const cloudflareToken = process.env.CLOUDFLARE_API_TOKEN ?? ''
-const vercelToken = process.env.VERCEL_TOKEN ?? ''
+const email = process.env.TAPFLOW_ACME_EMAIL ?? ''
+const cloudflareToken = process.env.TAPFLOW_CLOUDFLARE_TOKEN ?? ''
+const vercelToken = process.env.TAPFLOW_VERCEL_TOKEN ?? ''
 
 describe.skipIf(!RUN)('ACME STAGING issuance (integration)', () => {
   it('DNS-01로 실제 LE 스테이징 cert를 발급한다 (Vercel / Cloudflare)', async () => {
     expect(domain, 'set TAPFLOW_ACME_DOMAIN').toBeTruthy()
-    expect(cloudflareToken || vercelToken, 'set VERCEL_TOKEN or CLOUDFLARE_API_TOKEN').toBeTruthy()
+    expect(cloudflareToken || vercelToken, 'set TAPFLOW_VERCEL_TOKEN or TAPFLOW_CLOUDFLARE_TOKEN').toBeTruthy()
 
     const dns: DnsProvider = vercelToken
-      ? new VercelDnsProvider({ token: vercelToken, teamId: process.env.VERCEL_TEAM_ID || undefined })
+      ? new VercelDnsProvider({ token: vercelToken, teamId: process.env.TAPFLOW_VERCEL_TEAM_ID || undefined })
       : new CloudflareDnsProvider({ token: cloudflareToken })
     const issuer = new AcmeClientIssuer({ email, staging: true })
 

--- a/packages/relay/src/__tests__/createCertProvider.test.ts
+++ b/packages/relay/src/__tests__/createCertProvider.test.ts
@@ -15,31 +15,31 @@ describe('createCertProvider', () => {
   })
 
   it('byo-api-token 설정이면 AcmeCertProvider (토큰 env 필요)', () => {
-    vi.stubEnv('CLOUDFLARE_API_TOKEN', 'cf-token')
+    vi.stubEnv('TAPFLOW_CLOUDFLARE_TOKEN', 'cf-token')
     const p = createCertProvider({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'cloudflare' }, { dataDir: '/tmp/x' })
     expect(p).toBeInstanceOf(AcmeCertProvider)
     expect(p.strategy).toBe('byo-api-token')
   })
 
-  it('byo-api-token + vercel 설정이면 AcmeCertProvider (VERCEL_TOKEN 필요)', () => {
-    vi.stubEnv('VERCEL_TOKEN', 'vc-token')
+  it('byo-api-token + vercel 설정이면 AcmeCertProvider (TAPFLOW_VERCEL_TOKEN 필요)', () => {
+    vi.stubEnv('TAPFLOW_VERCEL_TOKEN', 'vc-token')
     const p = createCertProvider({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'vercel' }, { dataDir: '/tmp/x' })
     expect(p).toBeInstanceOf(AcmeCertProvider)
     expect(p.strategy).toBe('byo-api-token')
   })
 
-  it('vercel인데 VERCEL_TOKEN 미설정이면 throw', () => {
-    vi.stubEnv('VERCEL_TOKEN', '')
+  it('vercel인데 TAPFLOW_VERCEL_TOKEN 미설정이면 throw', () => {
+    vi.stubEnv('TAPFLOW_VERCEL_TOKEN', '')
     expect(() =>
       createCertProvider({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'vercel' }, { dataDir: '/tmp/x' }),
-    ).toThrow(/VERCEL_TOKEN/)
+    ).toThrow(/TAPFLOW_VERCEL_TOKEN/)
   })
 
-  it('byo-api-token인데 CLOUDFLARE_API_TOKEN 미설정이면 throw', () => {
-    vi.stubEnv('CLOUDFLARE_API_TOKEN', '')
+  it('byo-api-token인데 TAPFLOW_CLOUDFLARE_TOKEN 미설정이면 throw', () => {
+    vi.stubEnv('TAPFLOW_CLOUDFLARE_TOKEN', '')
     expect(() =>
       createCertProvider({ mode: 'byo-api-token', domain: 'tap.example.com', dnsProvider: 'cloudflare' }, { dataDir: '/tmp/x' }),
-    ).toThrow(/CLOUDFLARE_API_TOKEN/)
+    ).toThrow(/TAPFLOW_CLOUDFLARE_TOKEN/)
   })
 
   it('레지스트리에 없는 dnsProvider면 throw (available 목록 안내)', () => {

--- a/packages/relay/src/__tests__/dnsRegistry.test.ts
+++ b/packages/relay/src/__tests__/dnsRegistry.test.ts
@@ -14,7 +14,7 @@ describe('dnsProviders registry', () => {
   it('각 엔트리는 라벨·힌트·envVars를 들고 있다(wizard용)', () => {
     const cf = dnsProviders.get('cloudflare')
     expect(cf?.label).toBeTruthy()
-    expect(cf?.envVars).toContain('CLOUDFLARE_API_TOKEN')
+    expect(cf?.envVars).toContain('TAPFLOW_CLOUDFLARE_TOKEN')
   })
 
   it('알 수 없는 provider는 undefined / has=false', () => {
@@ -23,7 +23,7 @@ describe('dnsProviders registry', () => {
   })
 
   it('fromEnv가 env에서 DnsProvider를 만든다', () => {
-    vi.stubEnv('CLOUDFLARE_API_TOKEN', 'cf-token')
+    vi.stubEnv('TAPFLOW_CLOUDFLARE_TOKEN', 'cf-token')
     const dns = dnsProviders.get('cloudflare')!.fromEnv()
     expect(dns).toBeInstanceOf(CloudflareDnsProvider)
     expect(dns.name).toBe('cloudflare')

--- a/packages/relay/src/lib/cert/CloudflareDnsProvider.ts
+++ b/packages/relay/src/lib/cert/CloudflareDnsProvider.ts
@@ -1,7 +1,7 @@
 import type { DnsProvider } from './DnsProvider.js'
 
 // Cloudflare DNS-01 solver (issue #232). 사용자 자기 Cloudflare 계정 토큰으로 동작한다(BYO).
-// 토큰은 config가 아니라 env(CLOUDFLARE_API_TOKEN)에서 읽는다 — cloudflareDnsFromEnv 참고.
+// 토큰은 config가 아니라 env(TAPFLOW_CLOUDFLARE_TOKEN)에서 읽는다 — cloudflareDnsFromEnv 참고.
 
 const DEFAULT_API_BASE = 'https://api.cloudflare.com/client/v4'
 const TTL_SECONDS = 60
@@ -52,7 +52,7 @@ export class CloudflareDnsProvider implements DnsProvider {
   private readonly zoneIdCache = new Map<string, string>()
 
   constructor(opts: CloudflareDnsProviderOptions) {
-    if (!opts.token) throw new Error('Cloudflare API token is required (set CLOUDFLARE_API_TOKEN)')
+    if (!opts.token) throw new Error('Cloudflare API token is required (set TAPFLOW_CLOUDFLARE_TOKEN)')
     this.token = opts.token
     this.fetchFn = opts.fetchFn ?? (globalThis.fetch as unknown as FetchLike)
     this.apiBase = opts.apiBase ?? DEFAULT_API_BASE
@@ -126,9 +126,9 @@ export class CloudflareDnsProvider implements DnsProvider {
   }
 }
 
-/** env(CLOUDFLARE_API_TOKEN)에서 토큰을 읽어 provider를 만든다. 토큰 미설정 시 throw. */
+/** env(TAPFLOW_CLOUDFLARE_TOKEN)에서 토큰을 읽어 provider를 만든다. 토큰 미설정 시 throw. */
 export function cloudflareDnsFromEnv(zoneName?: string): CloudflareDnsProvider {
-  const token = process.env.CLOUDFLARE_API_TOKEN
-  if (!token) throw new Error('CLOUDFLARE_API_TOKEN is not set')
+  const token = process.env.TAPFLOW_CLOUDFLARE_TOKEN
+  if (!token) throw new Error('TAPFLOW_CLOUDFLARE_TOKEN is not set')
   return new CloudflareDnsProvider({ token, zoneName })
 }

--- a/packages/relay/src/lib/cert/VercelDnsProvider.ts
+++ b/packages/relay/src/lib/cert/VercelDnsProvider.ts
@@ -2,7 +2,7 @@ import type { DnsProvider } from './DnsProvider.js'
 import { DNS_API_TIMEOUT_MS, type FetchLike } from './CloudflareDnsProvider.js'
 
 // Vercel DNS-01 solver (issue #232). 사용자 자기 Vercel 계정 토큰으로 동작한다(BYO).
-// 토큰은 config가 아니라 env(VERCEL_TOKEN)에서 읽는다(vercelDnsFromEnv).
+// 토큰은 config가 아니라 env(TAPFLOW_VERCEL_TOKEN)에서 읽는다(vercelDnsFromEnv).
 // Vercel은 개별 레코드(id 보유) 모델: name은 도메인 기준 상대 subname(루트는 ''), TXT 값은 따옴표 없이.
 
 const DEFAULT_API_BASE = 'https://api.vercel.com'
@@ -37,7 +37,7 @@ export class VercelDnsProvider implements DnsProvider {
   private readonly zoneCache = new Map<string, string>()
 
   constructor(opts: VercelDnsProviderOptions) {
-    if (!opts.token) throw new Error('Vercel API token is required (set VERCEL_TOKEN)')
+    if (!opts.token) throw new Error('Vercel API token is required (set TAPFLOW_VERCEL_TOKEN)')
     this.token = opts.token
     this.fetchFn = opts.fetchFn ?? (globalThis.fetch as unknown as FetchLike)
     this.apiBase = opts.apiBase ?? DEFAULT_API_BASE
@@ -167,9 +167,9 @@ export class VercelDnsProvider implements DnsProvider {
   }
 }
 
-/** env(VERCEL_TOKEN)에서 토큰을 읽어 provider를 만든다. 미설정 시 throw. (팀이면 VERCEL_TEAM_ID) */
+/** env(TAPFLOW_VERCEL_TOKEN)에서 토큰을 읽어 provider를 만든다. 미설정 시 throw. (팀이면 TAPFLOW_VERCEL_TEAM_ID) */
 export function vercelDnsFromEnv(zoneName?: string): VercelDnsProvider {
-  const token = process.env.VERCEL_TOKEN
-  if (!token) throw new Error('VERCEL_TOKEN is not set')
-  return new VercelDnsProvider({ token, zoneName, teamId: process.env.VERCEL_TEAM_ID || undefined })
+  const token = process.env.TAPFLOW_VERCEL_TOKEN
+  if (!token) throw new Error('TAPFLOW_VERCEL_TOKEN is not set')
+  return new VercelDnsProvider({ token, zoneName, teamId: process.env.TAPFLOW_VERCEL_TEAM_ID || undefined })
 }

--- a/packages/relay/src/lib/cert/createCertProvider.ts
+++ b/packages/relay/src/lib/cert/createCertProvider.ts
@@ -14,9 +14,9 @@ export type TlsConfig =
 
 export interface CreateCertProviderDeps {
   dataDir: string
-  /** ACME 계정 이메일. 기본 env ACME_EMAIL. */
+  /** ACME 계정 이메일. 기본 env TAPFLOW_ACME_EMAIL. */
   email?: string
-  /** LE 스테이징 사용(테스트). 기본 env ACME_STAGING === '1'. */
+  /** LE 스테이징 사용(테스트). 기본 env TAPFLOW_ACME_STAGING === '1'. */
   staging?: boolean
 }
 
@@ -30,8 +30,8 @@ export function createCertProvider(tls: TlsConfig, deps: CreateCertProviderDeps)
   if (!entry) throw new Error(`unknown dnsProvider "${tls.dnsProvider}" — available: ${dnsProviders.names().join(', ')}`)
   const dns: DnsProvider = entry.fromEnv()
   const issuer = new AcmeClientIssuer({
-    email: deps.email ?? process.env.ACME_EMAIL ?? '',
-    staging: deps.staging ?? process.env.ACME_STAGING === '1',
+    email: deps.email ?? process.env.TAPFLOW_ACME_EMAIL ?? '',
+    staging: deps.staging ?? process.env.TAPFLOW_ACME_STAGING === '1',
     accountKeyPath: path.join(deps.dataDir, 'tls', 'account.pem'),
   })
   const store = new DiskCertStore(path.join(deps.dataDir, 'tls'))

--- a/packages/relay/src/lib/cert/dnsRegistry.ts
+++ b/packages/relay/src/lib/cert/dnsRegistry.ts
@@ -41,14 +41,14 @@ export const dnsProviders = new DnsProviderRegistry()
 dnsProviders.register({
   name: 'cloudflare',
   label: 'Cloudflare DNS',
-  hint: 'auto-issue & renew via API token (env CLOUDFLARE_API_TOKEN)',
-  envVars: ['CLOUDFLARE_API_TOKEN'],
+  hint: 'auto-issue & renew via API token (env TAPFLOW_CLOUDFLARE_TOKEN)',
+  envVars: ['TAPFLOW_CLOUDFLARE_TOKEN'],
   fromEnv: cloudflareDnsFromEnv,
 })
 dnsProviders.register({
   name: 'vercel',
   label: 'Vercel DNS',
-  hint: 'auto-issue & renew via API token (env VERCEL_TOKEN)',
-  envVars: ['VERCEL_TOKEN'],
+  hint: 'auto-issue & renew via API token (env TAPFLOW_VERCEL_TOKEN)',
+  envVars: ['TAPFLOW_VERCEL_TOKEN'],
   fromEnv: vercelDnsFromEnv,
 })

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -29,7 +29,7 @@ const tailscaleTunnelSchema = z.object({
 const tunnelSchema = z.discriminatedUnion('provider', [ratholeTunnelSchema, tailscaleTunnelSchema])
 
 // LAN HTTPS (issue #232) — secure context용 TLS 종단 설정. 골격: v1은 LAN 가지만 구현.
-// 비밀(DNS API 토큰)은 config 파일이 아니라 env에서 읽는다(예: CLOUDFLARE_API_TOKEN).
+// 비밀(DNS API 토큰)은 config 파일이 아니라 env에서 읽는다(예: TAPFLOW_CLOUDFLARE_TOKEN).
 const importCertTlsSchema = z.object({
   mode: z.literal('import-cert'),
   certPath: z.string().min(1),


### PR DESCRIPTION
The DNS-01 / ACME credential env vars shipped with vendor-native names and an inconsistent surface (`CLOUDFLARE_API_TOKEN` vs `VERCEL_TOKEN`). Normalize them under the `TAPFLOW_` prefix so the relay's credential inputs are consistent, namespaced, and greppable — matching how the project already prefixes its own env vars (`TAPFLOW_PORT`, `TAPFLOW_DATA_DIR`, …).

## Renames
| Old | New |
|-----|-----|
| `CLOUDFLARE_API_TOKEN` | `TAPFLOW_CLOUDFLARE_TOKEN` |
| `VERCEL_TOKEN` | `TAPFLOW_VERCEL_TOKEN` |
| `VERCEL_TEAM_ID` | `TAPFLOW_VERCEL_TEAM_ID` |
| `ACME_EMAIL` | `TAPFLOW_ACME_EMAIL` |
| `ACME_STAGING` | `TAPFLOW_ACME_STAGING` |

The field stays uniform (`_TOKEN`); the registry's `envVars` metadata drives the wizard hints and the `init` summary, so nothing else needed per-provider edits.

## Why now
The LAN HTTPS feature only just landed, so no deployments rely on the old names yet — this is the cheapest moment to fix the surface.

## Test plan
- relay 339 + cli 208 green; typecheck/build/lint pass.
- `createCertProvider` / `dnsRegistry` / `init` tests updated to the new names.
- Integration smoke (`acmeStaging`) instructions updated to the new env vars.

## Follow-up
Docs (`configuration.md`) are updated in the LAN HTTPS docs PR. A separate issue covers loading credentials from a gitignored env file so a long-running relay survives restarts without re-exporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable names to use `TAPFLOW_*` prefix convention for consistency. Users must update their configuration to use: `TAPFLOW_CLOUDFLARE_TOKEN`, `TAPFLOW_VERCEL_TOKEN`, `TAPFLOW_VERCEL_TEAM_ID`, `TAPFLOW_ACME_EMAIL`, and `TAPFLOW_ACME_STAGING` instead of the previous non-prefixed equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->