### PR TITLE
ci: build arm64 on a native runner instead of QEMU emulation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,13 +9,31 @@ on:
       - 'v*.*.*-*'
   pull_request:
 
+env:
+  IMAGE: tapflow/tapflow
+
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    # Publish only when Docker Hub credentials are configured; otherwise build-validate only.
+  # Build each architecture on its own native runner. arm64 used to build under
+  # QEMU emulation on an amd64 runner, where the native module compile could hang
+  # for hours; native runners remove the emulation entirely.
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     env:
       HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_USERNAME != '' }}
     steps:
+      - name: Prepare platform name
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -24,9 +42,6 @@ jobs:
       - name: Warn when Docker Hub credentials are missing
         if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB != 'true'
         run: echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set — building the image for validation but skipping push."
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,25 +53,95 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: tapflow/tapflow
+          images: ${{ env.IMAGE }}
+
+      - name: Build image (push by digest when publishing)
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          # Publish: push a per-architecture image by digest (merged into a manifest
+          # list in the merge job). Otherwise (PR / no credentials): build for
+          # validation only, keeping just the cache.
+          outputs: ${{ (github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || 'type=cacheonly' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-architecture digests into a single multi-arch manifest list.
+  # Only runs for real publishes; PRs and credential-less builds validate only.
+  merge:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_USERNAME != '' }}
+    steps:
+      - name: Note validation-only build
+        if: env.HAS_DOCKERHUB != 'true'
+        run: echo "::warning::No Docker Hub credentials — per-architecture validation builds succeeded, nothing to publish."
+
+      - name: Download digests
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags) for Docker
+        id: meta
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true' }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        if: env.HAS_DOCKERHUB == 'true'
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046  # intentional split: expand -t flags and per-digest refs
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        if: env.HAS_DOCKERHUB == 'true'
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# git is required by lefthook/prepare postinstall scripts that run during pnpm install.
+RUN apk add --no-cache git
+
 # Install pnpm
 RUN npm install -g pnpm@9.15.1
 


### PR DESCRIPTION
## Problem

The `main` **Docker Publish** run for the #367 merge ([run 28711404711](https://github.com/jo-duchan/tapflow/actions/runs/28711404711)) was **cancelled after the 6-hour limit**. amd64 finished in seconds, but `linux/arm64` — built under **QEMU emulation** on the amd64 runner — hung during `pnpm install` (native-module compile, e.g. `better-sqlite3` building from source on arm64/musl). The push was skipped anyway (no Docker Hub credentials), so this was a 6-hour validation build that wasted a runner and went red. Not related to the #367 code — amd64 built fine and all tests passed.

## Fix

**Build each architecture on its own native runner** (docker's official multi-runner pattern):

- Matrix: `linux/amd64` on `ubuntu-24.04`, `linux/arm64` on **`ubuntu-24.04-arm`** (free for public repos). No QEMU → no emulation → the hang can't recur, and builds are much faster.
- On a real publish, each job pushes a per-architecture image **by digest**; a `merge` job combines them into one **manifest list**. On PRs / when credentials are absent, jobs build for **validation only** (`type=cacheonly`) and `merge` just notes there's nothing to publish.
- Per-arch GHA cache scopes so the two builds don't clobber each other's cache.

Also **install `git` in the builder stage** — the logs showed lefthook/prepare postinstall scripts erroring with `git: not found` during `pnpm install` (non-fatal noise, now gone).

## Validation

- `actionlint` clean (the one intentional `SC2046` word-split in the manifest step is annotated with a `disable` comment).
- The workflow runs on this PR (`pull_request` trigger), so the PR's own checks exercise the native arm64 build path end-to-end — that's the real proof the hang is gone.

## Notes

- Behavior is unchanged when credentials exist: still publishes a multi-arch `tapflow/tapflow` manifest with the same tags (`edge`, semver, `sha`).
- No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now built per architecture and published as a combined multi-architecture manifest for more reliable installs across platforms.
  * Publishing now supports native builds on both amd64 and arm64 runners.

* **Bug Fixes**
  * Improved container builds by adding a missing build-time dependency needed during package installation.
  * Non-publish builds now run in validation mode, reducing unnecessary push behavior during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->