### PR TITLE
feat(relay): outbound webhooks for build review-status transitions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -41,6 +41,7 @@ const enSidebar = [
       { text: 'Uploading Builds', link: '/guide/upload-builds' },
       { text: 'Build Distribution', link: '/guide/build-distribution' },
       { text: 'Expo Build Integration', link: '/guide/build-expo-eas' },
+      { text: 'Webhooks', link: '/guide/build-status-webhooks' },
     ],
   },
   {
@@ -108,6 +109,7 @@ const koSidebar = [
       { text: '빌드 업로드', link: '/ko/guide/upload-builds' },
       { text: '빌드 배포', link: '/ko/guide/build-distribution' },
       { text: 'Expo 빌드 연동', link: '/ko/guide/build-expo-eas' },
+      { text: '웹훅', link: '/ko/guide/build-status-webhooks' },
     ],
   },
   {

--- a/docs/guide/build-status-webhooks.md
+++ b/docs/guide/build-status-webhooks.md
@@ -21,7 +21,37 @@ For automated testing where an LLM agent controls the simulator, see [MCP in CI/
 
 ## Register an endpoint
 
-Register a URL to notify with `POST /api/v1/webhooks`. Authentication is the same as build upload — a Personal Access Token with the `builds:write` scope. See [Build Distribution](/guide/build-distribution) for token generation.
+There are two ways to register. Declare endpoints in `config.json` if you manage settings as files, or use the REST API to add and remove them at runtime. Endpoints from both sources are delivered together.
+
+### Declare in config.json (recommended)
+
+Add entries to the `webhooks` array in `tapflow.config.json`. This keeps webhooks in the same file a self-hosted operator already uses for TLS, SMTP, and the rest.
+
+```json
+{
+  "webhooks": [
+    { "url": "https://ci.internal/hooks/tapflow", "secretEnv": "TAPFLOW_WEBHOOK_SECRET_CI" }
+  ]
+}
+```
+
+Secrets never go in config.json. Point `secretEnv` at an environment variable name and tapflow reads that value as the signing key. Keep the actual secret in `.env`.
+
+```
+TAPFLOW_WEBHOOK_SECRET_CI=a-long-random-string
+```
+
+| Field | Description |
+|-------|-------------|
+| `url` | Destination that receives the POST (required) |
+| `secretEnv` | Name of the env var holding the signing secret (optional, strongly recommended) |
+| `enabled` | Whether the endpoint is active (defaults to `true`) |
+
+Changes to config.json take effect after a relay restart.
+
+### Register via the REST API
+
+To add one at runtime, use `POST /api/v1/webhooks`. Authentication is the same as build upload — a Personal Access Token with the `builds:write` scope. See [Build Distribution](/guide/build-distribution) for token generation.
 
 ```sh
 curl -X POST https://your-relay/api/v1/webhooks \
@@ -36,9 +66,9 @@ curl -X POST https://your-relay/api/v1/webhooks \
 | `secret` | Key used to sign deliveries (optional, strongly recommended) |
 | `enabled` | Whether the endpoint is active (defaults to `true`) |
 
-Register several and every enabled endpoint receives its own POST — connect Slack and an internal CI hook at the same time.
+Unlike config.json, the REST API takes the secret directly in the request body. Register several and every enabled endpoint receives its own POST — connect Slack and an internal CI hook at the same time.
 
-The management endpoints:
+The REST management endpoints:
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/guide/build-status-webhooks.md
+++ b/docs/guide/build-status-webhooks.md
@@ -1,0 +1,116 @@
+# Webhooks
+
+When your team finishes a review and moves a build to `Done` or `Rejected`, tapflow notifies a URL you registered. Wire that signal into a Slack alert or the next deploy step, and review outcomes flow through automatically.
+
+This runs the opposite direction from an EAS webhook. tapflow doesn't build your app, so what it reports here isn't a build completion — it's the **review verdict a person made**.
+
+## How it works
+
+```
+Someone reviews the build in App Center
+  → moves status to Done / Rejected
+  → tapflow POSTs to your registered URL (signed metadata)
+  → your receiver fires a Slack alert · the next CI step
+```
+
+::: info Two testing paths
+This guide covers the **manual review path**: CI delivers the build; people do the testing.
+
+For automated testing where an LLM agent controls the simulator, see [MCP in CI/CD](/guide/mcp-ci). That is a separate, experimental feature.
+:::
+
+## Register an endpoint
+
+Register a URL to notify with `POST /api/v1/webhooks`. Authentication is the same as build upload — a Personal Access Token with the `builds:write` scope. See [Build Distribution](/guide/build-distribution) for token generation.
+
+```sh
+curl -X POST https://your-relay/api/v1/webhooks \
+  -H "Authorization: Bearer $TAPFLOW_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://ci.internal/hooks/tapflow","secret":"a-long-random-string"}'
+```
+
+| Field | Description |
+|-------|-------------|
+| `url` | Destination that receives the POST (required) |
+| `secret` | Key used to sign deliveries (optional, strongly recommended) |
+| `enabled` | Whether the endpoint is active (defaults to `true`) |
+
+Register several and every enabled endpoint receives its own POST — connect Slack and an internal CI hook at the same time.
+
+The management endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/webhooks` | Register an endpoint |
+| `GET` | `/api/v1/webhooks` | List endpoints (`secret` is never returned) |
+| `PATCH` | `/api/v1/webhooks/:id` | Update `url` · `secret` · `enabled` |
+| `DELETE` | `/api/v1/webhooks/:id` | Delete an endpoint |
+
+## Payload
+
+The delivered body is JSON:
+
+```json
+{
+  "event": "build.status_changed",
+  "build": {
+    "id": "42",
+    "platform": "ios",
+    "appVersion": "1.4.0",
+    "status": "Done"
+  },
+  "changedAt": "2026-07-03T10:00:00.000Z"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `event` | Event type. Currently always `build.status_changed` |
+| `build.id` | Build identifier |
+| `build.platform` | `ios` or `android` |
+| `build.appVersion` | App version, or `null` when unknown |
+| `build.status` | `Done` or `Rejected` |
+| `changedAt` | When the status changed (ISO 8601) |
+
+The body carries build identification only — no app binary or screen data.
+
+## Verifying the signature
+
+If you set a `secret` at registration, tapflow signs the body with HMAC-SHA256 and sends it in the `X-Tapflow-Signature` header, hex-encoded with a `sha256=` prefix. Re-sign the body with the same secret and compare — a match proves the request came from tapflow and the body wasn't tampered with.
+
+```js
+import crypto from 'crypto'
+
+function isFromTapflow(rawBody, signature, secret) {
+  const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
+  const a = Buffer.from(signature ?? '')
+  const b = Buffer.from(expected)
+  return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
+```
+
+Always verify against the raw, unparsed body — parsing the JSON and re-serializing it changes the bytes and breaks the signature.
+
+## When it fires
+
+A webhook is sent **only when** `status_label` changes to `Done` or `Rejected`.
+
+- A request that leaves the value unchanged — re-setting a `Done` build to `Done` — sends nothing.
+- Changes to `Backlog` or `In Progress`, or updates that touch only other fields, send nothing.
+- Delivery is best-effort. If your receiver is down or fails, the status change itself still succeeds, and each request times out after 5 seconds.
+
+| Status | Meaning |
+|--------|---------|
+| `Done` | Stakeholders approved |
+| `Rejected` | Issues found, needs fixes |
+
+## Security
+
+- The payload carries metadata only; app binaries are never sent.
+- Registration rejects loopback (`127.0.0.1`) and cloud-metadata (`169.254.169.254`) addresses. Private LAN addresses (`10.x`, `192.168.x`, …) are allowed for self-hosted CI.
+- `secret` is optional, but set one — an exposed URL can otherwise receive forged requests.
+
+## Relation to EAS integration
+
+This is an outbound notification tapflow sends. The opposite direction — receiving an EAS build-completion event and uploading the result into tapflow — is covered in [Expo build integration](/guide/build-expo-eas).

--- a/docs/ko/guide/build-status-webhooks.md
+++ b/docs/ko/guide/build-status-webhooks.md
@@ -21,7 +21,37 @@ LLM 에이전트가 시뮬레이터를 자동으로 조작하는 방식은 [CI/C
 
 ## 엔드포인트 등록
 
-`POST /api/v1/webhooks`로 알림 받을 URL을 등록합니다. 인증은 빌드 업로드와 동일하게 `builds:write` 스코프의 Personal Access Token을 사용합니다. 토큰 발급은 [빌드 배포](/ko/guide/build-distribution)의 토큰 생성 절을 참고하세요.
+등록 방법은 두 가지입니다. 설정을 파일로 관리하면 `config.json`으로 선언하고, 런타임에 추가·삭제하려면 REST API를 씁니다. 두 방식으로 등록한 엔드포인트는 함께 발송됩니다.
+
+### config.json으로 선언 (권장)
+
+`tapflow.config.json`의 `webhooks` 배열에 등록합니다. self-hosted 운영자가 TLS·SMTP 같은 다른 설정과 한 파일에서 함께 관리하는 방식입니다.
+
+```json
+{
+  "webhooks": [
+    { "url": "https://ci.internal/hooks/tapflow", "secretEnv": "TAPFLOW_WEBHOOK_SECRET_CI" }
+  ]
+}
+```
+
+secret은 config.json에 직접 쓰지 않습니다. `secretEnv`에 환경 변수 이름을 지정하면 tapflow가 그 값을 서명 키로 읽어옵니다. 실제 secret은 `.env`에 둡니다.
+
+```
+TAPFLOW_WEBHOOK_SECRET_CI=a-long-random-string
+```
+
+| 필드 | 설명 |
+|------|------|
+| `url` | 알림을 받을 주소 (필수) |
+| `secretEnv` | 서명 secret이 담긴 환경 변수 이름 (선택, 강하게 권장) |
+| `enabled` | 활성 여부 (기본 `true`) |
+
+config.json 변경은 relay를 다시 시작해야 반영됩니다.
+
+### REST API로 등록
+
+런타임에 추가하려면 `POST /api/v1/webhooks`를 씁니다. 인증은 빌드 업로드와 동일하게 `builds:write` 스코프의 Personal Access Token을 사용합니다. 토큰 발급은 [빌드 배포](/ko/guide/build-distribution)의 토큰 생성 절을 참고하세요.
 
 ```sh
 curl -X POST https://your-relay/api/v1/webhooks \
@@ -36,9 +66,9 @@ curl -X POST https://your-relay/api/v1/webhooks \
 | `secret` | 서명에 쓸 비밀 키 (선택, 강하게 권장) |
 | `enabled` | 활성 여부 (기본 `true`) |
 
-여러 개를 등록하면 활성화된 모든 엔드포인트로 각각 전송되므로, Slack과 사내 CI에 동시에 연결할 수 있습니다.
+REST API는 `config.json`과 달리 secret을 요청 본문에 직접 담습니다. 여러 개를 등록하면 활성화된 모든 엔드포인트로 각각 전송되므로, Slack과 사내 CI에 동시에 연결할 수 있습니다.
 
-관리용 엔드포인트는 다음과 같습니다.
+REST 관리용 엔드포인트는 다음과 같습니다.
 
 | Method | Path | 설명 |
 |--------|------|------|

--- a/docs/ko/guide/build-status-webhooks.md
+++ b/docs/ko/guide/build-status-webhooks.md
@@ -1,0 +1,116 @@
+# 웹훅
+
+팀이 리뷰를 마치고 빌드를 `Done` 또는 `Rejected`로 바꾸면, tapflow가 미리 등록해둔 URL로 그 사실을 알립니다. 이 신호를 Slack 알림이나 다음 배포 단계로 이어 붙이면 리뷰 결과가 자동으로 흐르게 됩니다.
+
+EAS 웹훅이 빌드 완료를 알리는 것과는 방향이 다릅니다. tapflow는 빌드를 직접 만들지 않으므로, 여기서 알리는 것은 빌드 완료가 아니라 **사람이 내린 리뷰 판정**입니다.
+
+## 동작 방식
+
+```
+팀원이 App Center에서 리뷰
+  → 상태를 Done / Rejected 로 변경
+  → tapflow가 등록된 URL로 POST (서명된 metadata)
+  → 수신 측이 Slack 알림 · 다음 CI 단계로 연결
+```
+
+::: info 두 가지 테스트 경로
+이 가이드는 **수동 리뷰 경로**를 다룹니다. CI가 빌드를 전달하고, 팀원이 직접 테스트하는 방식입니다.
+
+LLM 에이전트가 시뮬레이터를 자동으로 조작하는 방식은 [CI/CD에서 MCP 활용](/ko/guide/mcp-ci)을 참고하세요. 이는 별도의 실험적 기능입니다.
+:::
+
+## 엔드포인트 등록
+
+`POST /api/v1/webhooks`로 알림 받을 URL을 등록합니다. 인증은 빌드 업로드와 동일하게 `builds:write` 스코프의 Personal Access Token을 사용합니다. 토큰 발급은 [빌드 배포](/ko/guide/build-distribution)의 토큰 생성 절을 참고하세요.
+
+```sh
+curl -X POST https://your-relay/api/v1/webhooks \
+  -H "Authorization: Bearer $TAPFLOW_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://ci.internal/hooks/tapflow","secret":"a-long-random-string"}'
+```
+
+| 필드 | 설명 |
+|------|------|
+| `url` | 알림을 받을 주소 (필수) |
+| `secret` | 서명에 쓸 비밀 키 (선택, 강하게 권장) |
+| `enabled` | 활성 여부 (기본 `true`) |
+
+여러 개를 등록하면 활성화된 모든 엔드포인트로 각각 전송되므로, Slack과 사내 CI에 동시에 연결할 수 있습니다.
+
+관리용 엔드포인트는 다음과 같습니다.
+
+| Method | Path | 설명 |
+|--------|------|------|
+| `POST` | `/api/v1/webhooks` | 엔드포인트 등록 |
+| `GET` | `/api/v1/webhooks` | 목록 조회 (`secret`은 노출되지 않음) |
+| `PATCH` | `/api/v1/webhooks/:id` | `url` · `secret` · `enabled` 수정 |
+| `DELETE` | `/api/v1/webhooks/:id` | 엔드포인트 삭제 |
+
+## 페이로드
+
+전송되는 본문은 다음 형태의 JSON입니다.
+
+```json
+{
+  "event": "build.status_changed",
+  "build": {
+    "id": "42",
+    "platform": "ios",
+    "appVersion": "1.4.0",
+    "status": "Done"
+  },
+  "changedAt": "2026-07-03T10:00:00.000Z"
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `event` | 이벤트 종류. 현재는 `build.status_changed` |
+| `build.id` | 빌드 식별자 |
+| `build.platform` | `ios` 또는 `android` |
+| `build.appVersion` | 앱 버전. 없으면 `null` |
+| `build.status` | `Done` 또는 `Rejected` |
+| `changedAt` | 상태가 바뀐 시각 (ISO 8601) |
+
+본문에는 빌드 식별 정보만 담기며, 앱 바이너리나 스크린 데이터는 포함되지 않습니다.
+
+## 서명 검증
+
+등록할 때 `secret`을 지정하면, tapflow는 본문을 그 비밀 키로 HMAC-SHA256 서명해 `X-Tapflow-Signature` 헤더에 담아 보냅니다. 값은 `sha256=` 접두사가 붙은 16진수입니다. 수신 측이 같은 비밀 키로 본문을 다시 서명해 두 값이 일치하는지 확인하면, 요청이 tapflow에서 왔으며 본문이 변조되지 않았음을 검증할 수 있습니다.
+
+```js
+import crypto from 'crypto'
+
+function isFromTapflow(rawBody, signature, secret) {
+  const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
+  const a = Buffer.from(signature ?? '')
+  const b = Buffer.from(expected)
+  return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
+```
+
+서명 검증은 반드시 파싱 전의 원본 본문으로 해야 합니다. JSON으로 파싱한 뒤 다시 직렬화하면 바이트가 달라져 서명이 어긋납니다.
+
+## 발화 조건
+
+웹훅은 `status_label`이 `Done` 또는 `Rejected`로 **바뀔 때만** 전송됩니다.
+
+- 이미 `Done`인 빌드를 다시 `Done`으로 두는 요청처럼 값이 그대로면 전송하지 않습니다.
+- `Backlog`나 `In Progress`로의 변경, 상태 외 필드만 바뀐 변경도 전송하지 않습니다.
+- 전송은 best-effort입니다. 수신 측이 응답하지 않거나 실패해도 빌드 상태 변경 자체는 정상 처리되며, 각 요청은 5초 후 시간 초과로 끊깁니다.
+
+| 상태 | 의미 |
+|------|------|
+| `Done` | 이해관계자 승인 완료 |
+| `Rejected` | 문제 발견, 수정 필요 |
+
+## 보안
+
+- 페이로드에는 metadata만 담기고 앱 바이너리는 전송되지 않습니다.
+- 등록 URL은 loopback(`127.0.0.1`)과 클라우드 메타데이터 주소(`169.254.169.254`)를 거부합니다. 사내 사설망 주소(`10.x`, `192.168.x` 등)는 self-hosted CI를 위해 허용됩니다.
+- `secret`은 선택이지만, 등록 URL이 노출되면 위조 요청이 들어올 수 있으므로 지정하기를 강하게 권장합니다.
+
+## EAS 연동과의 관계
+
+이 기능은 tapflow가 외부로 보내는(outbound) 알림입니다. 반대 방향인, EAS 빌드가 끝났을 때 그 결과를 받아 tapflow로 업로드하는(inbound) 방법은 [Expo 빌드 연동](/ko/guide/build-expo-eas)에서 다룹니다.

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -19,7 +19,10 @@
     "secure": false,
     "user": "relay@example.com",
     "pass": "password"
-  }
+  },
+  "webhooks": [
+    { "url": "https://ci.internal/hooks/tapflow", "secretEnv": "TAPFLOW_WEBHOOK_SECRET_CI" }
+  ]
 }
 ```
 
@@ -29,6 +32,7 @@
 | `relay.url` | 연결할 relay URL. `tapflow agent start`, `tapflow admin init`, `tapflow status`, `tapflow logs`의 기본값으로 사용됩니다. 설정 시 `--relay` 플래그 없이 동작합니다. 비어있으면 로컬 모드(`ws://localhost:[local.port]`)를 사용합니다. |
 | `tls` | LAN HTTPS(보안 컨텍스트) 설정. WebCodecs 하드웨어 디코드에 필요합니다. 아래 HTTPS 섹션을 참고하세요. |
 | `smtp` | 초대·비밀번호 재설정 이메일 발송을 위한 SMTP 설정 |
+| `webhooks` | 빌드 리뷰 상태가 바뀔 때 알림을 보낼 아웃바운드 엔드포인트. 서명 secret은 `secretEnv`가 가리키는 환경 변수에서 읽습니다. 아래 웹훅 섹션을 참고하세요. |
 
 `smtp.from`은 `smtp.user`가 설정되어 있으면 `tapflow <smtp.user>` 형태로 자동 설정됩니다. 발신자 주소를 다르게 지정하려면 명시적으로 입력합니다.
 
@@ -172,3 +176,15 @@ your-directory/
 SMTP가 설정되지 않으면 초대 이메일과 비밀번호 재설정 이메일이 발송되지 않습니다. 이 경우 Admin이 초대 링크를 직접 복사해 공유할 수 있습니다.
 
 팀 초대에 이메일을 사용하려면 `smtp.host`와 `smtp.user`, `smtp.pass`를 설정합니다.
+
+## 웹훅
+
+빌드 리뷰 상태가 `Done` 또는 `Rejected`로 바뀌면 tapflow가 등록된 URL로 POST합니다. `webhooks` 배열로 엔드포인트를 선언하고, REST API로도 런타임에 더 등록할 수 있습니다. 페이로드·서명 검증·발화 조건은 [웹훅](/ko/guide/build-status-webhooks)에서 다룹니다.
+
+| 키 | 설명 |
+|----|------|
+| `webhooks[].url` | 알림을 받을 주소 (필수) |
+| `webhooks[].secretEnv` | HMAC 서명 secret이 담긴 환경 변수 이름. secret은 config.json에 직접 두지 않습니다. |
+| `webhooks[].enabled` | 활성 여부. 기본 `true` |
+
+`webhooks` 변경은 relay를 다시 시작해야 반영됩니다.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -19,7 +19,10 @@ The relay reads `tapflow.config.json` from the directory where it is started. Ge
     "secure": false,
     "user": "relay@example.com",
     "pass": "password"
-  }
+  },
+  "webhooks": [
+    { "url": "https://ci.internal/hooks/tapflow", "secretEnv": "TAPFLOW_WEBHOOK_SECRET_CI" }
+  ]
 }
 ```
 
@@ -29,6 +32,7 @@ The relay reads `tapflow.config.json` from the directory where it is started. Ge
 | `relay.url` | URL of the relay to connect to. Used by `tapflow agent start`, `tapflow admin init`, `tapflow status`, and `tapflow logs` as the default — no `--relay` flag needed when this is set. Leave empty for local mode (`ws://localhost:[local.port]`). |
 | `tls` | LAN HTTPS (secure context) settings, required for WebCodecs hardware decode. See the HTTPS section below. |
 | `smtp` | SMTP settings for sending invitation and password reset emails. |
+| `webhooks` | Outbound endpoints notified when a build's review status changes. Signing secrets are read from env vars named by `secretEnv`. See the Webhooks section below. |
 
 `smtp.from` defaults to `tapflow <smtp.user>` when `smtp.user` is set. Override it explicitly if you need a different sender address.
 
@@ -170,3 +174,15 @@ To change the data directory location, set `TAPFLOW_DATA_DIR` or `local.dataDir`
 Without SMTP, invitation emails and password reset emails will not be sent. In that case, Admins can copy and share the invite link directly.
 
 To send invitation emails, configure `smtp.host`, `smtp.user`, and `smtp.pass`.
+
+## Webhooks
+
+tapflow POSTs to registered URLs when a build's review status changes to `Done` or `Rejected`. Declare endpoints in the `webhooks` array; the REST API can register more at runtime. The full payload, signature verification, and firing rules are in [Webhooks](/guide/build-status-webhooks).
+
+| Key | Description |
+|-----|-------------|
+| `webhooks[].url` | Destination that receives the POST (required). |
+| `webhooks[].secretEnv` | Name of the env var holding the HMAC signing secret. Secrets never go in config.json. |
+| `webhooks[].enabled` | Whether the endpoint is active. Defaults to `true`. |
+
+Changes to `webhooks` take effect after a relay restart.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -53,6 +53,7 @@ const HEARTBEAT_MS = 30_000
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
 import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, handleScheduleBuildDeletion, handleCancelBuildDeletion, purgeExpiredBuilds } from './api/builds.js'
 import { handleListApps, handleCreateApp, handleUpdateApp, handleDeleteApp } from './api/apps.js'
+import { handleListWebhooks, handleCreateWebhook, handleUpdateWebhook, handleDeleteWebhook } from './api/webhooks.js'
 import { handleListComments, handleCreateComment, handleDeleteComment } from './api/comments.js'
 import { handleListMembers, handleInvite, handleUpdateMember, handleDeleteMember } from './api/team.js'
 import { handleListTokens, handleCreateToken, handleRevokeToken } from './api/tokens.js'
@@ -184,6 +185,12 @@ export class RelayServer {
     this.router.post('/api/v1/builds/:id/schedule-deletion', handleScheduleBuildDeletion)
     this.router.delete('/api/v1/builds/:id/schedule-deletion', handleCancelBuildDeletion)
     this.router.post('/api/v1/builds', (req, res) => handleUploadBuild(req, res, u))
+
+    // webhooks (outbound build-status notifications)
+    this.router.get('/api/v1/webhooks', handleListWebhooks)
+    this.router.post('/api/v1/webhooks', handleCreateWebhook)
+    this.router.patch('/api/v1/webhooks/:id', handleUpdateWebhook)
+    this.router.delete('/api/v1/webhooks/:id', handleDeleteWebhook)
 
     // comments
     this.router.get('/api/v1/comments', handleListComments)

--- a/packages/relay/src/__tests__/webhooks.test.ts
+++ b/packages/relay/src/__tests__/webhooks.test.ts
@@ -80,6 +80,9 @@ describe('validateWebhookUrl', () => {
     expect(validateWebhookUrl('http://localhost/hook')).toBeTruthy()
     expect(validateWebhookUrl('http://169.254.169.254/latest/meta-data')).toBeTruthy()
     expect(validateWebhookUrl('http://[::1]/hook')).toBeTruthy()
+    // IPv4-mapped IPv6 must not slip past — Node normalizes these to a hex form
+    expect(validateWebhookUrl('http://[::ffff:127.0.0.1]/hook')).toBeTruthy()
+    expect(validateWebhookUrl('http://[::ffff:169.254.169.254]/hook')).toBeTruthy()
   })
   it('#17 allows private LAN and public addresses', () => {
     expect(validateWebhookUrl('http://10.0.1.5/hook')).toBeNull()
@@ -123,7 +126,7 @@ describe('deliverWebhooks', () => {
     const calls: { url: string; headers: Record<string, string>; body: string }[] = []
     const fetchFn: FetchLike = async (url, init) => {
       calls.push({ url, headers: init.headers, body: init.body })
-      return { ok: true, status: 200 }
+      return { ok: true, status: 200, text: async () => '' }
     }
     return { fetchFn, calls }
   }
@@ -167,7 +170,7 @@ describe('deliverWebhooks', () => {
     const fetchFn: FetchLike = async (url) => {
       calls.push(url)
       if (url.endsWith('/bad')) throw new Error('connection refused')
-      return { ok: true, status: 200 }
+      return { ok: true, status: 200, text: async () => '' }
     }
     await expect(deliverWebhooks(payload, { fetchFn })).resolves.toBeUndefined()
     expect(calls.sort()).toEqual(['http://10.0.0.1/bad', 'http://10.0.0.2/good'])

--- a/packages/relay/src/__tests__/webhooks.test.ts
+++ b/packages/relay/src/__tests__/webhooks.test.ts
@@ -15,6 +15,7 @@ import {
   type FetchLike,
   type WebhookPayload,
 } from '../lib/webhooks'
+import { config, resolveWebhooksConfig } from '../lib/config'
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -105,6 +106,26 @@ describe('signPayload', () => {
   })
 })
 
+// ── unit: resolveWebhooksConfig ────────────────────────────────────────────────
+
+describe('resolveWebhooksConfig', () => {
+  it('resolves the signing secret from the named env var', () => {
+    const out = resolveWebhooksConfig([{ url: 'https://a/x', secretEnv: 'WH_SECRET' }], { WH_SECRET: 'sek' })
+    expect(out).toEqual([{ url: 'https://a/x', secret: 'sek', enabled: true }])
+  })
+  it('leaves secret empty when secretEnv is absent or unset', () => {
+    expect(resolveWebhooksConfig([{ url: 'https://a/x' }], {})[0].secret).toBe('')
+    expect(resolveWebhooksConfig([{ url: 'https://a/x', secretEnv: 'NOPE' }], {})[0].secret).toBe('')
+  })
+  it('keeps enabled:false and drops entries without a url', () => {
+    const out = resolveWebhooksConfig([{ url: 'https://a/x', enabled: false }, { secretEnv: 'X' }], {})
+    expect(out).toEqual([{ url: 'https://a/x', secret: '', enabled: false }])
+  })
+  it('returns [] for non-array input', () => {
+    expect(resolveWebhooksConfig(undefined, {})).toEqual([])
+  })
+})
+
 // ── unit: deliverWebhooks (injected fetch) ─────────────────────────────────────
 
 describe('deliverWebhooks', () => {
@@ -114,7 +135,7 @@ describe('deliverWebhooks', () => {
     initDb(path.join(tmpDir, 'test.db'))
   })
   afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
-  afterEach(() => { getDb().exec('DELETE FROM webhook_endpoints') })
+  afterEach(() => { getDb().exec('DELETE FROM webhook_endpoints'); config.webhooks.length = 0 })
 
   const payload: WebhookPayload = {
     event: 'build.status_changed',
@@ -161,6 +182,23 @@ describe('deliverWebhooks', () => {
     const { fetchFn, calls } = record()
     await deliverWebhooks(payload, { fetchFn })
     expect(calls).toHaveLength(0)
+  })
+
+  it('delivers to config.json endpoints alongside DB ones', async () => {
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.1/db', null)
+    config.webhooks.push({ url: 'http://10.0.0.2/cfg', secret: '', enabled: true })
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    expect(calls.map((c) => c.url).sort()).toEqual(['http://10.0.0.1/db', 'http://10.0.0.2/cfg'])
+  })
+
+  it('skips disabled config endpoints and signs with the config secret', async () => {
+    config.webhooks.push({ url: 'http://10.0.0.3/off', secret: 'x', enabled: false })
+    config.webhooks.push({ url: 'http://10.0.0.4/cfg', secret: 'cfgsecret', enabled: true })
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    expect(calls.map((c) => c.url)).toEqual(['http://10.0.0.4/cfg'])
+    expect(calls[0].headers['X-Tapflow-Signature']).toBe(signPayload('cfgsecret', calls[0].body))
   })
 
   it('#15 one endpoint failing does not stop the others', async () => {

--- a/packages/relay/src/__tests__/webhooks.test.ts
+++ b/packages/relay/src/__tests__/webhooks.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import crypto from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initDb, getDb, closeDb } from '../db'
+import { RelayServer } from '../RelayServer'
+import { makePasswordHash } from '../api/auth'
+import { signJwt } from '../middleware/auth'
+import {
+  validateWebhookUrl,
+  signPayload,
+  deliverWebhooks,
+  type FetchLike,
+  type WebhookPayload,
+} from '../lib/webhooks'
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function insertAppAndBuild(): number {
+  const db = getDb()
+  db.prepare(`INSERT INTO apps (name, bundle_id_key, platform) VALUES ('Coffee', 'com.example.coffee', 'ios')`).run()
+  const app = db.prepare('SELECT id FROM apps WHERE bundle_id_key = ?').get('com.example.coffee') as { id: number }
+  const r = db.prepare(`
+    INSERT INTO builds (app_id, version_name, build_number, bundle_id, file_path)
+    VALUES (?, '1.0.0', '1', 'com.example.coffee', '/tmp/x.zip')
+  `).run(app.id)
+  return Number(r.lastInsertRowid)
+}
+
+function httpJson(port: number, method: string, urlPath: string, cookie: string, body?: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? undefined : Buffer.from(JSON.stringify(body))
+    const headers: Record<string, string> = { Cookie: cookie }
+    if (payload) { headers['Content-Type'] = 'application/json'; headers['Content-Length'] = String(payload.length) }
+    const req = http.request({ hostname: '127.0.0.1', port, path: urlPath, method, headers }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve({ status: res.statusCode!, body: JSON.parse(Buffer.concat(chunks).toString() || '{}') }))
+    })
+    req.on('error', reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+// A local HTTP receiver that records incoming webhook requests.
+function makeReceiver(): { server: http.Server; requests: { headers: http.IncomingHttpHeaders; body: string }[] } {
+  const requests: { headers: http.IncomingHttpHeaders; body: string }[] = []
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c: Buffer) => chunks.push(c))
+    req.on('end', () => {
+      requests.push({ headers: req.headers, body: Buffer.concat(chunks).toString() })
+      res.writeHead(200)
+      res.end()
+    })
+  })
+  return { server, requests }
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve((server.address() as { port: number }).port)))
+}
+
+async function waitFor(pred: () => boolean, ms = 2000): Promise<void> {
+  const start = Date.now()
+  while (!pred()) {
+    if (Date.now() - start > ms) throw new Error('waitFor timed out')
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+
+// ── unit: validateWebhookUrl ───────────────────────────────────────────────────
+
+describe('validateWebhookUrl', () => {
+  it('#16 rejects loopback and metadata addresses', () => {
+    expect(validateWebhookUrl('http://127.0.0.1/hook')).toBeTruthy()
+    expect(validateWebhookUrl('http://localhost/hook')).toBeTruthy()
+    expect(validateWebhookUrl('http://169.254.169.254/latest/meta-data')).toBeTruthy()
+    expect(validateWebhookUrl('http://[::1]/hook')).toBeTruthy()
+  })
+  it('#17 allows private LAN and public addresses', () => {
+    expect(validateWebhookUrl('http://10.0.1.5/hook')).toBeNull()
+    expect(validateWebhookUrl('http://192.168.1.20/hook')).toBeNull()
+    expect(validateWebhookUrl('https://hooks.slack.com/services/xxx')).toBeNull()
+  })
+  it('rejects non-http(s) schemes and malformed URLs', () => {
+    expect(validateWebhookUrl('ftp://example.com')).toBeTruthy()
+    expect(validateWebhookUrl('not a url')).toBeTruthy()
+  })
+})
+
+// ── unit: signPayload ──────────────────────────────────────────────────────────
+
+describe('signPayload', () => {
+  it('#8 produces an HMAC-SHA256 of the body, prefixed sha256=', () => {
+    const body = JSON.stringify({ hello: 'world' })
+    const expected = 'sha256=' + crypto.createHmac('sha256', 's3cr3t').update(body).digest('hex')
+    expect(signPayload('s3cr3t', body)).toBe(expected)
+  })
+})
+
+// ── unit: deliverWebhooks (injected fetch) ─────────────────────────────────────
+
+describe('deliverWebhooks', () => {
+  let tmpDir: string
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-wh-deliver-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
+  afterEach(() => { getDb().exec('DELETE FROM webhook_endpoints') })
+
+  const payload: WebhookPayload = {
+    event: 'build.status_changed',
+    build: { id: '1', platform: 'ios', appVersion: '1.0.0', status: 'Done' },
+    changedAt: '2026-07-03T00:00:00.000Z',
+  }
+
+  function record(): { fetchFn: FetchLike; calls: { url: string; headers: Record<string, string>; body: string }[] } {
+    const calls: { url: string; headers: Record<string, string>; body: string }[] = []
+    const fetchFn: FetchLike = async (url, init) => {
+      calls.push({ url, headers: init.headers, body: init.body })
+      return { ok: true, status: 200 }
+    }
+    return { fetchFn, calls }
+  }
+
+  it('#14 fans out to every enabled endpoint', async () => {
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.1/a', null)
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.2/b', null)
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    expect(calls.map((c) => c.url).sort()).toEqual(['http://10.0.0.1/a', 'http://10.0.0.2/b'])
+  })
+
+  it('#7 skips disabled endpoints', async () => {
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 0)').run('http://10.0.0.9/off', null)
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('#8/#9 signs only when a secret is set', async () => {
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.1/signed', 'topsecret')
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.2/plain', null)
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    const signed = calls.find((c) => c.url.endsWith('/signed'))!
+    const plain = calls.find((c) => c.url.endsWith('/plain'))!
+    expect(signed.headers['X-Tapflow-Signature']).toBe(signPayload('topsecret', signed.body))
+    expect(plain.headers['X-Tapflow-Signature']).toBeUndefined()
+  })
+
+  it('#6 no endpoints → no fetch', async () => {
+    const { fetchFn, calls } = record()
+    await deliverWebhooks(payload, { fetchFn })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('#15 one endpoint failing does not stop the others', async () => {
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.1/bad', null)
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)').run('http://10.0.0.2/good', null)
+    const calls: string[] = []
+    const fetchFn: FetchLike = async (url) => {
+      calls.push(url)
+      if (url.endsWith('/bad')) throw new Error('connection refused')
+      return { ok: true, status: 200 }
+    }
+    await expect(deliverWebhooks(payload, { fetchFn })).resolves.toBeUndefined()
+    expect(calls.sort()).toEqual(['http://10.0.0.1/bad', 'http://10.0.0.2/good'])
+  })
+})
+
+// ── HTTP: CRUD ─────────────────────────────────────────────────────────────────
+
+describe('webhooks CRUD', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+  let uploadsDir: string
+  let cookie: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-wh-crud-'))
+    initDb(path.join(tmpDir, 'test.db'))
+    getDb().prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    cookie = `tapflow_token=${signJwt({ userId: 1, email: 'admin@example.com', role: 'Admin' })}`
+  })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  beforeEach(async () => {
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-wh-up-'))
+    server = new RelayServer({ port: 0, uploadsDir })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+  afterEach(async () => {
+    await server.stop()
+    fs.rmSync(uploadsDir, { recursive: true, force: true })
+    getDb().exec('DELETE FROM webhook_endpoints')
+  })
+
+  it('creates a webhook and never returns the secret', async () => {
+    const r = await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { url: 'https://hooks.slack.com/x', secret: 'shh' })
+    expect(r.status).toBe(201)
+    expect(r.body.url).toBe('https://hooks.slack.com/x')
+    expect(r.body.has_secret).toBe(true)
+    expect(r.body).not.toHaveProperty('secret')
+  })
+
+  it('#16 rejects a loopback URL at registration', async () => {
+    const r = await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { url: 'http://127.0.0.1:9000/hook' })
+    expect(r.status).toBe(400)
+  })
+
+  it('requires a url', async () => {
+    const r = await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { secret: 'x' })
+    expect(r.status).toBe(400)
+  })
+
+  it('lists webhooks without secrets', async () => {
+    await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { url: 'https://a.example/x', secret: 'shh' })
+    const r = await httpJson(port, 'GET', '/api/v1/webhooks', cookie)
+    expect(r.status).toBe(200)
+    const list = r.body.webhooks as Record<string, unknown>[]
+    expect(list).toHaveLength(1)
+    expect(list[0]).not.toHaveProperty('secret')
+    expect(list[0].has_secret).toBe(true)
+  })
+
+  it('toggles enabled via PATCH', async () => {
+    const created = await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { url: 'https://a.example/x' })
+    const id = created.body.id
+    const r = await httpJson(port, 'PATCH', `/api/v1/webhooks/${id}`, cookie, { enabled: false })
+    expect(r.status).toBe(200)
+    expect(r.body.enabled).toBe(false)
+  })
+
+  it('DELETE removes a webhook; missing id → 404', async () => {
+    const created = await httpJson(port, 'POST', '/api/v1/webhooks', cookie, { url: 'https://a.example/x' })
+    const del = await httpJson(port, 'DELETE', `/api/v1/webhooks/${created.body.id}`, cookie)
+    expect(del.status).toBe(200)
+    const missing = await httpJson(port, 'DELETE', '/api/v1/webhooks/999999', cookie)
+    expect(missing.status).toBe(404)
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const r = await httpJson(port, 'GET', '/api/v1/webhooks', '')
+    expect(r.status).toBe(401)
+  })
+})
+
+// ── HTTP: firing on status transition ──────────────────────────────────────────
+
+describe('webhook firing on build status transition', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+  let uploadsDir: string
+  let cookie: string
+  let buildId: number
+  let receiver: ReturnType<typeof makeReceiver>
+  let recvPort: number
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-wh-fire-'))
+    initDb(path.join(tmpDir, 'test.db'))
+    getDb().prepare('INSERT INTO users (email, display_name, role, password_hash) VALUES (?, ?, ?, ?)')
+      .run('admin@example.com', 'Admin', 'Admin', makePasswordHash('password123'))
+    cookie = `tapflow_token=${signJwt({ userId: 1, email: 'admin@example.com', role: 'Admin' })}`
+  })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  beforeEach(async () => {
+    buildId = insertAppAndBuild()
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-wh-fireup-'))
+    server = new RelayServer({ port: 0, uploadsDir })
+    await server.start()
+    port = (server.address() as { port: number }).port
+    receiver = makeReceiver()
+    recvPort = await listen(receiver.server)
+    // Register the receiver directly (bypasses URL validation, which rejects loopback).
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)')
+      .run(`http://127.0.0.1:${recvPort}/hook`, 'sig-secret')
+  })
+  afterEach(async () => {
+    await server.stop()
+    await new Promise<void>((r) => receiver.server.close(() => r()))
+    fs.rmSync(uploadsDir, { recursive: true, force: true })
+    getDb().exec('DELETE FROM builds; DELETE FROM apps; DELETE FROM webhook_endpoints')
+  })
+
+  it('#1/#8/#11 fires on transition to Done with signed metadata-only payload', async () => {
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Done' })
+    expect(r.status).toBe(200)
+    await waitFor(() => receiver.requests.length === 1)
+
+    const got = receiver.requests[0]
+    const parsed = JSON.parse(got.body) as WebhookPayload
+    expect(parsed.event).toBe('build.status_changed')
+    expect(parsed.build).toEqual({ id: String(buildId), platform: 'ios', appVersion: '1.0.0', status: 'Done' })
+    // signature matches the exact delivered body
+    expect(got.headers['x-tapflow-signature']).toBe(signPayload('sig-secret', got.body))
+    // metadata only: no binary / file path / download url leaked
+    expect(got.body).not.toMatch(/file_path|uploads|\.zip|\.tar/)
+  })
+
+  it('#2 fires on transition to Rejected', async () => {
+    await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Rejected' })
+    await waitFor(() => receiver.requests.length === 1)
+    expect((JSON.parse(receiver.requests[0].body) as WebhookPayload).build.status).toBe('Rejected')
+  })
+
+  it('#3 does not fire on transition to In Progress', async () => {
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'In Progress' })
+    expect(r.status).toBe(200)
+    await new Promise((res) => setTimeout(res, 150))
+    expect(receiver.requests).toHaveLength(0)
+  })
+
+  it('#4 does not fire on a no-op PATCH (Done → Done)', async () => {
+    getDb().prepare('UPDATE builds SET status_label = ? WHERE id = ?').run('Done', buildId)
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Done' })
+    expect(r.status).toBe(200)
+    await new Promise((res) => setTimeout(res, 150))
+    expect(receiver.requests).toHaveLength(0)
+  })
+
+  it('#5 does not fire when only version_label changes', async () => {
+    getDb().prepare('UPDATE builds SET status_label = ? WHERE id = ?').run('Done', buildId)
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { version_label: 'v2' })
+    expect(r.status).toBe(200)
+    await new Promise((res) => setTimeout(res, 150))
+    expect(receiver.requests).toHaveLength(0)
+  })
+
+  it('#10 a dead receiver does not fail the PATCH', async () => {
+    getDb().prepare('DELETE FROM webhook_endpoints').run()
+    await new Promise<void>((r) => receiver.server.close(() => r())) // now nothing is listening on recvPort
+    getDb().prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, 1)')
+      .run(`http://127.0.0.1:${recvPort}/hook`, null)
+    const r = await httpJson(port, 'PATCH', `/api/v1/builds/${buildId}`, cookie, { status_label: 'Done' })
+    expect(r.status).toBe(200)
+    const status = (getDb().prepare('SELECT status_label FROM builds WHERE id = ?').get(buildId) as { status_label: string }).status_label
+    expect(status).toBe('Done')
+  })
+})

--- a/packages/relay/src/__tests__/webhooks.test.ts
+++ b/packages/relay/src/__tests__/webhooks.test.ts
@@ -121,8 +121,17 @@ describe('resolveWebhooksConfig', () => {
     const out = resolveWebhooksConfig([{ url: 'https://a/x', enabled: false }, { secretEnv: 'X' }], {})
     expect(out).toEqual([{ url: 'https://a/x', secret: '', enabled: false }])
   })
-  it('returns [] for non-array input', () => {
+  it('returns [] for non-array or malformed input', () => {
     expect(resolveWebhooksConfig(undefined, {})).toEqual([])
+    expect(resolveWebhooksConfig('nope', {})).toEqual([])
+    expect(resolveWebhooksConfig([{ url: 123 }], {})).toEqual([])
+  })
+  it('drops entries that fail the SSRF/format gate', () => {
+    const out = resolveWebhooksConfig(
+      [{ url: 'http://127.0.0.1/x' }, { url: 'http://[::ffff:127.0.0.1]/x' }, { url: 'not a url' }, { url: 'https://ok/x' }],
+      {}
+    )
+    expect(out.map((w) => w.url)).toEqual(['https://ok/x'])
   })
 })
 

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -10,6 +10,7 @@ import { getDb } from '../db.js'
 import { requireAuth, requireBuildAuth } from '../middleware/auth.js'
 import { json, readJson } from '../router.js'
 import { unlinkSafe } from '../lib/uploads.js'
+import { deliverWebhooks } from '../lib/webhooks.js'
 
 // ── archive kind ───────────────────────────────────────────────────────────
 
@@ -370,6 +371,25 @@ export async function handleUpdateBuild(
   const result = db.prepare(`UPDATE builds SET ${updates.join(', ')} WHERE id = ?`).run(...values, params.id)
   if (result.changes === 0) return json(res, 404, { error: 'Build not found' })
   json(res, 200, { ok: true })
+
+  // Fire webhooks on a review-status transition into Done/Rejected. Fire-and-forget and
+  // best-effort: delivery must never block or fail the PATCH response sent above.
+  const next = body.status_label
+  if ('status_label' in body && (next === 'Done' || next === 'Rejected') && existing.status_label !== next) {
+    const info = db
+      .prepare('SELECT b.version_name, a.platform FROM builds b JOIN apps a ON a.id = b.app_id WHERE b.id = ?')
+      .get(params.id) as { version_name: string | null; platform: string | null } | undefined
+    void deliverWebhooks({
+      event: 'build.status_changed',
+      build: {
+        id: String(params.id),
+        platform: info?.platform ?? null,
+        appVersion: info?.version_name ?? null,
+        status: next,
+      },
+      changedAt: new Date().toISOString(),
+    }).catch(() => {})
+  }
 }
 
 // Schedule deletion: an explicit, manual action that puts the build on the purge

--- a/packages/relay/src/api/builds.ts
+++ b/packages/relay/src/api/builds.ts
@@ -338,13 +338,17 @@ export async function handleUpdateBuild(
   const auth = requireAuth(req, res)
   if (!auth) return
 
+  // Parse the body before reading current state, so the SELECT and UPDATE below run
+  // with no await between them. Closes a TOCTOU window where two concurrent PATCHes
+  // could both observe the old status_label and both fire the webhook.
+  const body = await readJson<{ status_label?: string | null; version_label?: string | null }>(req)
+
   const db = getDb()
   const existing = db.prepare('SELECT status_label FROM builds WHERE id = ?').get(params.id) as
     | { status_label: string | null }
     | undefined
   if (!existing) return json(res, 404, { error: 'Build not found' })
 
-  const body = await readJson<{ status_label?: string | null; version_label?: string | null }>(req)
   const VALID_STATUS = ['Backlog', 'In Progress', 'Done', 'Rejected']
   const updates: string[] = []
   const values: unknown[] = []
@@ -373,22 +377,27 @@ export async function handleUpdateBuild(
   json(res, 200, { ok: true })
 
   // Fire webhooks on a review-status transition into Done/Rejected. Fire-and-forget and
-  // best-effort: delivery must never block or fail the PATCH response sent above.
+  // best-effort: neither the synchronous lookup nor delivery may reject the handler
+  // after the response above has already been sent.
   const next = body.status_label
   if ('status_label' in body && (next === 'Done' || next === 'Rejected') && existing.status_label !== next) {
-    const info = db
-      .prepare('SELECT b.version_name, a.platform FROM builds b JOIN apps a ON a.id = b.app_id WHERE b.id = ?')
-      .get(params.id) as { version_name: string | null; platform: string | null } | undefined
-    void deliverWebhooks({
-      event: 'build.status_changed',
-      build: {
-        id: String(params.id),
-        platform: info?.platform ?? null,
-        appVersion: info?.version_name ?? null,
-        status: next,
-      },
-      changedAt: new Date().toISOString(),
-    }).catch(() => {})
+    try {
+      const info = db
+        .prepare('SELECT b.version_name, a.platform FROM builds b JOIN apps a ON a.id = b.app_id WHERE b.id = ?')
+        .get(params.id) as { version_name: string | null; platform: string | null } | undefined
+      void deliverWebhooks({
+        event: 'build.status_changed',
+        build: {
+          id: String(params.id),
+          platform: info?.platform ?? null,
+          appVersion: info?.version_name ?? null,
+          status: next,
+        },
+        changedAt: new Date().toISOString(),
+      }).catch(() => {})
+    } catch {
+      // best-effort: never let webhook wiring reject the already-sent response
+    }
   }
 }
 

--- a/packages/relay/src/api/webhooks.ts
+++ b/packages/relay/src/api/webhooks.ts
@@ -1,0 +1,84 @@
+import type http from 'http'
+import { getDb } from '../db.js'
+import { requireBuildAuth } from '../middleware/auth.js'
+import { json, readJson } from '../router.js'
+import { validateWebhookUrl } from '../lib/webhooks.js'
+
+interface WebhookRow {
+  id: number
+  url: string
+  secret: string | null
+  enabled: number
+  created_at: string
+}
+
+// secret is write-only: never returned, only whether one is set.
+function publicView(r: WebhookRow) {
+  return { id: r.id, url: r.url, enabled: !!r.enabled, has_secret: !!r.secret, created_at: r.created_at }
+}
+
+export function handleListWebhooks(req: http.IncomingMessage, res: http.ServerResponse): void {
+  if (!requireBuildAuth(req, res)) return
+  const rows = getDb().prepare('SELECT * FROM webhook_endpoints ORDER BY id').all() as WebhookRow[]
+  json(res, 200, { webhooks: rows.map(publicView) })
+}
+
+export async function handleCreateWebhook(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (!requireBuildAuth(req, res)) return
+  const body = await readJson<{ url?: string; secret?: string | null; enabled?: boolean }>(req)
+  if (!body.url || typeof body.url !== 'string') return json(res, 400, { error: 'url is required' })
+  const err = validateWebhookUrl(body.url)
+  if (err) return json(res, 400, { error: err })
+  const db = getDb()
+  const r = db
+    .prepare('INSERT INTO webhook_endpoints (url, secret, enabled) VALUES (?, ?, ?)')
+    .run(body.url, body.secret ?? null, body.enabled === false ? 0 : 1)
+  const row = db.prepare('SELECT * FROM webhook_endpoints WHERE id = ?').get(Number(r.lastInsertRowid)) as WebhookRow
+  json(res, 201, publicView(row))
+}
+
+export async function handleUpdateWebhook(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  params: Record<string, string>
+): Promise<void> {
+  if (!requireBuildAuth(req, res)) return
+  const db = getDb()
+  const existing = db.prepare('SELECT id FROM webhook_endpoints WHERE id = ?').get(params.id)
+  if (!existing) return json(res, 404, { error: 'Webhook not found' })
+
+  const body = await readJson<{ url?: string; secret?: string | null; enabled?: boolean }>(req)
+  const updates: string[] = []
+  const values: unknown[] = []
+  if ('url' in body) {
+    if (!body.url || typeof body.url !== 'string') return json(res, 400, { error: 'url is required' })
+    const err = validateWebhookUrl(body.url)
+    if (err) return json(res, 400, { error: err })
+    updates.push('url = ?')
+    values.push(body.url)
+  }
+  if ('secret' in body) {
+    updates.push('secret = ?')
+    values.push(body.secret ?? null)
+  }
+  if ('enabled' in body) {
+    updates.push('enabled = ?')
+    values.push(body.enabled ? 1 : 0)
+  }
+  if (updates.length === 0) return json(res, 400, { error: 'Nothing to update' })
+
+  db.prepare(`UPDATE webhook_endpoints SET ${updates.join(', ')} WHERE id = ?`).run(...values, params.id)
+  const row = db.prepare('SELECT * FROM webhook_endpoints WHERE id = ?').get(params.id) as WebhookRow
+  json(res, 200, publicView(row))
+}
+
+export function handleDeleteWebhook(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  params: Record<string, string>
+): void {
+  if (!requireBuildAuth(req, res)) return
+  const r = getDb().prepare('DELETE FROM webhook_endpoints WHERE id = ?').run(params.id)
+  if (r.changes === 0) return json(res, 404, { error: 'Webhook not found' })
+  json(res, 200, { ok: true })
+}

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -6,6 +6,7 @@ import { createLogger } from '@tapflowio/agent-core'
 import { parseTrustedProxies } from './clientAddress.js'
 import { dnsProviders } from './cert/dnsRegistry.js'
 import { loadDataDirEnv } from './loadEnvFile.js'
+import { validateWebhookUrl } from './webhookUrl.js'
 
 const logger = createLogger('relay:config')
 
@@ -114,18 +115,43 @@ function resolveDataDir(raw: string): string {
   return path.isAbsolute(raw) ? raw : path.join(process.cwd(), raw)
 }
 
+const rawWebhookEntrySchema = z.array(
+  z.object({
+    url: z.string().optional(),
+    secretEnv: z.string().optional(),
+    enabled: z.boolean().optional(),
+  })
+)
+
 // Map raw config.json webhook entries ({ url, secretEnv?, enabled? }) to resolved
-// endpoints. The signing secret is read from the named env var, never from the file;
-// entries without a url are dropped.
+// endpoints. The signing secret is read from the named env var, never from the file.
+// Entries are dropped (with a warning) when they have no url or fail the SSRF/format
+// gate, so config-file endpoints run under the same checks as REST-registered ones.
 export function resolveWebhooksConfig(raw: unknown, env: NodeJS.ProcessEnv): TapflowConfig['webhooks'] {
-  if (!Array.isArray(raw)) return []
-  return (raw as Array<{ url?: string; secretEnv?: string; enabled?: boolean }>)
-    .map((w) => ({
-      url: w.url ?? '',
+  if (raw === undefined) return []
+  const parsed = rawWebhookEntrySchema.safeParse(raw)
+  if (!parsed.success) {
+    logger.warn('webhooks in tapflow.config.json is malformed — ignoring')
+    return []
+  }
+  const out: TapflowConfig['webhooks'] = []
+  for (const w of parsed.data) {
+    if (!w.url) continue
+    const err = validateWebhookUrl(w.url)
+    if (err) {
+      logger.warn(`ignoring config webhook ${w.url}: ${err}`)
+      continue
+    }
+    if (w.secretEnv && !env[w.secretEnv]) {
+      logger.warn(`config webhook ${w.url}: secretEnv ${w.secretEnv} is not set — deliveries will be unsigned`)
+    }
+    out.push({
+      url: w.url,
       secret: w.secretEnv ? (env[w.secretEnv] ?? '') : '',
       enabled: w.enabled !== false,
-    }))
-    .filter((w) => w.url)
+    })
+  }
+  return out
 }
 
 // Populated by load(): path of the dataDir/.env that was loaded, or null. CLI/server use it for a "loaded credentials" log.

--- a/packages/relay/src/lib/config.ts
+++ b/packages/relay/src/lib/config.ts
@@ -72,6 +72,15 @@ const configSchema = z.object({
     pass: z.string(),
     from: z.string(),
   }),
+  // Declarative outbound webhook endpoints. secret is resolved from an env var
+  // (secretEnv in the file) — secrets never live in config.json.
+  webhooks: z.array(
+    z.object({
+      url: z.string().min(1),
+      secret: z.string(),
+      enabled: z.boolean(),
+    })
+  ),
 })
 
 export type TapflowConfig = z.infer<typeof configSchema>
@@ -98,10 +107,25 @@ const DEFAULTS = {
     pass: '',
     from: 'tapflow <noreply@tapflow.local>',
   },
+  webhooks: [],
 } satisfies TapflowConfig
 
 function resolveDataDir(raw: string): string {
   return path.isAbsolute(raw) ? raw : path.join(process.cwd(), raw)
+}
+
+// Map raw config.json webhook entries ({ url, secretEnv?, enabled? }) to resolved
+// endpoints. The signing secret is read from the named env var, never from the file;
+// entries without a url are dropped.
+export function resolveWebhooksConfig(raw: unknown, env: NodeJS.ProcessEnv): TapflowConfig['webhooks'] {
+  if (!Array.isArray(raw)) return []
+  return (raw as Array<{ url?: string; secretEnv?: string; enabled?: boolean }>)
+    .map((w) => ({
+      url: w.url ?? '',
+      secret: w.secretEnv ? (env[w.secretEnv] ?? '') : '',
+      enabled: w.enabled !== false,
+    }))
+    .filter((w) => w.url)
 }
 
 // Populated by load(): path of the dataDir/.env that was loaded, or null. CLI/server use it for a "loaded credentials" log.
@@ -182,6 +206,7 @@ function load(): TapflowConfig {
       pass: file.smtp?.pass ?? DEFAULTS.smtp.pass,
       from: file.smtp?.from ?? DEFAULTS.smtp.from,
     },
+    webhooks: resolveWebhooksConfig((file as { webhooks?: unknown }).webhooks, process.env),
   }
 
   if (process.env.TAPFLOW_PORT) cfg.local.port = Number(process.env.TAPFLOW_PORT)

--- a/packages/relay/src/lib/webhookUrl.ts
+++ b/packages/relay/src/lib/webhookUrl.ts
@@ -1,0 +1,40 @@
+/**
+ * Validate a webhook destination URL. Returns an error string, or null when allowed.
+ * Blocks loopback and cloud-metadata addresses; private LAN ranges (10/172.16/192.168)
+ * are intentionally allowed because self-hosted CI often lives there.
+ *
+ * Lives in its own module so both webhooks.ts (delivery) and config.ts (config-file
+ * endpoints) can validate without a circular import — webhooks.ts imports config.ts,
+ * so config.ts can't import back into webhooks.ts.
+ */
+export function validateWebhookUrl(raw: string): string | null {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return 'Invalid URL'
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return 'URL must use http or https'
+  }
+  let host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
+  // Node normalizes an IPv4-mapped IPv6 host (e.g. ::ffff:127.0.0.1) to a hex form
+  // like ::ffff:7f00:1, which would slip past the IPv4 checks below yet still connect
+  // to the embedded IPv4 — an SSRF bypass. Unwrap it back to dotted IPv4 first.
+  const mapped = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  if (mapped) {
+    const hi = parseInt(mapped[1], 16)
+    const lo = parseInt(mapped[2], 16)
+    host = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.')
+  }
+  if (
+    host === 'localhost' ||
+    host === '0.0.0.0' ||
+    host === '::1' ||
+    host.startsWith('127.') ||
+    host.startsWith('169.254.')
+  ) {
+    return 'URL host is not allowed (loopback or metadata address)'
+  }
+  return null
+}

--- a/packages/relay/src/lib/webhooks.ts
+++ b/packages/relay/src/lib/webhooks.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto'
+import { createLogger } from '@tapflowio/agent-core'
+import { getDb } from '../db.js'
+
+const logger = createLogger('relay:webhooks')
+
+// Each outbound request is bounded so a slow receiver can't tie up delivery.
+export const WEBHOOK_TIMEOUT_MS = 5000
+
+export interface WebhookPayload {
+  event: string
+  build: {
+    id: string
+    platform: string | null
+    appVersion: string | null
+    status: string
+  }
+  changedAt: string
+}
+
+// Minimal fetch shape so tests can inject a fake without pulling in DOM lib types.
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string; signal: AbortSignal }
+) => Promise<{ ok: boolean; status: number }>
+
+/**
+ * Validate a webhook destination URL. Returns an error string, or null when allowed.
+ * Blocks loopback and cloud-metadata addresses; private LAN ranges (10/172.16/192.168)
+ * are intentionally allowed because self-hosted CI often lives there.
+ */
+export function validateWebhookUrl(raw: string): string | null {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return 'Invalid URL'
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return 'URL must use http or https'
+  }
+  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
+  if (
+    host === 'localhost' ||
+    host === '0.0.0.0' ||
+    host === '::1' ||
+    host.startsWith('127.') ||
+    host.startsWith('169.254.')
+  ) {
+    return 'URL host is not allowed (loopback or metadata address)'
+  }
+  return null
+}
+
+/** HMAC-SHA256 signature of the raw request body, formatted like EAS's expo-signature. */
+export function signPayload(secret: string, body: string): string {
+  return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex')
+}
+
+interface EndpointRow {
+  url: string
+  secret: string | null
+}
+
+/**
+ * Deliver a payload to every enabled webhook endpoint. Best-effort: a failed or slow
+ * endpoint is logged and never throws to the caller (callers fire-and-forget so the
+ * originating request is unaffected). One endpoint's failure does not stop the others.
+ */
+export async function deliverWebhooks(
+  payload: WebhookPayload,
+  opts: { fetchFn?: FetchLike } = {}
+): Promise<void> {
+  const rows = getDb()
+    .prepare('SELECT url, secret FROM webhook_endpoints WHERE enabled = 1')
+    .all() as EndpointRow[]
+  if (rows.length === 0) return
+
+  const body = JSON.stringify(payload)
+  const fetchFn = opts.fetchFn ?? (globalThis.fetch as unknown as FetchLike)
+
+  await Promise.allSettled(
+    rows.map(async (ep) => {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (ep.secret) headers['X-Tapflow-Signature'] = signPayload(ep.secret, body)
+      try {
+        const res = await fetchFn(ep.url, {
+          method: 'POST',
+          headers,
+          body,
+          signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+        })
+        if (!res.ok) logger.warn(`webhook POST ${ep.url} returned ${res.status}`)
+      } catch (err) {
+        logger.warn(`webhook POST ${ep.url} failed: ${String(err)}`)
+      }
+    })
+  )
+}

--- a/packages/relay/src/lib/webhooks.ts
+++ b/packages/relay/src/lib/webhooks.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import { createLogger } from '@tapflowio/agent-core'
 import { getDb } from '../db.js'
+import { config } from './config.js'
 
 const logger = createLogger('relay:webhooks')
 
@@ -80,9 +81,14 @@ export async function deliverWebhooks(
   payload: WebhookPayload,
   opts: { fetchFn?: FetchLike } = {}
 ): Promise<void> {
-  const rows = getDb()
+  const dbRows = getDb()
     .prepare('SELECT url, secret FROM webhook_endpoints WHERE enabled = 1')
     .all() as EndpointRow[]
+  // Declarative config.json endpoints are delivered alongside the DB-registered ones.
+  const configRows: EndpointRow[] = config.webhooks
+    .filter((w) => w.enabled)
+    .map((w) => ({ url: w.url, secret: w.secret || null }))
+  const rows = [...configRows, ...dbRows]
   if (rows.length === 0) return
 
   const body = JSON.stringify(payload)

--- a/packages/relay/src/lib/webhooks.ts
+++ b/packages/relay/src/lib/webhooks.ts
@@ -22,7 +22,7 @@ export interface WebhookPayload {
 export type FetchLike = (
   url: string,
   init: { method: string; headers: Record<string, string>; body: string; signal: AbortSignal }
-) => Promise<{ ok: boolean; status: number }>
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>
 
 /**
  * Validate a webhook destination URL. Returns an error string, or null when allowed.
@@ -39,7 +39,16 @@ export function validateWebhookUrl(raw: string): string | null {
   if (u.protocol !== 'http:' && u.protocol !== 'https:') {
     return 'URL must use http or https'
   }
-  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
+  let host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
+  // Node normalizes an IPv4-mapped IPv6 host (e.g. ::ffff:127.0.0.1) to a hex form
+  // like ::ffff:7f00:1, which would slip past the IPv4 checks below yet still connect
+  // to the embedded IPv4 — an SSRF bypass. Unwrap it back to dotted IPv4 first.
+  const mapped = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  if (mapped) {
+    const hi = parseInt(mapped[1], 16)
+    const lo = parseInt(mapped[2], 16)
+    host = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.')
+  }
   if (
     host === 'localhost' ||
     host === '0.0.0.0' ||
@@ -90,6 +99,8 @@ export async function deliverWebhooks(
           body,
           signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
         })
+        // Drain the body so undici releases the connection back to the pool.
+        await res.text()
         if (!res.ok) logger.warn(`webhook POST ${ep.url} returned ${res.status}`)
       } catch (err) {
         logger.warn(`webhook POST ${ep.url} failed: ${String(err)}`)

--- a/packages/relay/src/lib/webhooks.ts
+++ b/packages/relay/src/lib/webhooks.ts
@@ -3,6 +3,10 @@ import { createLogger } from '@tapflowio/agent-core'
 import { getDb } from '../db.js'
 import { config } from './config.js'
 
+// Re-exported so existing importers keep using webhooks.ts; the implementation lives
+// in webhookUrl.ts to avoid a circular import with config.ts (which also validates).
+export { validateWebhookUrl } from './webhookUrl.js'
+
 const logger = createLogger('relay:webhooks')
 
 // Each outbound request is bounded so a slow receiver can't tie up delivery.
@@ -24,43 +28,6 @@ export type FetchLike = (
   url: string,
   init: { method: string; headers: Record<string, string>; body: string; signal: AbortSignal }
 ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>
-
-/**
- * Validate a webhook destination URL. Returns an error string, or null when allowed.
- * Blocks loopback and cloud-metadata addresses; private LAN ranges (10/172.16/192.168)
- * are intentionally allowed because self-hosted CI often lives there.
- */
-export function validateWebhookUrl(raw: string): string | null {
-  let u: URL
-  try {
-    u = new URL(raw)
-  } catch {
-    return 'Invalid URL'
-  }
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    return 'URL must use http or https'
-  }
-  let host = u.hostname.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
-  // Node normalizes an IPv4-mapped IPv6 host (e.g. ::ffff:127.0.0.1) to a hex form
-  // like ::ffff:7f00:1, which would slip past the IPv4 checks below yet still connect
-  // to the embedded IPv4 — an SSRF bypass. Unwrap it back to dotted IPv4 first.
-  const mapped = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
-  if (mapped) {
-    const hi = parseInt(mapped[1], 16)
-    const lo = parseInt(mapped[2], 16)
-    host = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.')
-  }
-  if (
-    host === 'localhost' ||
-    host === '0.0.0.0' ||
-    host === '::1' ||
-    host.startsWith('127.') ||
-    host.startsWith('169.254.')
-  ) {
-    return 'URL host is not allowed (loopback or metadata address)'
-  }
-  return null
-}
 
 /** HMAC-SHA256 signature of the raw request body, formatted like EAS's expo-signature. */
 export function signPayload(secret: string, body: string): string {

--- a/packages/relay/src/migrations/013_webhook_endpoints.sql
+++ b/packages/relay/src/migrations/013_webhook_endpoints.sql
@@ -1,0 +1,13 @@
+-- 013_webhook_endpoints.sql
+-- Outbound webhooks: notify registered URLs when a build's review status
+-- transitions to Done/Rejected. Payload carries metadata only (build id, status,
+-- platform, version) — never app binaries or screen data (see AGENTS.md).
+-- secret is optional; when set, deliveries are HMAC-SHA256 signed.
+
+CREATE TABLE webhook_endpoints (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  url        TEXT NOT NULL,
+  secret     TEXT,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
## What

Adds outbound webhooks that fire when a build's review status transitions to `Done` or `Rejected`. tapflow doesn't build apps, so unlike an EAS build webhook this reports **the review verdict a person made** — wire it into Slack or the next CI/deploy step.

## How it works

- **Trigger**: `handleUpdateBuild` already tracked the `Done` transition (for `completed_at`); delivery hooks onto that. Fires only on a real transition into `Done`/`Rejected` — no-op PATCHes, other statuses, and non-status field changes send nothing.
- **Delivery**: fire-and-forget after the `200` response, so it never blocks or fails the PATCH. Fans out to every enabled endpoint; one endpoint failing doesn't stop the others; each request times out after 5s.
- **Signing**: when an endpoint has a `secret`, the body is HMAC-SHA256 signed into `X-Tapflow-Signature` (EAS-style).
- **Payload**: metadata only (`event`, `build.id/platform/appVersion/status`, `changedAt`). No app binaries or screen data, per the relay's data-boundary rule.

## Changes

| File | |
|------|--|
| `migrations/013_webhook_endpoints.sql` | new `webhook_endpoints` table (url, secret, enabled) |
| `lib/webhooks.ts` | URL validation (blocks loopback/metadata, allows private LAN for self-hosted CI), signing, best-effort fan-out delivery |
| `api/webhooks.ts` | CRUD (`/api/v1/webhooks`) guarded by `builds:write`; `secret` is write-only, never returned |
| `api/builds.ts` · `RelayServer.ts` | fire on transition; register routes |
| `docs/{,ko/}guide/build-status-webhooks.md` | EN/KO guide under Distribution |

## Security

- Payload carries metadata only — no binaries.
- Registration rejects loopback (`127.0.0.1`) and cloud-metadata (`169.254.169.254`); private LAN allowed (self-hosted CI lives there).
- `secret` optional but strongly recommended; deliveries signed when set.

## Testing

- 22 new tests: URL validation, HMAC signing, fan-out / failure isolation, CRUD (auth, secret non-exposure), and end-to-end firing observed via a live local receiver (Done/Rejected fire; In Progress / no-op / field-only don't; a dead receiver still returns `200`; payload leaks no file paths).
- Typecheck clean; existing builds tests (37) pass; `pnpm docs:build` passes.

## Notes

- Non-breaking, purely additive. No WS-protocol / CLI / existing-API changes.
- Management UI is out of scope (register via `curl` with a `builds:write` PAT). Retry/backoff and additional events (`build.uploaded`, `Backlog`/`In Progress`) are intentionally deferred; the `event` field leaves room to add them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed outbound build review status webhooks that fire on `Done`/`Rejected` transitions only, sending metadata-only payloads.
  * Added Relay webhook endpoint CRUD via authenticated REST API and config-based registration using `webhooks` (`url`, `secretEnv`, `enabled`).
  * Linked new English and Korean Webhooks guides from the Distribution/빌드 배포 sidebar.
* **Bug Fixes**
  * Improved webhook security and reliability: HMAC-SHA256 `X-Tapflow-Signature` support, strict destination URL validation, and best-effort fan-out with a per-delivery timeout.
* **Tests**
  * Added comprehensive unit and integration test coverage for webhook validation, delivery, and firing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->