### PR TITLE
chore: release v0.9.2 — LAN TLS parity + stability & security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-20
+
+### Changed
+
+- cli: unify the stream-quality tier label to "Smooth".
+
+### Fixed
+
+- cli: `tapflow start` now wires TLS like `relay start`, so the all-in-one path can serve HTTPS/WSS for secure-context streaming (Smooth/WebCodecs) to LAN teammates — previously only `relay start` did. The co-located agent trusts the localhost `wss://` cert only (it never leaves the machine); external relays keep full verification.
+- cli: include `--token` in the agent connect hint for remote relays.
+- agent: prevent display sleep by default (`caffeinate -di`) so the host Mac keeps streaming during a session.
+- relay/agents: dedup agent re-register by machine id, removing duplicate "Stale" cards.
+- relay: reject in-flight screenshots when an agent is evicted on re-register.
+- ios: 16-align downscaled encode dimensions to remove the WASM (tinyh264) green edge on the no-downscale tier.
+
+### Security
+
+- Bump nodemailer to 9.0.1 — the message-level `raw` option bypassed `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response SSRF (GHSA-p6gq-j5cr-w38f). relay uses a plain SMTP send path, so real-world exposure was nil.
+- Bump undici to 7.28.0 (TLS certificate validation bypass via SOCKS5 ProxyAgent, GHSA-vmh5-mc38-953g) and override dompurify to 3.4.11 (`ALLOWED_ATTR` pollution via `setConfig()`, GHSA-cmwh-pvxp-8882) — both dev/build-only transitive dependencies. Remove an orphaned dashboard lockfile the security graph scanned as a duplicate manifest.
+
 ## [0.9.1] - 2026-06-18
 
 ### Changed
@@ -169,7 +189,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/jo-duchan/tapflow/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/jo-duchan/tapflow/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jo-duchan/tapflow/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/jo-duchan/tapflow/compare/v0.8.1...v0.8.2

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/agent-core
 
+## 0.9.2
+
+### Patch Changes
+
+- - Prevent display sleep by default (`caffeinate -di`) so the host Mac keeps streaming during a session.
+  - Dedup agent re-register by machine id to remove duplicate "Stale" cards.
+
 ## 0.9.1
 
 ## 0.9.0

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/android-agent
 
+## 0.9.2
+
+### Patch Changes
+
+- Dedup agent re-register by machine id to remove duplicate "Stale" cards.
+- Updated dependencies
+  - @tapflowio/agent-core@0.9.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # tapflow
 
+## 0.9.2
+
+### Patch Changes
+
+- Wire TLS into the all-in-one `tapflow start` so LAN teammates get secure-context streaming (Smooth/WebCodecs) — previously only `relay start` served HTTPS. The co-located agent accepts the localhost `wss://` cert only, while external relays keep full verification.
+
+  Include `--token` in the agent connect hint for remote relays, and unify the stream-quality tier label to "Smooth".
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @tapflowio/agent-core@0.9.2
+  - @tapflowio/android-agent@0.9.2
+  - @tapflowio/ios-agent@0.9.2
+  - @tapflowio/relay@0.9.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,9 +9,6 @@
   Include `--token` in the agent connect hint for remote relays, and unify the stream-quality tier label to "Smooth".
 
 - Updated dependencies
-- Updated dependencies
-- Updated dependencies
-- Updated dependencies
   - @tapflowio/agent-core@0.9.2
   - @tapflowio/android-agent@0.9.2
   - @tapflowio/ios-agent@0.9.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tapflowio/ios-agent
 
+## 0.9.2
+
+### Patch Changes
+
+- 16-align downscaled encode dimensions to remove the WASM (tinyh264) green edge on the no-downscale tier.
+- Updated dependencies
+  - @tapflowio/agent-core@0.9.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.9.1-experimental.1",
+  "version": "0.9.2-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tapflowio/relay
 
+## 0.9.2
+
+### Patch Changes
+
+- - Bump nodemailer to 9.0.1, resolving the `raw`-option file-access / SSRF advisory (GHSA-p6gq-j5cr-w38f).
+  - Reject in-flight screenshots when an agent is evicted on re-register.
+  - Dedup agent re-register by machine id to remove duplicate "Stale" cards.
+  - Extract `startTlsBackgroundTasks` (cert renewal + address publish) shared by all three entry points.
+- Updated dependencies
+  - @tapflowio/agent-core@0.9.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.9.2

Patch release. The **fixed group** (`tapflow`, `@tapflowio/agent-core`, `@tapflowio/ios-agent`, `@tapflowio/android-agent`, `@tapflowio/relay`) all bump together; `@tapflowio/mcp-server` bumps manually to the `experimental` dist-tag.

| Package | 0.9.1 → |
|---|---|
| tapflow | 0.9.2 |
| @tapflowio/agent-core | 0.9.2 |
| @tapflowio/ios-agent | 0.9.2 |
| @tapflowio/android-agent | 0.9.2 |
| @tapflowio/relay | 0.9.2 |
| @tapflowio/mcp-server | 0.9.2-experimental.1 |

### Why patch (not minor)

The headline change — TLS for `tapflow start` — is a **parity fix, not a new feature**. TLS already shipped via `relay start` / `server.ts`; the all-in-one `tapflow start` path simply never wired it up because the cert/renewal boilerplate was duplicated and drifted. This release extracts that wiring into a shared `startTlsBackgroundTasks` and closes the gap. No protocol / DB / CLI-flag breaking changes; the only public-API delta is additive helper exports on `@tapflowio/relay`.

### Changed
- cli: unify the stream-quality tier label to "Smooth".

### Fixed
- cli: `tapflow start` now wires TLS like `relay start` → the all-in-one path serves HTTPS/WSS for secure-context streaming (Smooth/WebCodecs) to LAN teammates. The co-located agent trusts the localhost `wss://` cert only; external relays keep full verification.
- cli: include `--token` in the agent connect hint for remote relays.
- agent: prevent display sleep by default (`caffeinate -di`).
- relay/agents: dedup agent re-register by machine id, removing duplicate "Stale" cards.
- relay: reject in-flight screenshots when an agent is evicted on re-register.
- ios: 16-align downscaled encode dims to remove the WASM (tinyh264) green edge on the no-downscale tier.

### Security
- nodemailer → 9.0.1 (`raw`-option file-access / SSRF, GHSA-p6gq-j5cr-w38f; relay uses a plain SMTP path, exposure nil).
- undici → 7.28.0 (TLS validation bypass via SOCKS5 ProxyAgent, GHSA-vmh5-mc38-953g) and dompurify → 3.4.11 (`ALLOWED_ATTR` pollution, GHSA-cmwh-pvxp-8882) — both dev/build-only transitive. Removed an orphaned dashboard lockfile the security graph double-scanned.

### Verification
- `pnpm changeset version` applied; 5 changesets consumed.
- Root CHANGELOG promoted to `[0.9.2] - 2026-06-20` with updated compare links.
- Lockfile unchanged (internal deps are `workspace:*`); lint + typecheck pass.

> After merge: tag the merge commit `v0.9.2` and push it to trigger `release.yml` (publish via GitHub OIDC). Merge-to-main alone does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes — Version 0.9.2

- **New Features**
  - Secure streaming support now integrated into the all-in-one workflow.

- **Bug Fixes**
  - Eliminated duplicate device re-registration cards.
  - Improved screenshot handling when agents are evicted during re-registration.
  - Enhanced iOS visual rendering (including no-downscale behavior).

- **Security**
  - Updated critical dependencies and removed an orphaned security-flagged lock artifact.

- **Changed**
  - Unified stream quality tier labeling.
  - Improved agent display/power behavior during active sessions.
  - Enhanced remote relay connection hints (including token support).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->