### PR TITLE
docs(readme): sharpen hero, cut redundancy, reframe v0.x note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
   </p>
 
   <p>
+    <strong>No WebDriverAgent</strong>
+    &nbsp;·&nbsp;
+    <strong>2-line setup</strong>
+    &nbsp;·&nbsp;
+    <strong>Self-hosted · Free · MIT</strong>
+  </p>
+
+  <p>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
     <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="Node.js ≥ 20" /></a>
     <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
@@ -30,7 +38,9 @@
 
 <video src="https://github.com/user-attachments/assets/75652346-93cb-4261-9210-6a24b883d44a" controls width="100%"></video>
 
-> **v0.x**: tapflow is under active development. Breaking changes may appear in minor versions until v1.0.0. See [ROADMAP](./ROADMAP.md) for the full plan.
+<p align="center"><em>Streams over H.264 with a zero-buffer decoder (no MSE) — <a href="contributing/streaming-latency-log.md">latency measurements ↗</a></em></p>
+
+> **v0.x, actively developed** — backward-compatible by default; breaking changes are rare and always noted in the [changelog](CHANGELOG.md). [Roadmap →](./ROADMAP.md)
 
 ---
 
@@ -57,31 +67,22 @@ We hit this exact problem, so we built tapflow.
 | Xcode / Android Studio | Each teammate needs a Mac and a full mobile toolchain |
 | **tapflow** | Reuse your own Macs — data stays on infrastructure you control, and the whole team does QA from a browser |
 
-## What tapflow does
+## How it works
 
 tapflow connects three parts:
 
-1. A **self-hosted relay** server (Linux or Mac)
-2. A **macOS agent** that drives iOS simulators and Android emulators
-3. A **browser dashboard** for the rest of the team
+1. A **self-hosted relay** (Linux or Mac) — also serves the dashboard on the same port, so there's no separate web server.
+2. A **macOS agent** that drives the iOS Simulator and Android emulator — it connects *outbound* to the relay (no inbound firewall rules) and injects iOS touch directly, without WebDriverAgent.
+3. A **browser dashboard** for the rest of the team — pick an available device and interact with it in real time while the simulators keep running on your Macs.
 
-The agent connects outbound to the relay. Teammates open the dashboard, pick an available device, and interact with it remotely — while the simulators and emulators keep running on your own Macs.
-
-## What tapflow is not
-
-tapflow doesn't replace native mobile development tools. Mobile developers still use Xcode, Android Studio, and their build tooling. tapflow makes the *running* simulators and emulators accessible to the rest of the team through a browser — it isn't an automation framework or a device farm.
-
-## How it works
-
-```
+```text
 Browser (your team)  ←─ WebSocket ─→  Relay Server  ←─ WebSocket (outbound) ─→  Mac Agent
                                     (Linux / Mac)                           (iOS · Android)
 ```
 
-1. The **Mac Agent** connects *outbound* to the relay — no inbound firewall rules needed.
-2. Anyone on the team opens the **dashboard** in any browser and sees all available devices.
-3. Touch events are forwarded in real time; the screen streams back to the browser.
-4. The **relay** also serves the dashboard SPA on the same port — no separate web server needed.
+## What tapflow is not
+
+tapflow doesn't replace native mobile development tools. Mobile developers still use Xcode, Android Studio, and their build tooling. tapflow makes the *running* simulators and emulators accessible to the rest of the team through a browser — it isn't an automation framework or a device farm.
 
 ## Quick Start
 
@@ -138,7 +139,7 @@ Navigate to `http://localhost:4000` and sign in with the account you just create
 ## Features
 
 - **No mobile toolchain for QA users** — teammates test from a browser without installing Xcode, Android Studio, or local simulator tooling.
-- **Self-hosted by default** — app builds, device streams, recordings, and account data stay on infrastructure you control.
+- **Self-hosted by default** — no third-party cloud and no external accounts; everything runs on hardware you already own.
 - **Use your existing Mac setup** — run agents on Macs that already have the iOS Simulator or Android emulator available.
 - **API-first** — REST endpoints and Personal Access Tokens support CI/CD and AI-agent workflows.
 
@@ -157,7 +158,7 @@ What's included:
 - **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 <a name="latency-note"></a>
-> <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [performance & latency reference](https://www.tapflow.dev/reference/performance) for the full measurements, conditions, and known limitations.
+> <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [streaming latency log](contributing/streaming-latency-log.md) for the full measurements, conditions, and known limitations.
 
 ## Security & Privacy
 
@@ -179,17 +180,7 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md). For the full model, read 
 
 ## Self-Hosting
 
-### Local (single Mac)
-
-Relay and agent on the same machine — ideal for a single developer or small team.
-
-```sh
-tapflow start
-```
-
-### Team (separate relay server)
-
-Run the relay on a Linux server or dedicated Mac. Each Mac with simulators runs the agent.
+A single Mac needs nothing beyond `tapflow start` (see [Quick Start](#quick-start)). For a team, run the relay on a separate Linux server or dedicated Mac, and point each Mac agent at it.
 
 **Relay server:**
 
@@ -231,33 +222,11 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
-**[www.tapflow.dev](https://www.tapflow.dev)**
+Full docs: **[www.tapflow.dev](https://www.tapflow.dev)**
 
-**Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started)
-- [Requirements](https://www.tapflow.dev/guide/requirements)
-
-**Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [Security & Privacy](https://www.tapflow.dev/guide/security)
-- [Agent Setup](https://www.tapflow.dev/guide/agent)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
-
-**Dashboard**
-- [First-time Setup](https://www.tapflow.dev/dashboard/setup)
-- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
-
-**AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
-
-**Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Configuration](https://www.tapflow.dev/reference/configuration)
-- [REST API](https://www.tapflow.dev/reference/api)
-
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
+- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Security & Privacy](https://www.tapflow.dev/guide/security) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api)
+- **AI Agent** — [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 ## Contributing
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,6 +9,14 @@
   </p>
 
   <p>
+    <strong>No WebDriverAgent</strong>
+    &nbsp;·&nbsp;
+    <strong>2-line setup</strong>
+    &nbsp;·&nbsp;
+    <strong>Self-hosted · Free · MIT</strong>
+  </p>
+
+  <p>
     <a href="https://github.com/jo-duchan/tapflow/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
     <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="Node.js ≥ 20" /></a>
     <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
@@ -35,6 +43,10 @@
   <p><em>Click to play</em></p>
 </div>
 
+<p align="center"><em>Streams over H.264 with a zero-buffer decoder (no MSE) — <a href="https://github.com/jo-duchan/tapflow/blob/main/contributing/streaming-latency-log.md">latency measurements ↗</a></em></p>
+
+> **v0.x, actively developed** — backward-compatible by default; breaking changes are rare and always noted in the [changelog](https://github.com/jo-duchan/tapflow/blob/main/CHANGELOG.md). [Roadmap →](https://github.com/jo-duchan/tapflow/blob/main/ROADMAP.md)
+
 ---
 
 ## Why tapflow?
@@ -60,31 +72,22 @@ We hit this exact problem, so we built tapflow.
 | Xcode / Android Studio | Each teammate needs a Mac and a full mobile toolchain |
 | **tapflow** | Reuse your own Macs — data stays on infrastructure you control, and the whole team does QA from a browser |
 
-## What tapflow does
+## How it works
 
 tapflow connects three parts:
 
-1. A **self-hosted relay** server (Linux or Mac)
-2. A **macOS agent** that drives iOS simulators and Android emulators
-3. A **browser dashboard** for the rest of the team
+1. A **self-hosted relay** (Linux or Mac) — also serves the dashboard on the same port, so there's no separate web server.
+2. A **macOS agent** that drives the iOS Simulator and Android emulator — it connects _outbound_ to the relay (no inbound firewall rules) and injects iOS touch directly, without WebDriverAgent.
+3. A **browser dashboard** for the rest of the team — pick an available device and interact with it in real time while the simulators keep running on your Macs.
 
-The agent connects outbound to the relay. Teammates open the dashboard, pick an available device, and interact with it remotely — while the simulators and emulators keep running on your own Macs.
-
-## What tapflow is not
-
-tapflow doesn't replace native mobile development tools. Mobile developers still use Xcode, Android Studio, and their build tooling. tapflow makes the *running* simulators and emulators accessible to the rest of the team through a browser — it isn't an automation framework or a device farm.
-
-## How it works
-
-```
+```text
 Browser (your team)  ←─ WebSocket ─→  Relay Server  ←─ WebSocket (outbound) ─→  Mac Agent
                                     (Linux / Mac)                           (iOS · Android)
 ```
 
-1. The **Mac Agent** connects _outbound_ to the relay — no inbound firewall rules needed.
-2. Anyone on the team opens the **dashboard** in any browser and sees all available devices.
-3. Touch events are forwarded in real time; the screen streams back to the browser.
-4. The **relay** also serves the dashboard SPA on the same port — no separate web server needed.
+## What tapflow is not
+
+tapflow doesn't replace native mobile development tools. Mobile developers still use Xcode, Android Studio, and their build tooling. tapflow makes the *running* simulators and emulators accessible to the rest of the team through a browser — it isn't an automation framework or a device farm.
 
 ## Quick Start
 
@@ -141,7 +144,7 @@ Navigate to `http://localhost:4000` and sign in with the account you just create
 ## Features
 
 - **No mobile toolchain for QA users** — teammates test from a browser without installing Xcode, Android Studio, or local simulator tooling.
-- **Self-hosted by default** — app builds, device streams, recordings, and account data stay on infrastructure you control.
+- **Self-hosted by default** — no third-party cloud and no external accounts; everything runs on hardware you already own.
 - **Use your existing Mac setup** — run agents on Macs that already have the iOS Simulator or Android emulator available.
 - **API-first** — REST endpoints and Personal Access Tokens support CI/CD and AI-agent workflows.
 
@@ -160,7 +163,7 @@ What's included:
 - **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
 <a name="latency-note"></a>
-> <sup>1</sup> On localhost, decode-to-present is in the single-to-low-double-digit milliseconds (WebCodecs ~2.5 ms, WASM ~9–14 ms); end-to-end "glass-to-glass" latency also depends on your network. See the [streaming latency log](https://github.com/jo-duchan/tapflow/blob/main/contributing/streaming-latency-log.md) for the full pipeline analysis and measurements.
+> <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [streaming latency log](https://github.com/jo-duchan/tapflow/blob/main/contributing/streaming-latency-log.md) for the full measurements, conditions, and known limitations.
 
 ## Security & Privacy
 
@@ -182,17 +185,7 @@ Found a vulnerability? See [SECURITY.md](https://github.com/jo-duchan/tapflow/bl
 
 ## Self-Hosting
 
-### Local (single Mac)
-
-Relay and agent on the same machine — ideal for a single developer or small team.
-
-```sh
-tapflow start
-```
-
-### Team (separate relay server)
-
-Run the relay on a Linux server or dedicated Mac. Each Mac with simulators runs the agent.
+A single Mac needs nothing beyond `tapflow start` (see [Quick Start](#quick-start)). For a team, run the relay on a separate Linux server or dedicated Mac, and point each Mac agent at it.
 
 **Relay server:**
 
@@ -234,33 +227,11 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 ## Documentation
 
-**[www.tapflow.dev](https://www.tapflow.dev)**
+Full docs: **[www.tapflow.dev](https://www.tapflow.dev)**
 
-**Getting Started**
-- [Introduction](https://www.tapflow.dev/guide/introduction)
-- [Quick Start](https://www.tapflow.dev/guide/getting-started)
-- [Requirements](https://www.tapflow.dev/guide/requirements)
-
-**Setup**
-- [Self-Hosting the Relay](https://www.tapflow.dev/guide/self-hosting)
-- [Security & Privacy](https://www.tapflow.dev/guide/security)
-- [Agent Setup](https://www.tapflow.dev/guide/agent)
-- [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds)
-- [Scaling Mac Resources](https://www.tapflow.dev/guide/scaling)
-
-**Dashboard**
-- [First-time Setup](https://www.tapflow.dev/dashboard/setup)
-- [Dashboard Overview](https://www.tapflow.dev/dashboard/overview)
-
-**AI Agent**
-- [MCP Server](https://www.tapflow.dev/guide/mcp-server)
-
-**Reference**
-- [CLI Reference](https://www.tapflow.dev/reference/cli)
-- [Configuration](https://www.tapflow.dev/reference/configuration)
-- [REST API](https://www.tapflow.dev/reference/api)
-
-**[Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)**
+- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Security & Privacy](https://www.tapflow.dev/guide/security) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api)
+- **AI Agent** — [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 ## Contributing
 


### PR DESCRIPTION
## What

Tightens both public READMEs (root + `packages/cli`) for scannability and trust, following the "make your open source popular" playbook (concrete first-screen value, cut redundancy, honest limitations framed as confidence).

## Changes

- **Hero differentiator strip** — `No WebDriverAgent · 2-line setup · Self-hosted · Free · MIT`, plus a latency caption linking the streaming latency log. Concrete, defensible proof without unqualified numbers.
- **Merge `What tapflow does` into `How it works`** and surface the WDA-free direct HID injection — removes a duplicated section.
- **Trim repetition** — varied the repeated "data stays on your infra" phrasing; dropped the redundant single-Mac self-hosting block (it just repeated Quick Start).
- **Condense the Documentation link tree** to key destinations (was a full docs-sidebar mirror).
- **Reframe the v0.x note** from "breaking changes may appear" to "backward-compatible by default; breaking changes are rare" — matches the changelog track record (one BREAKING change in project history) and links `CHANGELOG.md` as evidence.
- **Root ↔ CLI parity** — same content, differing only in relative vs absolute links and video vs click-thumbnail demo.

Net: **+51 / −111** lines across the two files.

## Verification

Docs-only change. Adversarial review record (with skip reason + fact/link checks) at `.work/reviews/docs__readme-hero-cleanup.md`:
- All relative links, the `#quick-start` anchor, and CLI absolute-only links verified.
- Latency and "breaking changes are rare" claims verified against `contributing/streaming-latency-log.md` and the changelogs.
- Pre-commit typecheck + lint passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed homepage-style README marketing copy and documentation navigation across the main site and CLI README.
  * Updated hero messaging to emphasize streamlined setup and self-hosting, including revised maintenance/backward-compatibility wording.
  * Reordered and rewrote “How it works” vs “What tapflow is not” content for clearer structure.
  * Condensed self-hosting guidance into a single setup/relay explanation and clarified team usage.
  * Shortened and grouped documentation links (“Full docs”, Guides, Reference, AI Agent).
  * Updated streaming/latency footnotes and related reference points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->