### PR TITLE
fix(cli): check relay port in doctor

### DIFF
--- a/.changeset/thick-falcons-smile.md
+++ b/.changeset/thick-falcons-smile.md
@@ -1,0 +1,5 @@
+---
+"tapflow": patch
+---
+
+Add a `tapflow doctor` check that warns when the default relay port 4000 is already occupied.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- cli: `tapflow doctor` now checks whether the default relay port 4000 is already in use and prints the `lsof -ti:4000 | xargs kill` recovery command before `tapflow start` hits `EADDRINUSE`.
 - cli: `tapflow setup android` now reminds users to open a new shell when the Android SDK rc block already exists but `adb` is still missing from the live `PATH`; `tapflow doctor` now points to the shell-refresh step instead of looping back to setup.
 
 ## [0.10.0] - 2026-06-23

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -156,7 +156,7 @@ describe('runDoctorChecks', () => {
 
     const result = await runDoctorChecks()
     const portCheck = result.common.find((c) => c.label === 'Port 4000')
-    expect(portCheck).toEqual({ label: 'Port 4000', ok: true })
+    expect(portCheck).toStrictEqual({ label: 'Port 4000', ok: true, detail: undefined })
   })
 
   it('Port 4000이 점유되어 있으면 해결 명령을 포함해 실패로 표시', async () => {

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -157,6 +157,7 @@ describe('runDoctorChecks', () => {
     const result = await runDoctorChecks()
     const portCheck = result.common.find((c) => c.label === 'Port 4000')
     expect(portCheck).toStrictEqual({ label: 'Port 4000', ok: true, detail: undefined })
+    expect(mockCreateServer.mock.results[0]?.value.listen).toHaveBeenCalledWith({ port: 4000, host: '::', ipv6Only: false })
   })
 
   it('Port 4000이 점유되어 있으면 해결 명령을 포함해 실패로 표시', async () => {

--- a/packages/cli/src/__tests__/lib/doctor.test.ts
+++ b/packages/cli/src/__tests__/lib/doctor.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('node:child_process')
 vi.mock('node:fs')
+vi.mock('node:net')
 
 import { execSync, spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { createServer } from 'node:net'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { runDoctorChecks } from '../../lib/doctor.js'
@@ -13,6 +15,7 @@ const mockExistsSync = vi.mocked(existsSync)
 
 const mockExecSync = vi.mocked(execSync)
 const mockSpawnSync = vi.mocked(spawnSync)
+const mockCreateServer = vi.mocked(createServer)
 const sdkmanagerLinux = join(homedir(), 'Android', 'Sdk', 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
 const emulatorLinux = join(homedir(), 'Android', 'Sdk', 'emulator', 'emulator')
 
@@ -31,10 +34,32 @@ const simctlNoneBooted = JSON.stringify({
   },
 })
 
+function mockPortAvailable(available: boolean): void {
+  mockCreateServer.mockImplementation(() => {
+    const handlers = new Map<string, () => void>()
+    const server = {
+      once: vi.fn((event: string, handler: () => void) => {
+        handlers.set(event, handler)
+        return server
+      }),
+      listen: vi.fn(() => {
+        handlers.get(available ? 'listening' : 'error')?.()
+        return server
+      }),
+      close: vi.fn((handler?: () => void) => {
+        handler?.()
+        return server
+      }),
+    }
+    return server as never
+  })
+}
+
 describe('runDoctorChecks', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockExistsSync.mockReturnValue(false)
+    mockPortAvailable(true)
   })
   afterEach(() => {
     vi.restoreAllMocks()
@@ -115,12 +140,34 @@ describe('runDoctorChecks', () => {
   it('Node 버전 < 20이면 실패 + detail 포함', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     vi.spyOn(process, 'version', 'get').mockReturnValue('v18.0.0')
+    mockPortAvailable(true)
     mockExecSync.mockImplementation(() => { throw new Error('not found') })
 
     const result = await runDoctorChecks()
     const nodeCheck = result.common.find((c) => c.label.includes('Node'))
     expect(nodeCheck?.ok).toBe(false)
     expect(nodeCheck?.detail).toContain('Node ≥ 20')
+  })
+
+  it('Port 4000이 사용 가능하면 common 진단에서 ok로 표시', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockPortAvailable(true)
+    mockExecSync.mockImplementation(() => { throw new Error('not found') })
+
+    const result = await runDoctorChecks()
+    const portCheck = result.common.find((c) => c.label === 'Port 4000')
+    expect(portCheck).toEqual({ label: 'Port 4000', ok: true })
+  })
+
+  it('Port 4000이 점유되어 있으면 해결 명령을 포함해 실패로 표시', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockPortAvailable(false)
+    mockExecSync.mockImplementation(() => { throw new Error('not found') })
+
+    const result = await runDoctorChecks()
+    const portCheck = result.common.find((c) => c.label === 'Port 4000')
+    expect(portCheck?.ok).toBe(false)
+    expect(portCheck?.detail).toBe('Port 4000 is already in use. Run: lsof -ti:4000 | xargs kill')
   })
 
   it('booted 시뮬레이터가 있으면 이름 포함', async () => {

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -1,5 +1,6 @@
 import { execSync, spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { createServer } from 'node:net'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -23,7 +24,7 @@ export async function runDoctorChecks(platform?: string): Promise<DoctorResult> 
   const wantAndroid = platform === 'android' || !platform
 
   return {
-    common: [checkNodeVersion()],
+    common: [checkNodeVersion(), await checkPort(4000)],
     ios: wantIos ? buildIosChecks(isMac) : null,
     android: wantAndroid ? buildAndroidChecks(resolveAdb()) : null,
   }
@@ -151,6 +152,24 @@ function checkNodeVersion(): DoctorCheck {
     ok,
     detail: ok ? undefined : 'Node ≥ 20 required. Install from https://nodejs.org/',
   }
+}
+
+async function checkPort(port: number): Promise<DoctorCheck> {
+  const ok = await isPortAvailable(port)
+  return {
+    label: `Port ${port}`,
+    ok,
+    detail: ok ? undefined : `Port ${port} is already in use. Run: lsof -ti:${port} | xargs kill`,
+  }
+}
+
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer()
+    server.once('error', () => resolve(false))
+    server.once('listening', () => server.close(() => resolve(true)))
+    server.listen(port, '127.0.0.1')
+  })
 }
 
 export interface AdbResolution {

--- a/packages/cli/src/lib/doctor.ts
+++ b/packages/cli/src/lib/doctor.ts
@@ -168,7 +168,7 @@ function isPortAvailable(port: number): Promise<boolean> {
     const server = createServer()
     server.once('error', () => resolve(false))
     server.once('listening', () => server.close(() => resolve(true)))
-    server.listen(port, '127.0.0.1')
+    server.listen({ port, host: '::', ipv6Only: false })
   })
 }
 


### PR DESCRIPTION
## Summary

Add a common `tapflow doctor` check for the default relay port so users get a clear recovery command before `tapflow start` runs into `EADDRINUSE`.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

N/A

Closes #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `tapflow doctor` check to verify whether the default relay port (`4000`) is available.
  * When `4000` is in use, the doctor output now includes a recovery command hint before `tapflow start` fails.

* **Bug Fixes**
  * Improved port-conflict diagnostics to avoid confusing `address already in use` issues.

* **Tests**
  * Expanded CLI tests to validate `Port 4000` reporting for both available and occupied cases using mocked networking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->