### PR TITLE
docs: harden relay systemd guide

### DIFF
--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -409,12 +409,39 @@ EnvironmentFile=/etc/tapflow/relay.env
 ExecStart=/usr/bin/env tapflow relay start
 Restart=on-failure
 RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/tapflow
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+The hardening directives keep the filesystem read-only except for
+`/var/lib/tapflow`, which includes the configured
+`/var/lib/tapflow/.tapflow-data` directory. If you move
+`TAPFLOW_DATA_DIR` outside `/var/lib/tapflow`, add that path to
+`ReadWritePaths` too.
+
 Place `tapflow.config.json` in `/var/lib/tapflow` if you need to customize the port or other settings, because that is the service `WorkingDirectory`.
+
+Run a foreground smoke test before enabling the service. This confirms the
+relay can bind and write to the data directory with the same dedicated user:
+
+```sh
+cd /var/lib/tapflow
+sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+```
+
+In another shell, confirm the relay responds:
+
+```sh
+tapflow status
+```
+
+Stop the foreground relay with Ctrl-C after the status check passes.
 
 Enable and start the service:
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -409,12 +409,40 @@ EnvironmentFile=/etc/tapflow/relay.env
 ExecStart=/usr/bin/env tapflow relay start
 Restart=on-failure
 RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/tapflow
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+하드닝 지시어는 파일 시스템을 읽기 전용으로 유지하되
+`/var/lib/tapflow`만 쓰기 가능하게 둡니다. 이 경로 안에는 설정한
+`/var/lib/tapflow/.tapflow-data` 데이터 디렉터리가 포함됩니다.
+`TAPFLOW_DATA_DIR`을 `/var/lib/tapflow` 밖으로 옮겼다면 그 경로도
+`ReadWritePaths`에 추가하세요.
+
 기본값이 아닌 포트나 다른 설정이 필요하다면 `tapflow.config.json`을 `WorkingDirectory`인 `/var/lib/tapflow`에 둡니다.
+
+서비스를 활성화하기 전에 포그라운드 스모크 테스트를 먼저 실행하세요.
+전용 사용자로 실행했을 때 릴레이가 바인딩되고 데이터 디렉터리에 쓸 수
+있는지 확인합니다.
+
+```sh
+cd /var/lib/tapflow
+sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+```
+
+다른 셸에서 릴레이가 응답하는지 확인합니다.
+
+```sh
+tapflow status
+```
+
+상태 확인이 끝나면 Ctrl-C로 포그라운드 릴레이를 중지합니다.
 
 서비스를 활성화하고 시작합니다:
 


### PR DESCRIPTION
Closes #365

Summary:
- Add a minimal systemd sandboxing baseline to the relay unit example.
- Document why ReadWritePaths=/var/lib/tapflow preserves the default data directory and what to change if TAPFLOW_DATA_DIR moves.
- Add a foreground first-run smoke test before systemctl enable --now.
- Mirror the same guidance in the Korean self-hosting page.

Validation:
- git diff --check
- npm install --ignore-scripts --no-package-lock (from docs)
- npm run build (from docs)

Note:
- 
pm --prefix docs install --no-package-lock initially failed on Windows because the repo lifecycle script uses lefthook install || true; retrying inside docs with --ignore-scripts installed the docs dependencies for the build check.