### PR TITLE
feat(setup): report per-step state (found / created / repaired)

### DIFF
--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -130,6 +130,28 @@ describe('cmdSetup', () => {
     expect(logLines.join('\n')).toMatch(/new terminal/i)
   })
 
+  // issue #326: ok 단계의 state를 체크 옆에 함께 출력한다.
+  it('state가 있으면 체크 옆에 (found/created/repaired) 표기', async () => {
+    mockRunSetupAndroid.mockResolvedValue([
+      { label: 'Homebrew installed', ok: true, state: 'found' },
+      { label: 'Android SDK installed', ok: true, state: 'created' },
+    ])
+
+    await cmdSetup('android')
+    const out = logLines.join('\n')
+    expect(out).toMatch(/Homebrew installed.*\(found\)/)
+    expect(out).toMatch(/Android SDK installed.*\(created\)/)
+  })
+
+  it('state가 없는 ok 단계는 기존처럼 표기 없이 출력 (회귀)', async () => {
+    mockRunSetupIos.mockResolvedValue([{ label: 'Xcode installed', ok: true }])
+
+    await cmdSetup('ios')
+    const out = logLines.join('\n')
+    expect(out).toContain('Xcode installed')
+    expect(out).not.toMatch(/Xcode installed.*\((found|created|repaired)\)/)
+  })
+
   it('인자 없음 + 감지 0개 → 안내, exit 없음', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     mockResolveAdb.mockReturnValue(null)

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -246,6 +246,60 @@ describe('runSetupAndroid', () => {
       expect.anything(),
     )
   })
+
+  // issue #326: state로 "이미 있었음(found)"과 "이번에 설치함(created)"을 구분한다.
+  it("state: 완전 구성 머신은 모든 단계가 'found'", async () => {
+    const results = await runSetupAndroid()
+    expect(results.every((r) => r.ok)).toBe(true)
+    expect(findStep(results, 'homebrew')?.state).toBe('found')
+    expect(findStep(results, 'java')?.state).toBe('found')
+    expect(findStep(results, 'android sdk')?.state).toBe('found')
+    expect(findStep(results, 'avd')?.state).toBe('found')
+  })
+
+  it("state: 이번 실행에 SDK를 부트스트랩하면 'created'", async () => {
+    setTTY(true)
+    let installed = false
+    mockExistsSync.mockImplementation((p) => {
+      if (p === SDK_SDKMANAGER || p === SDK_ADB) return installed
+      if (p === SDK_AVDMANAGER || p === SDK_EMULATOR) return true
+      return false
+    })
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (typeof cmd === 'string' && cmd.includes('sdkmanager') && a.includes('cmdline-tools;latest')) {
+        installed = true
+        return okSpawn as never
+      }
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) {
+        return { ...okSpawn, stdout: 'tapflow-phone\n' } as never
+      }
+      return okSpawn as never
+    })
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android sdk')?.state).toBe('created')
+  })
+
+  it("state: 이번 실행에 AVD를 생성하면 'created'", async () => {
+    setTTY(true)
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) {
+        return { ...okSpawn, stdout: '' } as never
+      }
+      if (cmd === SDK_AVDMANAGER && a.includes('device')) {
+        return {
+          ...okSpawn,
+          stdout: 'id: 0 or "pixel_5"\nid: 1 or "pixel_7"\nid: 2 or "pixel_7_pro"\nid: 3 or "pixel_c"\n',
+        } as never
+      }
+      return okSpawn as never
+    })
+
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'avd')?.state).toBe('created')
+  })
 })
 
 describe('runSetupIos', () => {
@@ -395,5 +449,56 @@ describe('runSetupIos', () => {
     const results = await runSetupIos()
     expect(results.every((r) => r.ok)).toBe(true)
     expect(mockSpawnSync).not.toHaveBeenCalled()
+  })
+
+  // issue #326: iOS 단계도 found / created / repaired를 구분한다.
+  it("state: 완전 구성 macOS는 'found' (xcode/simulator)", async () => {
+    const results = await runSetupIos()
+    expect(findStep(results, 'xcode installed')?.state).toBe('found')
+    expect(findStep(results, 'simulator')?.state).toBe('found')
+  })
+
+  it("state: 시뮬 런타임을 이번에 설치하면 'created'", async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(true as never)
+    let hasDevice = false
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Applications/Xcode.app/Contents/Developer\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return hasDevice ? simctlBooted : simctlEmpty
+      return ''
+    })
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (cmd === 'xcodebuild' && a.includes('-downloadPlatform')) {
+        hasDevice = true
+        return okSpawn as never
+      }
+      return okSpawn as never
+    })
+
+    const results = await runSetupIos()
+    expect(findStep(results, 'simulator')?.state).toBe('created')
+  })
+
+  it("state: 활성화를 sudo로 고치면 'repaired'", async () => {
+    setTTY(true)
+    mockConfirm.mockResolvedValue(true as never)
+    // active dir이 CommandLineTools라 xcode-select -s로 고쳐야 하는 상태
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === 'xcode-select -p') return '/Library/Developer/CommandLineTools\n'
+      if (c === 'xcodebuild -version') return 'Xcode 26.5\n'
+      if (c.includes('simctl list devices')) return simctlBooted
+      return ''
+    })
+
+    const results = await runSetupIos()
+    const ready = findStep(results, 'xcode ready')
+    expect(ready?.ok).toBe(true)
+    expect(ready?.state).toBe('repaired')
   })
 })

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -249,12 +249,35 @@ describe('runSetupAndroid', () => {
 
   // issue #326: state로 "이미 있었음(found)"과 "이번에 설치함(created)"을 구분한다.
   it("state: 완전 구성 머신은 모든 단계가 'found'", async () => {
+    // 완전 구성 = env(rc 마커)까지 이미 등록된 상태. 그래야 registerAndroidEnv가
+    // append 없이 added:false를 반환하고 SDK 단계가 'found'로 보고된다.
+    mockReadFileSync.mockReturnValue(
+      '# >>> tapflow android sdk >>>\nexport ANDROID_HOME="x"\n# <<< tapflow android sdk <<<\n',
+    )
+    mockExistsSync.mockImplementation(
+      (p) =>
+        p === SDK_SDKMANAGER ||
+        p === SDK_ADB ||
+        p === SDK_AVDMANAGER ||
+        p === SDK_EMULATOR ||
+        p === zshrc,
+    )
+
     const results = await runSetupAndroid()
     expect(results.every((r) => r.ok)).toBe(true)
     expect(findStep(results, 'homebrew')?.state).toBe('found')
     expect(findStep(results, 'java')?.state).toBe('found')
     expect(findStep(results, 'android sdk')?.state).toBe('found')
     expect(findStep(results, 'avd')?.state).toBe('found')
+  })
+
+  // issue #326: SDK 바이너리는 있지만 이번 실행에 env(rc)를 새로 등록하면 'repaired'.
+  it("state: SDK는 있고 env를 이번에 등록하면 'repaired'", async () => {
+    // 기본 mock은 rc가 비어 있어(readFileSync→'') registerAndroidEnv가 append하고 added:true.
+    const results = await runSetupAndroid()
+    expect(findStep(results, 'android sdk')?.ok).toBe(true)
+    expect(findStep(results, 'android sdk')?.state).toBe('repaired')
+    expect(mockAppendFileSync).toHaveBeenCalledWith(zshrc, expect.stringContaining('ANDROID_HOME'))
   })
 
   it("state: 이번 실행에 SDK를 부트스트랩하면 'created'", async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -25,7 +25,8 @@ async function detectPlatforms(): Promise<string[]> {
 function printResults(results: SetupStepResult[]): void {
   for (const r of results) {
     if (r.ok) {
-      console.log(`  ${GREEN}✓${R}  ${r.label}`)
+      const tag = r.state ? ` ${DIM}(${r.state})${R}` : ''
+      console.log(`  ${GREEN}✓${R}  ${r.label}${tag}`)
       if (r.detail) console.log(`${DIM}       ${r.detail}${R}`)
     } else if (r.warn) {
       console.log(`  ${YELLOW}⚠${R}  ${r.label}`)

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -6,9 +6,11 @@ import { confirm, text, isCancel } from '@clack/prompts'
 import { type DoctorCheck } from './doctor.js'
 import { step } from './print.js'
 
-// setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓴다.
+// setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓰되, 변화 유형(state)을 덧붙인다.
 // ok=true: 이미 OK이거나 방금 자동 수정함, warn=true: 수동 조치 필요(안내).
-export type SetupStepResult = DoctorCheck
+// state로 "이미 있었음 / 새로 설치함 / 고침"을 구분한다(ok는 그대로라 doctor엔 영향 없음).
+export type SetupStepState = 'found' | 'created' | 'repaired'
+export type SetupStepResult = DoctorCheck & { state?: SetupStepState }
 
 const PATH_MARKER_START = '# >>> tapflow android sdk >>>'
 const PATH_MARKER_END = '# <<< tapflow android sdk <<<'
@@ -120,7 +122,7 @@ export async function runSetupIos(): Promise<SetupStepResult[]> {
 
 async function checkAndFixXcode(): Promise<SetupStepResult> {
   if (existsSync(XCODE_APP)) {
-    return { label: 'Xcode installed', ok: true }
+    return { label: 'Xcode installed', ok: true, state: 'found' }
   }
   // Xcode는 App Store에서만 설치 가능 — CLI가 직접 설치할 수 없다.
   if (!process.stdout.isTTY) {
@@ -152,7 +154,7 @@ async function checkAndFixXcode(): Promise<SetupStepResult> {
     }
   }
   if (existsSync(XCODE_APP)) {
-    return { label: 'Xcode installed', ok: true }
+    return { label: 'Xcode installed', ok: true, state: 'created' }
   }
   return {
     label: 'Xcode',
@@ -168,6 +170,8 @@ async function checkXcodeActivation(xcodeInstalled: boolean): Promise<SetupStepR
     return { label: 'Xcode activation', ok: false, warn: true, detail: 'Install Xcode first.' }
   }
   const selectHint = `Run: sudo xcode-select -s ${XCODE_DEVELOPER_DIR}`
+  // 이번 실행에서 sudo로 재구성한 적이 있으면 found가 아니라 repaired로 보고한다.
+  let repaired = false
 
   // 1. active developer dir이 Xcode를 가리키게
   let dir = ''
@@ -186,11 +190,12 @@ async function checkXcodeActivation(xcodeInstalled: boolean): Promise<SetupStepR
     if (!ok) {
       return { label: 'Xcode command-line tools', ok: false, warn: true, detail: selectHint }
     }
+    repaired = true
   }
 
   // 2. license / first-launch
   if (isXcodeReady()) {
-    return { label: 'Xcode ready', ok: true }
+    return { label: 'Xcode ready', ok: true, state: repaired ? 'repaired' : 'found' }
   }
   const finishHint = 'Finish Xcode setup: sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch'
   if (!process.stdout.isTTY) {
@@ -201,7 +206,7 @@ async function checkXcodeActivation(xcodeInstalled: boolean): Promise<SetupStepR
     ['xcodebuild', '-runFirstLaunch'],
   ])
   if (ok && isXcodeReady()) {
-    return { label: 'Xcode ready', ok: true }
+    return { label: 'Xcode ready', ok: true, state: 'repaired' }
   }
   return { label: 'Xcode setup', ok: false, warn: true, detail: finishHint }
 }
@@ -209,7 +214,7 @@ async function checkXcodeActivation(xcodeInstalled: boolean): Promise<SetupStepR
 // 부팅하지 않는다 — 시뮬 런타임/디바이스가 준비됐는지만 보장(없으면 런타임 설치).
 async function checkAndFixSimulator(): Promise<SetupStepResult> {
   if (hasIosDevice()) {
-    return { label: 'Simulator ready', ok: true }
+    return { label: 'Simulator ready', ok: true, state: 'found' }
   }
   const hint = 'No simulator runtime. Run: xcodebuild -downloadPlatform iOS (or install one in Xcode).'
   if (!process.stdout.isTTY) {
@@ -222,7 +227,7 @@ async function checkAndFixSimulator(): Promise<SetupStepResult> {
   console.log()
   const r = spawnSync('xcodebuild', ['-downloadPlatform', 'iOS'], { stdio: 'inherit' })
   if (r.status === 0 && hasIosDevice()) {
-    return { label: 'Simulator runtime installed', ok: true }
+    return { label: 'Simulator runtime installed', ok: true, state: 'created' }
   }
   return { label: 'Simulator', ok: false, warn: true, detail: 'Could not prepare a simulator. Open Xcode to install a runtime.' }
 }
@@ -234,7 +239,7 @@ const HOMEBREW_INSTALL =
 async function checkAndFixHomebrew(): Promise<SetupStepResult> {
   try {
     execSync('which brew', { stdio: 'pipe' })
-    return { label: 'Homebrew installed', ok: true }
+    return { label: 'Homebrew installed', ok: true, state: 'found' }
   } catch {
     // 미설치 — 아래에서 확인 후 설치
   }
@@ -260,6 +265,7 @@ async function checkAndFixHomebrew(): Promise<SetupStepResult> {
     return {
       label: 'Homebrew installed',
       ok: true,
+      state: 'created',
       detail: "If later steps can't find brew, open a new terminal and re-run tapflow setup.",
     }
   }
@@ -274,7 +280,7 @@ async function checkAndFixHomebrew(): Promise<SetupStepResult> {
 // sdkmanager/avdmanager 실행에 JDK가 필요하다(없으면 'Unable to locate a Java Runtime').
 async function checkAndFixJdk(brewAvailable: boolean): Promise<SetupStepResult> {
   if (hasJava()) {
-    return { label: 'Java (JDK)', ok: true }
+    return { label: 'Java (JDK)', ok: true, state: 'found' }
   }
   if (!brewAvailable) {
     return { label: 'Java (JDK)', ok: false, detail: 'Install Homebrew first, then: brew install --cask temurin' }
@@ -291,7 +297,7 @@ async function checkAndFixJdk(brewAvailable: boolean): Promise<SetupStepResult> 
   console.log()
   const r = spawnSync('brew', ['install', '--cask', 'temurin'], { stdio: 'inherit' })
   if (r.status === 0 && hasJava()) {
-    return { label: 'Java (JDK) installed', ok: true }
+    return { label: 'Java (JDK) installed', ok: true, state: 'created' }
   }
   return { label: 'Java (JDK)', ok: false, detail: 'JDK install failed. Install manually: brew install --cask temurin' }
 }
@@ -303,6 +309,7 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
     return {
       label: 'Android SDK ready',
       ok: true,
+      state: 'found',
       detail: reg?.added ? newShellHint(reg.file) : undefined,
     }
   }
@@ -350,6 +357,7 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
   return {
     label: 'Android SDK installed',
     ok: true,
+    state: 'created',
     detail: `SDK at ${ANDROID_SDK_DIR}.${reg?.added ? ` ${newShellHint(reg.file)}` : ''}`,
   }
 }
@@ -367,7 +375,7 @@ async function checkAndFixAvd(sdkOk: boolean): Promise<SetupStepResult> {
   }
   const avds = listAvds()
   if (avds.length > 0) {
-    return { label: `AVD ready: ${avds.length} device(s)`, ok: true }
+    return { label: `AVD ready: ${avds.length} device(s)`, ok: true, state: 'found' }
   }
   const manualHint = 'Create an AVD with avdmanager (see Android docs).'
   if (!process.stdout.isTTY) {
@@ -379,7 +387,7 @@ async function checkAndFixAvd(sdkOk: boolean): Promise<SetupStepResult> {
   }
   const result = createAvds()
   if (result.ok) {
-    return { label: `AVDs created: ${result.created.join(', ')}`, ok: true }
+    return { label: `AVDs created: ${result.created.join(', ')}`, ok: true, state: 'created' }
   }
   return { label: 'AVD', ok: false, warn: true, detail: result.detail ?? manualHint }
 }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -6,9 +6,7 @@ import { confirm, text, isCancel } from '@clack/prompts'
 import { type DoctorCheck } from './doctor.js'
 import { step } from './print.js'
 
-// setup 단계 결과는 진단 결과(DoctorCheck)와 같은 형태를 쓰되, 변화 유형(state)을 덧붙인다.
-// ok=true: 이미 OK이거나 방금 자동 수정함, warn=true: 수동 조치 필요(안내).
-// state로 "이미 있었음 / 새로 설치함 / 고침"을 구분한다(ok는 그대로라 doctor엔 영향 없음).
+// SetupStepResult = DoctorCheck + optional state (found/created/repaired); ok is untouched so doctor is unaffected.
 export type SetupStepState = 'found' | 'created' | 'repaired'
 export type SetupStepResult = DoctorCheck & { state?: SetupStepState }
 
@@ -309,7 +307,7 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
     return {
       label: 'Android SDK ready',
       ok: true,
-      state: 'found',
+      state: reg?.added ? 'repaired' : 'found',
       detail: reg?.added ? newShellHint(reg.file) : undefined,
     }
   }


### PR DESCRIPTION
## What

Adds an optional `state` to the setup step result so the summary distinguishes what was **already present** from what this run **installed or repaired** — the gap described in the issue.

```ts
export type SetupStepState = 'found' | 'created' | 'repaired'
export type SetupStepResult = DoctorCheck & { state?: SetupStepState }
```

## Why this shape

The issue notes "keep `ok` so `doctor` is unaffected." Rather than add `state` to `DoctorCheck` (shared with `doctor`), I layered it onto `SetupStepResult` at the setup layer. `DoctorCheck` is untouched, so `doctor` is provably unaffected, and `ok` keeps its existing meaning.

## State mapping (per `checkAndFix*`)

- **found** — idempotent early-return, already satisfied (Homebrew/JDK/SDK/AVD/Xcode/Simulator all present)
- **created** — newly installed this run (Homebrew, JDK, Android SDK bootstrap, AVDs, simulator runtime, Xcode)
- **repaired** — reconfigured this run; currently the Xcode activation path when `sudo xcode-select -s` / license / first-launch runs

`printResults()` renders it next to the check, e.g. `✓ Android SDK ready (found)` / `✓ AVDs created: … (created)`.

## Scope

Matches the issue's listed files exactly:
- `packages/cli/src/lib/setup.ts` — type + `state` on each `ok` result
- `packages/cli/src/commands/setup.ts` — `printResults()` renders the state

The follow-up suggestion (strengthening `sdkSelfContained()` to detect a partial SDK as `repaired`) is intentionally left out of scope per the issue — happy to do it as a separate PR.

## Tests

Added to the existing suites:
- `__tests__/lib/setup.test.ts` — `found` on a fully-configured machine, `created` when SDK/AVD/sim-runtime are installed this run, `repaired` for the Xcode activation path (android + ios)
- `__tests__/commands/setup.test.ts` — `printResults()` renders `(found)`/`(created)`, plus a regression test that a state-less `ok` step prints unchanged

## Verification

- `pnpm --filter tapflow typecheck` → clean
- `eslint src` → clean
- `vitest run` on `setup.test.ts` + command `setup.test.ts` → **39/39 pass**
- The repo's own lefthook **pre-commit** ran full workspace `typecheck` + `lint` across all 9 packages → both ✔️

No `any`, no breaking changes (`state` is optional and additive).

Closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The setup command now shows per-step status tags on successful lines to indicate whether each prerequisite was already found, created during the run, or repaired.

* **Tests**
  * Expanded coverage for Android and iOS setup to validate correct state tagging across all major steps.
  * Added regression tests to confirm output formatting stays the same when a step has no state information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->