### PR TITLE
perf(dashboard): route-level code splitting

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,14 +1,11 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, type ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster, type ToasterProps } from 'sonner'
 import { useTheme } from 'next-themes'
 import { DashboardLayout } from './layouts/DashboardLayout'
 import { Login } from './pages/Login'
 
-// Route-level code splitting: Login (first paint for signed-out users) and the
-// layout shell stay in the entry bundle; everything else loads on navigation.
-// QASession is split too — the chunk loads before the viewer mounts, so it
-// never touches the live stream frame path (the tinyh264 worker is its own chunk).
+// Lazy-load routes (Login + shell stay eager); QASession's chunk loads before its viewer, off the stream frame path.
 const Setup = lazy(() => import('./pages/Setup').then((m) => ({ default: m.Setup })))
 const Invite = lazy(() => import('./pages/Invite').then((m) => ({ default: m.Invite })))
 const ResetPassword = lazy(() => import('./pages/ResetPassword').then((m) => ({ default: m.ResetPassword })))
@@ -20,28 +17,31 @@ const TeamSettings = lazy(() => import('./pages/settings/Team').then((m) => ({ d
 const TokenSettings = lazy(() => import('./pages/settings/Tokens').then((m) => ({ default: m.TokenSettings })))
 const NotFound = lazy(() => import('./pages/NotFound').then((m) => ({ default: m.NotFound })))
 
+const pageFallback = <div className="flex h-screen w-full items-center justify-center text-sm text-muted-foreground">Loading…</div>
+// Shell-less public routes wrap their own Suspense; authed routes lean on the
+// layout's Outlet boundary so the sidebar/header stay mounted while loading.
+const suspended = (el: ReactNode) => <Suspense fallback={pageFallback}>{el}</Suspense>
+
 export function App() {
   const { resolvedTheme } = useTheme()
   return (
     <BrowserRouter>
-      <Suspense fallback={<div className="flex h-screen w-full items-center justify-center text-sm text-muted-foreground">Loading…</div>}>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/setup" element={<Setup />} />
-          <Route path="/invite" element={<Invite />} />
-          <Route path="/reset-password" element={<ResetPassword />} />
-          <Route element={<DashboardLayout />}>
-            <Route index element={<Navigate to="/app-center" replace />} />
-            <Route path="/app-center" element={<AppCenter />} />
-            <Route path="/app-center/build" element={<QASession />} />
-            <Route path="/mac-resources" element={<MacResources />} />
-            <Route path="/settings/default" element={<DefaultSettings />} />
-            <Route path="/settings/team" element={<TeamSettings />} />
-            <Route path="/settings/tokens" element={<TokenSettings />} />
-          </Route>
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Suspense>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/setup" element={suspended(<Setup />)} />
+        <Route path="/invite" element={suspended(<Invite />)} />
+        <Route path="/reset-password" element={suspended(<ResetPassword />)} />
+        <Route element={<DashboardLayout />}>
+          <Route index element={<Navigate to="/app-center" replace />} />
+          <Route path="/app-center" element={<AppCenter />} />
+          <Route path="/app-center/build" element={<QASession />} />
+          <Route path="/mac-resources" element={<MacResources />} />
+          <Route path="/settings/default" element={<DefaultSettings />} />
+          <Route path="/settings/team" element={<TeamSettings />} />
+          <Route path="/settings/tokens" element={<TokenSettings />} />
+        </Route>
+        <Route path="*" element={suspended(<NotFound />)} />
+      </Routes>
       <Toaster position="bottom-right" richColors theme={resolvedTheme as ToasterProps['theme']} />
     </BrowserRouter>
   )

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,39 +1,47 @@
+import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster, type ToasterProps } from 'sonner'
 import { useTheme } from 'next-themes'
 import { DashboardLayout } from './layouts/DashboardLayout'
 import { Login } from './pages/Login'
-import { Setup } from './pages/Setup'
-import { Invite } from './pages/Invite'
-import { ResetPassword } from './pages/ResetPassword'
-import { AppCenter } from './pages/AppCenter'
-import { QASession } from './pages/QASession'
-import { MacResources } from './pages/MacResources'
-import { DefaultSettings } from './pages/settings/Default'
-import { TeamSettings } from './pages/settings/Team'
-import { TokenSettings } from './pages/settings/Tokens'
-import { NotFound } from './pages/NotFound'
+
+// Route-level code splitting: Login (first paint for signed-out users) and the
+// layout shell stay in the entry bundle; everything else loads on navigation.
+// QASession is split too — the chunk loads before the viewer mounts, so it
+// never touches the live stream frame path (the tinyh264 worker is its own chunk).
+const Setup = lazy(() => import('./pages/Setup').then((m) => ({ default: m.Setup })))
+const Invite = lazy(() => import('./pages/Invite').then((m) => ({ default: m.Invite })))
+const ResetPassword = lazy(() => import('./pages/ResetPassword').then((m) => ({ default: m.ResetPassword })))
+const AppCenter = lazy(() => import('./pages/AppCenter').then((m) => ({ default: m.AppCenter })))
+const QASession = lazy(() => import('./pages/QASession').then((m) => ({ default: m.QASession })))
+const MacResources = lazy(() => import('./pages/MacResources').then((m) => ({ default: m.MacResources })))
+const DefaultSettings = lazy(() => import('./pages/settings/Default').then((m) => ({ default: m.DefaultSettings })))
+const TeamSettings = lazy(() => import('./pages/settings/Team').then((m) => ({ default: m.TeamSettings })))
+const TokenSettings = lazy(() => import('./pages/settings/Tokens').then((m) => ({ default: m.TokenSettings })))
+const NotFound = lazy(() => import('./pages/NotFound').then((m) => ({ default: m.NotFound })))
 
 export function App() {
   const { resolvedTheme } = useTheme()
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/setup" element={<Setup />} />
-        <Route path="/invite" element={<Invite />} />
-        <Route path="/reset-password" element={<ResetPassword />} />
-        <Route element={<DashboardLayout />}>
-          <Route index element={<Navigate to="/app-center" replace />} />
-          <Route path="/app-center" element={<AppCenter />} />
-          <Route path="/app-center/build" element={<QASession />} />
-          <Route path="/mac-resources" element={<MacResources />} />
-          <Route path="/settings/default" element={<DefaultSettings />} />
-          <Route path="/settings/team" element={<TeamSettings />} />
-          <Route path="/settings/tokens" element={<TokenSettings />} />
-        </Route>
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Suspense fallback={<div className="flex h-screen w-full items-center justify-center text-sm text-muted-foreground">Loading…</div>}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/setup" element={<Setup />} />
+          <Route path="/invite" element={<Invite />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
+          <Route element={<DashboardLayout />}>
+            <Route index element={<Navigate to="/app-center" replace />} />
+            <Route path="/app-center" element={<AppCenter />} />
+            <Route path="/app-center/build" element={<QASession />} />
+            <Route path="/mac-resources" element={<MacResources />} />
+            <Route path="/settings/default" element={<DefaultSettings />} />
+            <Route path="/settings/team" element={<TeamSettings />} />
+            <Route path="/settings/tokens" element={<TokenSettings />} />
+          </Route>
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
       <Toaster position="bottom-right" richColors theme={resolvedTheme as ToasterProps['theme']} />
     </BrowserRouter>
   )

--- a/packages/dashboard/src/layouts/DashboardLayout.tsx
+++ b/packages/dashboard/src/layouts/DashboardLayout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { Outlet, Navigate, useLocation } from 'react-router-dom'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/AppSidebar'
@@ -57,7 +58,10 @@ export function DashboardLayout() {
         <SidebarInset>
           <DashboardHeader />
           <main className="flex-1 min-h-0 overflow-auto">
-            <Outlet />
+            {/* Outlet-level Suspense so lazy page chunks load without unmounting the sidebar/header. */}
+            <Suspense fallback={<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">Loading…</div>}>
+              <Outlet />
+            </Suspense>
           </main>
         </SidebarInset>
       </SidebarProvider>


### PR DESCRIPTION
Every route was statically imported into a single bundle. This lazy-loads them so heavy pages load on navigation.

## Results
| | before (single) | after (split) |
|---|--:|--:|
| entry bundle | 1108 KB / gzip 324 KB | **525 KB / gzip 164 KB (−49%)** |

Now separate chunks, fetched only when visited:
- **MacResources** 402 KB (chart library)
- **QASession** 98 KB (stream viewer)
- AppCenter / Settings / Invite / Setup / ResetPassword / NotFound

(`Login` and the layout shell stay eager — Login is the signed-out first paint.)

## Stream path is untouched
QASession is split too, but that **does not touch the live frame pipeline**: the chunk loads once *before* the viewer mounts (then it's cached), and the tinyh264 worker was already its own chunk. So there's no per-frame cost — only a one-time chunk fetch on first entry (small under brotli, see #297).

## Notes
- 190 dashboard tests pass (no regressions)
- entry bundle is on main here, so MacResources still bundles recharts (402 KB). Once #296 (visx) lands, that chunk shrinks further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved navigation performance by lazy-loading most dashboard routes to reduce initial load time (while keeping the login flow immediately available).
  * Added consistent route-level loading UI using suspense boundaries, including within the main dashboard layout and the wildcard “Not Found” route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->