### PR TITLE
ci(docker): skip Docker Hub login/push when credentials are absent

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,11 +12,18 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Publish only when Docker Hub credentials are configured; otherwise build-validate only.
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_USERNAME != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Warn when Docker Hub credentials are missing
+        if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB != 'true'
+        run: echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set — building the image for validation but skipping push."
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -25,7 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -47,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

The **Docker Publish** workflow (added in #352) fails on every push to `main` — and would fail on release tags too — at the `Log in to Docker Hub` step:

```
##[error]Username and password required
```

Root cause: `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repository secrets are not configured, so `docker/login-action@v3` receives empty credentials. The step ran unconditionally on non-PR events, so it hard-failed. (PR events skipped it, which is why it wasn't caught in review.)

This does not affect the npm release (`release.yml` is a separate workflow using OIDC), but it produces a red X on `main` and on every `vX.Y.Z` tag push.

## Fix

Gate Docker Hub login and push on a `HAS_DOCKERHUB` job-level flag derived from the secrets:

- **No secrets** → build the image for validation, **skip login and push**, emit a `::warning::`. No failure.
- **Secrets present** → unchanged behavior: login + multi-arch build + push. No extra config needed once secrets are added.
- **Pull requests** → unchanged: build only, never push.

## Verification

- YAML parses cleanly; job-level `env` referencing `secrets` and step `if` referencing `env` is a documented GitHub Actions pattern.
- pre-commit typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker publishing automation to better handle missing registry credentials.
  * Added a clear warning when a publish is expected but credentials are not available.
  * Docker images are now only pushed when publishing is possible; otherwise, the workflow performs a build-only run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->