### PR TITLE
refactor(build): TS project references + fix package type entrypoints (#345)

### DIFF
--- a/.changeset/package-type-entrypoints.md
+++ b/.changeset/package-type-entrypoints.md
@@ -1,0 +1,12 @@
+---
+"@tapflowio/agent-core": patch
+"@tapflowio/audiotap-helper": patch
+"@tapflowio/relay": patch
+"@tapflowio/ios-agent": patch
+"@tapflowio/android-agent": patch
+"tapflow": patch
+---
+
+Fix the package type entrypoint for npm consumers (#345). `exports.types` now points at the published `dist/*.d.ts` instead of `src/` — which isn't shipped in the tarball (`files` ships only `dist`/`bin`), so consumers couldn't resolve the package's types.
+
+The monorepo moves to **TypeScript project references** (each lib package gets `composite: true` + `references`, plus a root solution `tsconfig.json`). `typecheck`/`build` run via `tsc -b`, so workspace typecheck stays build-light (incremental, no manual dist build) while the published packages expose correct types from `dist`. No runtime or public API changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,6 @@ jobs:
 
       - run: pnpm lint
 
-      - run: |
-          echo "audiotap @types:"; ls -la packages/audiotap-helper/node_modules/@types 2>&1 || echo NONE
-          echo "root @types:"; ls -la node_modules/@types 2>&1 || echo NONE
-          echo "resolve from audiotap:"; node -e "console.log(require.resolve('@types/node/package.json',{paths:['packages/audiotap-helper']}))" 2>&1 || echo FAIL
       - run: pnpm typecheck
 
       - run: pnpm --filter @tapflowio/agent-core build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
 
       - run: pnpm lint
 
+      - run: |
+          echo "audiotap @types:"; ls -la packages/audiotap-helper/node_modules/@types 2>&1 || echo NONE
+          echo "root @types:"; ls -la node_modules/@types 2>&1 || echo NONE
+          echo "resolve from audiotap:"; node -e "console.log(require.resolve('@types/node/package.json',{paths:['packages/audiotap-helper']}))" 2>&1 || echo FAIL
       - run: pnpm typecheck
 
       - run: pnpm --filter @tapflowio/agent-core build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm typecheck
+
       - run: pnpm --filter @tapflowio/agent-core build
       - run: pnpm --filter @tapflowio/audiotap-helper build
       - run: pnpm --filter @tapflowio/dashboard build

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter tapflow build && pnpm --filter @tapflowio/mcp-server build",
     "test": "pnpm -r test --if-present",
     "lint": "pnpm -r --if-present lint",
-    "typecheck": "pnpm -r --if-present typecheck",
+    "typecheck": "tsc -b && pnpm --filter @tapflowio/dashboard --filter @tapflowio/mcp-server typecheck",
     "prepare": "lefthook install",
     "dev": "concurrently -k -n relay,dashboard,ios,android -c cyan,magenta,green,yellow \"pnpm dev:relay\" \"pnpm --filter @tapflowio/dashboard dev\" \"pnpm dev:ios\" \"pnpm dev:android\"",
     "dev:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm dev:relay\" \"pnpm dev:ios\" \"pnpm --filter @tapflowio/playground mock-agents\"",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -24,14 +24,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./utils": {
-      "types": "./src/utils/index.ts",
+      "types": "./dist/utils/index.d.ts",
       "source": "./src/utils/index.ts",
       "tsx": "./src/utils/index.ts",
       "import": "./dist/utils/index.js",
@@ -50,8 +50,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "lint": "eslint src"
   },

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "composite": true
+    "composite": true,
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -9,8 +9,16 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": []
 }

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "composite": true,
     "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -25,7 +25,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
@@ -46,8 +46,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "lint": "eslint src",
     "download-scrcpy-server": "node scripts/download-scrcpy-server.mjs"

--- a/packages/android-agent/tsconfig.json
+++ b/packages/android-agent/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/android-agent/tsconfig.json
+++ b/packages/android-agent/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/packages/android-agent/tsconfig.json
+++ b/packages/android-agent/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/android-agent/tsconfig.json
+++ b/packages/android-agent/tsconfig.json
@@ -10,8 +10,23 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../agent-core"
+    },
+    {
+      "path": "../audiotap-helper"
+    }
+  ]
 }

--- a/packages/audiotap-helper/package.json
+++ b/packages/audiotap-helper/package.json
@@ -24,7 +24,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
@@ -45,8 +45,8 @@
   },
   "scripts": {
     "postinstall": "node -e \"if (process.platform === 'darwin') { try { require('fs').chmodSync('bin/audiotap-helper.app/Contents/MacOS/audiotap-helper', 0o755) } catch {} }\"",
-    "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "lint": "eslint src"
   },

--- a/packages/audiotap-helper/tsconfig.json
+++ b/packages/audiotap-helper/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/audiotap-helper/tsconfig.json
+++ b/packages/audiotap-helper/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/packages/audiotap-helper/tsconfig.json
+++ b/packages/audiotap-helper/tsconfig.json
@@ -10,8 +10,20 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../agent-core"
+    }
+  ]
 }

--- a/packages/audiotap-helper/tsconfig.json
+++ b/packages/audiotap-helper/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,8 +43,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "lint": "eslint src",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "composite": true
+    "composite": true,
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,8 +9,29 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../agent-core"
+    },
+    {
+      "path": "../ios-agent"
+    },
+    {
+      "path": "../android-agent"
+    },
+    {
+      "path": "../relay"
+    }
+  ]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "composite": true,
     "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -28,7 +28,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
@@ -49,8 +49,8 @@
   },
   "scripts": {
     "postinstall": "node -e \"if (process.platform === 'darwin') { require('fs').readdirSync('bin').forEach(f => require('fs').chmodSync('bin/' + f, 0o755)) }\"",
-    "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "lint": "eslint src"
   },

--- a/packages/ios-agent/tsconfig.json
+++ b/packages/ios-agent/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/ios-agent/tsconfig.json
+++ b/packages/ios-agent/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/packages/ios-agent/tsconfig.json
+++ b/packages/ios-agent/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/ios-agent/tsconfig.json
+++ b/packages/ios-agent/tsconfig.json
@@ -10,8 +10,23 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../agent-core"
+    },
+    {
+      "path": "../audiotap-helper"
+    }
+  ]
 }

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -25,7 +25,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "tsx": "./src/index.ts",
       "import": "./dist/index.js",
@@ -45,8 +45,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc && rm -rf dist/migrations && cp -r src/migrations dist/migrations",
-    "typecheck": "tsc --noEmit",
+    "build": "tsc -b && rm -rf dist/migrations && cp -r src/migrations dist/migrations",
+    "typecheck": "tsc -b",
     "start": "node dist/server.js",
     "test": "vitest run",
     "lint": "eslint src"

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types"
+    ],
+    "types": [
+      "node"
     ]
   },
   "include": [

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "composite": true
+    "composite": true,
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -9,8 +9,20 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__", "dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/__tests__",
+    "dist",
+    "node_modules"
+  ],
+  "references": [
+    {
+      "path": "../agent-core"
+    }
+  ]
 }

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -12,10 +12,6 @@
     "esModuleInterop": true,
     "composite": true,
     "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
     "types": [
       "node"
     ]

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -11,7 +11,11 @@
     "strict": true,
     "esModuleInterop": true,
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "packages/agent-core"
+    },
+    {
+      "path": "packages/audiotap-helper"
+    },
+    {
+      "path": "packages/relay"
+    },
+    {
+      "path": "packages/ios-agent"
+    },
+    {
+      "path": "packages/android-agent"
+    },
+    {
+      "path": "packages/cli"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Fix the package type entrypoint for npm consumers (#345) and migrate the monorepo to TypeScript project references.

## Problem

`exports.types` pointed at `./src/index.ts`, but `files` ships only `dist`/`bin` — so an npm-installed consumer can't resolve a package's types (node16 resolution prefers `exports.types` over the top-level `types`). All 5 lib packages shared this pattern. Surfaced via PR #344 / CodeRabbit.

## Why project references (not "files: src")

The build-free cross-package typecheck relied on `exports.types=src` + pnpm symlink — a non-standard source-export trick. The standard is `exports.types→dist`, but then dev typecheck must resolve types from build output. TS-native **project references** (composite + `tsc -b`) gives exactly that while keeping typecheck incremental (no manual dist build, ~0.3s). No extra tooling (turbo/tsup); a plain paths approach was rejected (rootDir conflict, TS6059).

## Changes

- **6 lib packages** (agent-core, audiotap-helper, relay, ios-agent, android-agent, cli): `composite: true` + `references` per the dependency graph; `exports.types` (incl. subentries like `agent-core/utils`) → `dist/*.d.ts`.
- **Root solution `tsconfig.json`** (`files: []` + references to the 6 libs).
- **typecheck** → `tsc -b` (+ apps `tsc --noEmit`); **build** → `tsc -b` + asset steps (relay migrations, mcp chmod, dashboard vite). build/typecheck share the same `.tsbuildinfo` so typecheck doesn't make build skip emit (a subtle TS6305 trap).
- **CI**: explicit `pnpm typecheck` before build.
- dashboard/mcp-server (apps) unchanged — not composite.

## Verification

- Clean build (buildinfo + dist removed) → **all tests pass**: agent-core 132, relay 404, ios 200, android 149, cli 226, audiotap 4, dashboard 200, mcp 22.
- `npm pack --dry-run`: every lib ships `dist/*.d.ts`; the files `exports.types` points at exist.
- Incremental `tsc -b` ~0.3s; pre-commit typecheck ~3.7s.

No runtime or public API changes. Closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled TypeScript project references across the workspace using a root TypeScript configuration.
* **Bug Fixes**
  * Updated published type declarations resolution so TypeScript consumers use generated `.d.ts` files from `dist/` rather than source `src/`.
* **Chores**
  * Switched package build and typecheck scripts to TypeScript project build mode (`tsc -b`).
  * Added a CI `typecheck` step to run workspace typechecking during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->