### PR TITLE
ci: build all publishable packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: pnpm lint
 
       - run: pnpm --filter @tapflowio/agent-core build
+      - run: pnpm --filter @tapflowio/dashboard build
       - run: pnpm --filter @tapflowio/relay --filter @tapflowio/ios-agent --filter @tapflowio/android-agent build
 
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
       - run: pnpm --filter @tapflowio/agent-core build
       - run: pnpm --filter @tapflowio/dashboard build
       - run: pnpm --filter @tapflowio/relay --filter @tapflowio/ios-agent --filter @tapflowio/android-agent build
+      - run: pnpm --filter tapflow --filter @tapflowio/mcp-server build
 
       - run: pnpm test


### PR DESCRIPTION
## Why

The `v0.9.0` release build failed on a missing `@types/d3-array` (#302) that should have been caught on the PR. Root cause: CI only built `agent-core`, `relay`, `ios-agent`, and `android-agent`, so type/build errors in the other packages (dashboard, cli, mcp-server) only surfaced at release time. `pnpm typecheck` (`-r --if-present`) also skips packages whose `tsc` lives only in their `build` step.

## Change

Build every publishable package in CI — the full set the release workflow compiles — in the documented order:

```diff
       - run: pnpm --filter @tapflowio/agent-core build
+      - run: pnpm --filter @tapflowio/dashboard build
       - run: pnpm --filter @tapflowio/relay --filter @tapflowio/ios-agent --filter @tapflowio/android-agent build
+      - run: pnpm --filter tapflow --filter @tapflowio/mcp-server build
```

## Verification

Each added build (`dashboard`, `tapflow`, `mcp-server`) was run locally on current `main` and passes. CI on this PR exercises the new steps end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)