### PR TITLE
release: graduate mcp-server and flow-runner to the standard npm channel

### DIFF
--- a/.changeset/automated-qa-axis.md
+++ b/.changeset/automated-qa-axis.md
@@ -1,0 +1,17 @@
+---
+"tapflow": minor
+"@tapflowio/agent-core": minor
+"@tapflowio/ios-agent": minor
+"@tapflowio/android-agent": minor
+"@tapflowio/relay": minor
+"@tapflowio/flow-runner": minor
+"@tapflowio/mcp-server": minor
+---
+
+Automated QA axis: UI accessibility tree queries and the deterministic flow runner.
+
+- `query_ui_tree` (MCP) / `GET /api/v1/sessions/:sessionId/ui-tree` — unified element schema (`role`/`label`/`identifier`/`frame`/`enabled`), frames normalized 0-1 so a frame center feeds straight into `tap`. iOS reads the tree via macOS AXUIElement on Simulator.app (no WebDriverAgent); Android via `uiautomator dump` with a device-side timeout.
+- `@tapflowio/flow-runner` (new package) + `tapflow flow run` — replay YAML flows with zero LLM calls: 10-step vocabulary, identifier/label selector resolution, condition-based waits, JUnit reports, failure screenshots, CI exit-code contract (0/1/2).
+- `run_flow` (MCP) — agents author a flow once, then replay it deterministically over the existing session.
+- New relay message `app:clear-state` — reset app data (`pm clear` on Android, data-container wipe on iOS).
+- mcp-server and flow-runner graduate from the `experimental` dist-tag to the standard npm channel, versioned with the repo-wide fixed group.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,9 @@
       "@tapflowio/agent-core",
       "@tapflowio/ios-agent",
       "@tapflowio/android-agent",
-      "@tapflowio/relay"
+      "@tapflowio/relay",
+      "@tapflowio/flow-runner",
+      "@tapflowio/mcp-server"
     ]
   ],
   "linked": [],
@@ -17,8 +19,6 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@tapflowio/dashboard",
-    "@tapflowio/playground",
-    "@tapflowio/mcp-server",
-    "@tapflowio/flow-runner"
+    "@tapflowio/playground"
   ]
 }

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -38,16 +38,22 @@ model: claude-opus-4-8
 ## 5. changeset 작성/보완
 
 - 이번 테마를 담은 changeset이 없으면 추가한다(기본 changelog 생성기는 changeset 본문만 CHANGELOG에 넣으므로, 핵심 변경이 changeset에 없으면 누락된다).
-- **fixed 그룹**(`tapflow`·`agent-core`·`ios-agent`·`android-agent`·`relay`)은 멤버 하나만 명시해도 5개가 동반 bump되지만, CHANGELOG 본문은 명시된 패키지에만 들어간다 → 본문이 필요한 핵심 패키지를 모두 명시한다.
+- **fixed 그룹**(`tapflow`·`agent-core`·`ios-agent`·`android-agent`·`relay`·`flow-runner`·`mcp-server`)은 멤버 하나만 명시해도 전체가 동반 bump되지만, CHANGELOG 본문은 명시된 패키지에만 들어간다 → 본문이 필요한 핵심 패키지를 모두 명시한다.
 
 ## 6. 버전 적용
 
 - `pnpm changeset version`
-- fixed 그룹 5개가 함께 `X.Y.Z`로 올랐는지, changeset 파일이 소비됐는지 확인.
+- fixed 그룹 7개가 함께 `X.Y.Z`로 올랐는지, changeset 파일이 소비됐는지 확인.
 
 ## 7. 이 레포 전용 수동 단계 (놓치기 가장 쉬움)
 
-- **mcp-server**: `.changeset` `ignore` 대상이라 자동 bump 안 됨 → `package.json` version을 **`X.Y.Z-experimental.1`** 로 수동 변경(experimental dist-tag, graduation 전까지 수동).
+- **mcp-server·flow-runner는 2026-07 graduation 이후 fixed 그룹의 정규 멤버다** — experimental 접미사 수동 변경 절차는 폐기됐다. 되살리지 말 것.
+- **flow-runner 첫 발행 전제(1회성, v0.14.0 이전에만 해당)**: `@tapflowio/flow-runner`는 npm에 존재하지 않아 OIDC trusted publishing으로 첫 publish가 불가하다(신규 패키지에는 trusted publisher를 등록할 수 없음). **태그 push 전에** 반드시:
+  1. 로컬에서 seed publish — **반드시 pnpm 경로로**: `pnpm --filter @tapflowio/flow-runner publish --access public --no-git-checks` (raw `npm publish`는 `workspace:*`를 치환하지 않아 설치 불가 tarball이 나간다)
+  2. npmjs.com 패키지 설정에서 trusted publisher 등록: repo `jo-duchan/tapflow`, workflow `release.yml`
+  3. 이걸 건너뛰고 태그를 밀면: 다른 패키지는 발행되고 flow-runner만 실패 → exact pin 의존 때문에 **`npm i tapflow`가 전 사용자에게 깨진다** (복구: 태그 커밋에서 flow-runner 수동 pnpm publish 후 잡 재실행)
+- **graduation 릴리즈(v0.14.0) 태그 전제**: MCP 안정화(Track A — press_key/press_button 수정 + 툴 전수 검증) 머지 완료. `.work/2026-07-05-mcp-followups-plan.md` 확인.
+- **릴리즈 후 1회성**: 구 `experimental` dist-tag가 0.13.0-experimental.1에 고정돼 있어 `@experimental`로 설치한 기존 사용자는 업데이트가 끊긴다 → `npm dist-tag add @tapflowio/mcp-server@X.Y.Z experimental` 로 당겨주거나 태그 제거를 안내한다.
 - **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
   - **하단 compare 링크도 함께 갱신**(놓치기 쉬움): `[Unreleased]`를 `vX.Y.Z...HEAD`로 바꾸고, `[X.Y.Z]: .../compare/v{직전}...vX.Y.Z` 링크를 새로 추가한다. 직전 릴리즈 링크가 빠져 있으면 이번에 함께 메운다.
 - **dashboard**: private + `ignore` → 건드리지 않는다.
@@ -76,6 +82,6 @@ model: claude-opus-4-8
   `git fetch origin main && git tag vX.Y.Z <머지 커밋 SHA>`
 - **STOP** — 태그 push는 즉시 npm 발행을 유발하는 되돌리기 어려운 작업이다. 사용자 확인 후 진행한다.
 - `git push origin vX.Y.Z`
-- 워크플로우가 처리하는 것: `pnpm build` → `changeset publish`(stable 5종) → `mcp-server`는 experimental dist-tag로 별도 publish → GitHub Release 생성.
+- 워크플로우가 처리하는 것: `pnpm build` → `changeset publish`(공개 패키지 전부, 단일 경로) → GitHub Release 생성. changesets publish는 위상 정렬 없이 동시 발행하므로, 신규 패키지가 있으면 위 7번의 seed publish 전제를 반드시 지킨다.
 - npm 인증은 **GitHub OIDC(trusted publishing)** 로 동작한다 — NPM_TOKEN 등 별도 토큰이 필요 없다.
 - 발행 확인: Actions의 Release 워크플로우 `success`, `npm view tapflow version`, GitHub Releases 페이지.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,15 @@ jobs:
 
       - run: pnpm build
 
-      - name: Publish stable packages
-        run: |
-          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('packages/mcp-server/package.json','utf8'));p.private=true;fs.writeFileSync('packages/mcp-server/package.json',JSON.stringify(p,null,2))"
-          pnpm changeset publish --no-git-tag
-          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('packages/mcp-server/package.json','utf8'));delete p.private;fs.writeFileSync('packages/mcp-server/package.json',JSON.stringify(p,null,2))"
+      # All public packages (mcp-server and flow-runner graduated from the
+      # experimental dist-tag in 2026-07) go through the single changesets
+      # path — it publishes via pnpm, which rewrites workspace:* dependencies
+      # to real versions. Never publish these packages with raw `npm publish`:
+      # it keeps the literal workspace:* and ships an uninstallable tarball.
+      - name: Publish packages
+        run: pnpm changeset publish --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish mcp-server (experimental)
-        continue-on-error: true
-        run: pnpm --filter @tapflowio/mcp-server exec npm publish --tag experimental --access public
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/INDEX.md
+++ b/INDEX.md
@@ -22,8 +22,8 @@ Common rules are in the root [AGENTS.md](./AGENTS.md).
 | relay | [packages/relay/AGENTS.md](./packages/relay/AGENTS.md) | WebSocket relay server rules |
 | dashboard | [packages/dashboard/AGENTS.md](./packages/dashboard/AGENTS.md) | Vite + React SPA UI rules |
 | cli | [packages/cli/AGENTS.md](./packages/cli/AGENTS.md) | CLI UX rules |
-| mcp-server | [packages/mcp-server/AGENTS.md](./packages/mcp-server/AGENTS.md) | MCP server bridging tapflow to LLM agents — experimental |
-| flow-runner | [packages/flow-runner/AGENTS.md](./packages/flow-runner/AGENTS.md) | Deterministic YAML flow engine (automated QA axis) — experimental |
+| mcp-server | [packages/mcp-server/AGENTS.md](./packages/mcp-server/AGENTS.md) | MCP server bridging tapflow to LLM agents |
+| flow-runner | [packages/flow-runner/AGENTS.md](./packages/flow-runner/AGENTS.md) | Deterministic YAML flow engine (automated QA axis) |
 
 ## Local Only
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ What's included:
 - **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents.
 - **Mac resource monitoring** — CPU & RAM per agent, to spot overloaded hosts before assigning sessions.
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), and Personal Access Tokens.
-- **MCP Server** *(experimental)* — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
+- **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 <a name="latency-note"></a>
 > <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [performance & latency reference](https://www.tapflow.dev/reference/performance) for the full measurements, conditions, and known limitations.
@@ -250,7 +250,7 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 - [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
 
 **AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server) *(experimental)*
+- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 **Reference**
 - [CLI Reference](https://www.tapflow.dev/reference/cli)

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -1,12 +1,5 @@
 # MCP Server
 
-::: warning Experimental
-`@tapflowio/mcp-server` is experimental. APIs and tool schemas may change between releases. Install with the `experimental` tag:
-```sh
-npm install @tapflowio/mcp-server@experimental
-```
-:::
-
 `@tapflowio/mcp-server` exposes tapflow as a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. Claude Code, Codex, and any other MCP-compatible LLM agent can control iOS simulators and Android emulators as native tools — no scripting, no hardcoded selectors.
 
 ## When to use this

--- a/docs/ko/guide/mcp-server.md
+++ b/docs/ko/guide/mcp-server.md
@@ -1,12 +1,5 @@
 # MCP 서버
 
-::: warning 실험적 기능
-`@tapflowio/mcp-server`는 실험적 기능입니다. API와 툴 스키마는 릴리즈 간에 변경될 수 있습니다. `experimental` 태그로 설치하세요:
-```sh
-npm install @tapflowio/mcp-server@experimental
-```
-:::
-
 `@tapflowio/mcp-server`는 tapflow를 [Model Context Protocol(MCP)](https://modelcontextprotocol.io) 서버로 노출합니다. Claude Code, Codex 등 MCP를 지원하는 LLM 에이전트가 iOS 시뮬레이터와 Android 에뮬레이터를 네이티브 도구로 직접 제어할 수 있습니다. 스크립팅도, 좌표 하드코딩도 필요 없습니다.
 
 ## 이럴 때 쓰세요

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,7 +157,7 @@ What's included:
 - **Screenshot REST endpoint** — `GET /api/v1/sessions/:sessionId/screenshot` for CI and AI agents.
 - **Mac resource monitoring** — CPU & RAM per agent, to spot overloaded hosts before assigning sessions.
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), and Personal Access Tokens.
-- **MCP Server** *(experimental)* — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
+- **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 <a name="latency-note"></a>
 > <sup>1</sup> On localhost, decode-to-present is in the single-to-low-double-digit milliseconds (WebCodecs ~2.5 ms, WASM ~9–14 ms); end-to-end "glass-to-glass" latency also depends on your network. See the [streaming latency log](https://github.com/jo-duchan/tapflow/blob/main/contributing/streaming-latency-log.md) for the full pipeline analysis and measurements.
@@ -253,7 +253,7 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 - [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
 
 **AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server) *(experimental)*
+- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 **Reference**
 - [CLI Reference](https://www.tapflow.dev/reference/cli)

--- a/packages/flow-runner/AGENTS.md
+++ b/packages/flow-runner/AGENTS.md
@@ -9,7 +9,7 @@
 `@tapflowio/flow-runner`: deterministic YAML flow engine — the replay half of the automated QA axis.
 Flows are authored once (by an agent via MCP, or by hand) and replayed with **zero LLM calls**: same input → same execution, no API cost in CI.
 
-**Experimental** — published under the `experimental` dist-tag, excluded from changeset automatic versioning (like mcp-server).
+Published on the standard npm channel and versioned by changesets in the repo-wide fixed group. Never publish with raw `npm publish` — it does not rewrite the `workspace:*` dependency on agent-core; the changesets → pnpm publish path does.
 
 Consumers: `tapflow flow run` (CLI) and the `run_flow` MCP tool — both drive the same engine, so results never diverge.
 

--- a/packages/flow-runner/LICENSE
+++ b/packages/flow-runner/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tapflow contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flow-runner/README.md
+++ b/packages/flow-runner/README.md
@@ -1,0 +1,47 @@
+# @tapflowio/flow-runner
+
+Deterministic YAML flow runner for [tapflow](https://github.com/jo-duchan/tapflow) — replay UI test flows against iOS simulators and Android emulators with **zero LLM calls**.
+
+Flows are authored once (by an LLM agent through `@tapflowio/mcp-server`, or by hand) and replayed deterministically: same input, same execution, no API cost in CI.
+
+## Usage
+
+Most users run flows through the tapflow CLI:
+
+```sh
+tapflow flow run .tapflow/flows/*.yaml --build 42 --junit report.xml
+```
+
+Exit codes: `0` all flows passed · `1` a flow failed · `2` environment/config error.
+
+## Flow YAML
+
+```yaml
+name: login-smoke
+appId: com.example.app
+steps:
+  - clearState              # reset app data (pm clear / data-container wipe)
+  - launchApp               # launches the build under test (--build)
+  - assertVisible: "Sign in"
+  - tapOn: { id: "com.example.app:id/email" }
+  - inputText: "user@example.com"
+  - pressKey: Enter
+  - tapOn: "Sign in"
+  - assertVisible: { label: "Orders", timeout: 15 }
+```
+
+- 10-step vocabulary: `clearState / launchApp / tapOn / inputText / pressKey / swipe / scroll / openUrl / assertVisible / assertNotVisible`. No sleep step — waiting is always condition-based.
+- Selectors: a bare string matches exact identifier → exact label → partial label. Ambiguous `tapOn` matches fail loudly instead of picking one.
+- A JSON Schema for editor autocomplete ships at `schema/tapflow-flow.schema.json`.
+
+## Library API
+
+```ts
+import { parseFlow, runFlow, RelayClient, RelayDriver, toJUnitXml } from '@tapflowio/flow-runner'
+```
+
+The engine drives a transport-agnostic `FlowDriver` interface; `RelayDriver` implements it against a tapflow relay (WebSocket + REST).
+
+## License
+
+[MIT](LICENSE) — part of the [tapflow](https://github.com/jo-duchan/tapflow) project.

--- a/packages/flow-runner/package.json
+++ b/packages/flow-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/flow-runner",
-  "version": "0.13.0-experimental.1",
+  "version": "0.13.0",
   "description": "Deterministic YAML flow runner for tapflow — replay UI test flows against simulators/emulators with zero LLM calls",
   "keywords": [
     "tapflow",
@@ -36,7 +36,6 @@
     "schema"
   ],
   "publishConfig": {
-    "tag": "experimental",
     "access": "public"
   },
   "scripts": {

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -14,7 +14,7 @@ status: living
 
 `@tapflowio/mcp-server`: bridges tapflow to LLM agents via the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Published on the standard npm channel and versioned by changesets in the repo-wide fixed group (graduated from the `experimental` dist-tag in v0.14.0). Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies (the package depends on `@tapflowio/flow-runner`); the changesets → pnpm publish path does.
+Published on the standard npm channel and versioned by changesets in the repo-wide fixed group (graduated from the `experimental` dist-tag in 2026-07). Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies (the package depends on `@tapflowio/flow-runner`); the changesets → pnpm publish path does.
 
 Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP tools, and exposes them to any MCP-compatible client (Claude Code, Codex, Cursor, etc.) via stdio transport.
 

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 type: rules
-topics: [mcp, ai-agent, experimental]
+topics: [mcp, ai-agent]
 status: living
 ---
 
@@ -14,7 +14,7 @@ status: living
 
 `@tapflowio/mcp-server`: bridges tapflow to LLM agents via the [Model Context Protocol](https://modelcontextprotocol.io).
 
-**Experimental** — published under the `experimental` dist-tag. APIs and tool schemas may change between releases. Excluded from changeset automatic version management until promoted to stable.
+Published on the standard npm channel and versioned by changesets in the repo-wide fixed group (graduated from the `experimental` dist-tag in v0.14.0). Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies (the package depends on `@tapflowio/flow-runner`); the changesets → pnpm publish path does.
 
 Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP tools, and exposes them to any MCP-compatible client (Claude Code, Codex, Cursor, etc.) via stdio transport.
 
@@ -37,5 +37,3 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 
 - Do not add relay-side logic to this package — it is a client only.
 - Do not introduce stateful session management beyond what `TapflowClient` already tracks.
-- Do not promote to `latest` dist-tag until the experimental graduation checklist in `.work/2026-05-28-mcp-usability-todo.md` is complete.
-- Do not add this package to changeset automatic versioning until the `ignore` entry in `.changeset/config.json` is removed as part of graduation.

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tapflow contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,39 @@
+# @tapflowio/mcp-server
+
+[Model Context Protocol](https://modelcontextprotocol.io) server for [tapflow](https://github.com/jo-duchan/tapflow) — lets Claude Code, Codex, and any MCP-compatible LLM agent control iOS simulators and Android emulators as native tools.
+
+## Setup
+
+```sh
+npm install -g @tapflowio/mcp-server
+```
+
+Point it at your tapflow relay:
+
+```jsonc
+// e.g. Claude Code: .mcp.json
+{
+  "mcpServers": {
+    "tapflow": {
+      "command": "tapflow-mcp",
+      "env": {
+        "TAPFLOW_RELAY_URL": "ws://localhost:4000",
+        "TAPFLOW_TOKEN": "tflw_pat_..." // view-scope PAT (not needed for a localhost relay WS, but REST endpoints require it)
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+`list_devices`, `connect_device`, `disconnect_device`, `boot_device`, `screenshot`, `query_ui_tree`, `run_flow`, `tap`, `swipe`, `type_text`, `press_key`, `press_button`, `install_app`, `launch_app`, `list_builds`
+
+- `query_ui_tree` returns the accessibility tree as `{ role, label, identifier, frame, enabled }` with frames normalized 0-1 — tap by element instead of guessing coordinates from screenshots.
+- `run_flow` replays a [`@tapflowio/flow-runner`](https://www.npmjs.com/package/@tapflowio/flow-runner) YAML flow deterministically — author once with the agent, replay with zero LLM calls.
+
+Full guide: [tapflow.dev/guide/mcp-server](https://www.tapflow.dev/guide/mcp-server)
+
+## License
+
+[MIT](LICENSE) — part of the [tapflow](https://github.com/jo-duchan/tapflow) project.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.13.0-experimental.1",
+  "version": "0.13.0",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",
@@ -30,7 +30,6 @@
     "dist"
   ],
   "publishConfig": {
-    "tag": "experimental",
     "access": "public"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Closes the release-pipeline gap found while adding flow-runner: the experimental dist-tag scheme turned out to only work for **leaf** packages. Two structural facts, both surfaced by adversarial review and reproduced locally:

1. Once the stable CLI depends on flow-runner, changesets **hard-fails config validation** ("tapflow depends on the skipped package @tapflowio/flow-runner") — the next tag push would have died before publishing anything.
2. The existing `pnpm exec npm publish` path **never rewrote `workspace:*`** — published mcp-server tarballs were installable only because mcp-server had zero workspace deps until M2 added one. The next release would have shipped uninstallable tarballs.

Instead of patching the special-casing, both packages graduate to the standard channel.

## Changes

- **Both packages**: `0.13.0-experimental.1` → `0.13.0`, `publishConfig.tag` removed; joined the changesets **fixed group**, removed from `ignore`.
- **release.yml**: private-toggle + two per-package experimental publish steps deleted. A single `pnpm changeset publish` now covers every public package and publishes via pnpm, which rewrites `workspace:*` to exact versions — verified with `pnpm pack` on both tarballs.
- **Changeset added** for the M1/M2 feature set (missed at merge time). `changeset version` was simulated with the real CLI: the fixed group bumps cleanly to 0.14.0, no double-bump.
- **Docs**: experimental banners removed (README, cli README, `docs/guide/mcp-server.md` EN/KO, INDEX.md, both AGENTS.md). README + LICENSE added to both packages — their npm pages were blank.
- **`.claude/commands/release.md`** rewritten: the manual experimental-bump procedure is retired, and the one-time pre-tag requirements are documented.

## Before tagging the next release (one-time, documented in release.md §7)

- [ ] **Seed-publish flow-runner locally via the pnpm path**: `pnpm --filter @tapflowio/flow-runner publish --access public --no-git-checks`. npm OIDC trusted publishing cannot publish a brand-new package (a trusted publisher can only be registered on an existing one), and changesets publishes concurrently with no topological order — a partial failure would put a `tapflow` on `latest` that exact-pins a nonexistent flow-runner version.
- [ ] Register the trusted publisher for flow-runner on npmjs.com (repo `jo-duchan/tapflow`, workflow `release.yml`).
- [ ] MCP stabilization track (press_key/press_button fixes + full tool verification) merged first — graduating a package with a known no-op tool would be a bad first impression on `latest`.
- [ ] After the release: move or remove the stale `experimental` dist-tag (`npm dist-tag add @tapflowio/mcp-server@<ver> experimental`) so users who installed `@experimental` keep getting updates.

## Adversarial review

Two independent reviewer agents (general CI/release lens + npm/changesets publish lens), two rounds. Round 1 rejected the original "add an experimental publish step" approach outright (findings 1–2 above). Round 2 validated this design via a real `changeset version` simulation and npm registry checks, and produced the pre-tag checklist above. Full record kept locally in `.work/reviews/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released the MCP server and flow runner as stable packages.
  * Added an “Automated QA axis” for consistent UI tree querying and deterministic YAML flow replay (includes waits, selector handling, JUnit reports, and failure screenshots), plus support for `run_flow`.
  * Added an app state reset command for iOS/Android.
* **Bug Fixes**
  * Improved the package publishing workflow so all public packages publish via the same changeset path.
* **Documentation**
  * Updated MCP server and flow runner docs and removed “experimental” wording across the site and READMEs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->