### PR TITLE
fix(relay): exempt loopback origins from the CSRF guard

### DIFF
--- a/packages/relay/src/__tests__/csrf.test.ts
+++ b/packages/relay/src/__tests__/csrf.test.ts
@@ -16,6 +16,16 @@ describe('isCsrfBlocked', () => {
     expect(isCsrfBlocked('POST', { cookie, origin: 'http://192.168.0.9:4000', host: '192.168.0.9:4000' }, allowed)).toBe(false)
   })
 
+  it('loopback origin은 Host가 달라도 통과 (Vite dev proxy :3001 → relay :4000)', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'http://localhost:3001', host: 'localhost:4000' }, allowed)).toBe(false)
+    expect(isCsrfBlocked('POST', { cookie, origin: 'http://127.0.0.1:5173', host: 'localhost:4000' }, allowed)).toBe(false)
+    expect(isCsrfBlocked('POST', { cookie, origin: 'http://[::1]:3001', host: 'localhost:4000' }, allowed)).toBe(false)
+  })
+
+  it('loopback 예외가 원격 공격 origin을 풀어주지 않는다 (Origin은 위조 불가)', () => {
+    expect(isCsrfBlocked('POST', { cookie, origin: 'https://evil.com', host: 'localhost:4000' }, allowed)).toBe(true)
+  })
+
   it('쿠키 + 상태변경 + cross-origin → 차단', () => {
     expect(isCsrfBlocked('POST', { cookie, origin: 'https://evil.com', host: '192.168.0.9:4000' }, allowed)).toBe(true)
     expect(isCsrfBlocked('PATCH', { cookie, origin: 'https://evil.com', host: 'x:4000' }, allowed)).toBe(true)

--- a/packages/relay/src/lib/csrf.ts
+++ b/packages/relay/src/lib/csrf.ts
@@ -9,6 +9,13 @@ import type http from 'http'
 //       쿠키 없는 요청(미인증/login/init), Origin 없는 요청(비-브라우저; 브라우저는 cross-site에 Origin을 생략하지 못한다).
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
+// Loopback origins are the local dev machine (e.g. Vite :3001 proxying to the relay :4000), never a
+// remote attacker — a cross-site page can't forge a localhost Origin, so exempting these is safe.
+function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, '')
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1'
+}
+
 export function isCsrfBlocked(
   method: string | undefined,
   headers: http.IncomingHttpHeaders,
@@ -26,7 +33,9 @@ export function isCsrfBlocked(
 
   const host = headers['host']
   try {
-    if (host && new URL(origin).host === host) return false
+    const url = new URL(origin)
+    if (host && url.host === host) return false
+    if (isLoopbackHost(url.hostname)) return false
   } catch {
     // malformed Origin → treat as cross-origin (blocked below)
   }


### PR DESCRIPTION
## Symptom
Creating a build comment in the Vite dev workflow returned `403 (Forbidden)`:
`POST http://localhost:3001/api/v1/comments` → "Cross-origin state-changing request blocked (CSRF protection)".

## Cause
The CSRF guard allows a cookie-authed POST only when the Origin is same-origin (`Origin.host === Host`) or in the trusted allowlist. In dev the browser runs on `localhost:3001` (Vite) and proxies to the relay on `:4000`, so the relay sees **Origin `localhost:3001` vs Host `localhost:4000`** — host mismatch, not in the allowlist → blocked. (Not caused by the recent allowlist wiring; `:3001` is in neither the old nor new allowlist — it stems from the CSRF hardening not exempting loopback.)

## Fix
Exempt loopback origins (`localhost` / `127.0.0.1` / `::1`) in `isCsrfBlocked`.

Safe because **a remote cross-site page cannot forge a loopback Origin** (the browser sets Origin to the attacker's real domain), so the guard still blocks the remote-phishing threat it targets. Production is unaffected: the dashboard is served same-origin by the relay (`Origin === Host`).

## Test plan
- `csrf.test.ts`: loopback origins with a mismatched Host pass; a remote origin with a loopback Host is still blocked.
- relay 349 green; typecheck/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for loopback origin validation to ensure local connections are properly handled while blocking remote attacks.

* **Bug Fixes**
  * CSRF validation now safely permits requests from local loopback origins while maintaining protection against remote attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->