### PR TITLE
chore: release v0.10.0

### DIFF
--- a/.changeset/builds-error-messages-english.md
+++ b/.changeset/builds-error-messages-english.md
@@ -1,6 +1,0 @@
----
-"tapflow": patch
-"@tapflowio/relay": patch
----
-
-Build-upload validation errors are now returned in English, matching the rest of the API (previously the `.app.zip` format, missing-`.app`-directory, and device-only-slice messages were Korean only). Internal code comments are unchanged.

--- a/.changeset/ios-capture-wait-metric.md
+++ b/.changeset/ios-capture-wait-metric.md
@@ -1,6 +1,0 @@
----
-"tapflow": patch
-"@tapflowio/ios-agent": patch
----
-
-The iOS screen-capture helper now reports a `capture-wait` metric under `TAPFLOW_STREAM_METRICS=1` — the polling gap between an IOSurface change and when the frame is encoded, emitted as `info: capture-wait avg/max/n` per 150-sample window. Diagnostic only; capture behavior is unchanged.

--- a/.changeset/relay-ws-heartbeat.md
+++ b/.changeset/relay-ws-heartbeat.md
@@ -1,6 +1,0 @@
----
-"tapflow": patch
-"@tapflowio/relay": patch
----
-
-The relay now runs a WebSocket heartbeat (ping/pong, 30s) over every socket and terminates one that misses a pong window, so dead agent/browser/stream sockets (Wi-Fi loss, sleep, cable pull) are detected promptly instead of lingering until the TCP timeout. Termination reuses the existing close cleanup, evicting stale sessions and clearing the duplicate "Stale" card.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-23
+
+### Added
+
+- builds: deletion is now an explicit, manual action decoupled from review status (#258). Marking a build **Done** no longer schedules it for deletion — `status_label` stays a pure review state and purge keys off a new `delete_after` timestamp instead of `completed_at`. Schedule or cancel via `POST`/`DELETE /api/v1/builds/:id/schedule-deletion`; build payloads now include `delete_after`. Migration 012 grandfathers builds already on the old clock (`delete_after = completed_at + TTL`) so upgrades keep reclaiming disk. The App Center shows a deletion-countdown badge separate from the status column with explicit schedule/cancel controls.
+- relay: WebSocket heartbeat (ping/pong, 30s) terminates sockets that miss a pong window, so dead agent/browser/stream connections (Wi-Fi loss, sleep, cable pull) are detected promptly instead of lingering until the TCP timeout — evicting stale sessions and clearing the duplicate "Stale" card.
+- ios: `capture-wait` diagnostic metric under `TAPFLOW_STREAM_METRICS=1` — the polling gap between an IOSurface change and when the frame is encoded, emitted per 150-sample window. Capture behavior is unchanged.
+
+### Changed
+
+- cli: `tapflow setup` reports per-step state (found / created / repaired) instead of a binary result, so you can see which prerequisites were already in place versus newly provisioned. Android SDK env registration that was already present is reported as "repaired" rather than "found".
+- relay: build-upload validation errors are returned in English, matching the rest of the API (previously the `.app.zip` format, missing-`.app`-directory, and device-only-slice messages were Korean only).
+
 ## [0.9.2] - 2026-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/jo-duchan/tapflow/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/jo-duchan/tapflow/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/jo-duchan/tapflow/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jo-duchan/tapflow/compare/v0.8.2...v0.9.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.10.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/android-agent
 
+## 0.10.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.10.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # tapflow
 
+## 0.10.0
+
+### Minor Changes
+
+- Build review status is now decoupled from the storage deletion lifecycle (#258). Marking a build **Done** no longer schedules it for deletion — `status_label` is a pure review state, and purge keys off a new nullable `delete_after` timestamp instead of `completed_at`. Deletion is an explicit action via `POST /api/v1/builds/:id/schedule-deletion` (and `DELETE …/schedule-deletion` to cancel); the response and build payloads now include `delete_after`. Migration `012` adds the column and grandfathers builds already on the old `completed_at` clock (`delete_after = completed_at + TTL`) so upgrades keep reclaiming disk. The dashboard shows a deletion-countdown badge separate from the status column with explicit schedule/cancel actions.
+
+### Patch Changes
+
+- 9864d2d: Build-upload validation errors are now returned in English, matching the rest of the API (previously the `.app.zip` format, missing-`.app`-directory, and device-only-slice messages were Korean only). Internal code comments are unchanged.
+- `tapflow setup` now reports per-step state — `found` / `created` / `repaired` — instead of a binary result, so you can see which prerequisites were already in place versus newly provisioned. Android SDK environment registration that was already present is now reported as `repaired` rather than `found`.
+- c3ea54c: The iOS screen-capture helper now reports a `capture-wait` metric under `TAPFLOW_STREAM_METRICS=1` — the polling gap between an IOSurface change and when the frame is encoded, emitted as `info: capture-wait avg/max/n` per 150-sample window. Diagnostic only; capture behavior is unchanged.
+- d1b36a9: The relay now runs a WebSocket heartbeat (ping/pong, 30s) over every socket and terminates one that misses a pong window, so dead agent/browser/stream sockets (Wi-Fi loss, sleep, cable pull) are detected promptly instead of lingering until the TCP timeout. Termination reuses the existing close cleanup, evicting stale sessions and clearing the duplicate "Stale" card.
+- Updated dependencies
+- Updated dependencies [9864d2d]
+- Updated dependencies [c3ea54c]
+- Updated dependencies [d1b36a9]
+  - @tapflowio/relay@0.10.0
+  - @tapflowio/ios-agent@0.10.0
+  - @tapflowio/android-agent@0.10.0
+  - @tapflowio/agent-core@0.10.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/ios-agent
 
+## 0.10.0
+
+### Patch Changes
+
+- c3ea54c: The iOS screen-capture helper now reports a `capture-wait` metric under `TAPFLOW_STREAM_METRICS=1` — the polling gap between an IOSurface change and when the frame is encoded, emitted as `info: capture-wait avg/max/n` per 150-sample window. Diagnostic only; capture behavior is unchanged.
+  - @tapflowio/agent-core@0.10.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.9.2-experimental.1",
+  "version": "0.10.0-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tapflowio/relay
 
+## 0.10.0
+
+### Minor Changes
+
+- Build review status is now decoupled from the storage deletion lifecycle (#258). Marking a build **Done** no longer schedules it for deletion — `status_label` is a pure review state, and purge keys off a new nullable `delete_after` timestamp instead of `completed_at`. Deletion is an explicit action via `POST /api/v1/builds/:id/schedule-deletion` (and `DELETE …/schedule-deletion` to cancel); the response and build payloads now include `delete_after`. Migration `012` adds the column and grandfathers builds already on the old `completed_at` clock (`delete_after = completed_at + TTL`) so upgrades keep reclaiming disk. The dashboard shows a deletion-countdown badge separate from the status column with explicit schedule/cancel actions.
+
+### Patch Changes
+
+- 9864d2d: Build-upload validation errors are now returned in English, matching the rest of the API (previously the `.app.zip` format, missing-`.app`-directory, and device-only-slice messages were Korean only). Internal code comments are unchanged.
+- d1b36a9: The relay now runs a WebSocket heartbeat (ping/pong, 30s) over every socket and terminates one that misses a pong window, so dead agent/browser/stream sockets (Wi-Fi loss, sleep, cable pull) are detected promptly instead of lingering until the TCP timeout. Termination reuses the existing close cleanup, evicting stale sessions and clearing the duplicate "Stale" card.
+  - @tapflowio/agent-core@0.10.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
Release **v0.10.0**. Bumps the fixed package group (`tapflow`, `@tapflowio/relay`, `@tapflowio/agent-core`, `@tapflowio/ios-agent`, `@tapflowio/android-agent`) from 0.9.2 → 0.10.0 by consuming all pending changesets. `@tapflowio/mcp-server` is bumped manually to `0.10.0-experimental.1` (changeset-ignored, experimental dist-tag); `@tapflowio/dashboard` (private) is unaffected.

## Included since v0.9.2

### Added
- **builds**: deletion decoupled from review status (#258) — `Done` no longer auto-deletes; explicit `POST`/`DELETE /api/v1/builds/:id/schedule-deletion`, purge keys off `delete_after`, migration 012 grandfathers existing builds.
- **relay**: WebSocket heartbeat (ping/pong, 30s) to detect dead sockets fast (#321).
- **ios**: `capture-wait` diagnostic metric under `TAPFLOW_STREAM_METRICS=1` (#324).

### Changed
- **cli**: `tapflow setup` reports per-step state (found / created / repaired) (#326/#327).
- **relay**: build-upload validation errors returned in English (#328).

## Notes
- Minor bump driven by #258 (new public endpoints + DB migration + behavior change). Migration 012 grandfathers existing data, so upgrades are non-disruptive (backward-compatible).
- Two changesets (#258, cli setup) were missing and added in this release branch.

## Publishing (after merge)
npm publish is **not** triggered by merging this PR. The `release.yml` workflow fires only on a **`v0.10.0` tag push**:

1. Merge this PR.
2. Tag the merge commit and push the tag:
   ```
   git fetch origin main
   git tag v0.10.0 <merge-commit-sha>
   git push origin v0.10.0
   ```
3. The workflow runs `changeset publish` (5 stable packages) + publishes `@tapflowio/mcp-server` under the `experimental` dist-tag + creates the GitHub Release. Auth is via GitHub OIDC trusted publishing (no NPM_TOKEN needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Explicit build deletion scheduling with new schedule/cancel actions (includes `delete_after`).
  * Relay WebSocket ping/pong heartbeat to terminate stale connections promptly.
  * iOS `capture-wait` diagnostic metric support (when enabled).
  * `tapflow setup` now reports per-step state (found/created/repaired).

* **Bug Fixes**
  * Build-upload validation error messages are now returned in English.

* **Chores**
  * Versions updated to **0.10.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->