### PR TITLE
fix(dashboard): add @types/d3-array to fix release build

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -58,6 +58,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@tweakpane/core": "^2.0.5",
+    "@types/d3-array": "^3.2.2",
     "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@tweakpane/core':
         specifier: ^2.0.5
         version: 2.0.5
+      '@types/d3-array':
+        specifier: ^3.2.2
+        version: 3.2.2
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.41


### PR DESCRIPTION
## Problem

The `v0.9.0` release workflow failed at `pnpm build`:

```
src/pages/MacResources.tsx(16,26): error TS7016: Could not find a
declaration file for module 'd3-array'. ... implicitly has an 'any' type.
```

The visx migration imports `bisector` from `d3-array`, but `@types/d3-array` was never declared as a dependency. Under pnpm's strict `node_modules`, the dashboard's `tsc --noEmit` can't resolve the transitive types pulled in by visx, so the build fails in CI.

It slipped through because local `pnpm typecheck` (`-r --if-present`) skips the dashboard — it has no `typecheck` script, only `tsc` inside `build` — and `ci.yml` doesn't run the dashboard build.

## Fix

Add `@types/d3-array@^3.2.2` to the dashboard devDependencies.

## Verification

- `pnpm --filter @tapflowio/dashboard build` passes (the exact failing step).
- Full `pnpm build` passes (exit 0).
- dashboard is private + changeset-ignored, so no version impact.

## Follow-up (not in this PR)

`ci.yml` should run the dashboard build (or add a `typecheck` script) so this class of regression is caught on PRs, not at release time.

## Release recovery

`v0.9.0` was never published to npm (build failed before publish). After this merges, the `v0.9.0` tag will be moved to the fixed commit and re-pushed to re-trigger publishing — no version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to include TypeScript type definitions for enhanced tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->