### PR TITLE
feat(dashboard): surface Standard vs High performance + upgrade notice (#232)

### DIFF
--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ScanLine } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Separator } from '@/components/ui/separator';
 import { performanceMode } from '@/lib/decoders/pickDecoder';
 import { PerformanceModeNotice, shouldAutoShowPerfNotice, PERF_NOTICE_KEY } from '@/components/perf/PerformanceModeNotice';
 
@@ -67,28 +68,30 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
 
       {joined && (
         <div className="flex items-center" style={{ gap: 6 }}>
-          {/* Fixed width so the mode label after it doesn't shift as fps / Active·Idle change. */}
-          <span className="flex items-center shrink-0 w-[104px]" style={{ gap: 6 }}>
-            <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
-            <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
-            <span className="text-[12px] text-muted-foreground">fps</span>
-            {stateLabel && (
-              <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
-                · {stateLabel}
-              </span>
-            )}
-          </span>
-          {modeLabel && (mode === 'standard' ? (
-            <button
-              type="button"
-              onClick={() => setNoticeOpen(true)}
-              className="text-[11px] text-foreground/70 hover:text-foreground underline-offset-2 hover:underline"
-            >
-              · {modeLabel}
-            </button>
-          ) : (
-            <span className="text-[11px] text-muted-foreground">· {modeLabel}</span>
-          ))}
+          <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
+          <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
+          <span className="text-[12px] text-muted-foreground">fps</span>
+          {stateLabel && (
+            <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
+              · {stateLabel}
+            </span>
+          )}
+          {modeLabel && (
+            <>
+              <Separator orientation="vertical" className="h-3" />
+              {mode === 'standard' ? (
+                <button
+                  type="button"
+                  onClick={() => setNoticeOpen(true)}
+                  className="text-[11px] text-foreground/70 hover:text-foreground underline-offset-2 hover:underline"
+                >
+                  {modeLabel}
+                </button>
+              ) : (
+                <span className="text-[11px] text-muted-foreground">{modeLabel}</span>
+              )}
+            </>
+          )}
         </div>
       )}
 

--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ScanLine } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { performanceMode } from '@/lib/decoders/pickDecoder';
+import { PerformanceModeNotice, shouldAutoShowPerfNotice, PERF_NOTICE_KEY } from '@/components/perf/PerformanceModeNotice';
 
 // init wizard와 같은 프로파일 용어로 — 디코더 jargon(WebCodecs/WASM) 대신.
 const MODE_LABEL: Record<string, string | null> = {
@@ -44,7 +45,18 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
   const dotColor = isActive ? '#10b981' : isIdle ? '#94a3b8' : 'transparent';
   const stateLabel = isActive ? 'Active' : isIdle ? 'Idle' : null;
   // Decode path is a stable per-browser capability; compute once, not per device card.
-  const modeLabel = useMemo(() => MODE_LABEL[performanceMode()], []);
+  const mode = useMemo(() => performanceMode(), []);
+  const modeLabel = MODE_LABEL[mode];
+  const [noticeOpen, setNoticeOpen] = useState(false);
+  useEffect(() => {
+    let dismissed = false;
+    try { dismissed = localStorage.getItem(PERF_NOTICE_KEY) === '1'; } catch { /* no storage */ }
+    if (shouldAutoShowPerfNotice(mode, dismissed)) setNoticeOpen(true);
+  }, [mode]);
+  const handleNoticeOpenChange = (next: boolean) => {
+    setNoticeOpen(next);
+    if (!next) { try { localStorage.setItem(PERF_NOTICE_KEY, '1'); } catch { /* no storage */ } }
+  };
 
   return (
     <div className="w-[300px] shrink-0 mt-3 rounded-xl border bg-background px-4 py-4 flex flex-col gap-3">
@@ -66,15 +78,25 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
               </span>
             )}
           </span>
-          {modeLabel && (
+          {modeLabel && (mode === 'standard' ? (
+            <button
+              type="button"
+              onClick={() => setNoticeOpen(true)}
+              className="text-[11px] text-foreground/70 hover:text-foreground underline-offset-2 hover:underline"
+            >
+              · {modeLabel}
+            </button>
+          ) : (
             <span className="text-[11px] text-muted-foreground">· {modeLabel}</span>
-          )}
+          ))}
         </div>
       )}
 
       {statusText && (
         <p className="text-[12px] text-muted-foreground leading-relaxed break-all">{statusText}</p>
       )}
+
+      <PerformanceModeNotice open={noticeOpen} onOpenChange={handleNoticeOpenChange} />
     </div>
   );
 }

--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -1,7 +1,16 @@
 'use client';
 
+import { useMemo } from 'react';
 import { ScanLine } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { performanceMode } from '@/lib/decoders/pickDecoder';
+
+// init wizard와 같은 프로파일 용어로 — 디코더 jargon(WebCodecs/WASM) 대신.
+const MODE_LABEL: Record<string, string | null> = {
+  high: 'High performance',
+  standard: 'Standard',
+  unsupported: null,
+};
 
 interface SimulatorInfoCardProps {
   joined: boolean;
@@ -34,6 +43,8 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
   const isIdle = fps > 0 && fps <= 15;
   const dotColor = isActive ? '#10b981' : isIdle ? '#94a3b8' : 'transparent';
   const stateLabel = isActive ? 'Active' : isIdle ? 'Idle' : null;
+  // Decode path is a stable per-browser capability; compute once, not per device card.
+  const modeLabel = useMemo(() => MODE_LABEL[performanceMode()], []);
 
   return (
     <div className="w-[300px] shrink-0 mt-3 rounded-xl border bg-background px-4 py-4 flex flex-col gap-3">
@@ -42,15 +53,21 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
         <span className="text-[12px] font-medium">Focus</span>
       </div>
 
-      {joined && fps > 0 && (
+      {joined && (
         <div className="flex items-center" style={{ gap: 6 }}>
-          <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
-          <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
-          <span className="text-[12px] text-muted-foreground">fps</span>
-          {stateLabel && (
-            <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
-              · {stateLabel}
-            </span>
+          {/* Fixed width so the mode label after it doesn't shift as fps / Active·Idle change. */}
+          <span className="flex items-center shrink-0 w-[104px]" style={{ gap: 6 }}>
+            <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
+            <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
+            <span className="text-[12px] text-muted-foreground">fps</span>
+            {stateLabel && (
+              <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
+                · {stateLabel}
+              </span>
+            )}
+          </span>
+          {modeLabel && (
+            <span className="text-[11px] text-muted-foreground">· {modeLabel}</span>
           )}
         </div>
       )}

--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -78,7 +78,7 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
           )}
           {modeLabel && (
             <>
-              <Separator orientation="vertical" className="h-3" />
+              <Separator orientation="vertical" className="h-3 mx-1.5" />
               {mode === 'standard' ? (
                 <button
                   type="button"

--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -5,7 +5,11 @@ import { ScanLine } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
 import { performanceMode } from '@/lib/decoders/pickDecoder';
-import { PerformanceModeNotice, shouldAutoShowPerfNotice, PERF_NOTICE_KEY } from '@/components/perf/PerformanceModeNotice';
+import {
+  PerformanceModeNotice,
+  shouldAutoShowPerfNotice,
+  PERF_NOTICE_KEY,
+} from '@/components/perf/PerformanceModeNotice';
 
 // init wizard와 같은 프로파일 용어로 — 디코더 jargon(WebCodecs/WASM) 대신.
 const MODE_LABEL: Record<string, string | null> = {
@@ -29,7 +33,8 @@ function getStatusText(props: SimulatorInfoCardProps): string | null {
   const { connected, joined, bootError, deviceReady, installing, installError } = props;
   if (!connected) return 'Connecting…';
   if (!joined) return 'Joining session…';
-  if (bootError) return `Boot failed: ${bootError.length > 40 ? bootError.slice(0, 40) + '…' : bootError}`;
+  if (bootError)
+    return `Boot failed: ${bootError.length > 40 ? bootError.slice(0, 40) + '…' : bootError}`;
   if (!deviceReady) return 'Starting device…';
   if (installing) return 'Installing app…';
   if (installError) return `Install failed: ${installError}`;
@@ -51,34 +56,58 @@ export function SimulatorInfoCard(props: SimulatorInfoCardProps) {
   const [noticeOpen, setNoticeOpen] = useState(false);
   useEffect(() => {
     let dismissed = false;
-    try { dismissed = localStorage.getItem(PERF_NOTICE_KEY) === '1'; } catch { /* no storage */ }
+    try {
+      dismissed = localStorage.getItem(PERF_NOTICE_KEY) === '1';
+    } catch {
+      /* no storage */
+    }
     if (shouldAutoShowPerfNotice(mode, dismissed)) setNoticeOpen(true);
   }, [mode]);
   const handleNoticeOpenChange = (next: boolean) => {
     setNoticeOpen(next);
-    if (!next) { try { localStorage.setItem(PERF_NOTICE_KEY, '1'); } catch { /* no storage */ } }
+    if (!next) {
+      try {
+        localStorage.setItem(PERF_NOTICE_KEY, '1');
+      } catch {
+        /* no storage */
+      }
+    }
   };
 
   return (
     <div className="w-[300px] shrink-0 mt-3 rounded-xl border bg-background px-4 py-4 flex flex-col gap-3">
-      <div className={cn('flex items-center', keyboardActive ? 'text-emerald-500' : 'text-muted-foreground')} style={{ gap: 6 }}>
+      <div
+        className={cn(
+          'flex items-center',
+          keyboardActive ? 'text-emerald-500' : 'text-muted-foreground',
+        )}
+        style={{ gap: 6 }}
+      >
         <ScanLine className="h-3.5 w-3.5 shrink-0" />
         <span className="text-[12px] font-medium">Focus</span>
       </div>
 
       {joined && (
-        <div className="flex items-center" style={{ gap: 6 }}>
-          <span className="h-2 w-2 rounded-full shrink-0" style={{ background: dotColor }} />
-          <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
-          <span className="text-[12px] text-muted-foreground">fps</span>
-          {stateLabel && (
-            <span className={cn('text-[11px]', isActive ? 'text-emerald-500' : 'text-muted-foreground/60')}>
-              · {stateLabel}
-            </span>
-          )}
+        <div className="flex items-center gap-[12px]">
+          <div className="flex items-center gap-[4px]">
+            <span className="h-2 w-2 rounded-full shrink-0 mr-1" style={{ background: dotColor }} />
+            <span className="text-[12px] font-mono text-foreground/75">{fps}</span>
+            <span className="text-[12px] text-muted-foreground">fps</span>
+            {stateLabel && <span className="text-[11px] text-muted-foreground/60">·</span>}
+            {stateLabel && (
+              <span
+                className={cn(
+                  'text-[11px]',
+                  isActive ? 'text-emerald-500' : 'text-muted-foreground/60',
+                )}
+              >
+                {stateLabel}
+              </span>
+            )}
+          </div>
           {modeLabel && (
             <>
-              <Separator orientation="vertical" className="h-3 mx-1.5" />
+              <Separator orientation="vertical" className="h-3" />
               {mode === 'standard' ? (
                 <button
                   type="button"

--- a/packages/dashboard/components/perf/PerformanceModeNotice.tsx
+++ b/packages/dashboard/components/perf/PerformanceModeNotice.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { PerformanceMode } from '@/lib/decoders/pickDecoder';
+
+export const PERF_NOTICE_KEY = 'tapflow.perfModeNoticeDismissed';
+const DOCS_HTTPS_URL = 'https://www.tapflow.dev/reference/configuration#https-secure-context';
+
+// Auto-show only in Standard mode and only if not dismissed before (once per browser).
+export function shouldAutoShowPerfNotice(mode: PerformanceMode, dismissed: boolean): boolean {
+  return mode === 'standard' && !dismissed;
+}
+
+export function PerformanceModeNotice({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>Streaming in Standard mode</DialogTitle>
+          <DialogDescription className="space-y-3 pt-1">
+            <span className="block">
+              This screen is running in Standard mode. For a faster, smoother picture, switch to High performance.
+            </span>
+            <span className="block">
+              High performance needs the relay served over HTTPS. If you didn&apos;t set up tapflow, ask whoever did.
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => window.open(DOCS_HTTPS_URL, '_blank', 'noopener,noreferrer')}>
+            How to enable
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>Got it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard/lib/decoders/pickDecoder.ts
+++ b/packages/dashboard/lib/decoders/pickDecoder.ts
@@ -58,3 +58,19 @@ export function pickDecoder(caps: DecoderCapabilities = detectCapabilities()): D
 export function canDecodeH264(caps: DecoderCapabilities = detectCapabilities()): boolean {
   return (caps.secureContext && caps.webCodecs && caps.webgl2) || (caps.wasm && caps.webgl2)
 }
+
+export type PerformanceMode = 'high' | 'standard' | 'unsupported'
+
+/**
+ * Maps the active decode path to the init wizard's performance profile labels, so the UI can show
+ * the same wording (Standard / High performance) instead of decoder jargon. Same branch as
+ * pickDecoder, evaluated without constructing a decoder:
+ * - 'high' — WebCodecs (secure context): hardware decode.
+ * - 'standard' — WASM (tinyh264): software decode on plain HTTP.
+ * - 'unsupported' — neither (WebGL2 missing).
+ */
+export function performanceMode(caps: DecoderCapabilities = detectCapabilities()): PerformanceMode {
+  if (caps.secureContext && caps.webCodecs && caps.webgl2) return 'high'
+  if (caps.wasm && caps.webgl2) return 'standard'
+  return 'unsupported'
+}

--- a/packages/dashboard/src/__tests__/performanceModeNotice.test.ts
+++ b/packages/dashboard/src/__tests__/performanceModeNotice.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { shouldAutoShowPerfNotice } from '@/components/perf/PerformanceModeNotice'
+
+describe('shouldAutoShowPerfNotice — 자동 1회 노출 정책', () => {
+  it('standard + 미해제 → true', () => {
+    expect(shouldAutoShowPerfNotice('standard', false)).toBe(true)
+  })
+
+  it('standard + 이미 해제 → false (브라우저당 1회)', () => {
+    expect(shouldAutoShowPerfNotice('standard', true)).toBe(false)
+  })
+
+  it('high(이미 하드웨어 디코드)는 자동 안 뜸', () => {
+    expect(shouldAutoShowPerfNotice('high', false)).toBe(false)
+  })
+
+  it('unsupported(디코드 불가)는 자동 안 뜸 — 성능 안내 대상 아님', () => {
+    expect(shouldAutoShowPerfNotice('unsupported', false)).toBe(false)
+  })
+})

--- a/packages/dashboard/src/__tests__/pickDecoder.test.ts
+++ b/packages/dashboard/src/__tests__/pickDecoder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
-import { pickDecoder, canDecodeH264, detectCapabilities, type DecoderCapabilities } from '@/lib/decoders/pickDecoder'
+import { pickDecoder, canDecodeH264, detectCapabilities, performanceMode, type DecoderCapabilities } from '@/lib/decoders/pickDecoder'
 import { WebCodecsDecoder } from '@/lib/decoders/WebCodecsDecoder'
 import { WASMDecoder } from '@/lib/decoders/WASMDecoder'
 
@@ -80,6 +80,33 @@ describe('canDecodeH264 — boot acceptH264 판정 (pickDecoder와 동일 조건
 
   it('아무 것도 불가 → false', () => {
     expect(canDecodeH264(caps())).toBe(false)
+  })
+})
+
+// ── performanceMode (pickDecoder와 동일 분기를 UI 라벨 키로) ─────────────────────────
+describe('performanceMode — 디코드 경로를 init 프로파일 키로 매핑', () => {
+  it('secure + WebCodecs + WebGL2 → high (WebCodecs)', () => {
+    expect(performanceMode(caps({ secureContext: true, webCodecs: true, webgl2: true }))).toBe('high')
+  })
+
+  it('WebCodecs·WASM 모두 가능하면 high 우선', () => {
+    expect(performanceMode(caps({ secureContext: true, webCodecs: true, webgl2: true, wasm: true }))).toBe('high')
+  })
+
+  it('비-secure + wasm + WebGL2 → standard (WASM)', () => {
+    expect(performanceMode(caps({ wasm: true, webgl2: true }))).toBe('standard')
+  })
+
+  it('secure지만 WebCodecs 미지원 → standard', () => {
+    expect(performanceMode(caps({ secureContext: true, webCodecs: false, wasm: true, webgl2: true }))).toBe('standard')
+  })
+
+  it('WebGL2 없으면 unsupported', () => {
+    expect(performanceMode(caps({ secureContext: true, webCodecs: true, wasm: true, webgl2: false }))).toBe('unsupported')
+  })
+
+  it('아무 것도 불가 → unsupported', () => {
+    expect(performanceMode(caps())).toBe('unsupported')
   })
 })
 


### PR DESCRIPTION
The HTTP→software-decode downgrade was invisible: a viewer on a non-HTTPS relay silently got software decode with no signal. This surfaces the current decode path in the team's own (non-developer) language and nudges toward the faster path.

## What
- **`performanceMode()`** (`lib/decoders/pickDecoder.ts`) — maps the active decode path to the init wizard's profile keys (`high` / `standard` / `unsupported`) using the same branch as `pickDecoder`, without constructing a decoder.
- **Session info strip** (`SimulatorInfoCard`) — appends `· Standard` / `· High performance` after `fps · Active|Idle`, using the wizard's wording (not WebCodecs/WASM jargon). The fps·state cluster is fixed-width so the label doesn't shift, and the row now renders whenever joined (fps defaults to 0 instead of the row vanishing).
- **Upgrade notice** (`PerformanceModeNotice`) — a modal explaining Standard mode and how to enable High performance (HTTPS), with a docs link. Auto-opens **once per browser** in Standard mode; reopenable anytime by clicking the Standard label.

## Why this scope
This covers the "silent degradation" case — the highest-value, evidence-backed fallback (it only reads `detectCapabilities()`, no QA matrix needed). Browser-level blocks (cert warnings, connection refused) can't be shown by dashboard JS at all and are handled by the relay startup banner + docs.

## Design
- Monochrome per `DESIGN.md` — no accent color; the nudge is the click + one-time modal, not color.
- Mode is a stable per-browser capability, computed once via `useMemo`.

## Test plan
- `performanceMode` (6) and `shouldAutoShowPerfNotice` (4) unit tests; full dashboard suite 190 green; typecheck/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added performance mode detection to the device simulator card with clearer Standard/High/Unsupported labeling.
  * Introduced a dismissible Standard-mode warning dialog with “How to enable” and “Got it,” auto-shown once per browser.

* **Bug Fixes / Behavior Updates**
  * Updated the FPS/status section to show whenever the device is joined.
  * Improved status text formatting for boot error cases.

* **Tests**
  * Added unit tests for the one-time auto-show logic and performance mode capability mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->