### PR TITLE
docs(reference): document tls / LAN HTTPS configuration (#232)

### DIFF
--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -27,6 +27,7 @@
 |----|------|
 | `local` | 이 머신에서 실행하는 relay 서버 설정 |
 | `relay.url` | 연결할 relay URL. `tapflow agent start`, `tapflow admin init`, `tapflow status`, `tapflow logs`의 기본값으로 사용됩니다. 설정 시 `--relay` 플래그 없이 동작합니다. 비어있으면 로컬 모드(`ws://localhost:[local.port]`)를 사용합니다. |
+| `tls` | LAN HTTPS(보안 컨텍스트) 설정. WebCodecs 하드웨어 디코드에 필요합니다. 아래 HTTPS 섹션을 참고하세요. |
 | `smtp` | 초대·비밀번호 재설정 이메일 발송을 위한 SMTP 설정 |
 
 `smtp.from`은 `smtp.user`가 설정되어 있으면 `tapflow <smtp.user>` 형태로 자동 설정됩니다. 발신자 주소를 다르게 지정하려면 명시적으로 입력합니다.
@@ -45,6 +46,10 @@
 | `TAPFLOW_TRUSTED_PROXIES` | — | *(비어있음)* | 신뢰하는 리버스 프록시 IP 목록(콤마 구분, 예: `127.0.0.1,::1`). 릴레이를 같은 호스트의 리버스 프록시 뒤에서 실행할 때 이 값을 설정하면, 프록시 주소 대신 `X-Forwarded-For`에 담긴 실제 클라이언트 IP를 사용합니다. 비어 있으면 전달 헤더를 파싱하지 않습니다. |
 | `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Done 빌드 파일·레코드 자동 삭제 기간(일). 로컬 테스트 시 `0.001` 등 작은 값으로 즉시 확인 가능. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | 브라우저 소켓당 바이너리 프레임 드롭 임계값. 버퍼가 이 값을 초과하면 프레임이 드롭됩니다. |
+| `TAPFLOW_CLOUDFLARE_TOKEN` | — | *(비어있음)* | `tls.dnsProvider`가 `cloudflare`일 때 DNS-01 발급에 쓰는 Cloudflare API 토큰. |
+| `TAPFLOW_VERCEL_TOKEN` | — | *(비어있음)* | `tls.dnsProvider`가 `vercel`일 때 쓰는 Vercel API 토큰. |
+| `TAPFLOW_VERCEL_TEAM_ID` | — | *(비어있음)* | 도메인이 팀 스코프에 속할 때 필요한 Vercel 팀 ID. |
+| `TAPFLOW_ACME_EMAIL` | — | *(비어있음)* | Let's Encrypt 계정 연락 이메일(선택). |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP 호스트 |
 | `SMTP_PORT` | `smtp.port` | `587` | SMTP 포트 |
 | `SMTP_SECURE` | `smtp.secure` | `false` | TLS 사용 여부 (`true` 문자열로 설정) |
@@ -66,6 +71,65 @@ openssl rand -hex 32
 릴레이를 같은 호스트의 리버스 프록시(nginx, Caddy) 뒤에서 운영하면서 `TAPFLOW_TRUSTED_PROXIES`를 비워 두면, 프록시의 loopback 주소 때문에 **모든 원격 클라이언트가 localhost로 취급**됩니다. localhost는 무인증이므로 외부에 그대로 노출됩니다. 프록시 주소(예: `127.0.0.1,::1`)를 `TAPFLOW_TRUSTED_PROXIES`에 설정하고, 프록시가 `X-Forwarded-For`를 전달하도록 구성하세요.
 
 프록시나 터널로 노출하는 경우 공개 URL(`tunnel.publicUrl` 또는 `relay.url`)도 함께 설정하세요. 설정하지 않으면 CORS/CSRF 허용 목록이 loopback만 남아, 대시보드의 cross-origin 요청이 차단될 수 있습니다.
+:::
+
+## HTTPS (보안 컨텍스트)
+
+브라우저의 하드웨어 가속 영상 디코드(WebCodecs)는 보안 컨텍스트(HTTPS)에서만 동작합니다. HTTP로 접속하면 소프트웨어 디코드로 자동 폴백합니다. 같은 LAN의 팀원에게 더 부드러운 화면을 주려면 relay를 HTTPS로 종단하세요. `tls`를 설정하면 relay가 같은 포트에서 HTTPS와 WSS를 함께 종단합니다.
+
+발급 방식은 두 가지입니다.
+
+### 자기 DNS 계정으로 자동 발급 (`byo-api-token`)
+
+자기 도메인과 DNS 업체 API 토큰만 있으면 relay가 Let's Encrypt에서 DNS-01 방식으로 인증서를 자동 발급하고 갱신합니다.
+
+```json
+{
+  "local": { "port": 4000 },
+  "tls": {
+    "mode": "byo-api-token",
+    "domain": "tap.yourcompany.com",
+    "dnsProvider": "cloudflare"
+  }
+}
+```
+
+| 키 | 설명 |
+|----|------|
+| `tls.mode` | `byo-api-token`(Let's Encrypt DNS-01 자동 발급) 또는 `import-cert`(직접 준비한 파일). |
+| `tls.domain` | 인증서를 발급할 도메인. 팀원은 `https://[도메인]:[포트]`로 접속합니다. |
+| `tls.dnsProvider` | `cloudflare` 또는 `vercel`. 해당 업체 API 토큰은 환경변수에서 읽습니다. |
+| `tls.publishAddress` | 도메인 A 레코드를 이 머신의 LAN IP로 자동 발행합니다. 기본 `true`이며, DNS를 직접 관리하려면 `false`로 둡니다. |
+| `tls.address` | 자동 감지한 LAN IP 대신 사용할 IP. 멀티 NIC나 VPN 환경에서 오버라이드용입니다. |
+
+API 토큰은 설정 파일이 아니라 환경변수로 전달합니다. Cloudflare는 `TAPFLOW_CLOUDFLARE_TOKEN`, Vercel은 `TAPFLOW_VERCEL_TOKEN`을 씁니다. 팀 도메인이면 `TAPFLOW_VERCEL_TEAM_ID`도 함께 설정합니다.
+
+`publishAddress`가 켜져 있으면 relay가 부팅할 때 자기 LAN IP를 도메인 A 레코드로 발행하고 주기적으로 갱신합니다. 팀원은 DNS를 건드리지 않고 도메인만 열면 됩니다.
+
+### 직접 준비한 인증서 (`import-cert`)
+
+사내 PKI나 이미 보유한 와일드카드 인증서를 쓰려면 파일 경로를 지정합니다. 갱신은 직접 관리합니다.
+
+```json
+{
+  "tls": {
+    "mode": "import-cert",
+    "certPath": "/path/to/fullchain.pem",
+    "keyPath": "/path/to/privkey.pem"
+  }
+}
+```
+
+| 키 | 설명 |
+|----|------|
+| `tls.certPath` | fullchain 인증서 PEM 경로. |
+| `tls.keyPath` | 개인 키 PEM 경로. |
+
+::: tip 접속과 알려진 제약
+- 인증서는 도메인에 묶입니다. 따라서 `https://[도메인]:[포트]`로 접속해야 합니다. `localhost`나 IP로 접속하면 이름 불일치 경고가 납니다.
+- 일부 공유기는 공개 도메인이 사설 IP를 가리키는 응답을 차단합니다(DNS rebinding). 이 경우 공유기에 예외를 등록하거나 로컬 DNS로 도메인을 LAN IP에 매핑하세요.
+- WiFi 기기 격리(client isolation)가 켜진 망에서는 기기 간 통신이 막혀 LAN 접속 자체가 불가능합니다. 일반 가정·사무실 LAN을 사용하세요.
+- 테스트로 스테이징 인증서(`TAPFLOW_ACME_STAGING=1`)를 발급하면 브라우저가 신뢰하지 않아 경고가 납니다. 같은 도메인을 스테이징에서 운영용으로 바꾼 직후에는 브라우저가 이전 인증서 오류를 캐시할 수 있습니다. 이때는 시크릿 창이나 기록 삭제로 다시 확인하세요.
 :::
 
 ## 데이터 디렉토리

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -27,6 +27,7 @@ The relay reads `tapflow.config.json` from the directory where it is started. Ge
 |-----|-------------|
 | `local` | Settings for the relay server running on this machine. |
 | `relay.url` | URL of the relay to connect to. Used by `tapflow agent start`, `tapflow admin init`, `tapflow status`, and `tapflow logs` as the default — no `--relay` flag needed when this is set. Leave empty for local mode (`ws://localhost:[local.port]`). |
+| `tls` | LAN HTTPS (secure context) settings, required for WebCodecs hardware decode. See the HTTPS section below. |
 | `smtp` | SMTP settings for sending invitation and password reset emails. |
 
 `smtp.from` defaults to `tapflow <smtp.user>` when `smtp.user` is set. Override it explicitly if you need a different sender address.
@@ -45,6 +46,10 @@ Environment variables always take precedence over the config file — useful for
 | `TAPFLOW_TRUSTED_PROXIES` | — | *(empty)* | Comma-separated IPs of trusted reverse proxies (e.g. `127.0.0.1,::1`). Set this when the relay runs behind a same-host reverse proxy so it reads the real client IP from `X-Forwarded-For` instead of the proxy's address. Empty disables forwarded-header parsing. |
 | `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Days before a Done build's files and record are automatically deleted. Set to a small value (e.g. `0.001`) to verify cleanup quickly in local testing. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | Binary frame drop threshold per browser socket. Frames are silently dropped when the socket buffer exceeds this value. |
+| `TAPFLOW_CLOUDFLARE_TOKEN` | — | *(empty)* | Cloudflare API token for DNS-01 issuance when `tls.dnsProvider` is `cloudflare`. |
+| `TAPFLOW_VERCEL_TOKEN` | — | *(empty)* | Vercel API token for DNS-01 issuance when `tls.dnsProvider` is `vercel`. |
+| `TAPFLOW_VERCEL_TEAM_ID` | — | *(empty)* | Vercel team ID, required when the domain belongs to a team scope. |
+| `TAPFLOW_ACME_EMAIL` | — | *(empty)* | Optional contact email for the Let's Encrypt account. |
 | `SMTP_HOST` | `smtp.host` | `` | SMTP host |
 | `SMTP_PORT` | `smtp.port` | `587` | SMTP port |
 | `SMTP_SECURE` | `smtp.secure` | `false` | Enable TLS (set to string `"true"`) |
@@ -64,6 +69,65 @@ openssl rand -hex 32
 If the relay runs behind a same-host reverse proxy (nginx, Caddy) and `TAPFLOW_TRUSTED_PROXIES` is left unset, the proxy's loopback address makes **every remote client look like localhost** — and localhost is unauthenticated. Set `TAPFLOW_TRUSTED_PROXIES` to the proxy's address (e.g. `127.0.0.1,::1`) and configure the proxy to forward `X-Forwarded-For`.
 
 For proxied or tunneled deployments, also set a public URL (`tunnel.publicUrl` or `relay.url`). Otherwise the CORS/CSRF allowlist is loopback-only and the dashboard's cross-origin requests can be blocked.
+:::
+
+## HTTPS (secure context)
+
+Hardware-accelerated video decode (WebCodecs) only runs in a secure context (HTTPS). Over HTTP the dashboard falls back to software decode, so to give teammates on the LAN a smoother stream, terminate the relay over HTTPS. With `tls` set, the relay terminates HTTPS and WSS on the same port.
+
+There are two issuance modes.
+
+### Auto-issue with your own DNS account (`byo-api-token`)
+
+With your own domain and a DNS provider API token, the relay auto-issues and renews a Let's Encrypt certificate over DNS-01.
+
+```json
+{
+  "local": { "port": 4000 },
+  "tls": {
+    "mode": "byo-api-token",
+    "domain": "tap.yourcompany.com",
+    "dnsProvider": "cloudflare"
+  }
+}
+```
+
+| Key | Description |
+|-----|-------------|
+| `tls.mode` | `byo-api-token` (auto-issue via Let's Encrypt DNS-01) or `import-cert` (your own files). |
+| `tls.domain` | Domain the certificate is issued for. Teammates open `https://[domain]:[port]`. |
+| `tls.dnsProvider` | `cloudflare` or `vercel`. The matching API token is read from the environment. |
+| `tls.publishAddress` | Auto-publish the domain's A record to this machine's LAN IP. Default `true`; set `false` to manage DNS yourself. |
+| `tls.address` | IP to use instead of the auto-detected LAN IP, for multi-NIC or VPN overrides. |
+
+API tokens are passed via environment variables, not the config file. Cloudflare uses `TAPFLOW_CLOUDFLARE_TOKEN` and Vercel uses `TAPFLOW_VERCEL_TOKEN`, plus `TAPFLOW_VERCEL_TEAM_ID` for a team domain.
+
+When `publishAddress` is on, the relay publishes its LAN IP to the domain's A record on boot and refreshes it periodically, so teammates just open the domain without touching DNS.
+
+### Bring your own certificate (`import-cert`)
+
+To use an internal PKI or a wildcard certificate you already hold, point to the files. You manage renewal yourself.
+
+```json
+{
+  "tls": {
+    "mode": "import-cert",
+    "certPath": "/path/to/fullchain.pem",
+    "keyPath": "/path/to/privkey.pem"
+  }
+}
+```
+
+| Key | Description |
+|-----|-------------|
+| `tls.certPath` | Path to the fullchain certificate PEM. |
+| `tls.keyPath` | Path to the private key PEM. |
+
+::: tip Access and known limits
+- The certificate is bound to the domain, so open `https://[domain]:[port]`. Connecting via `localhost` or an IP raises a name-mismatch warning.
+- Some routers block responses where a public domain points to a private IP (DNS rebinding). Add a router exception, or map the domain to the LAN IP via local DNS.
+- On networks with WiFi client isolation, device-to-device traffic is blocked and LAN access is impossible. Use a normal home or office LAN.
+- A staging certificate (`TAPFLOW_ACME_STAGING=1`) is untrusted, so browsers warn. Right after switching the same domain from staging to production, the browser may cache the old certificate error — re-check in a private window or after clearing history.
 :::
 
 ## Data directory


### PR DESCRIPTION
`configuration.md` had no coverage of the `tls` block. Add it (KO source + EN mirror).

## What's added (KO + EN `reference/configuration.md`)
- `tls` row in the config key table.
- New **HTTPS (secure context)** section: why it's needed (WebCodecs needs a secure context), the two modes — `byo-api-token` (auto-issue via Let's Encrypt DNS-01) and `import-cert` — with per-key tables and JSON examples.
- Credential env vars: `TAPFLOW_CLOUDFLARE_TOKEN`, `TAPFLOW_VERCEL_TOKEN`, `TAPFLOW_VERCEL_TEAM_ID`, `TAPFLOW_ACME_EMAIL`.
- A tip covering access-by-domain (cert is bound to the domain, include the port) and the known LAN limits: DNS rebinding, WiFi client isolation, and the staging→production browser-cert caching gotcha — all observed during real-environment validation.

## Conventions followed
- KO-first, EN mirror with matching structure (per `docs/AGENTS.md`).
- No `<placeholder>` inside sh/bash blocks; no `---` between sections; platform-neutral wording.
- Ran the `/ai-tells detect` gate on both languages — KO and EN both clean.

> Uses the `TAPFLOW_`-prefixed credential env var names from #285. Merge that first (or together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)