### PR TITLE
fix(dashboard): session panel width alignment, copy-link toast, recordings flicker

### DIFF
--- a/packages/dashboard/components/CommentPanel.tsx
+++ b/packages/dashboard/components/CommentPanel.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Link2, ImagePlus, ArrowUp } from 'lucide-react'
+import { toast } from 'sonner'
 import type { Comment } from '@/lib/types'
 import { UserAvatar } from '@/components/UserAvatar'
 
@@ -78,7 +79,9 @@ export function CommentPanel({ buildId }: Props) {
 
   function copyLink(id: number) {
     const url = `${location.origin}${location.pathname}${location.search}#comment-${id}`
-    navigator.clipboard.writeText(url).catch(() => {})
+    navigator.clipboard.writeText(url)
+      .then(() => toast.success('Link copied'))
+      .catch(() => toast.error('Could not copy link'))
   }
 
   function handleFileChange(f: File) {
@@ -104,7 +107,7 @@ export function CommentPanel({ buildId }: Props) {
   const groups = groupByDate(comments)
 
   return (
-    <div className="flex h-full flex-col gap-3">
+    <div className="flex h-full flex-col gap-3 px-1">
       <ScrollArea className="flex-1 rounded-md border">
         <div className="p-3">
           {comments.length === 0 ? (
@@ -165,7 +168,7 @@ export function CommentPanel({ buildId }: Props) {
         </div>
       </ScrollArea>
 
-      <div className="px-1 pb-1">
+      <div className="pb-1">
       <form onSubmit={handleSubmit}>
         <div className="rounded-xl border border-input bg-background ring-offset-background transition-shadow focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
           <Textarea

--- a/packages/dashboard/components/RecordingsList.tsx
+++ b/packages/dashboard/components/RecordingsList.tsx
@@ -36,20 +36,28 @@ function formatExpiry(iso: string): { label: string; urgent: boolean } {
 export function RecordingsList({ buildId, refreshKey }: Props) {
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [loading, setLoading] = useState(true);
+  // Only show the loading text if the fetch is slow — avoids a flash on fast (few-ms) loads.
+  const [showLoading, setShowLoading] = useState(false);
 
   useEffect(() => {
     setLoading(true);
+    setShowLoading(false);
+    const t = setTimeout(() => setShowLoading(true), 250);
     fetch(`/api/v1/recordings?buildId=${buildId}`, {
       credentials: 'include',
     })
       .then((r) => (r.ok ? r.json() : []))
       .then((data: Recording[]) => setRecordings(data))
       .catch(() => setRecordings([]))
-      .finally(() => setLoading(false));
+      .finally(() => {
+        clearTimeout(t);
+        setLoading(false);
+      });
+    return () => clearTimeout(t);
   }, [buildId, refreshKey]);
 
   if (loading) {
-    return <p className="text-xs text-muted-foreground">Loading recordings…</p>;
+    return showLoading ? <p className="text-xs text-muted-foreground">Loading recordings…</p> : null;
   }
 
   if (recordings.length === 0) {

--- a/packages/dashboard/components/SessionPanel.tsx
+++ b/packages/dashboard/components/SessionPanel.tsx
@@ -11,16 +11,19 @@ interface Props {
 export function SessionPanel({ buildId, recordingsRefreshKey = 0 }: Props) {
   return (
     <Tabs defaultValue="comments" className="flex h-full flex-col">
-      <TabsList className="w-full shrink-0">
-        <TabsTrigger value="comments" className="flex-1 gap-1.5">
-          <MessageSquare className="h-3.5 w-3.5" />
-          Comments
-        </TabsTrigger>
-        <TabsTrigger value="recordings" className="flex-1 gap-1.5">
-          <Film className="h-3.5 w-3.5" />
-          Recordings
-        </TabsTrigger>
-      </TabsList>
+      {/* px-1 matches the comment textarea inset so tabs, list, and textarea share one width. */}
+      <div className="shrink-0 px-1">
+        <TabsList className="w-full">
+          <TabsTrigger value="comments" className="flex-1 gap-1.5">
+            <MessageSquare className="h-3.5 w-3.5" />
+            Comments
+          </TabsTrigger>
+          <TabsTrigger value="recordings" className="flex-1 gap-1.5">
+            <Film className="h-3.5 w-3.5" />
+            Recordings
+          </TabsTrigger>
+        </TabsList>
+      </div>
 
       <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-hidden">
         <CommentPanel buildId={buildId} />


### PR DESCRIPTION
Three small UX fixes in the build session panel.

## 1. Align tabs / comment list / textarea to one width
The textarea sat narrower than the tabs and the comment list because its wrapper has a `px-1` inset so the focus ring (`ring-offset-2`) isn't clipped by the overflow-hidden tab content. Rather than widen the textarea (which would clip the ring), apply the same inset to the tabs (wrapped) and move the inset to the comment panel root so the list shares it. All three now share one width; the ring inset stays inside the clipping container, so ring behavior is unchanged.

## 2. Toast on comment link copy
Copying a comment's permalink was silent (errors were swallowed). Now shows `Link copied` (or an error toast) via the existing sonner toaster.

## 3. Recordings loading flicker
`RecordingsList` showed "Loading recordings…" immediately on mount, flashing for a few ms on fast loads. Now the text appears only after a 250ms threshold, so fast loads render straight to content.

## Test plan
- dashboard 190 green; typecheck/lint pass.
- (#1/#2 are layout/feedback; verified by typecheck + visual.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment links now display success or error toast notifications when copied to the clipboard, providing immediate user feedback for the action.

* **Bug Fixes**
  * Loading indicators are now delayed by 250ms to prevent unnecessary visual flashing when recordings are loaded quickly.

* **Style**
  * Dashboard panel spacing and padding have been refined for improved visual consistency and alignment across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->