### PR TITLE
chore: release v0.11.1 — iOS button fixes + js-yaml security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-02
+
 ### Added
 
+- relay: Docker support and a container image publish workflow, so the relay can be self-hosted as an image instead of only from source (#352).
 - docs: add navigation links to the project changelog.
+
+### Changed
+
+- deps: bump the npm minor/patch dependency group (22 updates).
+
+### Fixed
+
+- ios: physical device-frame buttons are confined to the bezel — a tap inside the screen area is no longer hijacked as a button press on devices where a button sits near the edge (e.g. iPhone SE). HID buttons also support press-and-hold via an optional `phase: 'down' | 'up'` on `input:button`; existing single-press clients are unaffected.
+- dashboard: use the `TimerOff` icon for the cancel-deletion action.
+
+### Security
+
+- Patch js-yaml to 3.15.0 to address CVE-2026-53550.
 
 ## [0.11.0] - 2026-06-29
 
@@ -224,7 +240,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/jo-duchan/tapflow/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/jo-duchan/tapflow/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/jo-duchan/tapflow/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/jo-duchan/tapflow/compare/v0.9.1...v0.9.2

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.11.1
+
 ## 0.11.0
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/android-agent
 
+## 0.11.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.11.1
+- @tapflowio/audiotap-helper@0.2.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/audiotap-helper/CHANGELOG.md
+++ b/packages/audiotap-helper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/audiotap-helper
 
+## 0.2.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.11.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/audiotap-helper/package.json
+++ b/packages/audiotap-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/audiotap-helper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared macOS Core Audio process-tap helper for tapflow — iOS simulator audio capture and Android emulator host-mute",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # tapflow
 
+## 0.11.1
+
+### Patch Changes
+
+- Patch js-yaml to 3.15.0 to address CVE-2026-53550, and bump the npm minor/patch dependency group.
+- Updated dependencies
+  - @tapflowio/ios-agent@0.11.1
+  - @tapflowio/agent-core@0.11.1
+  - @tapflowio/android-agent@0.11.1
+  - @tapflowio/relay@0.11.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tapflowio/ios-agent
 
+## 0.11.1
+
+### Patch Changes
+
+- Confine physical device-frame buttons to the bezel and add button press-and-hold.
+
+  A tap inside the screen area is no longer hijacked as a button press (previously a circular hit-test around each button center could overlap the screen on devices where a button sits near the bezel, e.g. iPhone SE). HID buttons now support real-time hold: `input:button` accepts an optional `phase: 'down' | 'up'` so a button can be held instead of only tapped. The field is optional, so existing single-press clients (e.g. MCP sending `{ name }`) are unaffected.
+
+  - @tapflowio/agent-core@0.11.1
+  - @tapflowio/audiotap-helper@0.2.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.11.0-experimental.1",
+  "version": "0.11.1-experimental.1",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/relay
 
+## 0.11.1
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.11.1
+
 ## 0.11.0
 
 ### Patch Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
## Release v0.11.1 (patch)

Bundles the changes merged since v0.11.0 into a patch release. No new npm API and no breaking changes.

### Versions

| Package | Version | Note |
|---|---|---|
| `tapflow`, `@tapflowio/agent-core`, `@tapflowio/ios-agent`, `@tapflowio/android-agent`, `@tapflowio/relay` | `0.11.1` | fixed group |
| `@tapflowio/audiotap-helper` | `0.2.1` | dependent bump (depends on `agent-core`) |
| `@tapflowio/mcp-server` | `0.11.1-experimental.1` | manual (ignore group, experimental dist-tag) |

### Highlights

**Fixed**
- **ios**: physical device-frame buttons are confined to the bezel — a tap inside the screen area is no longer hijacked as a button press on devices where a button sits near the edge (e.g. iPhone SE). HID buttons also support press-and-hold via an optional `phase: 'down' | 'up'` on `input:button`; existing single-press clients (e.g. MCP `{ name }`) are unaffected.
- **dashboard**: use the `TimerOff` icon for the cancel-deletion action.

**Security**
- Patch js-yaml to 3.15.0 to address CVE-2026-53550.

**Added**
- **relay**: Docker support and a container image publish workflow (#352) — infra only, no npm package code change.
- **docs**: navigation links to the project changelog.

**Changed**
- **deps**: bump the npm minor/patch dependency group (22 updates).

### Compatibility

The `input:button` WebSocket message gained an **optional** `phase` field. Backward compatible: clients sending `{ name }` keep single-press behavior — verified by `ios-agent` unit tests (`input:button home (no phase) presses the legacy button once`). No envelope/API/CLI/schema breaking changes.

### Notes

- Changesets consumed; `pnpm changeset version` applied. No lockfile changes (internal deps are `workspace:*`).
- Root `CHANGELOG.md` promoted to `[0.11.1] - 2026-07-02` with compare links updated.
- typecheck + lint pass (pre-commit).

> Publishing is triggered by pushing the `vX.Y.Z` tag after merge — merging this PR alone does not publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for press-and-hold button actions on iOS devices, while keeping single-press behavior unchanged.
  * Updated release notes and version tracking for the latest patch release across the app.

* **Bug Fixes**
  * Improved button hit-testing on iOS device frames so taps are limited to the bezel area.
  * Refreshed the dashboard icon.

* **Security**
  * Included a security update for a third-party YAML dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->