### PR TITLE
docs: add systemd relay deployment guide

### DIFF
--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -362,3 +362,75 @@ pm2 restart relay
 ::: tip Next step
 Once the relay is running, open `http://localhost:4000` in a browser — the dashboard redirects to the setup page automatically. For headless servers, use `tapflow admin init` instead. For team invitations and your first build upload, see [First-time Setup](/dashboard/setup).
 :::
+
+## systemd (Linux relay server)
+
+Use systemd when the relay runs on a Linux host and you want it to start at boot, restart after crashes, and write logs to journald. Install tapflow globally first:
+
+```sh
+npm install -g tapflow
+```
+
+Create a dedicated user and data directory:
+
+```sh
+sudo useradd --system --create-home --home-dir /var/lib/tapflow --shell /usr/sbin/nologin tapflow
+sudo mkdir -p /etc/tapflow /var/lib/tapflow/.tapflow-data
+sudo chown -R tapflow:tapflow /var/lib/tapflow
+```
+
+Put relay secrets in `/etc/tapflow/relay.env`:
+
+```ini
+TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data
+JWT_SECRET=YOUR_JWT_SECRET
+```
+
+Generate `JWT_SECRET` with `openssl rand -hex 32`, then keep `/etc/tapflow/relay.env` readable only by root:
+
+```sh
+sudo chmod 600 /etc/tapflow/relay.env
+```
+
+Create `/etc/systemd/system/tapflow-relay.service`:
+
+```ini
+[Unit]
+Description=tapflow relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tapflow
+Group=tapflow
+WorkingDirectory=/var/lib/tapflow
+EnvironmentFile=/etc/tapflow/relay.env
+ExecStart=/usr/bin/env tapflow relay start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now tapflow-relay
+sudo systemctl status tapflow-relay
+```
+
+View logs with:
+
+```sh
+journalctl -u tapflow-relay -f
+```
+
+After updating the global package, restart the service:
+
+```sh
+npm update -g tapflow
+sudo systemctl restart tapflow-relay
+```

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -379,7 +379,7 @@ sudo mkdir -p /etc/tapflow /var/lib/tapflow/.tapflow-data
 sudo chown -R tapflow:tapflow /var/lib/tapflow
 ```
 
-Put relay secrets in `/etc/tapflow/relay.env`:
+Put relay secrets in `/etc/tapflow/relay.env`. The existing [JWT_SECRET](#jwt-secret) section also describes the `.tapflow-data/.env` convention that the relay reads directly:
 
 ```ini
 TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data
@@ -413,6 +413,8 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 ```
+
+Place `tapflow.config.json` in `/var/lib/tapflow` if you need to customize the port or other settings, because that is the service `WorkingDirectory`.
 
 Enable and start the service:
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -379,7 +379,7 @@ sudo mkdir -p /etc/tapflow /var/lib/tapflow/.tapflow-data
 sudo chown -R tapflow:tapflow /var/lib/tapflow
 ```
 
-릴레이 시크릿은 `/etc/tapflow/relay.env`에 둡니다:
+릴레이 시크릿은 `/etc/tapflow/relay.env`에 둡니다. 기존 [JWT_SECRET](#jwt-secret) 섹션은 릴레이가 직접 읽는 `.tapflow-data/.env` 방식도 설명합니다:
 
 ```ini
 TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data
@@ -413,6 +413,8 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 ```
+
+기본값이 아닌 포트나 다른 설정이 필요하다면 `tapflow.config.json`을 `WorkingDirectory`인 `/var/lib/tapflow`에 둡니다.
 
 서비스를 활성화하고 시작합니다:
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -362,3 +362,75 @@ pm2 restart relay
 ::: tip 다음 단계
 릴레이가 실행되면 브라우저에서 `http://localhost:4000`을 열면 설정 페이지로 자동 이동합니다. 브라우저를 사용할 수 없는 서버 환경이라면 `tapflow admin init`을 사용하세요. 팀원 초대와 첫 빌드 업로드는 [대시보드 최초 설정](/ko/dashboard/setup)을 참고하세요.
 :::
+
+## systemd (Linux 릴레이 서버)
+
+릴레이를 Linux 호스트에서 실행하고 부팅 시 자동 시작, 크래시 후 재시작, journald 로그 관리를 원한다면 systemd를 사용하세요. 먼저 tapflow를 전역으로 설치합니다:
+
+```sh
+npm install -g tapflow
+```
+
+전용 사용자와 데이터 디렉터리를 만듭니다:
+
+```sh
+sudo useradd --system --create-home --home-dir /var/lib/tapflow --shell /usr/sbin/nologin tapflow
+sudo mkdir -p /etc/tapflow /var/lib/tapflow/.tapflow-data
+sudo chown -R tapflow:tapflow /var/lib/tapflow
+```
+
+릴레이 시크릿은 `/etc/tapflow/relay.env`에 둡니다:
+
+```ini
+TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data
+JWT_SECRET=YOUR_JWT_SECRET
+```
+
+`JWT_SECRET`은 `openssl rand -hex 32`로 생성하고, `/etc/tapflow/relay.env`는 root만 읽을 수 있게 제한합니다:
+
+```sh
+sudo chmod 600 /etc/tapflow/relay.env
+```
+
+`/etc/systemd/system/tapflow-relay.service`를 만듭니다:
+
+```ini
+[Unit]
+Description=tapflow relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tapflow
+Group=tapflow
+WorkingDirectory=/var/lib/tapflow
+EnvironmentFile=/etc/tapflow/relay.env
+ExecStart=/usr/bin/env tapflow relay start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+서비스를 활성화하고 시작합니다:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now tapflow-relay
+sudo systemctl status tapflow-relay
+```
+
+로그는 다음으로 확인합니다:
+
+```sh
+journalctl -u tapflow-relay -f
+```
+
+전역 패키지를 업데이트한 뒤에는 서비스를 재시작합니다:
+
+```sh
+npm update -g tapflow
+sudo systemctl restart tapflow-relay
+```


### PR DESCRIPTION
## Summary\n- add a Linux systemd deployment example for the relay\n- document the service user, data directory, environment file, service unit, logs, and update flow\n- keep the Korean self-hosting docs in sync\n\nCloses #353\n\n## Validation\n- pnpm docs:build\n- pnpm typecheck (pre-commit)\n- pnpm lint (pre-commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “systemd (Linux relay server)” section to the self-hosting guides.
  * Includes steps to install the package globally, create a dedicated user and data directory, and configure a protected environment file with required relay settings.
  * Provides a systemd service unit setup plus commands to reload systemd, enable/start the service, check status, view logs, and restart after updates.
  * Updated the Korean self-hosting guide with the same systemd instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->