### PR TITLE
chore(audiotap-helper): add README + LICENSE for first npm publish

### DIFF
--- a/packages/audiotap-helper/LICENSE
+++ b/packages/audiotap-helper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tapflow contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/audiotap-helper/README.md
+++ b/packages/audiotap-helper/README.md
@@ -1,0 +1,24 @@
+# @tapflowio/audiotap-helper
+
+Shared macOS Core Audio process-tap helper for [tapflow](https://github.com/jo-duchan/tapflow).
+
+Taps a host process's audio by PID — no device routing, no dylib injection, no host-output hijack. Used internally by `@tapflowio/ios-agent` (iOS simulator audio capture) and `@tapflowio/android-agent` (Android emulator host-mute). Ships as a prebuilt, ad-hoc-signed `.app` so it holds its own one-time audio-recording (TCC) grant.
+
+## Requirements
+
+- macOS 14.2+ (Core Audio process taps)
+- Node.js ≥ 20
+
+## Usage
+
+Internal building block of tapflow — not intended for standalone use. The agents call it via the exported helpers:
+
+```ts
+import { ensureHelperApp, launchAudioHelper, launchMuteOnlyTap, isAudioSupported } from '@tapflowio/audiotap-helper'
+```
+
+See [contributing/simulator-audio.md](https://github.com/jo-duchan/tapflow/blob/main/contributing/simulator-audio.md) for the design.
+
+## License
+
+[MIT](LICENSE) — part of the [tapflow](https://github.com/jo-duchan/tapflow) project.


### PR DESCRIPTION
audiotap-helper package.json `files` lists README.md and LICENSE, but the files did not exist, so the npm tarball shipped without them. Add them before the first manual publish (npm page + license text).

 First publish of @tapflowio/audiotap-helper is manual (OIDC trusted publishing needs the package to already exist); these meta files should be in that initial tarball.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README for the audio tap helper with an overview, usage context, system requirements, and licensing info.
* **Chores**
  * Updated the included license text and copyright notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->