### PR TITLE
docs: define the two QA axes (manual dashboard / automated MCP) in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,13 +106,25 @@ The people who install, operate, and contribute. Make setup, diagnosis, and oper
 
 ## Phase 5 — Agent Experience (AX) `v0.5.0` and beyond
 
-Treat the LLM agent as a first-class user. The **additive** MCP path — opt-in, never affecting the
-manual testing path — gets optimized here. The foundation already exists (`@tapflowio/mcp-server`
-with MCP tools, plus the screenshot REST endpoint); Phase 5 builds on top.
+tapflow has two QA axes. The browser dashboard is the **manual QA axis**: the whole team tests by
+hand, no setup required. The MCP path is the **automated QA axis**: its main stage is CI/CD. Both
+axes share the same session infrastructure (relay, agents, dashboard observation); the automated
+axis is opt-in and never affects the manual path.
+
+The guiding principle for the automated axis: **an LLM is involved only at authoring time — replay
+is deterministic.** Agents explore the app through MCP tools and generate flow files; CI replays
+those flows with zero LLM calls, which keeps runs idempotent and API cost at zero. Flow files are
+a generated artifact, not a language users must learn.
+
+The foundation already exists (`@tapflowio/mcp-server` with MCP tools, plus the screenshot REST
+endpoint); Phase 5 builds on top.
 
 - [x] Screenshot REST endpoint — `GET /api/v1/sessions/:sessionId/screenshot` for programmatic capture
 - [x] `@tapflowio/mcp-server` — LLM-driven simulator control via MCP tools
-- [#133](https://github.com/jo-duchan/tapflow/issues/133) — UI accessibility tree query for semantic commands (tap by element, not coordinates)
+- [#133](https://github.com/jo-duchan/tapflow/issues/133) — UI accessibility tree query (`query_ui_tree`) — unified element schema with normalized frames, so agents tap by element instead of guessing coordinates
+- [ ] Deterministic YAML flow format + headless CLI runner — state reset and condition-based waits built in, JUnit report + failure screenshots, no LLM at replay time
+- [ ] `run_flow` MCP tool — agents replay verified flows through the same deterministic engine
+- [ ] Dashboard demo recording → YAML flow draft — capture channel for non-developers (after the runner ships)
 
 ---
 
@@ -131,7 +143,7 @@ Larger tracks that fit tapflow's mission but are not yet committed to a version.
 
 The following are out of scope for tapflow's core mission ("browser-based simulator control, data on-premises"):
 
-- **WebDriverAgent / Appium integration** — tapflow is a human QA tool, not an automation framework
+- **External automation framework integration (WebDriverAgent, Appium, Selenium)** — the automated QA axis is served by tapflow's own minimal, deterministic flow runner (Phase 5); wiring in external drivers is not planned
 - **Cloud hosting / SaaS mode** — tapflow is self-hosted by design
 - **Video streaming via WebRTC** — DataChannel instability and lack of P2P benefit in a relay-intermediary architecture make this a net negative
 


### PR DESCRIPTION
## Summary

Repositions the MCP path in ROADMAP.md ahead of the automated-QA work (#133 and the upcoming flow runner):

- **Two QA axes**: the browser dashboard is the manual QA axis (whole team, by hand); the MCP path is the automated QA axis, with CI/CD as its main stage. Both share the same session infrastructure, and the automated axis stays opt-in.
- **Guiding principle** stated in Phase 5: an LLM is involved only at authoring time — replay is deterministic (idempotent runs, zero LLM cost in CI). Flow files are a generated artifact, not a language users must learn.
- **Phase 5 items** now list the direction: `query_ui_tree` with a unified element schema and normalized frames (#133), a deterministic YAML flow format + headless CLI runner, a `run_flow` MCP tool, and (later) dashboard demo recording → YAML draft.
- **"Not planned" narrowed**: "tapflow is a human QA tool, not an automation framework" contradicted the direction above, so the entry now reads "no external automation framework integration (WDA / Appium / Selenium)" — the scope defense stays, the built-in runner is no longer excluded by our own wording.

Design details and decisions are recorded in issue #133 (finalized-contract comment).

## Notes

- Docs-only change; no code touched.
- README's "isn't an automation framework or a device farm" line is intentionally left as-is — it describes the current product truthfully and will be updated when the flow runner actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Agent Experience roadmap with clearer QA guidance, including manual dashboard review and automated CI/CD validation.
  * Clarified the unified UI accessibility schema and normalized element framing.
  * Added planned items for deterministic flow formats, a headless runner, a new MCP tool, and a dashboard demo path for capturing flow drafts.
  * Updated the out-of-scope section to note that external automation frameworks are not planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->