### PR TITLE
fix(relay): dedup agent re-register by machine id (duplicate "Stale" cards)

### DIFF
--- a/packages/agent-core/src/__tests__/machineId.test.ts
+++ b/packages/agent-core/src/__tests__/machineId.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getMachineId } from '../utils/machineId'
+
+const IOREG = `+-o IOPlatformExpertDevice  <class IOPlatformExpertDevice>
+    {
+      "IOPlatformUUID" = "ABCD1234-5678-90EF-FEDC-BA0987654321"
+      "IOPolledInterface" = "AppleARMWatchdogTimerHibernateHandler is not serializable"
+    }`
+
+describe('getMachineId', () => {
+  it('extracts IOPlatformUUID from ioreg output (macOS)', () => {
+    const execFn = vi.fn(() => IOREG)
+    expect(getMachineId('darwin', execFn as never)).toBe('ABCD1234-5678-90EF-FEDC-BA0987654321')
+    expect(execFn).toHaveBeenCalledWith('ioreg', ['-rd1', '-c', 'IOPlatformExpertDevice'], { encoding: 'utf8' })
+  })
+
+  it('returns undefined off macOS without running ioreg', () => {
+    const execFn = vi.fn(() => IOREG)
+    expect(getMachineId('linux', execFn as never)).toBeUndefined()
+    expect(execFn).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when ioreg throws', () => {
+    const execFn = vi.fn(() => { throw new Error('not found') })
+    expect(getMachineId('darwin', execFn as never)).toBeUndefined()
+  })
+
+  it('returns undefined when the UUID is absent from the output', () => {
+    const execFn = vi.fn(() => '+-o IOPlatformExpertDevice\n  { "Foo" = "bar" }')
+    expect(getMachineId('darwin', execFn as never)).toBeUndefined()
+  })
+})

--- a/packages/agent-core/src/utils/index.ts
+++ b/packages/agent-core/src/utils/index.ts
@@ -23,6 +23,7 @@ export { createThroughputSampler } from './throughput.js'
 export type { ThroughputSample } from './throughput.js'
 export { createSleepBlocker } from './power.js'
 export type { SleepBlocker } from './power.js'
+export { getMachineId } from './machineId.js'
 export { pickMaxSize } from './resolution.js'
 export {
   parseSpsVui,

--- a/packages/agent-core/src/utils/machineId.ts
+++ b/packages/agent-core/src/utils/machineId.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'child_process'
+
+/**
+ * Stable per-machine id from the macOS IOPlatformUUID, used by the relay to dedup an agent's
+ * stale socket on re-register without false-positives. Unlike os.hostname() it's unique per Mac
+ * (two hosts can share a hostname), and it survives reboots/reconnects. macOS-only — returns
+ * undefined elsewhere (and on any failure), so callers fall back to the hostname.
+ *
+ * `platform`/`execFn` are injectable for tests.
+ */
+export function getMachineId(
+  platform: NodeJS.Platform = process.platform,
+  execFn: typeof execFileSync = execFileSync,
+): string | undefined {
+  if (platform !== 'darwin') return undefined
+  try {
+    const out = execFn('ioreg', ['-rd1', '-c', 'IOPlatformExpertDevice'], { encoding: 'utf8' }) as string
+    return out.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)?.[1]
+  } catch {
+    return undefined
+  }
+}

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -12,6 +12,7 @@ import {
   createThroughputSampler,
   createSleepBlocker,
   type SleepBlocker,
+  getMachineId,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
   rewriteLowLatencySpsInFrame,
@@ -229,6 +230,7 @@ export class AndroidAgent implements DeviceAgent {
         ws.send(JSON.stringify({
           type: 'agent:register',
           platform: 'android',
+          agentId: getMachineId(),
           agentName: os.hostname(),
           devices: devices.map((d) => ({
             id: d.id,

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -19,6 +19,7 @@ import {
   createThroughputSampler,
   createSleepBlocker,
   type SleepBlocker,
+  getMachineId,
   DEFAULT_BACKPRESSURE_BYTES,
   writeEnvelopeHeader,
   rewriteLowLatencySpsInFrame,
@@ -139,6 +140,7 @@ export class IOSAgent implements DeviceAgent {
         ws.send(JSON.stringify({
           type: 'agent:register',
           platform: 'ios',
+          agentId: getMachineId(),
           agentName: os.hostname(),
           devices: devices.map((d) => ({
             id: d.id,

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -622,7 +622,21 @@ export class RelayServer {
   }
 
   private handleAgentRegister(ws: WebSocket, msg: RelayMessage): void {
-    const sessionIds = this.sessions.create(ws, msg.devices ?? [], msg.agentName, msg.platform)
+    // Re-register from the same Mac (machine id + platform): the old socket's close may not have
+    // fired yet after an unclean drop (Wi-Fi loss, sleep) — its TCP teardown lags — which would
+    // leave a duplicate, eventually-"Stale" card. Evict the stale agent's sessions and terminate
+    // its socket before creating the new ones. Identity is agentId (unique per Mac) when present,
+    // else agentName. (Heartbeat backstop for never-reconnecting agents: #313.)
+    const identity = msg.agentId ?? msg.agentName
+    if (identity) {
+      for (const old of this.sessions.getAgentSocketsByIdentity(identity, msg.platform)) {
+        if (old === ws) continue
+        for (const s of this.sessions.getAllByAgentSocket(old)) this.sessions.remove(s.id)
+        this.sessions.removeResources(old)
+        old.terminate()
+      }
+    }
+    const sessionIds = this.sessions.create(ws, msg.devices ?? [], msg.agentName, msg.platform, msg.agentId)
     const registeredSessions = (msg.devices ?? []).map((d, i) => ({
       deviceId: d.id,
       sessionId: sessionIds[i],

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -396,21 +396,8 @@ export class RelayServer {
     ws.on('close', () => {
       this.wsRoles.delete(ws)
       this.wsExternal.delete(ws)
-      // Agent main socket disconnected → remove all device sessions for this agent
-      const agentSessions = this.sessions.getAllByAgentSocket(ws)
-      if (agentSessions.length > 0) {
-        const agentSessionIds = new Set(agentSessions.map((s) => s.id))
-        for (const [reqId, pending] of this.pendingScreenshots.entries()) {
-          if (agentSessionIds.has(pending.sessionId)) {
-            clearTimeout(pending.timer)
-            this.pendingScreenshots.delete(reqId)
-            pending.reject(new Error('Agent disconnected'))
-          }
-        }
-        for (const s of agentSessions) this.sessions.remove(s.id)
-        this.sessions.removeResources(ws)
-        return
-      }
+      // Agent main socket disconnected → remove its sessions, reject in-flight screenshots, drop resources
+      if (this.evictAgentSocket(ws)) return
 
       // Stream socket disconnected → clear the streamSocket reference
       const streamSession = this.sessions.getByStreamSocket(ws)
@@ -621,6 +608,24 @@ export class RelayServer {
     }
   }
 
+  // Removes an agent socket's sessions + resources and rejects its in-flight screenshot requests.
+  // Shared by socket close and re-register eviction. Returns true if `ws` had agent sessions.
+  private evictAgentSocket(ws: WebSocket): boolean {
+    const agentSessions = this.sessions.getAllByAgentSocket(ws)
+    if (agentSessions.length === 0) return false
+    const agentSessionIds = new Set(agentSessions.map((s) => s.id))
+    for (const [reqId, pending] of this.pendingScreenshots.entries()) {
+      if (agentSessionIds.has(pending.sessionId)) {
+        clearTimeout(pending.timer)
+        this.pendingScreenshots.delete(reqId)
+        pending.reject(new Error('Agent disconnected'))
+      }
+    }
+    for (const s of agentSessions) this.sessions.remove(s.id)
+    this.sessions.removeResources(ws)
+    return true
+  }
+
   private handleAgentRegister(ws: WebSocket, msg: RelayMessage): void {
     // Re-register from the same Mac (machine id + platform): the old socket's close may not have
     // fired yet after an unclean drop (Wi-Fi loss, sleep) — its TCP teardown lags — which would
@@ -631,8 +636,9 @@ export class RelayServer {
     if (identity) {
       for (const old of this.sessions.getAgentSocketsByIdentity(identity, msg.platform)) {
         if (old === ws) continue
-        for (const s of this.sessions.getAllByAgentSocket(old)) this.sessions.remove(s.id)
-        this.sessions.removeResources(old)
+        // Evict before terminate: the old socket's close fires async, by which point its sessions are
+        // gone and its in-flight screenshots would be undiscoverable — reject them here instead.
+        this.evictAgentSocket(old)
         old.terminate()
       }
     }

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -6,6 +6,7 @@ import type { AgentResources, SessionInfo } from './types.js'
 
 export interface Session {
   id: string
+  agentId?: string
   agentName?: string
   agentPlatform?: string
   agentSocket: WebSocket
@@ -37,12 +38,13 @@ export class SessionManager {
     this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS
   }
 
-  create(agentSocket: WebSocket, devices: RawDevice[] = [], agentName?: string, agentPlatform?: string): string[] {
+  create(agentSocket: WebSocket, devices: RawDevice[] = [], agentName?: string, agentPlatform?: string, agentId?: string): string[] {
     const agentIds = this.agentSocketIndex.get(agentSocket) ?? new Set<string>()
     return devices.map((d) => {
       const id = randomUUID()
       this.sessions.set(id, {
         id,
+        agentId,
         agentName,
         agentPlatform,
         agentSocket,
@@ -69,6 +71,23 @@ export class SessionManager {
     const ids = this.agentSocketIndex.get(ws)
     if (!ids) return []
     return Array.from(ids).map((id) => this.sessions.get(id)).filter((s): s is Session => s !== undefined)
+  }
+
+  /**
+   * Agent sockets currently registered under the same identity (machine id + platform). Identity
+   * is `agentId ?? agentName`: agentId (macOS IOPlatformUUID) is unique per Mac, while agentName
+   * (os.hostname()) can collide across hosts — so older agents without an agentId fall back to the
+   * hostname. Platform disambiguates an iOS and Android agent on the same Mac (same agentId). Used
+   * on re-register to evict an agent's stale socket (the old connection whose close hasn't fired
+   * yet after an unclean drop) before it shows as a duplicate "Stale" card. Heartbeat backstop for
+   * never-reconnecting agents is tracked in #313.
+   */
+  getAgentSocketsByIdentity(identity: string, platform: string | undefined): WebSocket[] {
+    const sockets = new Set<WebSocket>()
+    for (const s of this.sessions.values()) {
+      if ((s.agentId ?? s.agentName) === identity && s.agentPlatform === platform) sockets.add(s.agentSocket)
+    }
+    return Array.from(sockets)
   }
 
   getByStreamSocket(ws: WebSocket): Session | undefined {

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -106,6 +106,80 @@ describe('RelayServer', () => {
     ws.close()
   })
 
+  it('re-register from the same agent (hostname+platform) evicts the stale socket — one card, not a duplicate', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+
+    const agent1 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent1)
+    agent1.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-1', agentName: 'MyMac', platform: 'ios', devices }))
+    await waitForType(agent1, 'agent:registered')
+    const agent1Closed = new Promise<void>((resolve) => agent1.on('close', () => resolve()))
+
+    // Unclean reconnect: a fresh socket from the same Mac before the old socket's close fires.
+    const agent2 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent2)
+    agent2.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-1', agentName: 'MyMac', platform: 'ios', devices }))
+    await waitForType(agent2, 'agent:registered')
+
+    // The relay terminates the stale socket.
+    await agent1Closed
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType(browser, 'agents:listed')
+    expect(listed.sessions!.filter((s) => s.agentName === 'MyMac')).toHaveLength(1)
+
+    agent2.close()
+    browser.close()
+  })
+
+  it('keeps iOS and Android agents on the same Mac as separate cards', async () => {
+    const iosAgent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(iosAgent)
+    iosAgent.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-mac', agentName: 'MyMac', platform: 'ios', devices: [{ id: 'i1', name: 'iPhone', platform: 'ios', status: 'shutdown' }] }))
+    await waitForType(iosAgent, 'agent:registered')
+
+    const androidAgent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(androidAgent)
+    androidAgent.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-mac', agentName: 'MyMac', platform: 'android', devices: [{ id: 'a1', name: 'Pixel', platform: 'android', status: 'shutdown' }] }))
+    await waitForType(androidAgent, 'agent:registered')
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType(browser, 'agents:listed')
+    expect(listed.sessions!.filter((s) => s.agentName === 'MyMac')).toHaveLength(2)
+
+    iosAgent.close()
+    androidAgent.close()
+    browser.close()
+  })
+
+  it('does not evict a different Mac that shares a hostname (distinct machine ids → two cards)', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+
+    const macA = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(macA)
+    macA.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-A', agentName: 'DupName', platform: 'ios', devices }))
+    await waitForType(macA, 'agent:registered')
+
+    const macB = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(macB)
+    macB.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-B', agentName: 'DupName', platform: 'ios', devices }))
+    await waitForType(macB, 'agent:registered')
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType(browser, 'agents:listed')
+    expect(listed.sessions!.filter((s) => s.agentName === 'DupName')).toHaveLength(2)
+
+    macA.close()
+    macB.close()
+    browser.close()
+  })
+
   it('allows a browser to join a device session', async () => {
     const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -103,6 +103,63 @@ describe('SessionManager', () => {
     })
   })
 
+  describe('getAgentSocketsByIdentity()', () => {
+    it('returns sockets sharing the same hostname + platform', () => {
+      const sm = new SessionManager()
+      const wsOld = mockSocket()
+      const wsNew = mockSocket()
+      sm.create(wsOld, [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'MyMac', 'ios')
+      sm.create(wsNew, [{ id: 'd2', name: 'B', platform: 'ios', status: 'shutdown' }], 'MyMac', 'ios')
+      const found = sm.getAgentSocketsByIdentity('MyMac', 'ios')
+      expect(found).toHaveLength(2)
+      expect(found).toContain(wsOld)
+      expect(found).toContain(wsNew)
+    })
+
+    it('does not mix platforms — iOS + Android on one Mac stay separate', () => {
+      const sm = new SessionManager()
+      const wsIos = mockSocket()
+      const wsAndroid = mockSocket()
+      sm.create(wsIos, [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'MyMac', 'ios')
+      sm.create(wsAndroid, [{ id: 'd2', name: 'B', platform: 'android', status: 'shutdown' }], 'MyMac', 'android')
+      expect(sm.getAgentSocketsByIdentity('MyMac', 'ios')).toEqual([wsIos])
+      expect(sm.getAgentSocketsByIdentity('MyMac', 'android')).toEqual([wsAndroid])
+    })
+
+    it('returns one socket once even with multiple device sessions', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      sm.create(ws, [
+        { id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' },
+        { id: 'd2', name: 'B', platform: 'ios', status: 'shutdown' },
+      ], 'MyMac', 'ios')
+      expect(sm.getAgentSocketsByIdentity('MyMac', 'ios')).toEqual([ws])
+    })
+
+    it('returns empty array when nothing matches', () => {
+      const sm = new SessionManager()
+      sm.create(mockSocket(), [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'MyMac', 'ios')
+      expect(sm.getAgentSocketsByIdentity('OtherMac', 'ios')).toEqual([])
+    })
+
+    it('keys on machine id — same hostname, different machine ids stay separate', () => {
+      const sm = new SessionManager()
+      const wsA = mockSocket()
+      const wsB = mockSocket()
+      sm.create(wsA, [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'DupName', 'ios', 'uuid-A')
+      sm.create(wsB, [{ id: 'd2', name: 'B', platform: 'ios', status: 'shutdown' }], 'DupName', 'ios', 'uuid-B')
+      expect(sm.getAgentSocketsByIdentity('uuid-A', 'ios')).toEqual([wsA])
+      expect(sm.getAgentSocketsByIdentity('uuid-B', 'ios')).toEqual([wsB])
+    })
+
+    it('falls back to hostname when machine id is absent (older agent)', () => {
+      const sm = new SessionManager()
+      const ws = mockSocket()
+      sm.create(ws, [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'OldMac', 'ios')
+      expect(sm.getAgentSocketsByIdentity('OldMac', 'ios')).toEqual([ws])
+    })
+  })
+
   describe('getByStreamSocket()', () => {
     it('returns undefined when no stream socket registered', () => {
       const sm = new SessionManager()

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -347,4 +347,33 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     agent.close()
     browser.close()
   })
+
+  it('TC9: re-register eviction rejects an in-flight screenshot immediately (502, not a 504 timeout)', async () => {
+    const devices = [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }]
+    const agent1 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent1)
+    agent1.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-1', platform: 'ios', devices }))
+    const reply = await waitForType(agent1, 'agent:registered')
+    const sessionId = reply.registeredSessions![0].sessionId
+
+    // On the screenshot request, the same Mac reconnects on a fresh socket → evicts agent1.
+    let agent2: WebSocket | undefined
+    agent1.on('message', (data) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === 'screenshot:request') {
+        agent2 = new WebSocket(`ws://localhost:${port}`)
+        agent2.on('open', () =>
+          agent2!.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-1', platform: 'ios', devices })),
+        )
+      }
+    })
+
+    const start = Date.now()
+    const res = await httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`, { Cookie: makeAuthCookie() })
+    expect(res.status).toBe(502)                 // rejected as Agent disconnected, not the 504 timeout
+    expect(Date.now() - start).toBeLessThan(300) // resolved before screenshotTimeoutMs
+
+    agent1.close()
+    agent2?.close()
+  })
 })

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -71,6 +71,9 @@ export interface RelayMessage {
   payload?: unknown
   message?: string
   agentName?: string
+  // agent:register: stable per-machine id (macOS IOPlatformUUID). Unique per Mac, unlike agentName
+  // (os.hostname() can collide). Absent from older agents → relay falls back to agentName for dedup.
+  agentId?: string
   // agent:register: raw device list (without sessionId/busy — added by relay)
   devices?: Array<{ id: string; name: string; platform: string; status: string; osVersion?: string }>
   platform?: string  // agent:register: agent platform ('ios' | 'android')


### PR DESCRIPTION
## Problem

After an agent reconnected (Wi-Fi drop, sleep, cable pull), the **Select Mac** screen showed the same Mac twice — one card going "Stale" after 30s.

`SessionManager.list()` groups sessions by `agentSocket` (the WebSocket instance). On reconnect the agent opens a **new** socket, but the old socket's `close` event lags the OS TCP teardown (tens of seconds). In that window the same Mac is grouped under two sockets → two cards; the dead one stops reporting resources and renders as "Stale".

## Fix

On `agent:register`, evict the prior socket's sessions and `terminate()` it before creating the new ones.

The dedup identity is a **stable per-machine id** — macOS `IOPlatformUUID` via a new `getMachineId()` — not `os.hostname()`. Two Macs can share a hostname (`MacBook-Pro.local`), so keying on the hostname could wrongly evict a *different* Mac. `platform` disambiguates an iOS and Android agent running on the same Mac (same machine id). Older agents that don't send `agentId` fall back to the hostname, so the change is backward-compatible.

## Changes

- `packages/agent-core/src/utils/machineId.ts` — `getMachineId()` (IOPlatformUUID, macOS-only, injectable for tests) + export.
- `packages/ios-agent`, `packages/android-agent` — send `agentId` in `agent:register`.
- `packages/relay` — `agentId` on the register message + `Session`; `getAgentSocketsByIdentity()` keys on `agentId ?? agentName` + platform; `handleAgentRegister` evicts the stale socket.

## Tests

- `getMachineId` — 4 cases (parse, off-macOS, throw, no-match).
- `SessionManager.getAgentSocketsByIdentity` — same machine id groups; same hostname + different machine id stays separate; hostname fallback; iOS/Android split.
- `RelayServer` integration — reconnect evicts the stale socket (one card); same hostname + distinct machine ids → two cards; iOS+Android on one Mac → two cards.

All relay (91) + agent-core + ios (48) + android (60) suites pass.

Heartbeat backstop for never-reconnecting agents: #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable machine-based agent identification to improve agent re-registration deduplication and prevent duplicate session cards.
  * Updated agent handshake to use this machine identifier and to keep iOS/Android sessions separate on the same host.
  * Improved relay eviction so reconnects replace stale sockets and fail in-flight screenshot requests immediately.

* **Tests**
  * Added new test coverage for machine ID extraction, session identity matching, agent eviction/re-registration behavior, and screenshot request failure timing during eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->