### PR TITLE
feat(relay): accept EAS .tar.gz simulator builds as a first-class upload

### DIFF
--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -27,7 +27,7 @@ The audience is the whole team (PO, PM, designers, backend, QA) — not just QA.
 - **App sidebar**: `GET /api/v1/apps` → selecting an app manages state via `?appId=N` URL parameter.
 - **Release Accordion**: `GET /api/v1/builds?app_id=N` → grouped by `version_name` (`groupByRelease()`). No dedicated `releases` table — UI grouping uses `version_name` metadata.
 - **Build card**: shows `build_number`, `platform`, `status_label`, uploader, `uploaded_at`. Inline status dropdown. **"Start QA" CTA** → `/app-center/build?id={build_id}`.
-- **Upload**: `UploadBuildDialog` — iOS `.app.zip` / Android `.apk`. `version_name` / `build_number` are auto-extracted from plist, so no manual input fields.
+- **Upload**: `UploadBuildDialog` — iOS `.app.zip` or `.tar.gz`/`.tgz` (EAS simulator build) / Android `.apk`. `version_name` / `build_number` are auto-extracted from plist, so no manual input fields.
 
 ## HOW
 

--- a/packages/dashboard/components/UploadBuildDialog.tsx
+++ b/packages/dashboard/components/UploadBuildDialog.tsx
@@ -88,12 +88,12 @@ export function UploadBuildDialog({ onSuccess, appId }: Props) {
             <input
               ref={inputRef}
               type="file"
-              accept=".zip,.apk"
+              accept=".zip,.apk,.tgz,.tar.gz,application/gzip,application/x-gzip"
               className="hidden"
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
             />
             <p className="text-xs text-muted-foreground">
-              iOS: <code>.app.zip</code> (zip the <code>.app</code> folder after <code>xcodebuild -sdk iphonesimulator</code>)
+              iOS: <code>.app.zip</code> or <code>.tar.gz</code> (e.g. an EAS simulator build)
               &nbsp;·&nbsp;Android: <code>.apk</code>
             </p>
           </div>

--- a/packages/dashboard/components/UploadBuildDialog.tsx
+++ b/packages/dashboard/components/UploadBuildDialog.tsx
@@ -93,7 +93,7 @@ export function UploadBuildDialog({ onSuccess, appId }: Props) {
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
             />
             <p className="text-xs text-muted-foreground">
-              iOS: <code>.app.zip</code> or <code>.tar.gz</code> (e.g. an EAS simulator build)
+              iOS: <code>.app.zip</code> or <code>.tar.gz</code> / <code>.tgz</code> (e.g. an EAS simulator build)
               &nbsp;·&nbsp;Android: <code>.apk</code>
             </p>
           </div>

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -45,6 +45,9 @@ import { KEY_CODE_MAP } from './KeyCodeMap.js'
 // long enough to keep `ps` overhead negligible.
 const AUDIO_POLL_MS = 1500
 
+// 아카이브 추출(tar/unzip) 시 stdout 상한. 기본 1MB 로는 파일 많은 큰 .app 에서 넘칠 수 있어 넉넉히 잡는다.
+const EXTRACT_MAXBUFFER = 256 * 1024 * 1024 // 256 MB
+
 export interface IOSAgentOptions {
   fps?: number
   intervalMs?: number
@@ -763,9 +766,16 @@ export class IOSAgent implements DeviceAgent {
     const tmpDir = path.join(tmpdir(), `tapflow-install-${randomUUID()}`)
     fs.mkdirSync(tmpDir, { recursive: true })
     try {
+      // tar 는 기본 무음, unzip 은 -q 로 무음화해 큰 .app 에서 verbose stdout 이 기본
+      // maxBuffer(1MB)를 넘겨 추출이 죽는 것을 막는다.
       const result = isTar
-        ? spawnSync('tar', ['-xzf', filePath, '-C', tmpDir])
-        : spawnSync('unzip', ['-o', filePath, '-d', tmpDir])
+        ? spawnSync('tar', ['-xzf', filePath, '-C', tmpDir], { maxBuffer: EXTRACT_MAXBUFFER })
+        : spawnSync('unzip', ['-q', '-o', filePath, '-d', tmpDir], { maxBuffer: EXTRACT_MAXBUFFER })
+      // 실행 자체 실패(tar/unzip 부재=ENOENT 등)는 아카이브 무효와 구분한다.
+      if (result.error) {
+        const code = (result.error as NodeJS.ErrnoException).code ?? result.error.message
+        throw new Error(`아카이브 추출 실행 실패 (${isTar ? 'tar' : 'unzip'}: ${code})`)
+      }
       if (result.status !== 0) {
         throw new ValidationError(
           isTar

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -744,30 +744,40 @@ export class IOSAgent implements DeviceAgent {
   }
 
   /**
-   * .app.zip 이면 임시 디렉토리에 풀어 .app 경로로 설치, .apk 이면 직접 설치.
-   * install 완료 후 임시 디렉토리를 정리한다.
+   * .app.zip / .tar.gz(.tgz) 이면 임시 디렉토리에 풀어 .app 경로로 설치, 그 외(.apk 등)는
+   * 직접 설치. tar 추출은 실행 비트·심볼릭 링크를 보존하고(재압축이 아니라 네이티브 보관),
+   * macOS tar(libarchive)가 path traversal·symlink 탈출을 기본 차단한다. 완료 후 임시 정리.
    */
   private async installBuild(filePath: string, bundleId?: string): Promise<void> {
     if (bundleId) {
       await this.simctl.uninstallApp(bundleId).catch(() => { /* 미설치 상태면 무시 */ })
     }
 
-    if (!filePath.endsWith('.zip')) {
+    const lower = filePath.toLowerCase()
+    const isTar = lower.endsWith('.tar.gz') || lower.endsWith('.tgz')
+    const isZip = lower.endsWith('.zip')
+    if (!isTar && !isZip) {
       return this.simctl.installApp(filePath)
     }
 
     const tmpDir = path.join(tmpdir(), `tapflow-install-${randomUUID()}`)
     fs.mkdirSync(tmpDir, { recursive: true })
     try {
-      const result = spawnSync('unzip', ['-o', filePath, '-d', tmpDir])
+      const result = isTar
+        ? spawnSync('tar', ['-xzf', filePath, '-C', tmpDir])
+        : spawnSync('unzip', ['-o', filePath, '-d', tmpDir])
       if (result.status !== 0) {
-        throw new ValidationError(`zip 압축 해제 실패 — 시뮬레이터용 .app.zip 파일인지 확인하세요.`)
+        throw new ValidationError(
+          isTar
+            ? 'tar.gz 압축 해제 실패 — 시뮬레이터용 .tar.gz(경로 탈출/심볼릭 링크 없는)인지 확인하세요.'
+            : 'zip 압축 해제 실패 — 시뮬레이터용 .app.zip 파일인지 확인하세요.',
+        )
       }
 
       const entries = fs.readdirSync(tmpDir)
       const appDir = entries.find(e => e.endsWith('.app') && fs.statSync(path.join(tmpDir, e)).isDirectory())
       if (!appDir) {
-        throw new ValidationError('.app 디렉토리를 찾을 수 없습니다. xcodebuild -sdk iphonesimulator 로 빌드한 .app 을 zip 압축해 업로드하세요.')
+        throw new ValidationError('.app 디렉토리를 찾을 수 없습니다. iphonesimulator 로 빌드한 .app 을 .app.zip 또는 .tar.gz 로 업로드하세요.')
       }
 
       await this.simctl.installApp(path.join(tmpDir, appDir))

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } 
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { spawnSync } from 'child_process'
 import { ValidationError } from '@tapflowio/agent-core'
 
 vi.mock('../TouchHelper', () => ({
@@ -191,6 +192,61 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({}, simctl)
       await agent.installApp('/path/MyApp.app')
       expect(simctl.installApp).toHaveBeenCalledWith('/path/MyApp.app')
+    })
+
+    // installBuild: extract .app.zip / .tar.gz to a temp dir, then simctl install the .app.
+    // The real simulator install+launch (fidelity/exec-bit) is manual QA; here we verify the
+    // archive branch resolves the .app path via mocked simctl.
+    type WithInstallBuild = { installBuild(filePath: string, bundleId?: string): Promise<void> }
+    const makeSimAppArchive = (name: string, ext: string): string => {
+      const src = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-arch-src-'))
+      const appDir = path.join(src, `${name}.app`)
+      fs.mkdirSync(appDir, { recursive: true })
+      fs.writeFileSync(path.join(appDir, 'Info.plist'), '<plist><dict/></plist>')
+      fs.writeFileSync(path.join(appDir, name), Buffer.from([0xcf, 0xfa, 0xed, 0xfe]))
+      const out = path.join(src, `${name}${ext}`)
+      if (ext.includes('tar') || ext.includes('tgz')) {
+        spawnSync('tar', ['-czf', out, '-C', src, `${name}.app`])
+      } else {
+        spawnSync('zip', ['-r', out, `${name}.app`], { cwd: src })
+      }
+      return out
+    }
+
+    it('installBuild extracts a .tar.gz and installs the .app (R4)', async () => {
+      const simctl = mockSimctl()
+      const agent = new IOSAgent({}, simctl) as unknown as WithInstallBuild
+      const tarPath = makeSimAppArchive('TarApp', '.tar.gz')
+      await agent.installBuild(tarPath)
+      expect(simctl.installApp).toHaveBeenCalledTimes(1)
+      expect((simctl.installApp as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(/\/TarApp\.app$/)
+    })
+
+    it('installBuild supports the .tgz extension', async () => {
+      const simctl = mockSimctl()
+      const agent = new IOSAgent({}, simctl) as unknown as WithInstallBuild
+      const tarPath = makeSimAppArchive('TgzApp', '.tgz')
+      await agent.installBuild(tarPath)
+      expect((simctl.installApp as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(/\/TgzApp\.app$/)
+    })
+
+    it('installBuild still handles legacy .app.zip (regression)', async () => {
+      const simctl = mockSimctl()
+      const agent = new IOSAgent({}, simctl) as unknown as WithInstallBuild
+      const zipPath = makeSimAppArchive('ZipApp', '.app.zip')
+      await agent.installBuild(zipPath)
+      expect((simctl.installApp as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(/\/ZipApp\.app$/)
+    })
+
+    it('installBuild rejects a tar.gz with no .app directory', async () => {
+      const simctl = mockSimctl()
+      const agent = new IOSAgent({}, simctl) as unknown as WithInstallBuild
+      const src = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-arch-noapp-'))
+      fs.writeFileSync(path.join(src, 'readme.txt'), 'hi')
+      const out = path.join(src, 'noapp.tar.gz')
+      spawnSync('tar', ['-czf', out, '-C', src, 'readme.txt'])
+      await expect(agent.installBuild(out)).rejects.toThrow(/\.app/)
+      expect(simctl.installApp).not.toHaveBeenCalled()
     })
 
     it('launchApp delegates to SimctlWrapper', async () => {

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -249,6 +249,16 @@ describe('IOSAgent', () => {
       expect(simctl.installApp).not.toHaveBeenCalled()
     })
 
+    it('installBuild throws a validation error on a corrupt .tar.gz (bad archive, not a spawn failure)', async () => {
+      const simctl = mockSimctl()
+      const agent = new IOSAgent({}, simctl) as unknown as WithInstallBuild
+      const src = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-arch-bad-'))
+      const out = path.join(src, 'corrupt.tar.gz')
+      fs.writeFileSync(out, Buffer.from('not a real gzip stream'))
+      await expect(agent.installBuild(out)).rejects.toThrow(/압축 해제 실패/)
+      expect(simctl.installApp).not.toHaveBeenCalled()
+    })
+
     it('launchApp delegates to SimctlWrapper', async () => {
       const simctl = mockSimctl()
       const agent = new IOSAgent({}, simctl)

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -50,7 +50,7 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 | `POST` | `/api/v1/apps` | Create an app entry |
 | `PATCH` | `/api/v1/apps/:id` | Manually rename an app (Admin/Developer) |
 | `DELETE` | `/api/v1/apps/:id` | Delete an app (and its builds) |
-| `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.tar.gz` / `.apk`) |
+| `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.tar.gz` / `.tgz` / `.apk`) |
 | `GET` | `/api/v1/builds` | Build list (filterable by `app_id`) |
 | `GET` | `/api/v1/builds/:id` | Single build |
 | `PATCH` | `/api/v1/builds/:id` | Update `status_label` / `version_label` |

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -25,9 +25,10 @@ A single process on a single configurable port (default: 4000) handles both WebS
 
 Build file storage path: `uploads/builds/`.
 
-iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
-- Auto-extracts `CFBundleIdentifier`, `CFBundleShortVersionString`, `CFBundleVersion`, `CFBundleDisplayName`/`CFBundleName` from `*.app/Info.plist`.
+iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator artifacts). `.ipa` uploads return 400. `.tar.gz` is stored natively (no re-zip) so the `.app`'s exec bits / symlinks survive to install time; `tar` extraction happens on the macOS agent.
+- Auto-extracts `CFBundleIdentifier`, `CFBundleShortVersionString`, `CFBundleVersion`, `CFBundleDisplayName`/`CFBundleName` from the top-level `*.app/Info.plist` (zip: `unzip -p`; tar: `tar -xzOf`).
 - Validates simulator slices via `lipo -info`. **Skipped in Linux environments (lipo not available) — errors surface at install time instead**.
+- `.tar.gz` uploads are validated before storage (`validateTarGz`): rejects path traversal (`..`/absolute), symlink/hardlink entries, corrupt gzip, and gzip bombs (`TAPFLOW_MAX_UNPACKED_BYTES`, default upload cap ×4). `tar` resolves PAX/GNU long names so header parsing can't be bypassed.
 
 ## HOW
 
@@ -49,7 +50,7 @@ iOS build format: `.app.zip` (simulator builds). `.ipa` uploads return 400.
 | `POST` | `/api/v1/apps` | Create an app entry |
 | `PATCH` | `/api/v1/apps/:id` | Manually rename an app (Admin/Developer) |
 | `DELETE` | `/api/v1/apps/:id` | Delete an app (and its builds) |
-| `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.apk`) |
+| `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.tar.gz` / `.apk`) |
 | `GET` | `/api/v1/builds` | Build list (filterable by `app_id`) |
 | `GET` | `/api/v1/builds/:id` | Single build |
 | `PATCH` | `/api/v1/builds/:id` | Update `status_label` / `version_label` |

--- a/packages/relay/src/__tests__/builds-tar-upload.test.ts
+++ b/packages/relay/src/__tests__/builds-tar-upload.test.ts
@@ -190,4 +190,21 @@ describe('POST /api/v1/builds — .tar.gz (EAS simulator) ingest', () => {
       fs.rmSync(shimDir, { recursive: true, force: true })
     }
   })
+
+  // CodeRabbit #362 (critical): a large .app whose `tar -tzf`/`-tzvf` listing exceeds Node's
+  // default 1 MB spawnSync maxBuffer must NOT be rejected (or silently skip the symlink check).
+  // Padding entries push the listing past 1 MB; the explicit maxBuffer keeps validation intact.
+  it('accepts a valid tar.gz whose listing exceeds the default spawnSync buffer', async () => {
+    const entries: { name: string; data?: Buffer }[] = [
+      { name: 'BigApp.app/Info.plist', data: Buffer.from(XML_PLIST) },
+    ]
+    // ~130-char safe paths × 12k ≈ 1.5 MB listing (> 1 MB default maxBuffer).
+    for (let i = 0; i < 12000; i++) {
+      entries.push({ name: `BigApp.app/pad/${String(i).padStart(6, '0')}_${'x'.repeat(100)}.bin` })
+    }
+    const big = writeRawTarGz(entries)
+    const r = await postTar(port, 'T14', 'BigApp.tar.gz', big, cookie)
+    expect(r.status).toBe(201)
+    expect(r.body.bundle_id).toBe('com.example.eas')
+  })
 })

--- a/packages/relay/src/__tests__/builds-tar-upload.test.ts
+++ b/packages/relay/src/__tests__/builds-tar-upload.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { RelayServer } from '../RelayServer'
+import { initDb, getDb, closeDb } from '../db'
+import { makePasswordHash } from '../api/auth'
+import { signJwt } from '../middleware/auth'
+import { makeAppTarGz, writeRawTarGz } from './helpers/tarFixture'
+
+const XML_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>CFBundleIdentifier</key><string>com.example.eas</string>
+  <key>CFBundleShortVersionString</key><string>2.1.0</string>
+  <key>CFBundleVersion</key><string>42</string>
+  <key>CFBundleDisplayName</key><string>EAS App</string>
+</dict></plist>`
+
+function multipartBody(boundary: string, parts: { name: string; filename?: string; contentType?: string; data: Buffer | string }[]): Buffer {
+  const chunks: Buffer[] = []
+  for (const p of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`))
+    let disp = `Content-Disposition: form-data; name="${p.name}"`
+    if (p.filename) disp += `; filename="${p.filename}"`
+    chunks.push(Buffer.from(disp + '\r\n'))
+    if (p.contentType) chunks.push(Buffer.from(`Content-Type: ${p.contentType}\r\n`))
+    chunks.push(Buffer.from('\r\n'))
+    chunks.push(Buffer.isBuffer(p.data) ? p.data : Buffer.from(p.data))
+    chunks.push(Buffer.from('\r\n'))
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`))
+  return Buffer.concat(chunks)
+}
+
+type UploadResult = { status: number; body: { error?: string; bundle_id?: string; version_name?: string; build_number?: string; platform?: string } }
+
+function postTar(port: number, boundary: string, filename: string, data: Buffer, cookie: string): Promise<UploadResult> {
+  const body = multipartBody(boundary, [{ name: 'file', filename, contentType: 'application/gzip', data }])
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: '/api/v1/builds', method: 'POST', headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}`, 'Content-Length': body.length, Cookie: cookie } },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => resolve({ status: res.statusCode!, body: JSON.parse(Buffer.concat(chunks).toString() || '{}') }))
+      },
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+describe('POST /api/v1/builds — .tar.gz (EAS simulator) ingest', () => {
+  let server: RelayServer
+  let port: number
+  let dbDir: string
+  let fixtureDir: string
+  let uploadsDir: string
+  let cookie: string
+
+  beforeAll(() => {
+    dbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-targz-db-'))
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-targz-fix-'))
+    initDb(path.join(dbDir, 'test.db'))
+    getDb().prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    cookie = `tapflow_token=${signJwt({ userId: 1, email: 'admin@example.com', role: 'Admin' })}`
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(dbDir, { recursive: true, force: true })
+    fs.rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-targz-up-'))
+    server = new RelayServer({ port: 0, uploadsDir })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => {
+    await server.stop()
+    fs.rmSync(uploadsDir, { recursive: true, force: true })
+    delete process.env.TAPFLOW_MAX_UNPACKED_BYTES
+  })
+
+  const buildsDir = () => path.join(uploadsDir, 'builds')
+  const leftover = () => (fs.existsSync(buildsDir()) ? fs.readdirSync(buildsDir()) : [])
+
+  // #1 — 정상 tar.gz 업로드 → 201 + 메타 추출
+  it('accepts a valid .tar.gz and extracts metadata (201)', async () => {
+    const tarPath = makeAppTarGz(fixtureDir, 'EasApp', XML_PLIST)
+    const r = await postTar(port, 'T1', 'EasApp.tar.gz', fs.readFileSync(tarPath), cookie)
+    expect(r.status).toBe(201)
+    expect(r.body.bundle_id).toBe('com.example.eas')
+    expect(r.body.version_name).toBe('2.1.0')
+    expect(r.body.build_number).toBe('42')
+    expect(r.body.platform).toBe('ios')
+    expect(leftover()).toHaveLength(1)
+  })
+
+  // #3 — .tgz 확장자
+  it('accepts the .tgz extension', async () => {
+    const tarPath = makeAppTarGz(fixtureDir, 'TgzApp', XML_PLIST, '.tgz')
+    const r = await postTar(port, 'T3', 'TgzApp.tgz', fs.readFileSync(tarPath), cookie)
+    expect(r.status).toBe(201)
+    expect(r.body.bundle_id).toBe('com.example.eas')
+  })
+
+  // #4 — .ipa 거절, 안내에 .tar.gz 포함
+  it('rejects .ipa with guidance mentioning .tar.gz', async () => {
+    const r = await postTar(port, 'T4', 'app.ipa', Buffer.alloc(50, 0x41), cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toContain('.tar.gz')
+  })
+
+  // #5 — .aab 거절
+  it('rejects .aab with .apk guidance', async () => {
+    const r = await postTar(port, 'T5', 'app.aab', Buffer.alloc(50, 0x41), cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toContain('.apk')
+  })
+
+  // #6 — path traversal 엔트리 → 400, 잔존 파일 0
+  it('rejects a tar.gz with a path-traversal entry and leaves no build file', async () => {
+    const evil = writeRawTarGz([{ name: '../../etc/passwd', data: Buffer.from('pwned') }])
+    const r = await postTar(port, 'T6', 'evil.tar.gz', evil, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toMatch(/unsafe path|\.\./i)
+    expect(leftover()).toEqual([])
+  })
+
+  // #7 — symlink 탈출 엔트리 → 400
+  it('rejects a tar.gz containing a symbolic link', async () => {
+    const evil = writeRawTarGz([{ name: 'EvilApp.app', type: '5' }, { name: 'link', type: '2', linkname: '/etc' }])
+    const r = await postTar(port, 'T7', 'symlink.tar.gz', evil, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toMatch(/link/i)
+    expect(leftover()).toEqual([])
+  })
+
+  // #8 — gzip bomb → 해제 크기 상한 초과로 400
+  it('rejects a gzip bomb that exceeds the unpacked size limit', async () => {
+    process.env.TAPFLOW_MAX_UNPACKED_BYTES = '1024'
+    // 2MB 의 0 → gzip 시 극히 작지만 해제 시 상한(1KB) 초과.
+    const bomb = writeRawTarGz([{ name: 'MyApp.app/big.bin', data: Buffer.alloc(2 * 1024 * 1024, 0) }])
+    const r = await postTar(port, 'T8', 'bomb.tar.gz', bomb, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toMatch(/unpacked size/i)
+    expect(leftover()).toEqual([])
+  })
+
+  // #9 — 손상된 tar.gz → 400
+  it('rejects a corrupt / truncated .tar.gz', async () => {
+    const r = await postTar(port, 'T9', 'corrupt.tar.gz', Buffer.from('not a real gzip stream'), cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toMatch(/corrupt|invalid/i)
+    expect(leftover()).toEqual([])
+  })
+
+  // #10 — .app 부재 → 400 (구조 오류)
+  it('rejects a valid tar.gz that has no .app directory', async () => {
+    const noApp = writeRawTarGz([{ name: 'readme.txt', data: Buffer.from('hello') }])
+    const r = await postTar(port, 'T10', 'noapp.tar.gz', noApp, cookie)
+    expect(r.status).toBe(400)
+    expect(r.body.error).toMatch(/\.app/i)
+    expect(leftover()).toEqual([])
+  })
+
+  // #13 — Linux relay parity: lipo unavailable → slice check skipped, upload still succeeds.
+  // Real Linux has no lipo (spawnSync → ENOENT, status=null); here we shadow lipo with a
+  // failing shim (status≠0). Both hit the same `status !== 0 → null → skip` branch.
+  it('stores + extracts metadata when lipo is unavailable (Linux parity)', async () => {
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-nolipo-'))
+    fs.writeFileSync(path.join(shimDir, 'lipo'), '#!/bin/sh\nexit 1\n', { mode: 0o755 })
+    const origPath = process.env.PATH
+    // shim 을 PATH 앞에 두어 실제 lipo 보다 먼저 잡히게 (tar/unzip/plutil 은 origPath 로 계속 resolve).
+    process.env.PATH = `${shimDir}:${origPath}`
+    try {
+      const tarPath = makeAppTarGz(fixtureDir, 'NoLipoApp', XML_PLIST)
+      const r = await postTar(port, 'T13', 'NoLipoApp.tar.gz', fs.readFileSync(tarPath), cookie)
+      expect(r.status).toBe(201)
+      expect(r.body.bundle_id).toBe('com.example.eas')
+      expect(r.body.version_name).toBe('2.1.0')
+    } finally {
+      process.env.PATH = origPath
+      fs.rmSync(shimDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/relay/src/__tests__/builds.test.ts
+++ b/packages/relay/src/__tests__/builds.test.ts
@@ -223,3 +223,51 @@ describe('extractAppZipInfo', () => {
     expect(info).toBeNull()
   })
 })
+
+// ── extractAppTarInfo unit tests (EAS .tar.gz) ─────────────────────────────
+
+describe('extractAppTarInfo', () => {
+  let tmpDir: string
+  let mod: typeof import('../api/builds')
+  let makeAppTarGz: typeof import('./helpers/tarFixture').makeAppTarGz
+  let writeRawTarGz: typeof import('./helpers/tarFixture').writeRawTarGz
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-tar-test-'))
+    mod = await import('../api/builds')
+    const fx = await import('./helpers/tarFixture')
+    makeAppTarGz = fx.makeAppTarGz
+    writeRawTarGz = fx.writeRawTarGz
+  })
+
+  afterAll(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  it('extracts metadata from the top-level *.app/Info.plist (not nested framework plist)', () => {
+    const tarPath = makeAppTarGz(tmpDir, 'CoffeeApp', XML_PLIST)
+    const info = mod.extractAppTarInfo(tarPath)
+    expect(info).not.toBeNull()
+    expect(info!.bundleId).toBe('com.example.coffee')
+    expect(info!.versionName).toBe('1.4.0')
+    expect(info!.buildNumber).toBe('89')
+    expect(info!.appName).toBe('Coffee App')
+  })
+
+  it('supports the .tgz extension', () => {
+    const tarPath = makeAppTarGz(tmpDir, 'TgzApp', XML_PLIST, '.tgz')
+    const info = mod.extractAppTarInfo(tarPath)
+    expect(info).not.toBeNull()
+    expect(info!.bundleId).toBe('com.example.coffee')
+  })
+
+  it('extractAppInfo dispatches to the tar path by extension', () => {
+    const tarPath = makeAppTarGz(tmpDir, 'DispatchApp', XML_PLIST)
+    const info = mod.extractAppInfo(tarPath)
+    expect(info?.bundleId).toBe('com.example.coffee')
+  })
+
+  it('returns null for a tar.gz with no .app directory', () => {
+    const noApp = path.join(tmpDir, 'noapp.tar.gz')
+    fs.writeFileSync(noApp, writeRawTarGz([{ name: 'readme.txt', data: Buffer.from('hi') }]))
+    expect(mod.extractAppTarInfo(noApp)).toBeNull()
+  })
+})

--- a/packages/relay/src/__tests__/helpers/tarFixture.ts
+++ b/packages/relay/src/__tests__/helpers/tarFixture.ts
@@ -1,0 +1,67 @@
+import fs from 'fs'
+import path from 'path'
+import zlib from 'zlib'
+import { spawnSync } from 'child_process'
+
+/**
+ * 유효한 EAS 스타일 시뮬레이터 .tar.gz 를 만든다 (루트에 <appName>.app/).
+ * 실제 tar 로 압축해 실전 아카이브 구조를 재현한다.
+ */
+export function makeAppTarGz(tmpDir: string, appName: string, plistXml: string, ext = '.tar.gz'): string {
+  const appDir = path.join(tmpDir, `${appName}.app`)
+  fs.mkdirSync(path.join(appDir, 'Frameworks', 'Foo.framework'), { recursive: true })
+  fs.writeFileSync(path.join(appDir, 'Info.plist'), plistXml)
+  // 프레임워크 내부에도 Info.plist 를 심어 최상위 선택 규칙을 검증한다.
+  fs.writeFileSync(path.join(appDir, 'Frameworks', 'Foo.framework', 'Info.plist'), '<plist><dict/></plist>')
+  fs.writeFileSync(path.join(appDir, appName), Buffer.from([0xcf, 0xfa, 0xed, 0xfe]))
+  const out = path.join(tmpDir, `${appName}${ext}`)
+  spawnSync('tar', ['-czf', out, '-C', tmpDir, `${appName}.app`])
+  return out
+}
+
+// ── raw ustar builder (악성/엣지 픽스처용) ─────────────────────────────────
+// 임의의 엔트리(경로 탈출, symlink 등)를 정밀하게 구성하기 위해 헤더를 직접 쓴다.
+
+export type RawTarEntry = {
+  name: string
+  data?: Buffer
+  /** '0'=file, '2'=symlink, '5'=dir. 기본 '0'. */
+  type?: '0' | '2' | '5'
+  linkname?: string
+}
+
+function tarHeader(e: RawTarEntry, size: number): Buffer {
+  const buf = Buffer.alloc(512)
+  buf.write(e.name.slice(0, 100), 0)
+  buf.write('0000644\0', 100) // mode
+  buf.write('0000000\0', 108) // uid
+  buf.write('0000000\0', 116) // gid
+  buf.write(size.toString(8).padStart(11, '0') + '\0', 124) // size (octal)
+  buf.write('00000000000\0', 136) // mtime
+  buf.write(e.type ?? '0', 156) // typeflag
+  if (e.linkname) buf.write(e.linkname.slice(0, 100), 157)
+  buf.write('ustar\0', 257)
+  buf.write('00', 263)
+  // checksum: 8 바이트를 공백으로 채운 뒤 합산.
+  buf.write('        ', 148)
+  let sum = 0
+  for (const b of buf) sum += b
+  buf.write(sum.toString(8).padStart(6, '0') + '\0 ', 148)
+  return buf
+}
+
+/** 임의 엔트리로 .tar.gz Buffer 를 만든다. */
+export function writeRawTarGz(entries: RawTarEntry[]): Buffer {
+  const parts: Buffer[] = []
+  for (const e of entries) {
+    const data = e.data ?? Buffer.alloc(0)
+    parts.push(tarHeader(e, data.length))
+    if (data.length) {
+      parts.push(data)
+      const pad = (512 - (data.length % 512)) % 512
+      if (pad) parts.push(Buffer.alloc(pad))
+    }
+  }
+  parts.push(Buffer.alloc(1024)) // 두 개의 zero 블록 = 아카이브 종료
+  return zlib.gzipSync(Buffer.concat(parts))
+}

--- a/packages/relay/src/__tests__/upload-limits.test.ts
+++ b/packages/relay/src/__tests__/upload-limits.test.ts
@@ -102,7 +102,7 @@ describe('upload size-limit handling', () => {
     const body = multipartBody(boundary, [{ name: 'file', filename: 'app.ipa', contentType: 'application/octet-stream', data: Buffer.alloc(50, 0x41) }])
     const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
     expect(r.status).toBe(400)
-    expect(r.body.error).toBe('iOS simulator builds must be in .app.zip format. Zip the .app directory built with xcodebuild -sdk iphonesimulator and upload it.')
+    expect(r.body.error).toBe('iOS simulator builds must be in .app.zip or .tar.gz format. Zip (or tar.gz, e.g. an EAS simulator build) the .app directory built for iphonesimulator and upload it.')
   })
 
   it('빌드: .app 디렉토리 없는 zip은 400 + 영어 안내', async () => {
@@ -114,7 +114,7 @@ describe('upload size-limit handling', () => {
     const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: fs.readFileSync(noAppZip) }])
     const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)
     expect(r.status).toBe(400)
-    expect(r.body.error).toBe('No .app directory found in the zip. Upload a zip that contains a .app directory.')
+    expect(r.body.error).toBe('No .app directory found in the archive. Upload a .app.zip or .tar.gz that contains a .app directory.')
   })
 
   it('댓글 첨부: 크기 상한 초과 → 400 + uploads/comments에 잔존 파일 없음', async () => {

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -1,5 +1,6 @@
 import http from 'http'
 import fs from 'fs'
+import zlib from 'zlib'
 import path from 'path'
 import { tmpdir } from 'os'
 import { randomUUID } from 'crypto'
@@ -9,6 +10,32 @@ import { getDb } from '../db.js'
 import { requireAuth, requireBuildAuth } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
 import { unlinkSafe } from '../lib/uploads.js'
+
+// ── archive kind ───────────────────────────────────────────────────────────
+
+// path.extname('app.tar.gz') === '.gz', so compound extensions can't be detected
+// with extname alone. Match the full suffix, longest first.
+export type BuildFileKind = 'ios-zip' | 'ios-tar' | 'android' | 'ipa' | 'aab' | 'unknown'
+
+export function buildFileKind(filename: string): BuildFileKind {
+  const lower = filename.toLowerCase()
+  if (lower.endsWith('.tar.gz') || lower.endsWith('.tgz')) return 'ios-tar'
+  if (lower.endsWith('.zip')) return 'ios-zip'
+  if (lower.endsWith('.apk')) return 'android'
+  if (lower.endsWith('.ipa')) return 'ipa'
+  if (lower.endsWith('.aab')) return 'aab'
+  return 'unknown'
+}
+
+/** 알려진 아카이브 확장자를 벗긴 베이스 이름(메타 부재 시 앱 이름 폴백용). */
+function stripArchiveExt(filename: string): string {
+  const base = path.basename(filename)
+  const lower = base.toLowerCase()
+  for (const ext of ['.tar.gz', '.tgz', '.app.zip', '.zip', '.apk', '.ipa', '.aab']) {
+    if (lower.endsWith(ext)) return base.slice(0, base.length - ext.length)
+  }
+  return base.replace(/\.[^.]+$/, '')
+}
 
 // ── zip / plist helpers ────────────────────────────────────────────────────
 
@@ -20,34 +47,15 @@ function parseXmlPlist(xml: string): Record<string, string> {
   return result
 }
 
-/** zip 내 루트 수준 *.app 디렉토리 이름을 찾는다. 없으면 null. */
-function findAppDirInZip(zipPath: string): string | null {
-  const list = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8' })
-  if (list.status !== 0) return null
-  // "  12345  2024-01-01 00:00:00  MyApp.app/"  형태를 매칭 (앱 이름에 공백 포함 가능)
-  // HH:MM 시간 컬럼을 기준점으로 삼아 filename 컬럼만 캡처
-  const re = /\d{2}:\d{2}\s+(\S[^/\n]*\.app)\/\s*$/m
-  const m = re.exec(list.stdout as string)
-  if (!m) return null
-  // 루트 레벨만 (슬래시 미포함)
-  const candidate = m[1]
-  return candidate.includes('/') ? null : candidate
-}
-
-/** .app.zip에서 앱 메타데이터를 추출한다. 구조 오류 시 null. */
-export function extractAppZipInfo(zipPath: string): {
+type AppInfo = {
   bundleId: string | null
   versionName: string | null
   buildNumber: string | null
   appName: string | null
-} | null {
-  const appDir = findAppDirInZip(zipPath)
-  if (!appDir) return null
+}
 
-  const extract = spawnSync('unzip', ['-p', zipPath, `${appDir}/Info.plist`])
-  if (extract.status !== 0 || !extract.stdout) return null
-
-  const plistBuf = extract.stdout as Buffer
+/** Info.plist Buffer(xml 또는 bplist)에서 CFBundle* 를 파싱한다. 아카이브 종류와 무관. */
+function parseInfoPlist(plistBuf: Buffer): AppInfo {
   let parsed: Record<string, string>
 
   if (plistBuf.subarray(0, 6).toString() === 'bplist') {
@@ -68,6 +76,76 @@ export function extractAppZipInfo(zipPath: string): {
     buildNumber: parsed['CFBundleVersion'] ?? null,
     appName: parsed['CFBundleDisplayName'] ?? parsed['CFBundleName'] ?? null,
   }
+}
+
+/** zip 내 루트 수준 *.app 디렉토리 이름을 찾는다. 없으면 null. */
+function findAppDirInZip(zipPath: string): string | null {
+  const list = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8' })
+  if (list.status !== 0) return null
+  // "  12345  2024-01-01 00:00:00  MyApp.app/"  형태를 매칭 (앱 이름에 공백 포함 가능)
+  // HH:MM 시간 컬럼을 기준점으로 삼아 filename 컬럼만 캡처
+  const re = /\d{2}:\d{2}\s+(\S[^/\n]*\.app)\/\s*$/m
+  const m = re.exec(list.stdout as string)
+  if (!m) return null
+  // 루트 레벨만 (슬래시 미포함)
+  const candidate = m[1]
+  return candidate.includes('/') ? null : candidate
+}
+
+/** .app.zip에서 앱 메타데이터를 추출한다. 구조 오류 시 null. */
+export function extractAppZipInfo(zipPath: string): AppInfo | null {
+  const appDir = findAppDirInZip(zipPath)
+  if (!appDir) return null
+
+  const extract = spawnSync('unzip', ['-p', zipPath, `${appDir}/Info.plist`])
+  if (extract.status !== 0 || !extract.stdout) return null
+
+  return parseInfoPlist(extract.stdout as Buffer)
+}
+
+// ── tar.gz helpers (EAS 시뮬레이터 산출물) ──────────────────────────────────
+// tar 는 순차 스캔이라 zip 처럼 랜덤액세스가 어렵다. tar 바이너리가 이름을 해석하게
+// 두어(-tzf/-xzOf) PAX/GNU long-name 도 안전하게 처리한다 (손으로 파싱하지 않음).
+
+/** tar.gz 내 루트 수준 *.app 디렉토리 이름을 찾는다. 없으면 null. */
+function findAppDirInTar(tarPath: string): string | null {
+  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8' })
+  if (list.status !== 0) return null
+  // 최상위 "Foo.app/..." 만 — 프레임워크 내부 중첩 .app/Info.plist 오탐 방지.
+  const re = /^(?:\.\/)?([^/]+\.app)\//m
+  const m = re.exec(list.stdout as string)
+  return m ? m[1] : null
+}
+
+/** tar.gz 안 특정 엔트리를 stdout Buffer 로 읽는다. 실패 시 null. */
+function readTarEntry(tarPath: string, entry: string): Buffer | null {
+  // 아카이브가 "./Foo.app/..." 형태일 수 있어 두 후보를 시도한다.
+  for (const name of [entry, `./${entry}`]) {
+    const r = spawnSync('tar', ['-xzOf', tarPath, name])
+    if (r.status === 0 && r.stdout && (r.stdout as Buffer).length) return r.stdout as Buffer
+  }
+  return null
+}
+
+/** .tar.gz 안 *.app/Info.plist 에서 앱 메타데이터를 추출한다. 구조 오류 시 null. */
+export function extractAppTarInfo(tarPath: string): AppInfo | null {
+  const appDir = findAppDirInTar(tarPath)
+  if (!appDir) return null
+
+  const buf = readTarEntry(tarPath, `${appDir}/Info.plist`)
+  if (!buf) return null
+
+  return parseInfoPlist(buf)
+}
+
+// ── archive-agnostic dispatch ───────────────────────────────────────────────
+
+function findAppDir(filePath: string): string | null {
+  return buildFileKind(filePath) === 'ios-tar' ? findAppDirInTar(filePath) : findAppDirInZip(filePath)
+}
+
+export function extractAppInfo(filePath: string): AppInfo | null {
+  return buildFileKind(filePath) === 'ios-tar' ? extractAppTarInfo(filePath) : extractAppZipInfo(filePath)
 }
 
 /** ANDROID_HOME/build-tools 아래에서 최신 aapt 경로를 찾는다. macOS 기본 경로 + PATH fallback 포함. */
@@ -120,16 +198,12 @@ function extractApkInfo(apkPath: string): {
 }
 
 /**
- * lipo로 시뮬레이터 슬라이스 존재를 확인한다.
+ * Mach-O 바이너리 Buffer에 lipo -info 를 돌려 시뮬레이터 슬라이스 존재를 확인한다.
  * lipo 미설치(Linux relay) 시 null 반환 → 검증 skip.
  */
-function hasSimulatorSlice(zipPath: string, appDir: string): boolean | null {
-  const binaryName = path.basename(appDir, '.app')
-  const extract = spawnSync('unzip', ['-p', zipPath, `${appDir}/${binaryName}`])
-  if (extract.status !== 0 || !extract.stdout?.length) return null
-
+function lipoHasSimSlice(binaryBuf: Buffer): boolean | null {
   const tmpBin = path.join(tmpdir(), `tapflow-lipo-${randomUUID()}`)
-  fs.writeFileSync(tmpBin, extract.stdout as Buffer)
+  fs.writeFileSync(tmpBin, binaryBuf)
   try {
     const lipo = spawnSync('lipo', ['-info', tmpBin], { encoding: 'utf8' })
     if (lipo.status !== 0) return null // lipo 없음 → skip
@@ -140,6 +214,22 @@ function hasSimulatorSlice(zipPath: string, appDir: string): boolean | null {
   } finally {
     try { fs.unlinkSync(tmpBin) } catch { /* ignore */ }
   }
+}
+
+/** .app.zip / .tar.gz 의 .app 실행 바이너리에 시뮬레이터 슬라이스가 있는지 확인. */
+function hasSimulatorSlice(filePath: string, appDir: string): boolean | null {
+  const binaryName = path.basename(appDir, '.app')
+  let binaryBuf: Buffer | null = null
+
+  if (buildFileKind(filePath) === 'ios-tar') {
+    binaryBuf = readTarEntry(filePath, `${appDir}/${binaryName}`)
+  } else {
+    const extract = spawnSync('unzip', ['-p', filePath, `${appDir}/${binaryName}`])
+    if (extract.status === 0 && extract.stdout?.length) binaryBuf = extract.stdout as Buffer
+  }
+
+  if (!binaryBuf?.length) return null
+  return lipoHasSimSlice(binaryBuf)
 }
 
 // ── app 자동 생성 / 조회 ──────────────────────────────────────────────────
@@ -313,6 +403,68 @@ function maxBuildUploadBytes(): number {
   return Number.isFinite(v) && v > 0 ? v : 500 * 1024 * 1024
 }
 
+// 해제 후 크기 상한(gzip bomb 방어). 압축 전 상한과 별개. 기본 업로드 상한×4.
+function maxUnpackedBytes(): number {
+  const v = Number(process.env.TAPFLOW_MAX_UNPACKED_BYTES)
+  return Number.isFinite(v) && v > 0 ? v : maxBuildUploadBytes() * 4
+}
+
+/**
+ * 업로드된 .tar.gz 를 설치 전에 검증한다 (R7). tar 바이너리가 이름을 해석하므로
+ * PAX/GNU long-name 우회가 없다. 문제 시 에러 문구, 정상 시 null.
+ * - 손상/비-gzip: tar -tzf 실패
+ * - path traversal: 절대경로 또는 `..` 세그먼트
+ * - symlink/hardlink 탈출: -tzvf 의 타입 문자(l/h)
+ * - gzip bomb: 해제 스트림 바이트가 상한 초과 (전체 버퍼링 없이 조기 중단)
+ */
+export async function validateTarGz(tarPath: string): Promise<string | null> {
+  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8' })
+  if (list.status !== 0) return 'Corrupt or invalid .tar.gz archive.'
+
+  const names = (list.stdout as string).split('\n').filter(Boolean)
+  for (const raw of names) {
+    const name = raw.replace(/^\.\//, '')
+    if (name.startsWith('/') || name.split('/').some((seg) => seg === '..')) {
+      return 'Archive contains an unsafe path (absolute or ".." escape) and was rejected.'
+    }
+  }
+
+  // 엔트리 타입 검사: ls -l 스타일 첫 문자 l(symlink)/h(hardlink) 거부.
+  const verbose = spawnSync('tar', ['-tzvf', tarPath], { encoding: 'utf8' })
+  if (verbose.status === 0) {
+    for (const line of (verbose.stdout as string).split('\n')) {
+      const c = line[0]
+      if (c === 'l' || c === 'h') {
+        return 'Archive contains a symbolic or hard link and was rejected.'
+      }
+    }
+  }
+
+  // gzip bomb: 스트리밍 해제 바이트를 세며 상한 초과 시 즉시 중단 (t3.small 메모리 보호).
+  const cap = maxUnpackedBytes()
+  return await new Promise<string | null>((resolve) => {
+    let total = 0
+    let done = false
+    const input = fs.createReadStream(tarPath)
+    const gunzip = zlib.createGunzip()
+    const finish = (r: string | null) => {
+      if (done) return
+      done = true
+      input.destroy()
+      gunzip.destroy()
+      resolve(r)
+    }
+    gunzip.on('data', (chunk: Buffer) => {
+      total += chunk.length
+      if (total > cap) finish('Archive exceeds the maximum unpacked size limit.')
+    })
+    gunzip.on('end', () => finish(null))
+    gunzip.on('error', () => finish('Corrupt or invalid .tar.gz archive.'))
+    input.on('error', () => finish('Corrupt or invalid .tar.gz archive.'))
+    input.pipe(gunzip)
+  })
+}
+
 export function handleUploadBuild(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -332,20 +484,26 @@ export function handleUploadBuild(
 
   bb.on('file', (_field, stream, info) => {
     originalName = info.filename
-    const ext = path.extname(originalName).toLowerCase()
+    const kind = buildFileKind(originalName)
 
-    if (ext === '.ipa') {
-      fileError = 'iOS simulator builds must be in .app.zip format. Zip the .app directory built with xcodebuild -sdk iphonesimulator and upload it.'
+    if (kind === 'ipa') {
+      fileError = 'iOS simulator builds must be in .app.zip or .tar.gz format. Zip (or tar.gz, e.g. an EAS simulator build) the .app directory built for iphonesimulator and upload it.'
       stream.resume()
       return
     }
-    if (!['.zip', '.apk'].includes(ext)) {
-      fileError = 'Only .app.zip (iOS) or .apk (Android) files allowed'
+    if (kind === 'aab') {
+      fileError = 'Android emulator installs require an .apk. Build an .apk (not .aab) and upload it.'
+      stream.resume()
+      return
+    }
+    if (kind === 'unknown') {
+      fileError = 'Only .app.zip / .tar.gz (iOS) or .apk (Android) files allowed'
       stream.resume()
       return
     }
 
-    const fileName = `${Date.now()}_${path.basename(originalName)}`
+    // 충돌 방지: 같은 ms + 같은 파일명 동시 업로드(특히 CI 자동화) 시 file_path 공유를 막는다.
+    const fileName = `${Date.now()}-${randomUUID().slice(0, 8)}_${path.basename(originalName)}`
     savedPath = path.join(uploadsDir, 'builds', fileName)
     fs.mkdirSync(path.dirname(savedPath), { recursive: true })
     const ws = fs.createWriteStream(savedPath)
@@ -366,8 +524,8 @@ export function handleUploadBuild(
     }
     if (!savedPath) return json(res, 400, { error: 'File required' })
 
-    const ext = path.extname(originalName).toLowerCase()
-    const isIos = ext === '.zip'
+    const kind = buildFileKind(originalName)
+    const isIos = kind === 'ios-zip' || kind === 'ios-tar'
     const platform = fields.platform ?? (isIos ? 'ios' : 'android')
     const status = ['Backlog', 'In Progress', 'Done', 'Rejected'].includes(fields.status)
       ? fields.status : null
@@ -378,19 +536,28 @@ export function handleUploadBuild(
     let resolvedAppName: string | null = null
 
     if (isIos) {
-      const info = extractAppZipInfo(savedPath)
+      // .tar.gz 는 설치 전에 traversal/symlink/bomb/손상을 걸러낸다 (R7).
+      if (kind === 'ios-tar') {
+        const tarError = await validateTarGz(savedPath)
+        if (tarError) {
+          unlinkSafe(savedPath, 'rejected upload')
+          return json(res, 400, { error: tarError })
+        }
+      }
+
+      const info = extractAppInfo(savedPath)
       if (info === null) {
         fs.unlinkSync(savedPath)
-        return json(res, 400, { error: 'No .app directory found in the zip. Upload a zip that contains a .app directory.' })
+        return json(res, 400, { error: 'No .app directory found in the archive. Upload a .app.zip or .tar.gz that contains a .app directory.' })
       }
 
       // lipo 슬라이스 검증 (macOS only; Linux에서는 null → skip)
-      const appDir = findAppDirInZip(savedPath)
+      const appDir = findAppDir(savedPath)
       if (appDir) {
         const sliceOk = hasSimulatorSlice(savedPath, appDir)
         if (sliceOk === false) {
           fs.unlinkSync(savedPath)
-          return json(res, 400, { error: 'This build contains device-only slices. Build with xcodebuild -sdk iphonesimulator to include a simulator slice.' })
+          return json(res, 400, { error: 'This build contains device-only slices. Build for iphonesimulator to include a simulator slice.' })
         }
       }
 
@@ -407,7 +574,7 @@ export function handleUploadBuild(
     }
 
     const bundleIdKey = bundleId ?? '__unknown__'
-    const appName     = resolvedAppName ?? fields.label ?? path.basename(originalName, ext)
+    const appName     = resolvedAppName ?? fields.label ?? stripArchiveExt(originalName)
 
     const db = getDb()
     let appId: number

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -78,9 +78,14 @@ function parseInfoPlist(plistBuf: Buffer): AppInfo {
   }
 }
 
+// 아카이브 리스트/엔트리 읽기의 stdout 상한. 기본 maxBuffer(1MB)는 파일 많은 큰 .app
+// 리스트나 큰 실행 바이너리에서 넘쳐(ENOBUFS, status=null) 검증을 스킵/오탐시킬 수 있어
+// 넉넉히 잡는다. 초과 시엔 각 호출부가 fail-closed(거절)로 처리한다.
+const ARCHIVE_READ_MAXBUFFER = 256 * 1024 * 1024 // 256 MB
+
 /** zip 내 루트 수준 *.app 디렉토리 이름을 찾는다. 없으면 null. */
 function findAppDirInZip(zipPath: string): string | null {
-  const list = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8' })
+  const list = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8', maxBuffer: ARCHIVE_READ_MAXBUFFER })
   if (list.status !== 0) return null
   // "  12345  2024-01-01 00:00:00  MyApp.app/"  형태를 매칭 (앱 이름에 공백 포함 가능)
   // HH:MM 시간 컬럼을 기준점으로 삼아 filename 컬럼만 캡처
@@ -97,7 +102,7 @@ export function extractAppZipInfo(zipPath: string): AppInfo | null {
   const appDir = findAppDirInZip(zipPath)
   if (!appDir) return null
 
-  const extract = spawnSync('unzip', ['-p', zipPath, `${appDir}/Info.plist`])
+  const extract = spawnSync('unzip', ['-p', zipPath, `${appDir}/Info.plist`], { maxBuffer: ARCHIVE_READ_MAXBUFFER })
   if (extract.status !== 0 || !extract.stdout) return null
 
   return parseInfoPlist(extract.stdout as Buffer)
@@ -109,7 +114,7 @@ export function extractAppZipInfo(zipPath: string): AppInfo | null {
 
 /** tar.gz 내 루트 수준 *.app 디렉토리 이름을 찾는다. 없으면 null. */
 function findAppDirInTar(tarPath: string): string | null {
-  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8' })
+  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8', maxBuffer: ARCHIVE_READ_MAXBUFFER })
   if (list.status !== 0) return null
   // 최상위 "Foo.app/..." 만 — 프레임워크 내부 중첩 .app/Info.plist 오탐 방지.
   const re = /^(?:\.\/)?([^/]+\.app)\//m
@@ -121,7 +126,7 @@ function findAppDirInTar(tarPath: string): string | null {
 function readTarEntry(tarPath: string, entry: string): Buffer | null {
   // 아카이브가 "./Foo.app/..." 형태일 수 있어 두 후보를 시도한다.
   for (const name of [entry, `./${entry}`]) {
-    const r = spawnSync('tar', ['-xzOf', tarPath, name])
+    const r = spawnSync('tar', ['-xzOf', tarPath, name], { maxBuffer: ARCHIVE_READ_MAXBUFFER })
     if (r.status === 0 && r.stdout && (r.stdout as Buffer).length) return r.stdout as Buffer
   }
   return null
@@ -224,7 +229,7 @@ function hasSimulatorSlice(filePath: string, appDir: string): boolean | null {
   if (buildFileKind(filePath) === 'ios-tar') {
     binaryBuf = readTarEntry(filePath, `${appDir}/${binaryName}`)
   } else {
-    const extract = spawnSync('unzip', ['-p', filePath, `${appDir}/${binaryName}`])
+    const extract = spawnSync('unzip', ['-p', filePath, `${appDir}/${binaryName}`], { maxBuffer: ARCHIVE_READ_MAXBUFFER })
     if (extract.status === 0 && extract.stdout?.length) binaryBuf = extract.stdout as Buffer
   }
 
@@ -418,8 +423,10 @@ function maxUnpackedBytes(): number {
  * - gzip bomb: 해제 스트림 바이트가 상한 초과 (전체 버퍼링 없이 조기 중단)
  */
 export async function validateTarGz(tarPath: string): Promise<string | null> {
-  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8' })
-  if (list.status !== 0) return 'Corrupt or invalid .tar.gz archive.'
+  // fail-closed: 버퍼 초과(ENOBUFS, status=null)나 tar 부재(ENOENT)면 stdout이 잘려
+  // 검증이 우회될 수 있으므로 거절한다. maxBuffer 를 넉넉히 잡아 정상 아카이브는 통과.
+  const list = spawnSync('tar', ['-tzf', tarPath], { encoding: 'utf8', maxBuffer: ARCHIVE_READ_MAXBUFFER })
+  if (list.error || list.status !== 0) return 'Corrupt or invalid .tar.gz archive.'
 
   const names = (list.stdout as string).split('\n').filter(Boolean)
   for (const raw of names) {
@@ -430,13 +437,13 @@ export async function validateTarGz(tarPath: string): Promise<string | null> {
   }
 
   // 엔트리 타입 검사: ls -l 스타일 첫 문자 l(symlink)/h(hardlink) 거부.
-  const verbose = spawnSync('tar', ['-tzvf', tarPath], { encoding: 'utf8' })
-  if (verbose.status === 0) {
-    for (const line of (verbose.stdout as string).split('\n')) {
-      const c = line[0]
-      if (c === 'l' || c === 'h') {
-        return 'Archive contains a symbolic or hard link and was rejected.'
-      }
+  // 목록을 못 얻으면(에러/잘림) symlink 검사를 건너뛰지 말고 fail-closed 로 거절한다.
+  const verbose = spawnSync('tar', ['-tzvf', tarPath], { encoding: 'utf8', maxBuffer: ARCHIVE_READ_MAXBUFFER })
+  if (verbose.error || verbose.status !== 0) return 'Corrupt or invalid .tar.gz archive.'
+  for (const line of (verbose.stdout as string).split('\n')) {
+    const c = line[0]
+    if (c === 'l' || c === 'h') {
+      return 'Archive contains a symbolic or hard link and was rejected.'
     }
   }
 


### PR DESCRIPTION
## What

Accept EAS `eas build` iOS simulator artifacts (`.tar.gz`/`.tgz`) directly, alongside the existing `.app.zip` / `.apk` paths. The archive is stored as-is (no re-compression) and extracted with `tar` only at install time on the macOS agent.

## Why

`eas build` (iOS simulator) emits a `.tar.gz` natively, so the target flow is **EAS build → CI → tapflow**. Accepting only `.app.zip` forced CI to unpack and re-zip the artifact — an unnecessary, non-native step in the Expo pipeline. Removing that re-compression is the point; `.tar.gz` is the EAS-conventional format.

> **Rationale note:** the intuitive "re-zip drops the Mach-O exec bit → app won't launch" premise does **not** hold on the iOS simulator. Verified: `simctl install` normalizes the exec bit of the app/appex main executables, and nested dylibs are `mmap`-loaded (no exec bit needed). So the justification is friction removal + EAS-format fit, not exec-bit corruption.

## Changes

**relay (`builds.ts`)**
- `buildFileKind()` detects `.tar.gz`/`.tgz` (note: `path.extname('x.tar.gz') === '.gz'`, so the compound suffix is matched explicitly) → iOS; `.apk` → Android.
- `extractAppTarInfo()` / `findAppDirInTar()` / `readTarEntry()`: read the **top-level** `*.app/Info.plist` via `tar -tzf`/`-xzOf` (excludes nested framework plists). plist + lipo logic shared with the zip path.
- `validateTarGz()` (upload-time, before storage): rejects path traversal (`..`/absolute), symlink/hardlink entries, corrupt gzip, and gzip bombs (`TAPFLOW_MAX_UNPACKED_BYTES`, default upload cap ×4). `tar` resolves PAX/GNU long names, so header handling can't be bypassed.
- Upload filename carries a `randomUUID` slice to avoid a same-millisecond same-name collision (mainly under CI automation) sharing one `file_path`.
- `.ipa`/`.aab` rejection messages updated.

**ios-agent (`IOSAgent.installBuild`)**
- `.tar.gz`/`.tgz` → `tar -xzf` into a temp dir → install the `.app`. macOS `tar` (libarchive) refuses `..`/symlink escapes by default (verified) — a second layer behind relay validation.

**dashboard (`UploadBuildDialog`)**
- `accept` includes `.tgz,.tar.gz` plus gzip MIME types so the macOS file picker enables the compound extension; hint mentions EAS.

## Tests

- **relay 418 pass** — tar metadata extraction + handler cases: valid upload, `.tgz`, `.ipa`/`.aab` rejection, path traversal, symlink, gzip bomb, corrupt, no-`.app`, and Linux `lipo`-unavailable parity (TC1,3–10,13).
- **ios-agent 206 pass** — `installBuild` tar / tgz / `.app.zip` regression / no-`.app`.
- **Manual QA (TC#2)** — a real EAS `.tar.gz` was uploaded through the dashboard, installed, and launched with its UI rendered on a booted simulator.

## Notes

- Storage is native (no re-zip); `file_path` extension drives downstream dispatch, no DB schema change.
- `agent-core` interface unchanged (`installApp(path)` branches internally).
- Dashboard build output (`relay/public/`) is gitignored and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS simulator builds can now be uploaded as `.tar.gz` or `.tgz` in addition to `.app.zip`.
  * Upload guidance and accepted file types now reflect the supported formats.

* **Bug Fixes**
  * iOS archive handling now reliably extracts app details from both zip and tar-based uploads.
  * Added stronger validation for `.tar.gz` uploads (e.g., safety checks and clearer rejection reasons).

* **Documentation**
  * Updated dashboard and relay upload instructions to specify the accepted iOS simulator archive formats and expected file guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->