### PR TITLE
feat(relay): WebSocket heartbeat to detect dead sockets fast

### DIFF
--- a/.changeset/relay-ws-heartbeat.md
+++ b/.changeset/relay-ws-heartbeat.md
@@ -1,0 +1,6 @@
+---
+"tapflow": patch
+"@tapflowio/relay": patch
+---
+
+The relay now runs a WebSocket heartbeat (ping/pong, 30s) over every socket and terminates one that misses a pong window, so dead agent/browser/stream sockets (Wi-Fi loss, sleep, cable pull) are detected promptly instead of lingering until the TCP timeout. Termination reuses the existing close cleanup, evicting stale sessions and clearing the duplicate "Stale" card.

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -33,6 +33,7 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 - Serves the `public/` directory as HTTP static files (dashboard build output).
 - The relay does not buffer stream data — it forwards immediately on arrival.
 - WebSocket upgrade requests and regular HTTP requests are split on the same port.
+- A heartbeat (`runHeartbeat`, every `HEARTBEAT_MS`=30s) pings every socket (agent/browser/stream); one missed pong window → `ws.terminate()`, which fires the existing `close` cleanup — detects dead sockets without waiting for TCP timeout.
 
 ### API Endpoints (builds / apps)
 

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -46,8 +46,7 @@ export function isExternalAddress(addr: string): boolean {
 // Min gap between IDR requests per session — one IDR resyncs the stream, so avoid
 // spamming the agent in the frames between request and the IDR arriving.
 const IDR_REQUEST_THROTTLE_MS = 500
-// WebSocket heartbeat: probe every connection each interval; a socket that misses one full
-// interval without a pong is terminated (≈2× this = worst-case dead-socket detection).
+// Ping every socket each interval; a missed pong window (~2× this) terminates the dead socket.
 const HEARTBEAT_MS = 30_000
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
 import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, purgeExpiredBuilds } from './api/builds.js'
@@ -295,9 +294,7 @@ export class RelayServer {
     return this.httpServer.address()
   }
 
-  // Heartbeat sweep: ping every live socket and mark it pending; a socket still pending from the
-  // previous sweep (no pong) is dead — terminate it, which fires the existing close cleanup. Covers
-  // agent/browser/stream uniformly (all share wss.clients). `clients` is injectable for tests.
+  // Terminate sockets that missed the previous pong; ping the rest. Covers all roles via wss.clients.
   private runHeartbeat(clients: Iterable<WebSocket> = this.wss.clients): void {
     for (const ws of clients) {
       if (this.wsAlive.get(ws) === false) { ws.terminate(); continue }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -46,6 +46,9 @@ export function isExternalAddress(addr: string): boolean {
 // Min gap between IDR requests per session — one IDR resyncs the stream, so avoid
 // spamming the agent in the frames between request and the IDR arriving.
 const IDR_REQUEST_THROTTLE_MS = 500
+// WebSocket heartbeat: probe every connection each interval; a socket that misses one full
+// interval without a pong is terminated (≈2× this = worst-case dead-socket detection).
+const HEARTBEAT_MS = 30_000
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
 import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, purgeExpiredBuilds } from './api/builds.js'
 import { handleListApps, handleCreateApp, handleUpdateApp, handleDeleteApp } from './api/apps.js'
@@ -102,6 +105,9 @@ export class RelayServer {
   private purgeOldResourcesTimer: ReturnType<typeof setInterval> | null = null
   private purgeBuildsTimer: ReturnType<typeof setInterval> | null = null
   private flushResourcesTimer: ReturnType<typeof setInterval> | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  // Liveness per socket for the heartbeat sweep. WeakMap → no manual cleanup on close (GC handles it).
+  private wsAlive = new WeakMap<WebSocket, boolean>()
   private dropHandlers = new Map<string, () => void>()
   // Per-session keyframe-aware sender: drops to the next keyframe under backpressure (no H.264 P-frame tearing).
   private droppers = new Map<string, KeyframeAwareSender>()
@@ -254,6 +260,9 @@ export class RelayServer {
     this.flushResourcesTimer = setInterval(() => this.flushResourceBuffers(), 60_000)
     this.flushResourcesTimer.unref()
 
+    this.heartbeatTimer = setInterval(() => this.runHeartbeat(), HEARTBEAT_MS)
+    this.heartbeatTimer.unref()
+
     return new Promise((resolve, reject) => {
       this.httpServer.once('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EADDRINUSE') {
@@ -273,6 +282,7 @@ export class RelayServer {
     if (this.purgeOldResourcesTimer) { clearInterval(this.purgeOldResourcesTimer); this.purgeOldResourcesTimer = null }
     if (this.purgeBuildsTimer) { clearInterval(this.purgeBuildsTimer); this.purgeBuildsTimer = null }
     if (this.flushResourcesTimer) { clearInterval(this.flushResourcesTimer); this.flushResourcesTimer = null }
+    if (this.heartbeatTimer) { clearInterval(this.heartbeatTimer); this.heartbeatTimer = null }
     return new Promise((resolve, reject) => {
       this.wss.clients.forEach((ws) => ws.terminate())
       this.wss.close(() => {
@@ -283,6 +293,17 @@ export class RelayServer {
 
   address() {
     return this.httpServer.address()
+  }
+
+  // Heartbeat sweep: ping every live socket and mark it pending; a socket still pending from the
+  // previous sweep (no pong) is dead — terminate it, which fires the existing close cleanup. Covers
+  // agent/browser/stream uniformly (all share wss.clients). `clients` is injectable for tests.
+  private runHeartbeat(clients: Iterable<WebSocket> = this.wss.clients): void {
+    for (const ws of clients) {
+      if (this.wsAlive.get(ws) === false) { ws.terminate(); continue }
+      this.wsAlive.set(ws, false)
+      if (ws.readyState === WebSocket.OPEN) ws.ping()
+    }
   }
 
   // 갱신된 cert를 재시작 없이 핫스왑한다(https 종단일 때만 의미 있음).
@@ -350,6 +371,9 @@ export class RelayServer {
       return
     }
     this.wsExternal.set(ws, isExternalAddress(addr))
+    // Heartbeat liveness: alive until proven otherwise; each pong revives it (see runHeartbeat).
+    this.wsAlive.set(ws, true)
+    ws.on('pong', () => this.wsAlive.set(ws, true))
     if (decision.role === 'browser') this.wsRoles.set(ws, 'browser')
     // 'first-message' → role is determined by the first message (agent:register / stream:register)
 

--- a/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket, WebSocketServer } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import type { RelayMessage } from '../types'
+
+const waitForOpen = (ws: WebSocket) =>
+  new Promise<void>((resolve) => ws.once('open', resolve))
+
+const waitForMessage = (ws: WebSocket) =>
+  new Promise<RelayMessage>((resolve) =>
+    ws.once('message', (data) => resolve(JSON.parse(data.toString()))),
+  )
+
+// Minimal stand-in for a ws socket — only the surface runHeartbeat() touches.
+type MockSocket = { readyState: number; ping: ReturnType<typeof vi.fn>; terminate: ReturnType<typeof vi.fn> }
+const makeSock = (readyState: number = WebSocket.OPEN): MockSocket => ({
+  readyState,
+  ping: vi.fn(),
+  terminate: vi.fn(),
+})
+
+// Internal surface poked by these tests (mirrors the `as unknown as {...}` idiom in RelayServer.test.ts).
+type HeartbeatInternals = {
+  wss: WebSocketServer
+  wsAlive: WeakMap<object, boolean>
+  heartbeatTimer: ReturnType<typeof setInterval> | null
+  runHeartbeat: (clients?: Iterable<unknown>) => void
+}
+const internals = (server: RelayServer) => server as unknown as HeartbeatInternals
+
+const sweep = (server: RelayServer, socks: MockSocket[]) => internals(server).runHeartbeat(socks)
+const setAlive = (server: RelayServer, sock: MockSocket, alive: boolean) =>
+  internals(server).wsAlive.set(sock, alive)
+
+describe('RelayServer — WebSocket heartbeat (#313)', () => {
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-relay-hb-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  describe('runHeartbeat sweep (mock sockets)', () => {
+    let server: RelayServer
+
+    beforeEach(async () => {
+      server = new RelayServer({ port: 0 })
+      await server.start()
+    })
+
+    afterEach(async () => {
+      await server.stop()
+    })
+
+    it('terminates a socket that missed the previous pong window', () => {
+      const sock = makeSock()
+      setAlive(server, sock, true)
+
+      // 1st sweep: alive → mark dead, ping (probe).
+      sweep(server, [sock])
+      expect(sock.terminate).not.toHaveBeenCalled()
+      expect(sock.ping).toHaveBeenCalledTimes(1)
+
+      // No pong arrived → still marked dead. 2nd sweep: terminate, no further ping.
+      sweep(server, [sock])
+      expect(sock.terminate).toHaveBeenCalledTimes(1)
+      expect(sock.ping).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps a socket that ponged between sweeps', () => {
+      const sock = makeSock()
+      setAlive(server, sock, true)
+
+      sweep(server, [sock]) // probe 1, marks dead
+      setAlive(server, sock, true) // pong handler would do this
+      sweep(server, [sock]) // alive again → survives, probe 2
+
+      expect(sock.terminate).not.toHaveBeenCalled()
+      expect(sock.ping).toHaveBeenCalledTimes(2)
+    })
+
+    it('probes every client regardless of role (agent/browser/stream all in wss.clients)', () => {
+      const agent = makeSock()
+      const browser = makeSock()
+      const stream = makeSock()
+      for (const s of [agent, browser, stream]) setAlive(server, s, true)
+
+      sweep(server, [agent, browser, stream])
+
+      for (const s of [agent, browser, stream]) {
+        expect(s.terminate).not.toHaveBeenCalled()
+        expect(s.ping).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    it('does not ping a non-OPEN socket (avoids ws throw)', () => {
+      const connecting = makeSock(WebSocket.CONNECTING)
+      const closing = makeSock(WebSocket.CLOSING)
+      setAlive(server, connecting, true)
+      setAlive(server, closing, true)
+
+      sweep(server, [connecting, closing])
+
+      expect(connecting.ping).not.toHaveBeenCalled()
+      expect(closing.ping).not.toHaveBeenCalled()
+    })
+
+    it('does not terminate a freshly-connected socket on its first sweep (unseeded)', () => {
+      const fresh = makeSock() // never marked alive (just connected, no entry yet)
+
+      sweep(server, [fresh])
+
+      expect(fresh.terminate).not.toHaveBeenCalled()
+      expect(fresh.ping).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('integration — real sockets', () => {
+    let server: RelayServer
+    let port: number
+
+    beforeEach(async () => {
+      server = new RelayServer({ port: 0 })
+      await server.start()
+      port = (server.address() as { port: number }).port
+    })
+
+    afterEach(async () => {
+      await server.stop()
+    })
+
+    it('terminates a dead agent socket and evicts its sessions (terminate → existing close cleanup)', async () => {
+      const agent = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(agent)
+      agent.send(JSON.stringify({ type: 'agent:register', agentName: 'DeadMac', devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }] }))
+      await waitForMessage(agent) // agent:registered
+
+      const closed = new Promise<void>((resolve) => agent.on('close', () => resolve()))
+
+      // Force the server-side socket to look dead, then run a real sweep.
+      const serverWs = [...internals(server).wss.clients][0]
+      internals(server).wsAlive.set(serverWs, false)
+      internals(server).runHeartbeat()
+
+      await closed // terminate() fired the close handler
+
+      const observer = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(observer)
+      await vi.waitFor(async () => {
+        observer.send(JSON.stringify({ type: 'agents:list' }))
+        const listed = await waitForMessage(observer)
+        expect(listed.sessions).toHaveLength(0)
+      }, { timeout: 2000 })
+      observer.close()
+    })
+
+    it('keeps a live agent connected across heartbeats (real auto-pong)', async () => {
+      const agent = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(agent)
+      agent.send(JSON.stringify({ type: 'agent:register', agentName: 'LiveMac', devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }] }))
+      await waitForMessage(agent)
+
+      let closedUnexpectedly = false
+      agent.on('close', () => { closedUnexpectedly = true })
+
+      internals(server).runHeartbeat() // probe → marks dead, sends ping
+      await new Promise<void>((r) => setTimeout(r, 50)) // client auto-pongs over loopback
+      internals(server).runHeartbeat() // pong revived it → survives
+
+      expect(closedUnexpectedly).toBe(false)
+      expect(agent.readyState).toBe(WebSocket.OPEN)
+
+      const observer = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(observer)
+      observer.send(JSON.stringify({ type: 'agents:list' }))
+      const listed = await waitForMessage(observer)
+      expect(listed.sessions!.filter((s) => s.agentName === 'LiveMac')).toHaveLength(1)
+
+      agent.close()
+      observer.close()
+    })
+  })
+
+  describe('lifecycle', () => {
+    it('stop() clears the heartbeat timer', async () => {
+      const server = new RelayServer({ port: 0 })
+      await server.start()
+      expect(internals(server).heartbeatTimer).not.toBeNull() // started by start()
+      await server.stop()
+      expect(internals(server).heartbeatTimer).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds an application-level WebSocket heartbeat to the relay's `WebSocketServer`. Every `HEARTBEAT_MS` (30s) the relay pings every socket — agent, browser, and stream alike — and tracks liveness via the `pong` handler. A socket that misses a full interval without a pong is `terminate()`d, which fires the **existing** `close` cleanup.

## Why

Without a heartbeat, when an agent drops uncleanly (Wi-Fi loss, sleep, cable pull) the socket's `close` only fires once the OS TCP stack times out — tens of seconds to minutes. Until then the relay holds the dead socket and its sessions.

This closes the **slow-decay half** of the duplicate "Stale" Mac card bug. The register-time dedup fix handled the primary symptom (re-register evicts the stale socket); this handles the case where a dead socket lingers because the agent never reconnects.

Closes #313.

## Design

- Liveness stored in `wsAlive: WeakMap<WebSocket, boolean>` — GC handles cleanup, no manual `delete` on close.
- `runHeartbeat(clients = this.wss.clients)`: `alive === false` → `terminate()` (and reuse existing cleanup); otherwise mark pending and `ping()` **only when `readyState === OPEN`** (avoids ws throw on CONNECTING/CLOSING).
- Timer created in `start()` (`.unref()`), cleared in `stop()` alongside the other interval timers.
- Worst-case dead-socket detection ≈ 2× interval (~60s). Kept conservative because register-time dedup already closes stale sockets instantly on reconnect — the heartbeat only covers sockets that never reconnect.

## Not a breaking change

`ping`/`pong` are RFC 6455 control frames — the application message protocol is unchanged, and clients (browsers and the node `ws` agent) auto-pong, so no client changes are needed. Relay-only.

## Tests

New `RelayServer.heartbeat.test.ts` (8 cases), written test-first:

- **Sweep (mock sockets)**: terminate after a missed pong window · keep a socket that ponged · probe all three roles · never `ping()` a non-OPEN socket · don't terminate a freshly-connected socket on its first sweep.
- **Integration (real ws)**: a dead agent socket is terminated and its sessions evicted (terminate → existing close cleanup) · a live agent survives across heartbeats via real auto-pong.
- **Lifecycle**: `stop()` clears the heartbeat timer.

Full relay suite green (392 passed, 1 skipped), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket heartbeat monitoring: connections are pinged every 30 seconds and responsive clients stay alive.
  * Unresponsive connections that miss the expected pong are automatically terminated to improve reliability.

* **Bug Fixes**
  * Improved cleanup for stale relay connections, evicting stale sessions more effectively and preventing duplicate “Stale” indicators.

* **Tests**
  * Added coverage for heartbeat behavior, including termination on missed pong and proper start/stop lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->