### PR TITLE
fix(cli): repair partial Android SDK setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- cli: `tapflow setup android` now treats a missing emulator binary or Android system image as a partial SDK and repairs it instead of reporting the SDK as ready.
 - cli: `tapflow doctor` now checks whether the default relay port 4000 is already in use and prints the `lsof -ti:4000 | xargs kill` recovery command before `tapflow start` hits `EADDRINUSE`.
 - cli: `tapflow setup android` now reminds users to open a new shell when the Android SDK rc block already exists but `adb` is still missing from the live `PATH`; `tapflow doctor` now points to the shell-refresh step instead of looping back to setup.
 

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -186,9 +186,19 @@ describe('runSetupAndroid', () => {
       if (p === SDK_EMULATOR || p === SDK_SYSTEM_IMAGE) return installed
       return false
     })
+    const expectedSystemImage =
+      process.arch === 'arm64'
+        ? 'system-images;android-35;google_apis;arm64-v8a'
+        : 'system-images;android-35;google_apis;x86_64'
+
     mockSpawnSync.mockImplementation((cmd, args) => {
       const a = Array.isArray(args) ? args : []
-      if (typeof cmd === 'string' && cmd.includes('sdkmanager') && a.includes('cmdline-tools;latest')) {
+      if (
+        typeof cmd === 'string' &&
+        cmd.includes('sdkmanager') &&
+        a.includes('cmdline-tools;latest') &&
+        a.includes(expectedSystemImage)
+      ) {
         installed = true
         return okSpawn as never
       }
@@ -202,7 +212,13 @@ describe('runSetupAndroid', () => {
 
     expect(mockSpawnSync).toHaveBeenCalledWith(
       SDK_SDKMANAGER,
-      expect.arrayContaining([`--sdk_root=${SDK_DIR}`, 'cmdline-tools;latest', 'platform-tools', 'emulator']),
+      expect.arrayContaining([
+        `--sdk_root=${SDK_DIR}`,
+        'cmdline-tools;latest',
+        'platform-tools',
+        'emulator',
+        expectedSystemImage,
+      ]),
       expect.anything(),
     )
     expect(findStep(results, 'android sdk')?.label).toBe('Android SDK installed')

--- a/packages/cli/src/__tests__/lib/setup.test.ts
+++ b/packages/cli/src/__tests__/lib/setup.test.ts
@@ -33,6 +33,13 @@ const SDK_SDKMANAGER = join(SDK_DIR, 'cmdline-tools', 'latest', 'bin', 'sdkmanag
 const SDK_AVDMANAGER = join(SDK_DIR, 'cmdline-tools', 'latest', 'bin', 'avdmanager')
 const SDK_ADB = join(SDK_DIR, 'platform-tools', 'adb')
 const SDK_EMULATOR = join(SDK_DIR, 'emulator', 'emulator')
+const SDK_SYSTEM_IMAGE = join(
+  SDK_DIR,
+  'system-images',
+  'android-35',
+  'google_apis',
+  process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64',
+)
 const zshrc = join(homedir(), '.zshrc')
 
 const okSpawn = { status: 0, stdout: '', stderr: '', pid: 1, output: [], signal: null }
@@ -60,7 +67,7 @@ describe('runSetupAndroid', () => {
       return ''
     })
     mockExistsSync.mockImplementation(
-      (p) => p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_AVDMANAGER || p === SDK_EMULATOR,
+      (p) => p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_AVDMANAGER || p === SDK_EMULATOR || p === SDK_SYSTEM_IMAGE,
     )
     mockSpawnSync.mockImplementation((cmd, args) => {
       if (cmd === SDK_EMULATOR && Array.isArray(args) && args.includes('-list-avds')) {
@@ -135,7 +142,7 @@ describe('runSetupAndroid', () => {
     setTTY(true)
     let installed = false
     mockExistsSync.mockImplementation((p) => {
-      if (p === SDK_SDKMANAGER || p === SDK_ADB) return installed
+      if (p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_SYSTEM_IMAGE) return installed
       if (p === SDK_AVDMANAGER || p === SDK_EMULATOR) return true
       return false
     })
@@ -166,6 +173,40 @@ describe('runSetupAndroid', () => {
 
     const results = await runSetupAndroid()
     expect(findStep(results, 'android sdk')?.warn).toBe(true)
+  })
+
+  it('partial SDK without emulator/system image is repaired instead of reported as found', async () => {
+    setTTY(true)
+    mockReadFileSync.mockReturnValue(
+      '# >>> tapflow android sdk >>>\nexport ANDROID_HOME="x"\n# <<< tapflow android sdk <<<\n',
+    )
+    let installed = false
+    mockExistsSync.mockImplementation((p) => {
+      if (p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_AVDMANAGER || p === zshrc) return true
+      if (p === SDK_EMULATOR || p === SDK_SYSTEM_IMAGE) return installed
+      return false
+    })
+    mockSpawnSync.mockImplementation((cmd, args) => {
+      const a = Array.isArray(args) ? args : []
+      if (typeof cmd === 'string' && cmd.includes('sdkmanager') && a.includes('cmdline-tools;latest')) {
+        installed = true
+        return okSpawn as never
+      }
+      if (cmd === SDK_EMULATOR && a.includes('-list-avds')) {
+        return { ...okSpawn, stdout: 'tapflow-phone\n' } as never
+      }
+      return okSpawn as never
+    })
+
+    const results = await runSetupAndroid()
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      SDK_SDKMANAGER,
+      expect.arrayContaining([`--sdk_root=${SDK_DIR}`, 'cmdline-tools;latest', 'platform-tools', 'emulator']),
+      expect.anything(),
+    )
+    expect(findStep(results, 'android sdk')?.label).toBe('Android SDK installed')
+    expect(findStep(results, 'android sdk')?.state).toBe('created')
   })
 
   it('AVD가 있으면 ok (생성 안 함)', async () => {
@@ -237,6 +278,7 @@ describe('runSetupAndroid', () => {
         p === SDK_ADB ||
         p === SDK_AVDMANAGER ||
         p === SDK_EMULATOR ||
+        p === SDK_SYSTEM_IMAGE ||
         p === zshrc,
     )
 
@@ -261,6 +303,7 @@ describe('runSetupAndroid', () => {
         p === SDK_ADB ||
         p === SDK_AVDMANAGER ||
         p === SDK_EMULATOR ||
+        p === SDK_SYSTEM_IMAGE ||
         p === zshrc,
     )
     mockExecSync.mockImplementation((cmd) => {
@@ -293,6 +336,7 @@ describe('runSetupAndroid', () => {
         p === SDK_ADB ||
         p === SDK_AVDMANAGER ||
         p === SDK_EMULATOR ||
+        p === SDK_SYSTEM_IMAGE ||
         p === zshrc,
     )
 
@@ -317,7 +361,7 @@ describe('runSetupAndroid', () => {
     setTTY(true)
     let installed = false
     mockExistsSync.mockImplementation((p) => {
-      if (p === SDK_SDKMANAGER || p === SDK_ADB) return installed
+      if (p === SDK_SDKMANAGER || p === SDK_ADB || p === SDK_SYSTEM_IMAGE) return installed
       if (p === SDK_AVDMANAGER || p === SDK_EMULATOR) return true
       return false
     })

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -33,6 +33,10 @@ function androidSystemImage(): string {
   return `system-images;${AVD_IMAGE_API};google_apis;${abi}`
 }
 
+function androidSystemImageDir(): string {
+  return join(ANDROID_SDK_DIR, ...androidSystemImage().split(';'))
+}
+
 // 디바이스 부팅은 하지 않는다 — QA Session 접속 시 relay가 on-demand로 부팅한다.
 // setup은 "부팅 가능한 디바이스/AVD가 준비된 상태"까지만 보장한다.
 
@@ -88,7 +92,12 @@ const SDK_CMDLINE_BIN = join(ANDROID_SDK_DIR, 'cmdline-tools', 'latest', 'bin')
 
 // cmdline-tools가 SDK 안에 있고 platform-tools(adb)까지 갖춘 자기완결 상태인지.
 function sdkSelfContained(): boolean {
-  return existsSync(join(SDK_CMDLINE_BIN, 'sdkmanager')) && existsSync(join(ANDROID_SDK_DIR, 'platform-tools', 'adb'))
+  return (
+    existsSync(join(SDK_CMDLINE_BIN, 'sdkmanager')) &&
+    existsSync(join(ANDROID_SDK_DIR, 'platform-tools', 'adb')) &&
+    existsSync(join(ANDROID_SDK_DIR, 'emulator', 'emulator')) &&
+    existsSync(androidSystemImageDir())
+  )
 }
 
 function hasJava(): boolean {


### PR DESCRIPTION
## Summary

- Tighten Android SDK readiness so `tapflow setup android` only reports the SDK as ready when cmdline-tools, platform-tools, the emulator binary, and the expected system image are all present.
- Let partial SDK installs fall back through the existing sdkmanager repair path instead of being reported as `found`.
- Add a regression test for the partial-SDK case and update the changelog.

Closes #330

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

N/A — small scoped CLI setup fix.

## Verification

- `pnpm --filter tapflow exec vitest run src/__tests__/lib/setup.test.ts`
- `pnpm --filter tapflow exec vitest run src/__tests__/lib/setup.test.ts src/__tests__/commands/setup.test.ts src/__tests__/lib/doctor.test.ts`
- `pnpm --filter tapflow lint`
- `pnpm --filter tapflow typecheck`
- pre-commit hook: root `pnpm -r --if-present lint` and `pnpm -r --if-present typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android SDK setup detection: missing emulator binary or the configured system image is now recognized as a partial SDK and automatically repaired.
  * Android setup now labels and classifies the “Android SDK” step more accurately when components are incomplete, preventing “ready” status from appearing too early.
* **Documentation**
  * Added a release note describing that `tapflow setup android` will repair a partial Android SDK instead of treating it as fully configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->