### PR TITLE
process: adversarial review gate before every code-change PR

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -66,6 +66,7 @@ model: claude-opus-4-8
 
 - `git push -u origin release/vX.Y.Z`
 - `gh pr create --base main` — 본문에 버전 표 + 릴리즈노트 + 호환성 근거.
+- adversarial review gate가 릴리즈 PR에도 적용된다 — 버전 범프 PR은 docs-only 취급으로 리뷰 생략 가능하되 `.work/reviews/<브랜치>.md`에 스킵 사유 + full HEAD 해시(git rev-parse HEAD) 기록은 필수.
 - **PR을 머지하지 않는다.** 머지는 사용자 몫.
 
 ## 11. 머지 후 — 태그 push로 발행 트리거 (놓치면 발행이 안 됨)

--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# PreToolUse(Bash) gate: blocks `gh pr create` unless an adversarial review
+# record exists for the current branch AND references the current HEAD commit.
+# Review records live in .work/reviews/<branch>.md (local-only, gitignored with
+# the rest of .work/). The HEAD-hash check guarantees "reviewed code == PR code":
+# any commit after the review invalidates the record until it is refreshed.
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+# Match `gh pr create` only in command position (line start or after ; && |) —
+# a plain substring match false-positives on commit messages / heredoc bodies
+# that merely mention the command.
+printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\|)[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create' || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+head=$(git rev-parse HEAD 2>/dev/null) || exit 0
+record=".work/reviews/${branch//\//__}.md"
+
+if [ ! -f "$record" ]; then
+  echo "Blocked: adversarial review 기록이 없습니다 ($record). PR 생성 전에 독립 컨텍스트(서브에이전트 또는 Codex) 리뷰를 수행하고, 발견사항과 처리 내역(수정 또는 스킵+사유)을 해당 파일에 기록하세요. 기록에는 리뷰한 HEAD 커밋 해시를 포함해야 합니다. 절차: AGENTS.md Workflow 3. Review 참고." >&2
+  exit 2
+fi
+if ! grep -q "$head" "$record"; then
+  echo "Blocked: $record 가 현재 HEAD($head)를 참조하지 않습니다. 리뷰 이후 커밋이 추가되었습니다 — 현재 diff 기준으로 리뷰를 갱신하고 기록에 새 HEAD 해시를 반영한 뒤 다시 시도하세요." >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -7,10 +7,13 @@
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
-# Match `gh pr create` only in command position (line start or after ; && |) —
-# a plain substring match false-positives on commit messages / heredoc bodies
-# that merely mention the command.
-printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\|)[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create' || exit 0
+# Match the PR-create invocation only in command position: line start, after
+# ; && |, inside $( ) capture, or after then/do. A plain substring match would
+# false-positive on commit messages / docs that merely mention the command.
+# Backticks are deliberately NOT a command position (markdown quoting).
+# Fail-open by design (jq/git missing, not a repo): this gate guards a
+# cooperative-but-forgetful agent, not an adversary.
+printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\(|then|do)[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create' || exit 0
 
 cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
@@ -18,11 +21,11 @@ head=$(git rev-parse HEAD 2>/dev/null) || exit 0
 record=".work/reviews/${branch//\//__}.md"
 
 if [ ! -f "$record" ]; then
-  echo "Blocked: adversarial review 기록이 없습니다 ($record). PR 생성 전에 독립 컨텍스트(서브에이전트 또는 Codex) 리뷰를 수행하고, 발견사항과 처리 내역(수정 또는 스킵+사유)을 해당 파일에 기록하세요. 기록에는 리뷰한 HEAD 커밋 해시를 포함해야 합니다. 절차: AGENTS.md Workflow 3. Review 참고." >&2
+  echo "Blocked: adversarial review 기록이 없습니다 ($record). PR 생성 전에 독립 컨텍스트(서브에이전트 또는 Codex) 리뷰를 수행하고, 발견사항과 처리 내역(수정 또는 스킵+사유)을 해당 파일에 기록하세요. 기록에는 full 40자 HEAD 해시(git rev-parse HEAD)를 포함해야 합니다. docs-only PR이면 리뷰는 생략하되 스킵 사유를 담은 기록은 작성하세요. 이 명령이 PR 생성이 아닌데 차단됐다면(문서·메시지 본문 속 언급) 해당 텍스트를 별도 명령으로 분리하세요. 절차: AGENTS.md Adversarial Review 참고." >&2
   exit 2
 fi
 if ! grep -q "$head" "$record"; then
-  echo "Blocked: $record 가 현재 HEAD($head)를 참조하지 않습니다. 리뷰 이후 커밋이 추가되었습니다 — 현재 diff 기준으로 리뷰를 갱신하고 기록에 새 HEAD 해시를 반영한 뒤 다시 시도하세요." >&2
+  echo "Blocked: $record 가 현재 HEAD($head)를 참조하지 않습니다. 리뷰 이후 커밋이 추가되었거나 기록에 축약 해시를 적었습니다 — 현재 diff 기준으로 리뷰를 갱신하고 full 40자 해시(git rev-parse HEAD)를 기록에 반영한 뒤 다시 시도하세요." >&2
   exit 2
 fi
 exit 0

--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -13,7 +13,7 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 # Backticks are deliberately NOT a command position (markdown quoting).
 # Fail-open by design (jq/git missing, not a repo): this gate guards a
 # cooperative-but-forgetful agent, not an adversary.
-printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\(|then|do)[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create' || exit 0
+printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:space:]])(then|do)[[:space:]]+)gh[[:space:]]+pr[[:space:]]+create' || exit 0
 
 cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // \"\"'); printf '%s' \"$cmd\" | perl -CSD -e 'local $/; my $c=<>; if ($c =~ /gh\\s+(pr|issue)\\s+(create|edit)/ && $c =~ /\\p{Hangul}/) { print STDERR \"Blocked: the gh pr/issue command contains Korean. Rewrite the PR/Issue title and body in English, then re-run.\\n\"; exit 2 }'"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/adversarial-review-gate.sh\""
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,12 +103,12 @@ Custom commands: `/work-plan {topic}` · `/deep-research {problem}` · `/qa {tar
 
 ### Adversarial Review (required before every code-change PR)
 
-The authoring session inherits its own assumptions, so before `gh pr create` the diff must be refuted by an **independent context** that has NOT seen the working conversation. Docs-only PRs may skip this.
+The authoring session inherits its own assumptions, so before creating a PR the diff must be refuted by an **independent context** that has NOT seen the working conversation. Docs-only PRs may skip the review itself, but still write the record (with the skip reason) — the gate always requires it.
 
 - **Default reviewer**: a fresh subagent given only the diff, repo access, and a refute-first prompt — "find bugs, contract violations, and missing cases; verify every claim with commands; report findings with severity and evidence, plus a checked-and-cleared list". Do not share the authoring session's reasoning with it.
 - **Escalation**: protocol / public-interface / release-infrastructure changes get a second independent channel (a second subagent with a different lens, or Codex for cross-model independence).
-- **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the reviewed HEAD commit hash. Mention the review in the PR body.
-- **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks `gh pr create` unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
+- **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
+- **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 
 ### Design Principles (SOLID — priority subset)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,19 @@ Work logs go in `.work/`. Conventions: [.work/CLAUDE.md](./.work/CLAUDE.md).
 
 1. **Plan** — define requirements + test cases first (`type: plan`).
 2. **Work** — write tests first, implement until they pass.
-3. **Review** — edge cases + real data validation → PR (`type: review`).
+3. **Review** — edge cases + real data validation → **adversarial review** (below) → PR (`type: review`).
 4. **Compound** — extract repeating patterns into test + code + prompt bundles (`type: compound`).
 
 Custom commands: `/work-plan {topic}` · `/deep-research {problem}` · `/qa {target}` · `/doc-sync` · `/compound` · `/promote-decision {topic}` · `/release {major|minor|patch}`.
+
+### Adversarial Review (required before every code-change PR)
+
+The authoring session inherits its own assumptions, so before `gh pr create` the diff must be refuted by an **independent context** that has NOT seen the working conversation. Docs-only PRs may skip this.
+
+- **Default reviewer**: a fresh subagent given only the diff, repo access, and a refute-first prompt — "find bugs, contract violations, and missing cases; verify every claim with commands; report findings with severity and evidence, plus a checked-and-cleared list". Do not share the authoring session's reasoning with it.
+- **Escalation**: protocol / public-interface / release-infrastructure changes get a second independent channel (a second subagent with a different lens, or Codex for cross-model independence).
+- **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the reviewed HEAD commit hash. Mention the review in the PR body.
+- **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks `gh pr create` unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 
 ### Design Principles (SOLID — priority subset)
 


### PR DESCRIPTION
## Summary

Encodes the adversarial-review step into the workflow and enforces it mechanically. The motivation is fresh: this process just caught two release-pipeline blockers on the graduation PR (#373) that the authoring session had missed — the authoring context inherits its own assumptions, so refutation must come from an independent context.

## What this adds

- **AGENTS.md — Adversarial Review section**: every code-change PR gets refuted by a fresh subagent that has NOT seen the working conversation (diff + repo access + refute-first prompt only). Protocol / public-interface / release-infra changes escalate to a second independent channel (different-lens subagent, or Codex for cross-model independence). Findings and dispositions (fixed / skipped+reason) go to `.work/reviews/<branch>.md` with the full 40-char reviewed HEAD hash. Docs-only PRs may skip the review but still write the record.
- **`.claude/hooks/adversarial-review-gate.sh`** (registered in `.claude/settings.json`): a PreToolUse gate that blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed. Matches the gh invocation only in command position (line start / `;` `&&` `|` / `$(` / `then` `do`) so commit messages and docs that merely mention the command don't false-block. Fail-open by design: the gate guards a cooperative-but-forgetful agent, not an adversary.

## Dogfooding

This PR went through its own gate, twice over:

- The gate **blocked this branch's first commit attempt** — the commit message mentioned the gh command and the initial substring matcher false-positived. That produced the command-position matcher.
- The change was then adversarially reviewed by an independent shell/hooks-lens subagent, which found 4 majors (docs-only contradiction, `$(...)`/`then` accidental bypasses, short-hash trap with a misleading error, quoted-mention false positives) — all fixed or documented in the second commit, with a 7-scenario regression test.
- This PR's creation itself passed only after the review record for the final HEAD was written.

Verified live on PR #373 as well: blocked without a record, blocked on stale hash, passed with a valid record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the release workflow to require an adversarial review record before creating release PRs.
  * Added guidance that version-bump PRs can skip review only when a skip reason and the full HEAD commit hash are recorded.
  * Documented the required diff refutation step and review record format enforced before code-change PRs.
* **Chores**
  * Added an automated preflight gate that blocks PR creation unless a local review record exists for the branch and matches the current HEAD commit hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->