### PR TITLE
chore: release v0.9.1 — .env as the default path for all relay secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-18
+
+### Changed
+
+- relay: every secret can now live in `.tapflow-data/.env`, not just DNS/ACME tokens. The relay loads `.env` before reading its config, so `JWT_SECRET`, the SMTP password, and the tunnel token are picked up from there too. Precedence is shell env > `.env` > config file (a shell variable still overrides the file); `TAPFLOW_DATA_DIR` is the exception since it determines where `.env` lives.
+
 ## [0.9.0] - 2026-06-17
 
 ### Added
@@ -163,7 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/jo-duchan/tapflow/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jo-duchan/tapflow/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/jo-duchan/tapflow/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/jo-duchan/tapflow/compare/v0.8.0...v0.8.1

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.9.1
+
 ## 0.9.0
 
 ## 0.8.2

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.9.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.9.1
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # tapflow
 
+## 0.9.1
+
+### Patch Changes
+
+- The relay now loads `.tapflow-data/.env` before reading its config, so every secret can live in that file — not just DNS/ACME tokens. `JWT_SECRET`, the SMTP password, and the tunnel token are all picked up from `.env` now. Precedence is shell env > `.env` > config file (a shell variable still overrides the file). `TAPFLOW_DATA_DIR` is the one exception, since it decides where `.env` lives.
+- Updated dependencies
+  - @tapflowio/relay@0.9.1
+  - @tapflowio/android-agent@0.9.1
+  - @tapflowio/ios-agent@0.9.1
+  - @tapflowio/agent-core@0.9.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/ios-agent
 
+## 0.9.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.9.1
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.9.0-experimental.1",
+  "version": "0.9.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/relay
 
+## 0.9.1
+
+### Patch Changes
+
+- The relay now loads `.tapflow-data/.env` before reading its config, so every secret can live in that file — not just DNS/ACME tokens. `JWT_SECRET`, the SMTP password, and the tunnel token are all picked up from `.env` now. Precedence is shell env > `.env` > config file (a shell variable still overrides the file). `TAPFLOW_DATA_DIR` is the one exception, since it decides where `.env` lives.
+  - @tapflowio/agent-core@0.9.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.9.1 (patch)

Follow-up release for #305, which landed after v0.9.0 and is not yet on npm.

### Versions
| Package | From | To |
|---------|------|----|
| `tapflow`, `@tapflowio/relay`, `@tapflowio/agent-core`, `@tapflowio/ios-agent`, `@tapflowio/android-agent` | 0.9.0 | **0.9.1** |
| `@tapflowio/mcp-server` (experimental) | 0.9.0-experimental.1 | **0.9.1-experimental.1** |

### Changed
- **relay: every secret can now live in `.tapflow-data/.env`, not just DNS/ACME tokens.** The relay loads `.env` before reading its config, so `JWT_SECRET`, the SMTP password, and the tunnel token are picked up from there too. Precedence is **shell env > `.env` > config file** (a shell variable still overrides the file). `TAPFLOW_DATA_DIR` is the one exception, since it determines where `.env` lives.

### Compatibility
- **No breaking change for users.** Shell env injection still works (and now takes precedence over `.env`); CLI commands/flags, the WebSocket protocol, and the DB schema are unchanged.
- Library note: `@tapflowio/relay` swapped a public export — `loadDataDirEnv` was removed and `loadedEnvPath` added. The only consumer is the in-repo CLI, updated in the same change.
- Verified: relay 368 + cli 212 tests pass; lockfile unchanged (`workspace:*`).

### After merge
The release workflow publishes on a `v0.9.1` **tag push** only — merging to main does not publish. Tag the merge commit and push it to trigger npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Relay now loads secrets from `.tapflow-data/.env` with precedence: shell environment > `.env` > config file (location determined by `TAPFLOW_DATA_DIR`).

* **Chores**
  * Version bumped to 0.9.1 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->