### PR TITLE
fix(relay): return build-upload errors in English (#263)

### DIFF
--- a/.changeset/builds-error-messages-english.md
+++ b/.changeset/builds-error-messages-english.md
@@ -1,0 +1,6 @@
+---
+"tapflow": patch
+"@tapflowio/relay": patch
+---
+
+Build-upload validation errors are now returned in English, matching the rest of the API (previously the `.app.zip` format, missing-`.app`-directory, and device-only-slice messages were Korean only). Internal code comments are unchanged.

--- a/packages/relay/src/__tests__/upload-limits.test.ts
+++ b/packages/relay/src/__tests__/upload-limits.test.ts
@@ -3,6 +3,7 @@ import http from 'http'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { spawnSync } from 'child_process'
 import { RelayServer } from '../RelayServer'
 import { initDb, getDb, closeDb } from '../db'
 import { makePasswordHash } from '../api/auth'
@@ -93,6 +94,27 @@ describe('upload size-limit handling', () => {
     const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: Buffer.alloc(200, 0x41) }])
     const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
     expect(r.body.error).not.toBe('File exceeds the upload size limit')
+  })
+
+  // #263 — build-validation errors are returned in English, not Korean
+  it('빌드: .ipa 업로드는 400 + 영어 안내', async () => {
+    const boundary = 'X3'
+    const body = multipartBody(boundary, [{ name: 'file', filename: 'app.ipa', contentType: 'application/octet-stream', data: Buffer.alloc(50, 0x41) }])
+    const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toBe('iOS simulator builds must be in .app.zip format. Zip the .app directory built with xcodebuild -sdk iphonesimulator and upload it.')
+  })
+
+  it('빌드: .app 디렉토리 없는 zip은 400 + 영어 안내', async () => {
+    const readme = path.join(uploadsDir, 'readme.txt')
+    fs.writeFileSync(readme, 'hello')
+    const noAppZip = path.join(uploadsDir, 'noapp.zip')
+    spawnSync('zip', ['-j', noAppZip, readme])
+    const boundary = 'X4'
+    const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: fs.readFileSync(noAppZip) }])
+    const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toBe('No .app directory found in the zip. Upload a zip that contains a .app directory.')
   })
 
   it('댓글 첨부: 크기 상한 초과 → 400 + uploads/comments에 잔존 파일 없음', async () => {

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -305,7 +305,7 @@ export function handleUploadBuild(
     const ext = path.extname(originalName).toLowerCase()
 
     if (ext === '.ipa') {
-      fileError = 'iOS 시뮬레이터용 빌드는 .app.zip 형식이어야 합니다. xcodebuild -sdk iphonesimulator 로 빌드한 .app 디렉토리를 zip 압축해 업로드하세요.'
+      fileError = 'iOS simulator builds must be in .app.zip format. Zip the .app directory built with xcodebuild -sdk iphonesimulator and upload it.'
       stream.resume()
       return
     }
@@ -351,7 +351,7 @@ export function handleUploadBuild(
       const info = extractAppZipInfo(savedPath)
       if (info === null) {
         fs.unlinkSync(savedPath)
-        return json(res, 400, { error: 'zip 안에서 .app 디렉토리를 찾을 수 없습니다. .app 디렉토리를 포함한 zip 파일을 업로드하세요.' })
+        return json(res, 400, { error: 'No .app directory found in the zip. Upload a zip that contains a .app directory.' })
       }
 
       // lipo 슬라이스 검증 (macOS only; Linux에서는 null → skip)
@@ -360,7 +360,7 @@ export function handleUploadBuild(
         const sliceOk = hasSimulatorSlice(savedPath, appDir)
         if (sliceOk === false) {
           fs.unlinkSync(savedPath)
-          return json(res, 400, { error: '디바이스용 슬라이스만 포함된 빌드입니다. xcodebuild -sdk iphonesimulator 로 빌드해 시뮬레이터 슬라이스를 포함하세요.' })
+          return json(res, 400, { error: 'This build contains device-only slices. Build with xcodebuild -sdk iphonesimulator to include a simulator slice.' })
         }
       }
 


### PR DESCRIPTION
## What

Three user-facing upload-validation messages in `packages/relay/src/api/builds.ts` were Korean-only while the rest of the API replies in English. Unified to English (AGENTS.md: user-facing messages default to English).

| Path | After (now English) |
|---|---|
| `.ipa` upload | `iOS simulator builds must be in .app.zip format. Zip the .app directory built with xcodebuild -sdk iphonesimulator and upload it.` |
| no `.app` dir in zip | `No .app directory found in the zip. Upload a zip that contains a .app directory.` |
| device-only slices | `This build contains device-only slices. Build with xcodebuild -sdk iphonesimulator to include a simulator slice.` |

**Internal code comments are left as-is** — the issue scopes this to user-facing messages (AGENTS.md keeps code comments under the existing language rules).

## Tests synced

These error responses had **no coverage** before. Added HTTP-level tests (`upload-limits.test.ts`) for the two reproducible paths — a `.ipa` upload and a real zip with no `.app` directory — asserting the exact English text. The device-only-slice path is `lipo`/macOS-gated (returns null, skipped on Linux), so it isn't covered by a test.

## Verification

- relay suite **394 passed** (1 skipped), +2 new; typecheck + lint green.
- No Korean user-facing strings remain in `builds.ts` (comments only).

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build upload validation error messages for Tapflow packages are now returned in English, providing consistent messaging across the API. This includes errors for invalid `.app.zip` formats, missing `.app` directories, and device-only slice configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->