### PR TITLE
fix: English contributor-facing messages in the adversarial review gate

### DIFF
--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -21,7 +21,7 @@ head=$(git rev-parse HEAD 2>/dev/null) || exit 0
 record=".work/reviews/${branch//\//__}.md"
 
 if [ ! -f "$record" ]; then
-  echo "Blocked: no adversarial review record ($record). Before creating a PR, have an independent context (a fresh subagent — no extra accounts needed; Codex is optional) review the diff, then write findings and dispositions (fixed / skipped+reason) to that file, including the full 40-char HEAD hash (git rev-parse HEAD). Docs-only PR: skip the review but still write the record with the skip reason. If this command is not actually creating a PR (the text merely mentions the command), split that text into a separate command. See: AGENTS.md > Adversarial Review." >&2
+  echo "Blocked: no adversarial review record ($record). Before creating a PR, have an independent context (a fresh subagent — no extra accounts needed; Codex is optional) review the diff, then write findings and dispositions (fixed / skipped+reason) to that file, including the full 40-char HEAD hash (git rev-parse HEAD). Docs-only PR: skip the review but still write the record with the skip reason and the same full HEAD hash. If this command is not actually creating a PR (the text merely mentions the command), split that text into a separate command. See: AGENTS.md > Adversarial Review." >&2
   exit 2
 fi
 if ! grep -q "$head" "$record"; then

--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -21,11 +21,11 @@ head=$(git rev-parse HEAD 2>/dev/null) || exit 0
 record=".work/reviews/${branch//\//__}.md"
 
 if [ ! -f "$record" ]; then
-  echo "Blocked: adversarial review 기록이 없습니다 ($record). PR 생성 전에 독립 컨텍스트(서브에이전트 또는 Codex) 리뷰를 수행하고, 발견사항과 처리 내역(수정 또는 스킵+사유)을 해당 파일에 기록하세요. 기록에는 full 40자 HEAD 해시(git rev-parse HEAD)를 포함해야 합니다. docs-only PR이면 리뷰는 생략하되 스킵 사유를 담은 기록은 작성하세요. 이 명령이 PR 생성이 아닌데 차단됐다면(문서·메시지 본문 속 언급) 해당 텍스트를 별도 명령으로 분리하세요. 절차: AGENTS.md Adversarial Review 참고." >&2
+  echo "Blocked: no adversarial review record ($record). Before creating a PR, have an independent context (a fresh subagent — no extra accounts needed; Codex is optional) review the diff, then write findings and dispositions (fixed / skipped+reason) to that file, including the full 40-char HEAD hash (git rev-parse HEAD). Docs-only PR: skip the review but still write the record with the skip reason. If this command is not actually creating a PR (the text merely mentions the command), split that text into a separate command. See: AGENTS.md > Adversarial Review." >&2
   exit 2
 fi
 if ! grep -q "$head" "$record"; then
-  echo "Blocked: $record 가 현재 HEAD($head)를 참조하지 않습니다. 리뷰 이후 커밋이 추가되었거나 기록에 축약 해시를 적었습니다 — 현재 diff 기준으로 리뷰를 갱신하고 full 40자 해시(git rev-parse HEAD)를 기록에 반영한 뒤 다시 시도하세요." >&2
+  echo "Blocked: $record does not reference the current HEAD ($head). Either commits were added after the review, or the record contains an abbreviated hash — refresh the review against the current diff and record the full 40-char hash (git rev-parse HEAD), then retry." >&2
   exit 2
 fi
 exit 0


### PR DESCRIPTION
## Summary

Follow-up to #374 (the commit was lost to a tool error right before that PR merged). The gate's block messages were in Korean — they are the first thing an external contributor using Claude Code would see, and contributor-facing text is English in this repo.

- Both block messages translated to English.
- The message now states that the **default review channel is a fresh subagent (no extra accounts needed)** and Codex is optional escalation — answering the natural "do contributors need a Codex account?" question inline. (They don't; and contributors not using Claude Code are never gated — the hook intercepts only the agent's tool calls, while human-made PRs are covered by CodeRabbit post-PR.)
- Review finding folded in: the docs-only guidance now also states the full-hash requirement, so a docs-only contributor following the message verbatim doesn't pass the file check only to trip the hash check.

## Verification

- 8-scenario gate regression (4 real invocations blocked, 4 false-positive shapes pass).
- Independent light-weight adversarial review with a 4-case runtime proof (no record / short hash / valid record / backtick mention) — 1 Low finding fixed, quoting and message-vs-enforcement accuracy cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)