### PR TITLE
fix(dashboard): resolve a11y-lens accessibility findings

### DIFF
--- a/packages/dashboard/src/pages/AppCenter.tsx
+++ b/packages/dashboard/src/pages/AppCenter.tsx
@@ -105,7 +105,7 @@ export function AppCenter() {
         onAdd={fetchApps}
       />
 
-      <main className="flex-1 flex flex-col gap-4 p-4 overflow-y-auto min-w-0">
+      <div className="flex-1 flex flex-col gap-4 p-4 overflow-y-auto min-w-0">
         <div className="flex items-center justify-between flex-wrap gap-2">
           <h1 className="text-xl font-semibold tracking-display-sm">
             {selectedApp ? selectedApp.name : 'App Center'}
@@ -166,7 +166,7 @@ export function AppCenter() {
         )}
         </>
         )}
-      </main>
+      </div>
     </div>
   )
 }

--- a/packages/dashboard/src/pages/Invite.tsx
+++ b/packages/dashboard/src/pages/Invite.tsx
@@ -99,7 +99,7 @@ export function Invite() {
                 render={({ field }) => (
                   <div className="relative w-14 h-14">
                     {avatarPreview ? (
-                      <img src={avatarPreview} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
+                      <img src={avatarPreview} alt="Avatar preview" className="w-14 h-14 rounded-full object-cover border" />
                     ) : (
                       <div
                         className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
@@ -110,10 +110,11 @@ export function Invite() {
                     )}
                     <button
                       type="button"
+                      aria-label="Change avatar"
                       onClick={() => avatarRef.current?.click()}
                       className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
                     >
-                      <Pencil className="w-3 h-3" />
+                      <Pencil className="w-3 h-3" aria-hidden="true" />
                     </button>
                     <input
                       ref={avatarRef}

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -143,7 +143,7 @@ export function MacResources() {
         ) : (
           <div className="flex flex-col gap-6 p-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold">{selectedAgent}</h2>
+              <h1 className="text-base font-semibold">{selectedAgent}</h1>
               <Tabs value={range} onValueChange={(v) => setRange(v as Range)}>
                 <TabsList>
                   {(Object.keys(RANGE_LABELS) as Range[]).map((r) => (

--- a/packages/dashboard/src/pages/settings/Default.tsx
+++ b/packages/dashboard/src/pages/settings/Default.tsx
@@ -221,13 +221,14 @@ export function DefaultSettings() {
                   control={workspaceForm.control}
                   render={({ field }) => (
                     <div className="relative w-16 h-16">
-                      <img src={logoUrl ?? defaultLogo} alt="logo" className="w-16 h-16 rounded-lg object-contain" />
+                      <img src={logoUrl ?? defaultLogo} alt="Workspace logo" className="w-16 h-16 rounded-lg object-contain" />
                       <button
                         type="button"
+                        aria-label="Change logo"
                         onClick={() => logoRef.current?.click()}
                         className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
                       >
-                        <Pencil className="w-3 h-3" />
+                        <Pencil className="w-3 h-3" aria-hidden="true" />
                       </button>
                       <input ref={logoRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
                         onChange={(e) => {
@@ -271,7 +272,7 @@ export function DefaultSettings() {
                 render={({ field }) => (
                   <div className="relative w-14 h-14">
                     {avatarUrl ? (
-                      <img src={avatarUrl} alt="avatar" className="w-14 h-14 rounded-full object-cover border" />
+                      <img src={avatarUrl} alt="Profile avatar" className="w-14 h-14 rounded-full object-cover border" />
                     ) : (
                       <div
                         className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-medium"
@@ -282,10 +283,11 @@ export function DefaultSettings() {
                     )}
                     <button
                       type="button"
+                      aria-label="Change avatar"
                       onClick={() => avatarRef.current?.click()}
                       className="absolute bottom-0 right-0 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center hover:bg-accent transition-colors"
                     >
-                      <Pencil className="w-3 h-3" />
+                      <Pencil className="w-3 h-3" aria-hidden="true" />
                     </button>
                     <input ref={avatarRef} type="file" accept=".png,.jpg,.jpeg" className="hidden"
                       onChange={(e) => {

--- a/packages/dashboard/src/pages/settings/Team.tsx
+++ b/packages/dashboard/src/pages/settings/Team.tsx
@@ -150,13 +150,13 @@ export function TeamSettings() {
                   {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
                 </div>
                 <div className="grid gap-2">
-                  <Label>Role</Label>
+                  <Label htmlFor="invite-role">Role</Label>
                   <Controller
                     name="role"
                     control={control}
                     render={({ field }) => (
                       <Select value={field.value} onValueChange={field.onChange}>
-                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectTrigger id="invite-role"><SelectValue /></SelectTrigger>
                         <SelectContent>
                           <SelectItem value="Admin">Admin</SelectItem>
                           <SelectItem value="Developer">Developer</SelectItem>

--- a/packages/dashboard/src/pages/settings/Tokens.tsx
+++ b/packages/dashboard/src/pages/settings/Tokens.tsx
@@ -166,9 +166,9 @@ export function TokenSettings() {
                   {errors.expiresDays && <p className="text-sm text-destructive">{errors.expiresDays.message}</p>}
                 </div>
                 <div className="grid gap-2">
-                  <Label>Type</Label>
+                  <Label htmlFor="token-type">Type</Label>
                   <Select value={tokenType} onValueChange={(v) => setTokenType(v as TokenType)}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger id="token-type"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="api">API — CI uploads &amp; API access</SelectItem>
                       <SelectItem value="agent">Agent — connect remote device agents (Admin only)</SelectItem>


### PR DESCRIPTION
## What

Resolves 10 accessibility findings surfaced by `a11y-lens` across the dashboard UI.

| Area | Fix |
| --- | --- |
| Icon-only buttons | Add `aria-label` ("Change avatar" / "Change logo") to the avatar/logo edit buttons in `Invite.tsx` and `settings/Default.tsx`; mark the decorative `<Pencil>` `aria-hidden="true"` |
| Image alt text | Replace filler `alt` ("avatar", "logo") with meaningful text ("Avatar preview", "Workspace logo", "Profile avatar") |
| Landmarks | Demote the nested `<main>` in `AppCenter.tsx` to `<div>` — `DashboardLayout` already provides the page's single `<main>` |
| Headings | Promote the agent-title heading in `MacResources.tsx` from `<h2>` to `<h1>` so the route has a top-level heading (matches the AppCenter convention) |
| Form labels | Tie the Role/Type Radix `Select` triggers to their visible `<Label>` via `htmlFor`/`id` in `Team.tsx` and `Tokens.tsx` |

Visual output is unchanged (only semantic attributes / element types change; heading className preserved).

## Verification

- `pnpm --filter @tapflowio/dashboard typecheck` — pass
- `pnpm --filter @tapflowio/dashboard lint` — pass
- Re-ran `a11y-lens` on the six files: none of the original 10 findings reappear.

## Adversarial review

An independent refute-first review (fresh context) verified the fixes are effective (not cosmetic) — confirmed Radix forwards `id` to the `<button role="combobox">` so `<label for>` produces a real accessible name; confirmed balanced JSX, no duplicate ids, typecheck/lint green. Record: `.work/reviews/fix__dashboard-a11y.md` (HEAD `b9e9401`). One LOW, out-of-scope note: MacResources' empty state still has no heading (pre-existing; strictly an improvement).

## Scope note

`a11y-lens` is a sampling (non-deterministic) reviewer — subsequent runs surface a different batch (form-error `aria-describedby`/`aria-invalid` association, live-region loading states, chart keyboard access). Those are intentionally deferred to a follow-up; this PR lands the first, verified set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility across several dashboard pages by adding clearer labels, better button descriptions, and properly hidden decorative icons.
  * Updated form controls so labels are correctly associated with their inputs, making invite and token creation fields easier to use.
  * Adjusted page heading structure and a top-level layout wrapper to better match expected document semantics.
  * Refined avatar and logo preview text for more descriptive screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->