### PR TITLE
fix(cli): clarify Android PATH refresh guidance

### DIFF
--- a/.changeset/quiet-mangos-serve.md
+++ b/.changeset/quiet-mangos-serve.md
@@ -1,0 +1,5 @@
+---
+"tapflow": patch
+---
+
+Clarify the Android setup/doctor PATH refresh guidance when the SDK rc block already exists but the current shell has not loaded it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- cli: `tapflow setup android` now reminds users to open a new shell when the Android SDK rc block already exists but `adb` is still missing from the live `PATH`; `tapflow doctor` now points to the shell-refresh step instead of looping back to setup.
+
 ## [0.10.0] - 2026-06-23
 
 ### Added

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -123,7 +123,7 @@ describe('cmdSetup', () => {
 
   it('env를 방금 등록(detail에 new terminal)하면 새 터미널 안내 출력', async () => {
     mockRunSetupAndroid.mockResolvedValue([
-      { label: 'Android SDK installed', ok: true, detail: 'SDK at /x. Added ANDROID_HOME/PATH to ~/.zshrc — open a new terminal (or run: exec zsh) to use them.' },
+      { label: 'Android SDK installed', ok: true, detail: 'SDK at /x. ANDROID_HOME/PATH is configured in ~/.zshrc — open a new terminal (or run: exec zsh) to use them.' },
     ])
 
     await cmdSetup('android')

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -206,7 +206,8 @@ describe('runDoctorChecks', () => {
     expect(result.android).not.toBeNull()
     const adbCheck = result.android?.find((c) => c.label.includes('not in PATH'))
     expect(adbCheck?.warn).toBe(true)
-    expect(adbCheck?.detail).toContain('setup android')
+    expect(adbCheck?.detail).toContain('new terminal')
+    expect(adbCheck?.detail).toContain('tapflow doctor')
     expect(adbCheck?.detail).toContain(sdkAdb)
   })
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -247,6 +247,35 @@ describe('runSetupAndroid', () => {
     )
   })
 
+  it('shows a new-shell hint when the rc block exists but adb is not in the live PATH', async () => {
+    mockReadFileSync.mockReturnValue(
+      '# >>> tapflow android sdk >>>\nexport ANDROID_HOME="x"\n# <<< tapflow android sdk <<<\n',
+    )
+    mockExistsSync.mockImplementation(
+      (p) =>
+        p === SDK_SDKMANAGER ||
+        p === SDK_ADB ||
+        p === SDK_AVDMANAGER ||
+        p === SDK_EMULATOR ||
+        p === zshrc,
+    )
+    mockExecSync.mockImplementation((cmd) => {
+      const c = cmd as string
+      if (c === 'which brew') return '/opt/homebrew/bin/brew\n'
+      if (c === '/usr/libexec/java_home') return '/Library/Java/.../Home\n'
+      if (c === 'which sdkmanager') return '/opt/homebrew/bin/sdkmanager\n'
+      if (c === 'which adb') throw new Error('not found')
+      return ''
+    })
+
+    const results = await runSetupAndroid()
+    const sdk = findStep(results, 'android sdk')
+    expect(sdk?.ok).toBe(true)
+    expect(sdk?.state).toBe('found')
+    expect(sdk?.detail).toContain('open a new terminal')
+    expect(mockAppendFileSync).not.toHaveBeenCalled()
+  })
+
   // issue #326: state로 "이미 있었음(found)"과 "이번에 설치함(created)"을 구분한다.
   it("state: 완전 구성 머신은 모든 단계가 'found'", async () => {
     // 완전 구성 = env(rc 마커)까지 이미 등록된 상태. 그래야 registerAndroidEnv가

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -73,8 +73,8 @@ export async function cmdSetup(platform?: string): Promise<void> {
   }
   banner(allReady ? 'success' : 'error', allReady ? 'SETUP COMPLETE' : 'SETUP INCOMPLETE', summary)
 
-  // env를 방금 등록했으면 현재 쉘엔 반영 안 됨 → 새 터미널 안내(doctor가 PATH 경고를 내지 않도록).
+  // env가 rc에 있지만 현재 쉘엔 반영 안 됨 → 새 터미널 안내(doctor가 PATH 경고를 내지 않도록).
   if (needsNewShell) {
-    step('Open a new terminal (or run: exec $SHELL), then `tapflow doctor` to verify — ANDROID_HOME/PATH was just added to your shell config.')
+    step("Open a new terminal (or run: exec $SHELL), then `tapflow doctor` to verify — ANDROID_HOME/PATH is configured in your shell, but the current session hasn't loaded it yet.")
   }
 }

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -85,7 +85,7 @@ function checkAdbStatus(adb: AdbResolution | null): DoctorCheck {
     label: 'adb (not in PATH)',
     ok: false,
     warn: true,
-    detail: `adb found at ${adb.path} but not in PATH. Run: tapflow setup android`,
+    detail: `adb found at ${adb.path} but not in PATH. Open a new terminal or run: exec $SHELL, then re-run tapflow doctor`,
   }
 }
 

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -363,10 +363,10 @@ async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): P
   }
 }
 
-// env를 방금 rc에 등록한 경우의 안내. cmdSetup이 이 문구('new terminal')를 감지해 배너 뒤에 강조한다.
+// env가 rc에 있지만 현재 쉘엔 반영 안 된 경우의 안내. cmdSetup이 이 문구('new terminal')를 감지해 배너 뒤에 강조한다.
 function newShellHint(file: string): string {
   const shell = file.endsWith('.zshrc') ? 'zsh' : file.endsWith('.bashrc') ? 'bash' : '$SHELL'
-  return `Added ANDROID_HOME/PATH to ${file} — open a new terminal (or run: exec ${shell}) to use them.`
+  return `ANDROID_HOME/PATH is configured in ${file} — open a new terminal (or run: exec ${shell}) to use them.`
 }
 
 // 부팅하지 않는다 — AVD가 준비됐는지만 보장(없으면 폼팩터별 AVD 생성). 시스템 이미지는 SDK 단계에서 설치됨.

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, appendFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { confirm, text, isCancel } from '@clack/prompts'
-import { type DoctorCheck } from './doctor.js'
+import { resolveAdb, type DoctorCheck } from './doctor.js'
 import { step } from './print.js'
 
 // SetupStepResult = DoctorCheck + optional state (found/created/repaired); ok is untouched so doctor is unaffected.
@@ -303,12 +303,15 @@ async function checkAndFixJdk(brewAvailable: boolean): Promise<SetupStepResult> 
 // Android SDK를 ~/Library/Android/sdk에 자기완결로 구성한다(Android Studio GUI 불필요).
 async function checkAndFixAndroidSdk(brewAvailable: boolean, javaOk: boolean): Promise<SetupStepResult> {
   if (sdkSelfContained()) {
+    const adb = resolveAdb()
     const reg = registerAndroidEnv()
+    const needsLiveShellRefresh = Boolean(reg && !reg.added && adb && !adb.inPath)
+    const detail = reg && (reg.added || needsLiveShellRefresh) ? newShellHint(reg.file) : undefined
     return {
       label: 'Android SDK ready',
       ok: true,
       state: reg?.added ? 'repaired' : 'found',
-      detail: reg?.added ? newShellHint(reg.file) : undefined,
+      detail,
     }
   }
   if (!javaOk) {


### PR DESCRIPTION
## Summary

Fixes the Android setup/doctor PATH guidance loop from #307.

When `adb` is already present at the self-contained SDK path but not loaded in the current shell's `PATH`, `doctor` now points users to refresh the shell instead of re-running setup. `setup android` also repeats the new-shell hint when the rc block already exists but the live shell has not picked it up yet.

## Checklist
- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

None.

Fixes #307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `tapflow setup android` and `tapflow doctor` guidance for cases where the Android SDK is present, but `adb` is missing from the current shell PATH—now prompts to open a new terminal or refresh the shell before re-running `tapflow doctor`.
* **Documentation**
  * Clarified Android setup/doctor instructions to match the new terminal-refresh behavior (instead of pointing back to setup).
* **Chores**
  * Updated release metadata to use a patch bump for `tapflow`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->