### PR TITLE
ci: pin npm to 11.18.0 in release workflow (avoid npm 12 provenance crash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
+      # Pin npm: npm@12.0.0 broke provenance signing under trusted publishing
+      # ("Cannot find module 'sigstore'"). 11.18.0 is the last known-good line
+      # above the trusted-publishing floor. Revisit once npm ships a 12.x fix.
+      - run: npm install -g npm@11.18.0
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

`npm@12.0.0` (GA 2026-07-08) broke provenance signing under OIDC trusted publishing — `npm publish` fails with `Cannot find module 'sigstore'` ([npm/cli#9722](https://github.com/npm/cli/issues/9722), still open). The release job installed `npm@latest`, and `npm dist-tags` now resolves `latest` → `12.0.0`, so the **next release would pull the broken version and fail to publish**. v0.14.0 shipped fine only because it predates 12.0.0.

This is on the real publish path here: `pnpm changeset publish` → changesets spawns `pnpm publish` → pnpm 9.15.1 delegates the registry upload to the global `npm` binary → OIDC trusted publishing auto-generates provenance → the sigstore crash.

## Change

Pin the release job's global npm to `11.18.0` (the head of the 11.x line, above the ~11.5.1 trusted-publishing floor, validated on a sibling project). One line + comment in `.github/workflows/release.yml`.

## Adversarial review

Release-infrastructure change → reviewed through **two independent channels** (mechanics/regression lens + fact-check/alternatives lens). Both confirmed the pin is **load-bearing, not a no-op** (traced changesets → pnpm 9 → global npm delegation from source), verified 11.18.0 is valid with no engine conflict, and cleared scope/YAML. Bottom line from both: **ship as-is**. Record: `.work/reviews/ci__pin-npm-release.md` (HEAD `ddee9c0`).

**Alternatives considered:** `npm@11` (floating — keeps 11.x security patches, but less deterministic) and deleting the line to use Node 24's bundled npm 11.9.0 (simpler, but drifts with Node patches). Kept the explicit pin for determinism and consistency with the sibling project. To be revisited once npm ships a 12.x fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by standardizing the npm version used during the release process, reducing the risk of signing or publishing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->