### PR TITLE
docs: add setup walkthrough video to environment-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
     <a href="https://www.tapflow.dev/guide/getting-started">🚀 Quick Start</a>
     &nbsp;·&nbsp;
     <a href="https://www.tapflow.dev/guide/introduction">🎥 Demo</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/environment-setup#tapflow-setup">🎬 Setup</a>
   </p>
 </div>
 

--- a/docs/guide/environment-setup.md
+++ b/docs/guide/environment-setup.md
@@ -37,6 +37,8 @@ tapflow doctor --json
 
 `tapflow setup` installs and configures whatever `doctor` reported as missing. Run it without an argument to detect the environment and set up every supported platform.
 
+<VideoPlayer src="/tapflow-setup.mp4" />
+
 ```sh
 tapflow setup
 ```

--- a/docs/ko/guide/environment-setup.md
+++ b/docs/ko/guide/environment-setup.md
@@ -37,6 +37,8 @@ tapflow doctor --json
 
 `tapflow setup`은 doctor가 찾아낸 부족한 부분을 직접 설치·구성합니다. 인자 없이 실행하면 환경을 감지해 가능한 플랫폼을 모두 설정합니다.
 
+<VideoPlayer src="/tapflow-setup.mp4" />
+
 ```sh
 tapflow setup
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,8 @@
     <a href="https://www.tapflow.dev/guide/getting-started">🚀 Quick Start</a>
     &nbsp;·&nbsp;
     <a href="https://www.tapflow.dev/guide/introduction">🎥 Demo</a>
+    &nbsp;·&nbsp;
+    <a href="https://www.tapflow.dev/guide/environment-setup#tapflow-setup">🎬 Setup</a>
   </p>
 </div>
 


### PR DESCRIPTION
## What

Adds the one-take **setup → in-browser simulator** walkthrough (4:52) to the docs and links it from the READMEs.

- **docs** `environment-setup.md` (EN + KO): embedded in the `## tapflow setup` section via `<VideoPlayer src="/tapflow-setup.mp4" />`, served from the committed `docs/public/tapflow-setup.mp4` (7.9 MB).
- **READMEs** (root + cli): a `🎬 Setup` nav link to `…/guide/environment-setup#tapflow-setup` — **no second inline player** (both already carry the hero demo video).

## Why this hosting split

Mirrors the existing demo-video pattern. GitHub `user-attachments` video URLs only render reliably on github.com — embedding one in the VitePress site (an external domain) breaks on auth-redirect/CORS. So the docs copy is committed (like `tapflow-demo.mp4`), while READMEs, which render on github.com / npm, keep using CDN/links. Zero-bloat isn't achievable for the docs surface; only the READMEs avoid an embed by linking.

## Verification

- `pnpm --filter @tapflowio/docs build` succeeds; `tapflow-setup.mp4` ships to `dist/`.
- `VideoPlayer` is globally registered (theme `index.ts`), already used in `introduction.md`.
- EN/KO parity kept; pre-commit lint + typecheck green.

docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guide link to navigation menus for improved discoverability
  * Enhanced setup documentation with embedded video tutorials providing visual guidance for the setup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->