### PR TITLE
feat(builds): decouple Done status from the deletion lifecycle (#258)

### DIFF
--- a/docs/ko/reference/api.md
+++ b/docs/ko/reference/api.md
@@ -352,9 +352,12 @@ Query:
   "status_label": "In Progress",
   "platform": "ios",
   "bundle_id": "com.example.app",
-  "uploaded_at": "2025-05-15T12:00:00.000Z"
+  "uploaded_at": "2025-05-15T12:00:00.000Z",
+  "delete_after": null
 }
 ```
+
+`delete_after`는 빌드 파일이 삭제되는 시각입니다. 삭제가 예약되지 않았으면 `null`입니다. `status_label`과 독립적이라 빌드를 `Done`으로 표시해도 삭제가 예약되지 않습니다.
 
 
 ### `PATCH /api/v1/builds/:id`
@@ -366,6 +369,28 @@ Body (JSON):
   status_label  Backlog|In Progress|Done|Rejected|null  선택
   version_label string|null                              선택
 ```
+
+**응답 `200`**
+
+```json
+{ "ok": true }
+```
+
+
+### `POST /api/v1/builds/:id/schedule-deletion`
+
+빌드 삭제를 예약합니다. 서버가 `delete_after = now + TAPFLOW_BUILD_TTL_DAYS`로 설정하고 그 시각이 지나면 파일과 레코드를 삭제합니다.
+
+**응답 `200`**
+
+```json
+{ "ok": true }
+```
+
+
+### `DELETE /api/v1/builds/:id/schedule-deletion`
+
+예약한 삭제를 취소하고 `delete_after`를 비웁니다.
 
 **응답 `200`**
 

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -46,7 +46,7 @@
 | `TAPFLOW_RELAY_URL` | `relay.url` | *(비어있음)* | CLI 명령어의 기본 relay URL |
 | `TAPFLOW_AGENT_TOKEN` | — | *(비어있음)* | 원격 릴레이 인증용 `agent` 스코프 토큰. `--token` 플래그가 우선합니다. [에이전트 설정](/ko/guide/agent#원격-릴레이-인증)을 참고하세요. |
 | `TAPFLOW_TRUSTED_PROXIES` | — | *(비어있음)* | 신뢰하는 리버스 프록시 IP 목록(콤마 구분, 예: `127.0.0.1,::1`). 릴레이를 같은 호스트의 리버스 프록시 뒤에서 실행할 때 이 값을 설정하면, 프록시 주소 대신 `X-Forwarded-For`에 담긴 실제 클라이언트 IP를 사용합니다. 비어 있으면 전달 헤더를 파싱하지 않습니다. |
-| `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Done 빌드 파일·레코드 자동 삭제 기간(일). 로컬 테스트 시 `0.001` 등 작은 값으로 즉시 확인 가능. |
+| `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | 삭제를 예약한 빌드의 파일·레코드를 실제로 지우기까지 보관하는 기간(일). 예약은 수동 동작이라 **Done** 표시만으로는 삭제되지 않는다. 로컬 테스트 시 `0.001` 등 작은 값으로 즉시 확인 가능. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | 브라우저 소켓당 바이너리 프레임 드롭 임계값. 버퍼가 이 값을 초과하면 프레임이 드롭됩니다. |
 | `TAPFLOW_CLOUDFLARE_TOKEN` | — | *(비어있음)* | `tls.dnsProvider`가 `cloudflare`일 때 DNS-01 발급에 쓰는 Cloudflare API 토큰. |
 | `TAPFLOW_VERCEL_TOKEN` | — | *(비어있음)* | `tls.dnsProvider`가 `vercel`일 때 쓰는 Vercel API 토큰. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -352,9 +352,12 @@ Return a single build.
   "status_label": "In Progress",
   "platform": "ios",
   "bundle_id": "com.example.app",
-  "uploaded_at": "2025-05-15T12:00:00.000Z"
+  "uploaded_at": "2025-05-15T12:00:00.000Z",
+  "delete_after": null
 }
 ```
+
+`delete_after` is the time the build's files are purged, or `null` when no deletion is scheduled. It is independent of `status_label` — marking a build `Done` does not schedule deletion.
 
 
 ### `PATCH /api/v1/builds/:id`
@@ -366,6 +369,28 @@ Body (JSON):
   status_label  Backlog|In Progress|Done|Rejected|null  optional
   version_label string|null                              optional
 ```
+
+**Response `200`**
+
+```json
+{ "ok": true }
+```
+
+
+### `POST /api/v1/builds/:id/schedule-deletion`
+
+Schedule the build for deletion. The server sets `delete_after = now + TAPFLOW_BUILD_TTL_DAYS`; the files and record are purged after that time.
+
+**Response `200`**
+
+```json
+{ "ok": true }
+```
+
+
+### `DELETE /api/v1/builds/:id/schedule-deletion`
+
+Cancel a scheduled deletion, clearing `delete_after`.
 
 **Response `200`**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,7 @@ Secrets can also live in the `.tapflow-data/.env` file. The relay loads it first
 | `TAPFLOW_RELAY_URL` | `relay.url` | *(empty)* | Relay URL used as default by CLI commands |
 | `TAPFLOW_AGENT_TOKEN` | — | *(empty)* | Token with the `agent` scope for remote relay authentication. The `--token` flag takes precedence. See [Agent Setup](/guide/agent#remote-relay-authentication). |
 | `TAPFLOW_TRUSTED_PROXIES` | — | *(empty)* | Comma-separated IPs of trusted reverse proxies (e.g. `127.0.0.1,::1`). Set this when the relay runs behind a same-host reverse proxy so it reads the real client IP from `X-Forwarded-For` instead of the proxy's address. Empty disables forwarded-header parsing. |
-| `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Days before a Done build's files and record are automatically deleted. Set to a small value (e.g. `0.001`) to verify cleanup quickly in local testing. |
+| `TAPFLOW_BUILD_TTL_DAYS` | — | `7` | Days a build is kept after its deletion is scheduled before the files and record are purged. Scheduling is a manual action — marking a build **Done** no longer deletes it. Set to a small value (e.g. `0.001`) to verify cleanup quickly in local testing. |
 | `TAPFLOW_WS_BACKPRESSURE_BYTES` | — | `1048576` (1 MB) | Binary frame drop threshold per browser socket. Frames are silently dropped when the socket buffer exceeds this value. |
 | `TAPFLOW_CLOUDFLARE_TOKEN` | — | *(empty)* | Cloudflare API token for DNS-01 issuance when `tls.dnsProvider` is `cloudflare`. |
 | `TAPFLOW_VERCEL_TOKEN` | — | *(empty)* | Vercel API token for DNS-01 issuance when `tls.dnsProvider` is `vercel`. |

--- a/packages/dashboard/components/app-center/BuildRow.tsx
+++ b/packages/dashboard/components/app-center/BuildRow.tsx
@@ -1,66 +1,85 @@
-import { useState } from 'react'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { TechLabel } from '@/components/ui/tech-label'
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { TechLabel } from '@/components/ui/tech-label';
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '@/components/ui/select'
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel,
-  AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
-  AlertDialogHeader, AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
-import { Separator } from '@/components/ui/separator'
-import { Play } from 'lucide-react'
-import type { Build } from '@/lib/types'
-import { STATUS_TONE } from '@/lib/build-format'
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Separator } from '@/components/ui/separator';
+import { Play, Trash2, Clock } from 'lucide-react';
+import type { Build } from '@/lib/types';
+import { STATUS_TONE } from '@/lib/build-format';
 
-function formatBuildExpiry(completedAt: string): { label: string; urgent: boolean } {
-  const TTL_DAYS = 7
-  const expiresAt = new Date(completedAt).getTime() + TTL_DAYS * 24 * 3_600_000
-  const diff = expiresAt - Date.now()
-  if (diff <= 0) return { label: 'Expired', urgent: true }
-  const h = Math.floor(diff / 3_600_000)
-  if (h < 1) return { label: '< 1 hour left', urgent: true }
-  if (h < 24) return { label: `Expires in ${h}h`, urgent: h < 6 }
-  return { label: `Expires in ${Math.floor(h / 24)}d`, urgent: false }
+// delete_after is the absolute time the build is purged. Countdown is independent
+// of the review status (issue #258).
+function formatDeletionCountdown(deleteAfter: string): { label: string; urgent: boolean } {
+  const diff = new Date(deleteAfter).getTime() - Date.now();
+  if (diff <= 0) return { label: 'Deleting…', urgent: true };
+  const h = Math.floor(diff / 3_600_000);
+  if (h < 1) return { label: 'Deletes in < 1h', urgent: true };
+  if (h < 24) return { label: `Deletes in ${h}h`, urgent: h < 6 };
+  return { label: `Deletes in ${Math.floor(h / 24)}d`, urgent: false };
 }
 
 interface Props {
-  build: Build
-  isLast: boolean
-  onNavigate: (buildId: number) => void
-  onStatusChange: (buildId: number, status: string | null) => void
+  build: Build;
+  isLast: boolean;
+  onNavigate: (buildId: number) => void;
+  onStatusChange: (buildId: number, status: string | null) => void;
+  onScheduleDeletion: (buildId: number) => void;
+  onCancelDeletion: (buildId: number) => void;
 }
 
-export function BuildRow({ build, isLast, onNavigate, onStatusChange }: Props) {
-  const [pendingDone, setPendingDone] = useState(false)
-  const isDone = build.status_label === 'Done'
-  const expiry = isDone && build.completed_at ? formatBuildExpiry(build.completed_at) : null
+export function BuildRow({
+  build,
+  isLast,
+  onNavigate,
+  onStatusChange,
+  onScheduleDeletion,
+  onCancelDeletion,
+}: Props) {
+  const [pendingSchedule, setPendingSchedule] = useState(false);
+  const isDone = build.status_label === 'Done';
+  const deletion = build.delete_after ? formatDeletionCountdown(build.delete_after) : null;
 
   function handleValueChange(val: string) {
-    if (val === 'Done') {
-      setPendingDone(true)
-      return
-    }
-    onStatusChange(build.id, val === 'none' ? null : val)
+    onStatusChange(build.id, val === 'none' ? null : val);
   }
 
   return (
     <>
-      <AlertDialog open={pendingDone} onOpenChange={setPendingDone}>
+      <AlertDialog open={pendingSchedule} onOpenChange={setPendingSchedule}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Mark as Done?</AlertDialogTitle>
+            <AlertDialogTitle>Schedule deletion?</AlertDialogTitle>
             <AlertDialogDescription>
-              Build files will be automatically deleted after 7 days.
-              Reverting the status will cancel the scheduled deletion.
+              Build files will be deleted after 7 days. You can cancel the scheduled deletion
+              anytime before then.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => { onStatusChange(build.id, 'Done'); setPendingDone(false) }}>
-              Confirm
+            <AlertDialogAction
+              onClick={() => {
+                onScheduleDeletion(build.id);
+                setPendingSchedule(false);
+              }}
+            >
+              Schedule deletion
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -72,7 +91,10 @@ export function BuildRow({ build, isLast, onNavigate, onStatusChange }: Props) {
             <span className="text-sm font-medium">
               build <TechLabel>{build.build_number ?? '—'}</TechLabel>
             </span>
-            <Badge tone={build.platform === 'ios' ? 'ios' : 'android'} className="text-xs capitalize">
+            <Badge
+              tone={build.platform === 'ios' ? 'ios' : 'android'}
+              className="text-xs capitalize"
+            >
               {build.platform}
             </Badge>
             {build.status_label && (
@@ -80,8 +102,22 @@ export function BuildRow({ build, isLast, onNavigate, onStatusChange }: Props) {
                 {build.status_label}
               </Badge>
             )}
+            {deletion && (
+              <Badge tone={deletion.urgent ? 'rejected' : 'backlog'} className="text-xs">
+                {deletion.label}
+              </Badge>
+            )}
           </div>
-          <div style={{ display: 'flex', flexDirection: 'row', gap: '14px', marginTop: '0.7rem', alignItems: 'center' }} className="text-xs text-muted-foreground">
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '14px',
+              marginTop: '0.7rem',
+              alignItems: 'center',
+            }}
+            className="text-xs text-muted-foreground"
+          >
             {build.uploader && (
               <>
                 <span>{build.uploader}</span>
@@ -89,24 +125,17 @@ export function BuildRow({ build, isLast, onNavigate, onStatusChange }: Props) {
               </>
             )}
             <TechLabel>{new Date(build.uploaded_at).toLocaleDateString()}</TechLabel>
-            {expiry && (
-              <>
-                <Separator orientation="vertical" className="h-3" />
-                <span className={expiry.urgent ? 'text-destructive' : ''}>{expiry.label}</span>
-              </>
-            )}
           </div>
         </div>
 
-        <Select
-          value={build.status_label ?? 'none'}
-          onValueChange={handleValueChange}
-        >
+        <Select value={build.status_label ?? 'none'} onValueChange={handleValueChange}>
           <SelectTrigger className="h-9 w-32 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="none"><span className="text-muted-foreground">—</span></SelectItem>
+            <SelectItem value="none">
+              <span className="text-muted-foreground">—</span>
+            </SelectItem>
             <SelectItem value="Backlog">Backlog</SelectItem>
             <SelectItem value="In Progress">In Progress</SelectItem>
             <SelectItem value="Done">Done</SelectItem>
@@ -114,11 +143,31 @@ export function BuildRow({ build, isLast, onNavigate, onStatusChange }: Props) {
           </SelectContent>
         </Select>
 
+        {deletion ? (
+          <Button
+            size="icon-sm"
+            variant="outline"
+            onClick={() => onCancelDeletion(build.id)}
+            title="Cancel scheduled deletion"
+          >
+            <Clock className="h-3.5 w-3.5" />
+          </Button>
+        ) : (
+          <Button
+            size="icon-sm"
+            variant="destructive"
+            onClick={() => setPendingSchedule(true)}
+            title="Schedule deletion"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+
         <Button size="sm" onClick={() => onNavigate(build.id)} disabled={isDone}>
           <Play className="mr-1.5 h-3.5 w-3.5" />
           Start QA
         </Button>
       </div>
     </>
-  )
+  );
 }

--- a/packages/dashboard/components/app-center/BuildRow.tsx
+++ b/packages/dashboard/components/app-center/BuildRow.tsx
@@ -24,10 +24,12 @@ import { Play, Trash2, Clock } from 'lucide-react';
 import type { Build } from '@/lib/types';
 import { STATUS_TONE } from '@/lib/build-format';
 
-// delete_after is the absolute time the build is purged. Countdown is independent
-// of the review status (issue #258).
+// delete_after is the absolute purge time; the countdown is independent of review status (#258).
 function formatDeletionCountdown(deleteAfter: string): { label: string; urgent: boolean } {
-  const diff = new Date(deleteAfter).getTime() - Date.now();
+  // SQLite datetime() returns naive UTC ("YYYY-MM-DD HH:MM:SS") — append Z so it isn't read as local time.
+  const hasTz = /[zZ]|[+-]\d{2}:?\d{2}$/.test(deleteAfter);
+  const ms = new Date(hasTz ? deleteAfter : deleteAfter.replace(' ', 'T') + 'Z').getTime();
+  const diff = ms - Date.now();
   if (diff <= 0) return { label: 'Deleting…', urgent: true };
   const h = Math.floor(diff / 3_600_000);
   if (h < 1) return { label: 'Deletes in < 1h', urgent: true };

--- a/packages/dashboard/components/app-center/ReleaseAccordion.tsx
+++ b/packages/dashboard/components/app-center/ReleaseAccordion.tsx
@@ -10,6 +10,8 @@ interface Props {
   onToggle: () => void
   onNavigate: (buildId: number) => void
   onStatusChange: (buildId: number, status: string | null) => void
+  onScheduleDeletion: (buildId: number) => void
+  onCancelDeletion: (buildId: number) => void
 }
 
 export function ReleaseAccordion({
@@ -19,6 +21,8 @@ export function ReleaseAccordion({
   onToggle,
   onNavigate,
   onStatusChange,
+  onScheduleDeletion,
+  onCancelDeletion,
 }: Props) {
   return (
     <div className="rounded-lg shadow-card-2 overflow-hidden">
@@ -44,6 +48,8 @@ export function ReleaseAccordion({
               isLast={idx === builds.length - 1}
               onNavigate={onNavigate}
               onStatusChange={onStatusChange}
+              onScheduleDeletion={onScheduleDeletion}
+              onCancelDeletion={onCancelDeletion}
             />
           ))}
         </div>

--- a/packages/dashboard/components/ui/button.tsx
+++ b/packages/dashboard/components/ui/button.tsx
@@ -1,60 +1,54 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive/10 text-destructive hover:bg-destructive/20',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        'icon-sm': 'h-9 w-9',
+        icon: 'h-10 w-10',
         /** 48px 마케팅 스케일 pill — rounded-pill(100px) 오버라이드 */
-        pill: "h-12 px-6 rounded-pill",
+        pill: 'h-12 px-6 rounded-pill',
         /** 28px nav 스케일 — rounded-md(6px) 유지 */
-        nav: "h-7 px-3 text-xs",
+        nav: 'h-7 px-3 text-xs',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : 'button';
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/packages/dashboard/lib/queries.ts
+++ b/packages/dashboard/lib/queries.ts
@@ -58,14 +58,19 @@ export async function updateBuildStatus(
   })
 }
 
-// Put a build on the deletion clock (server sets delete_after = now + TTL).
-export async function scheduleBuildDeletion(id: number): Promise<void> {
-  await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'POST', credentials: 'include' })
+// Put a build on the deletion clock (server sets delete_after = now + TTL) and
+// return the server's authoritative delete_after.
+export async function scheduleBuildDeletion(id: number): Promise<string> {
+  const res = await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'POST', credentials: 'include' })
+  if (!res.ok) throw new Error(`Failed to schedule deletion (${res.status})`)
+  const data = await res.json()
+  return data.delete_after as string
 }
 
 // Take a build back off the deletion clock.
 export async function cancelBuildDeletion(id: number): Promise<void> {
-  await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'DELETE', credentials: 'include' })
+  const res = await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'DELETE', credentials: 'include' })
+  if (!res.ok) throw new Error(`Failed to cancel scheduled deletion (${res.status})`)
 }
 
 export async function getBuild(buildId: string | number): Promise<Build | null> {

--- a/packages/dashboard/lib/queries.ts
+++ b/packages/dashboard/lib/queries.ts
@@ -58,6 +58,16 @@ export async function updateBuildStatus(
   })
 }
 
+// Put a build on the deletion clock (server sets delete_after = now + TTL).
+export async function scheduleBuildDeletion(id: number): Promise<void> {
+  await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'POST', credentials: 'include' })
+}
+
+// Take a build back off the deletion clock.
+export async function cancelBuildDeletion(id: number): Promise<void> {
+  await fetch(`/api/v1/builds/${id}/schedule-deletion`, { method: 'DELETE', credentials: 'include' })
+}
+
 export async function getBuild(buildId: string | number): Promise<Build | null> {
   const res = await fetch(`/api/v1/builds/${buildId}`, { credentials: 'include' })
   return res.ok ? res.json() : null

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -121,6 +121,7 @@ export interface Build {
   bundle_id: string | null
   uploaded_at: string
   completed_at: string | null
+  delete_after: string | null
   uploader: string | null
 }
 

--- a/packages/dashboard/src/__tests__/BuildRow.test.tsx
+++ b/packages/dashboard/src/__tests__/BuildRow.test.tsx
@@ -50,6 +50,14 @@ describe('BuildRow — deletion lifecycle', () => {
     expect(screen.getByText(/Deletes in 5h/)).toBeTruthy()
   })
 
+  it('parses naive SQLite UTC timestamps, not as local time', () => {
+    // server format: "YYYY-MM-DD HH:MM:SS" (UTC, no tz) — must read identically to the ISO path
+    const d = new Date(Date.now() + 5 * 3_600_000 + 1_800_000)
+    const sqlite = d.toISOString().slice(0, 19).replace('T', ' ')
+    renderRow(makeBuild({ delete_after: sqlite }))
+    expect(screen.getByText(/Deletes in 5h/)).toBeTruthy()
+  })
+
   it('scheduling deletion goes through a confirm dialog', async () => {
     const onScheduleDeletion = vi.fn()
     renderRow(makeBuild({ delete_after: null }), { onScheduleDeletion })

--- a/packages/dashboard/src/__tests__/BuildRow.test.tsx
+++ b/packages/dashboard/src/__tests__/BuildRow.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BuildRow } from '@/components/app-center/BuildRow'
+import type { Build } from '@/lib/types'
+
+// issue #258 — the deletion countdown is driven by delete_after, not by "Done".
+
+function makeBuild(overrides: Partial<Build> = {}): Build {
+  return {
+    id: 1,
+    app_id: 1,
+    name: 'Coffee',
+    version_name: '1.0.0',
+    build_number: '1',
+    version_label: null,
+    status_label: null,
+    platform: 'ios',
+    bundle_id: 'com.example.coffee',
+    uploaded_at: '2026-06-20T00:00:00Z',
+    completed_at: null,
+    delete_after: null,
+    uploader: 'jo',
+    ...overrides,
+  }
+}
+
+function renderRow(build: Build, handlers: Partial<Record<'onScheduleDeletion' | 'onCancelDeletion', (id: number) => void>> = {}) {
+  render(
+    <BuildRow
+      build={build}
+      isLast
+      onNavigate={() => {}}
+      onStatusChange={() => {}}
+      onScheduleDeletion={handlers.onScheduleDeletion ?? (() => {})}
+      onCancelDeletion={handlers.onCancelDeletion ?? (() => {})}
+    />,
+  )
+}
+
+describe('BuildRow — deletion lifecycle', () => {
+  it('#14 Done build with no delete_after shows no deletion countdown', () => {
+    renderRow(makeBuild({ status_label: 'Done', completed_at: '2026-06-20T00:00:00Z', delete_after: null }))
+    expect(screen.queryByText(/Deletes in/)).toBeNull()
+  })
+
+  it('#13 delete_after set shows a "Deletes in" badge regardless of status', () => {
+    const future = new Date(Date.now() + 5 * 3_600_000 + 1_800_000).toISOString()
+    renderRow(makeBuild({ status_label: 'Backlog', delete_after: future }))
+    expect(screen.getByText(/Deletes in 5h/)).toBeTruthy()
+  })
+
+  it('scheduling deletion goes through a confirm dialog', async () => {
+    const onScheduleDeletion = vi.fn()
+    renderRow(makeBuild({ delete_after: null }), { onScheduleDeletion })
+    await userEvent.click(screen.getByTitle('Schedule deletion'))
+    expect(onScheduleDeletion).not.toHaveBeenCalled() // confirm required first
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule deletion' }))
+    expect(onScheduleDeletion).toHaveBeenCalledWith(1)
+  })
+
+  it('cancel action fires immediately for a scheduled build', async () => {
+    const onCancelDeletion = vi.fn()
+    renderRow(makeBuild({ delete_after: new Date(Date.now() + 3_600_000).toISOString() }), { onCancelDeletion })
+    await userEvent.click(screen.getByTitle('Cancel scheduled deletion'))
+    expect(onCancelDeletion).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/dashboard/src/pages/AppCenter.tsx
+++ b/packages/dashboard/src/pages/AppCenter.tsx
@@ -75,15 +75,22 @@ export function AppCenter() {
   }
 
   async function handleScheduleDeletion(buildId: number) {
-    await scheduleBuildDeletion(buildId)
-    // 7d = default TAPFLOW_BUILD_TTL_DAYS; the server is authoritative, this is the optimistic countdown.
-    const deleteAfter = new Date(Date.now() + 7 * 24 * 3_600_000).toISOString()
-    setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: deleteAfter } : b))
+    try {
+      // Use the server's delete_after — don't re-derive the TTL on the client.
+      const deleteAfter = await scheduleBuildDeletion(buildId)
+      setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: deleteAfter } : b))
+    } catch (err) {
+      console.error('Failed to schedule deletion', err)
+    }
   }
 
   async function handleCancelDeletion(buildId: number) {
-    await cancelBuildDeletion(buildId)
-    setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: null } : b))
+    try {
+      await cancelBuildDeletion(buildId)
+      setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: null } : b))
+    } catch (err) {
+      console.error('Failed to cancel scheduled deletion', err)
+    }
   }
 
   const releaseGroups = groupByRelease(builds)

--- a/packages/dashboard/src/pages/AppCenter.tsx
+++ b/packages/dashboard/src/pages/AppCenter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { toast } from 'sonner'
 import { Layers, Package } from 'lucide-react'
 import { SearchInput } from '@/components/ui/search-input'
 import {
@@ -79,8 +80,8 @@ export function AppCenter() {
       // Use the server's delete_after — don't re-derive the TTL on the client.
       const deleteAfter = await scheduleBuildDeletion(buildId)
       setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: deleteAfter } : b))
-    } catch (err) {
-      console.error('Failed to schedule deletion', err)
+    } catch {
+      toast.error('Failed to schedule deletion')
     }
   }
 
@@ -88,8 +89,8 @@ export function AppCenter() {
     try {
       await cancelBuildDeletion(buildId)
       setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: null } : b))
-    } catch (err) {
-      console.error('Failed to cancel scheduled deletion', err)
+    } catch {
+      toast.error('Failed to cancel scheduled deletion')
     }
   }
 

--- a/packages/dashboard/src/pages/AppCenter.tsx
+++ b/packages/dashboard/src/pages/AppCenter.tsx
@@ -8,7 +8,7 @@ import {
 import { UploadBuildDialog } from '@/components/UploadBuildDialog'
 import { AppSidebar } from '@/components/app-center/AppSidebar'
 import { ReleaseAccordion } from '@/components/app-center/ReleaseAccordion'
-import { getApps, getBuilds, updateBuildStatus, groupByRelease } from '@/lib/queries'
+import { getApps, getBuilds, updateBuildStatus, scheduleBuildDeletion, cancelBuildDeletion, groupByRelease } from '@/lib/queries'
 import type { App, Build } from '@/lib/types'
 
 export function AppCenter() {
@@ -72,6 +72,18 @@ export function AppCenter() {
     setBuilds(prev => prev.map(b =>
       b.id === buildId ? { ...b, status_label: status as Build['status_label'] } : b
     ))
+  }
+
+  async function handleScheduleDeletion(buildId: number) {
+    await scheduleBuildDeletion(buildId)
+    // 7d = default TAPFLOW_BUILD_TTL_DAYS; the server is authoritative, this is the optimistic countdown.
+    const deleteAfter = new Date(Date.now() + 7 * 24 * 3_600_000).toISOString()
+    setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: deleteAfter } : b))
+  }
+
+  async function handleCancelDeletion(buildId: number) {
+    await cancelBuildDeletion(buildId)
+    setBuilds(prev => prev.map(b => b.id === buildId ? { ...b, delete_after: null } : b))
   }
 
   const releaseGroups = groupByRelease(builds)
@@ -138,6 +150,8 @@ export function AppCenter() {
                 onToggle={() => handleToggleRelease(versionName)}
                 onNavigate={(id) => navigate(`/app-center/build?id=${id}`)}
                 onStatusChange={handleStatusChange}
+                onScheduleDeletion={handleScheduleDeletion}
+                onCancelDeletion={handleCancelDeletion}
               />
             ))}
           </div>

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -46,7 +46,11 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 | `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.apk`) |
 | `GET` | `/api/v1/builds` | Build list (filterable by `app_id`) |
 | `GET` | `/api/v1/builds/:id` | Single build |
-| `PATCH` | `/api/v1/builds/:id` | Update `status_label` |
+| `PATCH` | `/api/v1/builds/:id` | Update `status_label` / `version_label` |
+| `POST` | `/api/v1/builds/:id/schedule-deletion` | Put the build on the deletion clock (`delete_after = now + TTL`) |
+| `DELETE` | `/api/v1/builds/:id/schedule-deletion` | Cancel a scheduled deletion |
+
+> **Deletion lifecycle (issue #258)**: review status and deletion are orthogonal. `status_label` (incl. `Done`) is a pure review state and never schedules deletion; purge keys off `delete_after` only, which is set by the explicit schedule-deletion action. `completed_at` is informational.
 
 ## Environment Variables
 

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -49,7 +49,7 @@ const IDR_REQUEST_THROTTLE_MS = 500
 // Ping every socket each interval; a missed pong window (~2× this) terminates the dead socket.
 const HEARTBEAT_MS = 30_000
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
-import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, purgeExpiredBuilds } from './api/builds.js'
+import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, handleScheduleBuildDeletion, handleCancelBuildDeletion, purgeExpiredBuilds } from './api/builds.js'
 import { handleListApps, handleCreateApp, handleUpdateApp, handleDeleteApp } from './api/apps.js'
 import { handleListComments, handleCreateComment, handleDeleteComment } from './api/comments.js'
 import { handleListMembers, handleInvite, handleUpdateMember, handleDeleteMember } from './api/team.js'
@@ -177,6 +177,8 @@ export class RelayServer {
     this.router.get('/api/v1/builds', handleListBuilds)
     this.router.get('/api/v1/builds/:id', handleGetBuild)
     this.router.patch('/api/v1/builds/:id', handleUpdateBuild)
+    this.router.post('/api/v1/builds/:id/schedule-deletion', handleScheduleBuildDeletion)
+    this.router.delete('/api/v1/builds/:id/schedule-deletion', handleCancelBuildDeletion)
     this.router.post('/api/v1/builds', (req, res) => handleUploadBuild(req, res, u))
 
     // comments

--- a/packages/relay/src/__tests__/builds-deletion-lifecycle.test.ts
+++ b/packages/relay/src/__tests__/builds-deletion-lifecycle.test.ts
@@ -181,6 +181,7 @@ describe('builds deletion lifecycle: HTTP endpoints', () => {
     expect(r.status).toBe(200)
     const da = deleteAfterOf(buildId)
     expect(da).not.toBeNull()
+    expect(r.body.delete_after).toBe(da) // server returns the authoritative timestamp
     expect(new Date(da! + 'Z').getTime()).toBeGreaterThan(Date.now())
     const status = (getDb().prepare('SELECT status_label FROM builds WHERE id = ?').get(buildId) as { status_label: string }).status_label
     expect(status).toBe('Done')

--- a/packages/relay/src/__tests__/builds-deletion-lifecycle.test.ts
+++ b/packages/relay/src/__tests__/builds-deletion-lifecycle.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initDb, getDb, closeDb } from '../db'
+import { purgeExpiredBuilds } from '../api/builds'
+import { RelayServer } from '../RelayServer'
+import { makePasswordHash } from '../api/auth'
+import { signJwt } from '../middleware/auth'
+
+// issue #258 — review status ("Done") decoupled from the deletion lifecycle.
+// delete_after is the sole purge driver; completed_at is informational only.
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function insertAppAndBuild(filePath: string): number {
+  const db = getDb()
+  db.prepare(`INSERT INTO apps (name, bundle_id_key, platform) VALUES ('Coffee', 'com.example.coffee', 'ios')`).run()
+  const app = db.prepare('SELECT id FROM apps WHERE bundle_id_key = ?').get('com.example.coffee') as { id: number }
+  const r = db.prepare(`
+    INSERT INTO builds (app_id, version_name, build_number, bundle_id, file_path)
+    VALUES (?, '1.0.0', '1', 'com.example.coffee', ?)
+  `).run(app.id, filePath)
+  return Number(r.lastInsertRowid)
+}
+
+function deleteAfterOf(id: number): string | null {
+  return (getDb().prepare('SELECT delete_after FROM builds WHERE id = ?').get(id) as { delete_after: string | null }).delete_after
+}
+function completedAtOf(id: number): string | null {
+  return (getDb().prepare('SELECT completed_at FROM builds WHERE id = ?').get(id) as { completed_at: string | null }).completed_at
+}
+
+// ── Migration 012: schema + grandfather ──────────────────────────────────────
+
+describe('Migration 012: delete_after column', () => {
+  let tmpDir: string
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-da-mig-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  it('#1 builds table has delete_after column + index', () => {
+    const cols = (getDb().prepare('PRAGMA table_info(builds)').all() as { name: string }[]).map(c => c.name)
+    expect(cols).toContain('delete_after')
+    const idx = (getDb().prepare('PRAGMA index_list(builds)').all() as { name: string }[]).map(i => i.name)
+    expect(idx).toContain('idx_builds_delete_after')
+  })
+
+  it('#3/#4 grandfather: completed_at → delete_after = completed_at + 7d; NULL stays NULL', () => {
+    const db = getDb()
+    const completed = insertAppAndBuild('/tmp/completed.zip')
+    const fresh = insertAppAndBuild('/tmp/fresh.zip')
+    // simulate pre-012 state (rows that existed before the migration ran)
+    db.prepare(`UPDATE builds SET completed_at = '2026-06-01 00:00:00', delete_after = NULL WHERE id = ?`).run(completed)
+    db.prepare(`UPDATE builds SET completed_at = NULL, delete_after = NULL WHERE id = ?`).run(fresh)
+
+    // run the exact grandfather UPDATE shipped in the migration
+    const sql = fs.readFileSync(path.join(import.meta.dirname, '../migrations/012_build_delete_after.sql'), 'utf-8')
+    const stripped = sql.split('\n').filter(l => !l.trim().startsWith('--')).join('\n')
+    const update = stripped.split(';').map(s => s.trim()).find(s => s.toUpperCase().startsWith('UPDATE'))
+    expect(update).toBeTruthy()
+    db.exec(update!)
+
+    expect(deleteAfterOf(completed)).toBe('2026-06-08 00:00:00')
+    expect(deleteAfterOf(fresh)).toBeNull()
+  })
+})
+
+// ── purgeExpiredBuilds keys off delete_after ─────────────────────────────────
+
+describe('purgeExpiredBuilds: delete_after is the purge driver', () => {
+  let tmpDir: string
+  let recordingsDir: string
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-da-purge-'))
+    recordingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-da-rec-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    fs.rmSync(recordingsDir, { recursive: true, force: true })
+  })
+
+  it('#9/#10 deletes only past delete_after; Done-but-unscheduled and future survive', () => {
+    const db = getDb()
+    const expired = insertAppAndBuild('/tmp/expired.zip')
+    const future = insertAppAndBuild('/tmp/future.zip')
+    const doneUnscheduled = insertAppAndBuild('/tmp/done.zip')
+
+    db.prepare(`UPDATE builds SET delete_after = datetime('now','-1 hour') WHERE id = ?`).run(expired)
+    db.prepare(`UPDATE builds SET delete_after = datetime('now','+1 hour') WHERE id = ?`).run(future)
+    // Done but never scheduled: completed_at set, delete_after NULL → must NOT be purged
+    db.prepare(`UPDATE builds SET status_label = 'Done', completed_at = datetime('now'), delete_after = NULL WHERE id = ?`).run(doneUnscheduled)
+
+    purgeExpiredBuilds(recordingsDir)
+
+    const ids = (db.prepare('SELECT id FROM builds').all() as { id: number }[]).map(r => r.id)
+    expect(ids).not.toContain(expired)
+    expect(ids).toContain(future)
+    expect(ids).toContain(doneUnscheduled)
+  })
+
+  it('#11 cascade: expired build removes its recording row + file', () => {
+    const db = getDb()
+    const build = insertAppAndBuild('/tmp/withrec.zip')
+    const recFile = 'rec-cascade.mp4'
+    fs.writeFileSync(path.join(recordingsDir, recFile), 'x')
+    db.prepare(`INSERT INTO recordings (filename, file_size, mime, expires_at, build_id) VALUES (?, 1, 'video/mp4', datetime('now','+1 day'), ?)`).run(recFile, build)
+    db.prepare(`UPDATE builds SET delete_after = datetime('now','-1 hour') WHERE id = ?`).run(build)
+
+    purgeExpiredBuilds(recordingsDir)
+
+    const rec = db.prepare('SELECT id FROM recordings WHERE build_id = ?').get(build)
+    expect(rec).toBeUndefined()
+    expect(fs.existsSync(path.join(recordingsDir, recFile))).toBe(false)
+  })
+})
+
+// ── HTTP: status decoupling + schedule/cancel endpoints ──────────────────────
+
+function httpJson(port: number, method: string, urlPath: string, cookie: string, body?: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? undefined : Buffer.from(JSON.stringify(body))
+    const headers: Record<string, string> = { Cookie: cookie }
+    if (payload) { headers['Content-Type'] = 'application/json'; headers['Content-Length'] = String(payload.length) }
+    const req = http.request({ hostname: '127.0.0.1', port, path: urlPath, method, headers }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve({ status: res.statusCode!, body: JSON.parse(Buffer.concat(chunks).toString() || '{}') }))
+    })
+    req.on('error', reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+describe('builds deletion lifecycle: HTTP endpoints', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+  let uploadsDir: string
+  let cookie: string
+  let buildId: number
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-da-http-'))
+    initDb(path.join(tmpDir, 'test.db'))
+    getDb().prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    cookie = `tapflow_token=${signJwt({ userId: 1, email: 'admin@example.com', role: 'Admin' })}`
+  })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  beforeEach(async () => {
+    buildId = insertAppAndBuild('/tmp/http.zip')
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-da-up-'))
+    server = new RelayServer({ port: 0, uploadsDir })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+  afterEach(async () => {
+    await server.stop()
+    fs.rmSync(uploadsDir, { recursive: true, force: true })
+    getDb().exec('DELETE FROM builds; DELETE FROM apps')
+  })
+
+  it('#5 PATCH status_label=Done records completed_at but does NOT set delete_after', async () => {
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Done' })
+    expect(r.status).toBe(200)
+    expect(completedAtOf(buildId)).not.toBeNull()
+    expect(deleteAfterOf(buildId)).toBeNull()
+  })
+
+  it('#7 POST schedule-deletion sets delete_after in the future, status unchanged', async () => {
+    await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Done' })
+    const r = await httpJson(port, 'POST', `/api/v1/builds/${buildId}/schedule-deletion`, cookie)
+    expect(r.status).toBe(200)
+    const da = deleteAfterOf(buildId)
+    expect(da).not.toBeNull()
+    expect(new Date(da! + 'Z').getTime()).toBeGreaterThan(Date.now())
+    const status = (getDb().prepare('SELECT status_label FROM builds WHERE id = ?').get(buildId) as { status_label: string }).status_label
+    expect(status).toBe('Done')
+  })
+
+  it('#8 DELETE schedule-deletion clears delete_after', async () => {
+    await httpJson(port, 'POST', `/api/v1/builds/${buildId}/schedule-deletion`, cookie)
+    expect(deleteAfterOf(buildId)).not.toBeNull()
+    const r = await httpJson(port, 'DELETE', `/api/v1/builds/${buildId}/schedule-deletion`, cookie)
+    expect(r.status).toBe(200)
+    expect(deleteAfterOf(buildId)).toBeNull()
+  })
+
+  it('schedule-deletion on missing build → 404', async () => {
+    const r = await httpJson(port, 'POST', `/api/v1/builds/999999/schedule-deletion`, cookie)
+    expect(r.status).toBe(404)
+  })
+
+  it('#12 GET build includes delete_after field', async () => {
+    await httpJson(port, 'POST', `/api/v1/builds/${buildId}/schedule-deletion`, cookie)
+    const r = await httpJson(port, 'GET', `/api/v1/builds/${buildId}`, cookie)
+    expect(r.status).toBe(200)
+    expect(r.body).toHaveProperty('delete_after')
+    expect(r.body.delete_after).not.toBeNull()
+  })
+})

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -285,11 +285,14 @@ export function handleScheduleBuildDeletion(
   params: Record<string, string>
 ): void {
   if (!requireAuth(req, res)) return
-  const result = getDb()
+  const db = getDb()
+  const result = db
     .prepare(`UPDATE builds SET delete_after = datetime('now', '+' || ? || ' days') WHERE id = ?`)
     .run(BUILD_TTL_DAYS, params.id)
   if (result.changes === 0) return json(res, 404, { error: 'Build not found' })
-  json(res, 200, { ok: true })
+  // Return the authoritative timestamp so the client doesn't re-derive the TTL.
+  const row = db.prepare('SELECT delete_after FROM builds WHERE id = ?').get(params.id) as { delete_after: string }
+  json(res, 200, { ok: true, delete_after: row.delete_after })
 }
 
 // Cancel a scheduled deletion: take the build back off the purge clock.
@@ -451,7 +454,10 @@ export function handleUploadBuild(
   req.pipe(bb)
 }
 
-const BUILD_TTL_DAYS = Number(process.env['TAPFLOW_BUILD_TTL_DAYS'] ?? 7)
+// Fall back to 7 when the env var is missing or malformed; a NaN here would make
+// SQLite store delete_after as NULL and silently skip scheduling.
+const ttlEnv = Number(process.env['TAPFLOW_BUILD_TTL_DAYS'])
+const BUILD_TTL_DAYS = Number.isFinite(ttlEnv) && ttlEnv > 0 ? ttlEnv : 7
 const SQLITE_MAX_PARAMS = 999
 
 function chunkArray<T>(arr: T[], size: number): T[][] {

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -204,7 +204,7 @@ export function handleListBuilds(req: http.IncomingMessage, res: http.ServerResp
   const items = db.prepare(`
     SELECT b.id, b.app_id, ap.name, b.version_name, b.build_number,
            b.version_label, b.status_label, b.platform,
-           b.bundle_id, b.uploaded_at, b.completed_at,
+           b.bundle_id, b.uploaded_at, b.completed_at, b.delete_after,
            COALESCE(u.display_name, substr(u.email, 1, instr(u.email, '@') - 1)) as uploader
     ${baseFrom}
     ${where}
@@ -224,7 +224,7 @@ export function handleGetBuild(
 
   const build = getDb().prepare(`
     SELECT b.id, b.app_id, ap.name, b.version_name, b.build_number,
-           b.version_label, b.status_label, b.platform, b.bundle_id, b.uploaded_at, b.completed_at
+           b.version_label, b.status_label, b.platform, b.bundle_id, b.uploaded_at, b.completed_at, b.delete_after
     FROM builds b
     LEFT JOIN apps ap ON ap.id = b.app_id
     WHERE b.id = ?
@@ -273,6 +273,33 @@ export async function handleUpdateBuild(
   if (updates.length === 0) return json(res, 400, { error: 'Nothing to update' })
 
   const result = db.prepare(`UPDATE builds SET ${updates.join(', ')} WHERE id = ?`).run(...values, params.id)
+  if (result.changes === 0) return json(res, 404, { error: 'Build not found' })
+  json(res, 200, { ok: true })
+}
+
+// Schedule deletion: an explicit, manual action that puts the build on the purge
+// clock (delete_after = now + TTL). Orthogonal to status_label (issue #258).
+export function handleScheduleBuildDeletion(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  params: Record<string, string>
+): void {
+  if (!requireAuth(req, res)) return
+  const result = getDb()
+    .prepare(`UPDATE builds SET delete_after = datetime('now', '+' || ? || ' days') WHERE id = ?`)
+    .run(BUILD_TTL_DAYS, params.id)
+  if (result.changes === 0) return json(res, 404, { error: 'Build not found' })
+  json(res, 200, { ok: true })
+}
+
+// Cancel a scheduled deletion: take the build back off the purge clock.
+export function handleCancelBuildDeletion(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  params: Record<string, string>
+): void {
+  if (!requireAuth(req, res)) return
+  const result = getDb().prepare('UPDATE builds SET delete_after = NULL WHERE id = ?').run(params.id)
   if (result.changes === 0) return json(res, 404, { error: 'Build not found' })
   json(res, 200, { ok: true })
 }
@@ -437,8 +464,8 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
 export function purgeExpiredBuilds(recordingsDir: string): void {
   const db = getDb()
   const expired = db.prepare(
-    `SELECT id, file_path FROM builds WHERE completed_at < datetime('now', '-' || ? || ' days')`
-  ).all(BUILD_TTL_DAYS) as { id: number; file_path: string }[]
+    `SELECT id, file_path FROM builds WHERE delete_after IS NOT NULL AND delete_after < datetime('now')`
+  ).all() as { id: number; file_path: string }[]
 
   if (expired.length === 0) return
 

--- a/packages/relay/src/migrations/012_build_delete_after.sql
+++ b/packages/relay/src/migrations/012_build_delete_after.sql
@@ -1,0 +1,14 @@
+-- 012_build_delete_after.sql
+-- Decouple the deletion lifecycle from the "Done" review status (issue #258).
+-- delete_after is the sole purge driver; status_label / completed_at no longer
+-- schedule deletion. Deletion is now an explicit, manual action.
+
+ALTER TABLE builds ADD COLUMN delete_after TEXT;
+CREATE INDEX IF NOT EXISTS idx_builds_delete_after ON builds(delete_after);
+
+-- Grandfather: builds already on the old deletion clock keep their schedule, so
+-- upgrading doesn't silently stop reclaiming disk. 7 = the default
+-- TAPFLOW_BUILD_TTL_DAYS at the time of this migration (pure SQL can't read env).
+UPDATE builds
+   SET delete_after = datetime(completed_at, '+7 days')
+ WHERE completed_at IS NOT NULL;


### PR DESCRIPTION
## Problem

Review status and storage deletion were coupled through `completed_at`: marking a build **Done** started the purge clock (`completed_at = now`, then `purgeExpiredBuilds` deletes where `completed_at < now - TTL`). So you could not mark a build complete without scheduling its files for deletion. Closes #258.

## Approach

Treat review status and deletion as **orthogonal axes**:

- `status_label` (incl. `Done`) stays a pure review state and never schedules deletion.
- A new nullable `delete_after` timestamp becomes the **sole purge driver**, set only by an explicit, manual schedule-deletion action.
- `completed_at` is kept as informational only.

## Changes

- **Migration `012`** — add nullable `delete_after` + index. **Grandfather**: existing `completed_at` builds get `delete_after = completed_at + 7d` so upgrades keep reclaiming disk (no silent retention change).
- **Purge** — keys off `delete_after IS NOT NULL AND delete_after < now()` instead of `completed_at`.
- **API** — `POST /api/v1/builds/:id/schedule-deletion` (server sets `delete_after = now + TTL`) and `DELETE …/schedule-deletion` (cancel). `delete_after` added to list/get responses.
- **Dashboard** — deletion countdown badge driven by `delete_after` (separate from the status badge), explicit schedule/cancel actions, and the false "Done auto-deletes after 7 days" warning removed. Adds an `icon-sm` button size.
- **Docs** — `reference/api.md` + `reference/configuration.md` (EN/KO) and the relay `AGENTS.md` endpoint table.

## Breaking change note

This is a DB schema change (per AGENTS.md breaking-change scope). The grandfather migration preserves existing deletion behavior, so upgrades are non-disruptive.

## Tests

- relay `builds-deletion-lifecycle.test.ts` (9): migration schema, grandfather, purge keys off `delete_after`, status decoupling, schedule/cancel endpoints, `delete_after` in responses.
- dashboard `BuildRow.test.tsx` (4): countdown badge from `delete_after`, Done no longer schedules deletion, schedule-confirm flow, cancel action.
- Full suites: relay 403 passed, dashboard 194 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build file deletion can now be scheduled or canceled explicitly, independent of marking builds “Done”.
  * Dashboard displays a “Deletes in …” countdown badge and provides schedule/cancel controls.
  * Added API endpoints to schedule and cancel build deletion.

* **Bug Fixes**
  * Purging is now driven solely by the scheduled `delete_after` timestamp.
  * TTL configuration now safely falls back when invalid.

* **Documentation**
  * Updated API and TTL/retention documentation to describe `delete_after`.

* **Tests**
  * Added UI and server tests covering the deletion lifecycle and countdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->