### PR TITLE
fix(cli): include --token in agent connect hint for remote relays

### DIFF
--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -100,6 +100,13 @@ describe('cmdRelayStart', () => {
     expect(output.join('\n')).toContain('localhost:4000')
   })
 
+  it('Connect Mac agents 안내에 --token PAT와 발급처가 포함됨', async () => {
+    await cmdRelayStart({})
+    const out = output.join('\n')
+    expect(out).toContain('--token <agent-PAT>')
+    expect(out).toContain('Settings → Tokens')
+  })
+
   it('포트 범위 초과(99999) → exit(1)', async () => {
     await expect(cmdRelayStart({ port: 99999 })).rejects.toThrow('process.exit')
     expect(exitSpy).toHaveBeenCalledWith(1)

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -79,7 +79,8 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   banner('success', 'TAPFLOW RELAY READY', [
     `Relay  : ${httpScheme}://${displayHost}:${port}`,
     ...(publicUrl ? [`Public : ${publicUrl}`] : []),
-    `Connect Mac agents:  tapflow agent start --relay ${wsScheme}://<host>:${port}`,
+    `Connect Mac agents:  tapflow agent start --relay ${wsScheme}://<host>:${port} --token <agent-PAT>`,
+    `  Issue an 'agent'-scope token in the dashboard (Settings → Tokens).`,
     'Press Ctrl+C to stop.',
   ])
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -57,7 +57,8 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
       `Relay  : http://localhost:${RELAY_PORT}`,
       ...(publicUrl ? [`Public : ${publicUrl}`] : []),
       'No agent environment detected — running relay only.',
-      `Connect a Mac agent:  tapflow agent start --relay ws://<this-ip>:${RELAY_PORT}`,
+      `Connect a Mac agent:  tapflow agent start --relay ws://<this-ip>:${RELAY_PORT} --token <agent-PAT>`,
+      `  Issue an 'agent'-scope token in the dashboard (Settings → Tokens).`,
       'Press Ctrl+C to stop.',
     ])
     process.on('SIGINT', () => { void tunnel?.stop(); process.exit(0) })


### PR DESCRIPTION
## Problem

The agent connection hint printed by `relay start` (and the "Connect a Mac agent" hint in `start`) showed only:

```
Connect Mac agents:  tapflow agent start --relay wss://<host>:4000
```

It omitted `--token`. Agents on a different machine are non-localhost and must authenticate with an `agent`-scope PAT (the localhost-only path is unauthenticated). Following the hint verbatim made the relay reject the agent:

```
[relay] WS connection rejected from 192.168.219.113 — no credentials (agents: PAT with 'agent' scope via --token)
```

## Fix

Add `--token <agent-PAT>` to the hint plus a one-line pointer to where the token is issued:

```
Connect Mac agents:  tapflow agent start --relay wss://<host>:4000 --token <agent-PAT>
  Issue an 'agent'-scope token in the dashboard (Settings → Tokens).
```

Applied to both `relay start` (`relay-start.ts`) and the "different Mac" hint in `start` (`start.ts`).

## Test

- Added a `relay-start` test asserting the hint includes `--token <agent-PAT>` and the issuer pointer.
- `vitest run` (relay-start + start): 33 passed. Typecheck + lint clean (pre-commit).

## Out of scope

Auto-issuing/printing an `agent`-scope PAT from `relay start` is a larger feature; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced messaging for connecting Mac agents to the Tapflow Relay with improved clarity on token requirements and dashboard instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->