### PR TITLE
chore(deps): bump @a11y-lens/cli to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
-    "@a11y-lens/cli": "^0.4.0",
+    "@a11y-lens/cli": "^0.4.1",
     "@changesets/cli": "^2.31.0",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^9.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     devDependencies:
       '@a11y-lens/cli':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.1
+        version: 0.4.1
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@20.19.43)
@@ -518,8 +518,8 @@ importers:
 
 packages:
 
-  '@a11y-lens/cli@0.4.0':
-    resolution: {integrity: sha512-ZXWTlg8VkF3zBKX3Mvl+lDp6dxJUcmjgiK6PJZ06ypJr4dIysdFBp+KWyNQ6pCZ0fhWbYyP9W6iY4Gu78f0hKw==}
+  '@a11y-lens/cli@0.4.1':
+    resolution: {integrity: sha512-ttJs3AZ5l9nmN1L70gm0g7GX7qt0bCpOgT8tG2FoniwY8RyrP/ErF7J6jr8xbSFykRXhaRx4+U9UqldeEtcTIg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5232,7 +5232,7 @@ packages:
 
 snapshots:
 
-  '@a11y-lens/cli@0.4.0': {}
+  '@a11y-lens/cli@0.4.1': {}
 
   '@adobe/css-tools@4.4.4': {}
 


### PR DESCRIPTION
## What

Bumps the `@a11y-lens/cli` devDependency `^0.4.0` → `^0.4.1`.

0.4.1 lands the fixes reported back from using the tool on this repo:
- `cat` shell-out replaced with `readFileSync` (Windows portability + `-`-prefixed filenames)
- a diagnostic hint when multiple files arrive as one whitespace-joined argument (instead of silently skipping them)
- a README note that a11y-lens is a **sampling** reviewer — a clean run ≠ zero issues; intended for `--staged` diff gating, not full-codebase audit

## Safety

- Zero-dependency package (lock snapshot `{}`) — no new transitive surface.
- `pnpm install --frozen-lockfile` passes (CI-consistent).
- CLI surface (`check --staged`, flags, bin, engines) identical to 0.4.0 — the pre-commit hook contract is unchanged.
- Scope: `package.json` + `pnpm-lock.yaml` only.

## Adversarial review

Independent refute-first review (fresh context): npm integrity matches the lockfile byte-for-byte, self-published by the repo author with no install scripts, tarball diff limited to README/version/`staged.mjs`. **Ship** — no blocker/high findings (one nit is an upstream dead import, not in this repo). Record: `.work/reviews/chore__bump-a11y-lens.md` (HEAD `5278666`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI development dependency to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->