### PR TITLE
docs: self-contained EAS receiver example + build upload field table

### DIFF
--- a/docs/guide/build-expo-eas.md
+++ b/docs/guide/build-expo-eas.md
@@ -59,7 +59,60 @@ curl -X POST "$TAPFLOW_RELAY_URL/api/v1/builds" \
 
 The bundle ID, version, and build number are extracted automatically from the uploaded build, so there is nothing to type in.
 
-To upload automatically when an EAS build finishes, add a small receiver that takes the EAS Webhook completion event, downloads the artifact URL, and makes the same request above. tapflow's job is to accept that standard multipart upload.
+### Automating the upload with an EAS webhook
+
+The curl above is a manual upload. To run it automatically when an EAS build finishes, point an [EAS webhook](https://docs.expo.dev/eas/webhooks/) at a small receiver you host. tapflow does not receive the EAS webhook directly; it only accepts the standard multipart upload. The receiver bridges the two: it verifies the event, downloads the artifact, and POSTs it to the relay.
+
+```
+EAS build finishes
+  → EAS webhook       → your receiver: verify signature → download artifact
+                      → POST /api/v1/builds (tapflow relay)
+  → Build appears in App Center → team reviews
+  → status → Done / Rejected  → tapflow webhook → Slack · next deploy step
+```
+
+A minimal receiver (Node):
+
+```js
+import express from 'express'
+import crypto from 'crypto'
+
+const app = express()
+app.use(express.raw({ type: 'application/json' })) // EAS signs the raw body
+
+app.post('/eas', async (req, res) => {
+  // 1. Verify the expo-signature header (HMAC-SHA1 of the raw body)
+  const expected = 'sha1=' + crypto.createHmac('sha1', process.env.EAS_WEBHOOK_SECRET).update(req.body).digest('hex')
+  const got = Buffer.from(req.get('expo-signature') ?? '')
+  if (got.length !== expected.length || !crypto.timingSafeEqual(got, Buffer.from(expected))) {
+    return res.status(401).end()
+  }
+
+  const build = JSON.parse(req.body.toString())
+  if (build.status !== 'finished') return res.status(200).end() // ignore errored / canceled
+
+  // 2. Download the artifact (iOS .tar.gz / Android .apk)
+  const artifact = await fetch(build.artifacts.applicationArchiveUrl).then((r) => r.arrayBuffer())
+  const name = build.platform === 'ios' ? 'build.tar.gz' : 'build.apk'
+
+  // 3. Hand it to tapflow — the same multipart upload as the curl above
+  const form = new FormData()
+  form.append('file', new Blob([artifact]), name)
+  form.append('status', 'In Progress')
+  const up = await fetch(`${process.env.TAPFLOW_RELAY_URL}/api/v1/builds`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${process.env.TAPFLOW_PAT}` },
+    body: form,
+  })
+  res.status(up.ok ? 200 : 502).end()
+})
+
+app.listen(3000)
+```
+
+Set the same secret on both sides: pass it to `eas webhook:create --event BUILD` and read it from `EAS_WEBHOOK_SECRET` in the receiver. Mind the direction — EAS signs with **HMAC-SHA1** (`expo-signature`), whereas tapflow's own outbound webhooks use HMAC-SHA256 (see [Webhooks](/guide/build-status-webhooks)).
+
+If you'd rather not host a service, an EAS webhook can instead trigger a GitHub Actions run via `repository_dispatch`, and the workflow does the download-and-POST — the same three steps, with no always-on receiver.
 
 ## 4. The team tests in the browser
 

--- a/docs/ko/guide/build-expo-eas.md
+++ b/docs/ko/guide/build-expo-eas.md
@@ -59,7 +59,60 @@ curl -X POST "$TAPFLOW_RELAY_URL/api/v1/builds" \
 
 bundle ID, 버전, 빌드 번호는 업로드한 빌드에서 자동으로 추출되므로 따로 입력하지 않아도 됩니다.
 
-EAS Build가 끝나는 시점에 자동으로 올리려면 작은 수신 엔드포인트를 하나 둡니다. EAS Webhook의 완료 알림을 받아 산출물 URL을 내려받은 뒤 위 요청을 그대로 호출하면 됩니다. tapflow는 이 표준 멀티파트 업로드를 받는 것까지 책임집니다.
+### EAS 웹훅으로 업로드 자동화
+
+위 curl은 수동 업로드입니다. EAS Build가 끝나는 시점에 자동으로 올리려면, 직접 호스팅하는 작은 수신 엔드포인트로 [EAS 웹훅](https://docs.expo.dev/eas/webhooks/)을 보내면 됩니다. tapflow는 EAS 웹훅을 직접 받지 않고 표준 멀티파트 업로드만 받으므로, 이 수신 엔드포인트가 둘을 잇습니다. 이벤트를 검증하고, 산출물을 내려받고, relay로 POST합니다.
+
+```
+EAS Build 완료
+  → EAS 웹훅          → 수신 엔드포인트: 서명 검증 → 산출물 다운로드
+                      → POST /api/v1/builds (tapflow relay)
+  → App Center에 빌드 등장 → 팀 리뷰
+  → 상태 → Done / Rejected → tapflow 웹훅 → Slack · 다음 배포 단계
+```
+
+간단한 수신 엔드포인트 예시입니다(Node).
+
+```js
+import express from 'express'
+import crypto from 'crypto'
+
+const app = express()
+app.use(express.raw({ type: 'application/json' })) // EAS는 원본 본문에 서명한다
+
+app.post('/eas', async (req, res) => {
+  // 1. expo-signature 헤더 검증 (원본 본문의 HMAC-SHA1)
+  const expected = 'sha1=' + crypto.createHmac('sha1', process.env.EAS_WEBHOOK_SECRET).update(req.body).digest('hex')
+  const got = Buffer.from(req.get('expo-signature') ?? '')
+  if (got.length !== expected.length || !crypto.timingSafeEqual(got, Buffer.from(expected))) {
+    return res.status(401).end()
+  }
+
+  const build = JSON.parse(req.body.toString())
+  if (build.status !== 'finished') return res.status(200).end() // errored / canceled 무시
+
+  // 2. 산출물 다운로드 (iOS .tar.gz / Android .apk)
+  const artifact = await fetch(build.artifacts.applicationArchiveUrl).then((r) => r.arrayBuffer())
+  const name = build.platform === 'ios' ? 'build.tar.gz' : 'build.apk'
+
+  // 3. tapflow로 넘기기 — 위 curl과 동일한 멀티파트 업로드
+  const form = new FormData()
+  form.append('file', new Blob([artifact]), name)
+  form.append('status', 'In Progress')
+  const up = await fetch(`${process.env.TAPFLOW_RELAY_URL}/api/v1/builds`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${process.env.TAPFLOW_PAT}` },
+    body: form,
+  })
+  res.status(up.ok ? 200 : 502).end()
+})
+
+app.listen(3000)
+```
+
+양쪽에 같은 시크릿을 설정합니다. `eas webhook:create --event BUILD`에 넘긴 값을 수신 쪽에서 `EAS_WEBHOOK_SECRET`으로 읽습니다. 서명 방식의 방향에 주의하세요. EAS는 **HMAC-SHA1**(`expo-signature`)로 서명하는 반면, tapflow의 발신 웹훅은 HMAC-SHA256을 씁니다([웹훅](/ko/guide/build-status-webhooks) 참고).
+
+서비스를 상시 띄우기 부담스럽다면, EAS 웹훅이 `repository_dispatch`로 GitHub Actions 실행을 트리거하고 워크플로가 다운로드와 POST를 대신하게 할 수도 있습니다. 같은 세 단계이고 상시 수신 서버가 필요 없습니다.
 
 ## 4. 팀이 브라우저에서 테스트
 

--- a/docs/ko/reference/api.md
+++ b/docs/ko/reference/api.md
@@ -280,17 +280,20 @@ Body (JSON):
 ```
 Content-Type: multipart/form-data
 Authorization: Bearer tflw_pat_<token>  (또는 세션 쿠키)
-
-Fields:
-  file    .app.zip (iOS) 또는 .apk (Android) — 최대 500MB  필수
-  status  Backlog | In Progress | Done | Rejected            선택
-  label   커스텀 레이블 (예: "rc-1", "hotfix")               선택
-  app_id  기존 App에 명시적으로 연결                          선택
 ```
 
+`file`만 필수이고 나머지는 모두 선택입니다.
+
+| 필드 | 필수 | 설명 |
+|------|------|------|
+| `file` | 필수 | 빌드 산출물. iOS는 `.app.zip` 또는 `.tar.gz`/`.tgz`(EAS 시뮬레이터 빌드), Android는 `.apk`입니다. 최대 500MB이고 `.ipa`·`.aab`는 거부됩니다. |
+| `status` | 선택 | 초기 리뷰 상태로 `Backlog`, `In Progress`, `Done`, `Rejected` 중 하나입니다. 생략하면 미설정으로 둡니다. |
+| `label` | 선택 | App Center에서 빌드를 식별하는 자유 텍스트 레이블입니다(예: 브랜치명이나 `rc-1`). |
+| `platform` | 선택 | `ios` 또는 `android`입니다. 생략하면 파일 형식에서 자동으로 정해집니다. |
+| `app_id` | 선택 | 기존 앱에 명시적으로 연결합니다. 보통은 bundle ID로 앱이 자동 결정됩니다. |
+
 ::: warning iOS 빌드 주의사항
-`.ipa` 파일은 지원하지 않습니다. `.app.zip`만 허용됩니다.
-`xcodebuild -sdk iphonesimulator`로 빌드한 `.app` 폴더를 zip으로 압축하세요.
+`.ipa` 파일은 지원하지 않습니다. `.app.zip`을 올리거나, `eas build`가 시뮬레이터용으로 만드는 `.tar.gz`/`.tgz`를 올리세요. `xcodebuild -sdk iphonesimulator`로 빌드한 `.app` 폴더를 zip으로 압축하거나 EAS 시뮬레이터 프로필을 사용하면 됩니다.
 :::
 
 **응답 `201`**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -280,17 +280,20 @@ Upload a build.
 ```
 Content-Type: multipart/form-data
 Authorization: Bearer tflw_pat_<token>  (or session cookie)
-
-Fields:
-  file    .app.zip (iOS) or .apk (Android) — max 500 MB  required
-  status  Backlog | In Progress | Done | Rejected          optional
-  label   custom label (e.g. "rc-1", "hotfix")             optional
-  app_id  link to an existing App explicitly               optional
 ```
 
+Only `file` is required; every other field is optional.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `file` | Yes | The build artifact. iOS: `.app.zip` or `.tar.gz` / `.tgz` (an EAS simulator build); Android: `.apk`. Max 500 MB. `.ipa` and `.aab` are rejected. |
+| `status` | No | Initial review status — one of `Backlog`, `In Progress`, `Done`, `Rejected`. Omit to leave it unset. |
+| `label` | No | Free-text label to identify the build in App Center (e.g. a branch name or `rc-1`). |
+| `platform` | No | `ios` or `android`. Derived from the file type when omitted. |
+| `app_id` | No | Attach to an existing app explicitly. Normally the app is resolved automatically from the bundle ID. |
+
 ::: warning iOS builds
-`.ipa` files are not supported. Use `.app.zip` only.
-Build with `xcodebuild -sdk iphonesimulator`, then zip the `.app` folder.
+`.ipa` files are not supported. Upload `.app.zip`, or the `.tar.gz` / `.tgz` that `eas build` produces for the simulator. Build with `xcodebuild -sdk iphonesimulator` and zip the `.app` folder, or use the EAS simulator profile.
 :::
 
 **Response `201`**


### PR DESCRIPTION
## What
Two docs gaps found during manual E2E:

- **EAS receiver (plan G)** — the Expo build guide stopped at "add a small receiver". This adds a self-contained one (EN + KO): verify the `expo-signature` (HMAC-SHA1) → download `artifacts.applicationArchiveUrl` → POST the multipart upload, with a full-pipeline diagram, a `repository_dispatch` alternative, and a cross-link to the outbound [Webhooks](/guide/build-status-webhooks) guide (EAS signs SHA1; tapflow's outbound signs SHA256).
- **Build upload fields (plan M5)** — `POST /api/v1/builds` in the API reference now lists fields as a required/optional table, adds the missing `platform` field, and notes that `.tar.gz` / `.tgz` simulator builds are accepted (the doc still said `.app.zip` only).

`build-status-webhooks.md` already carried the direction contrast and reverse cross-link, so it is unchanged.

## Why
Real confusion surfaced in E2E: EAS→tapflow automation looked undocumented (the receiver is a user-built bridge tapflow doesn't ship), and the upload API didn't make required vs optional fields clear or mention the `.tar.gz` path shipped earlier.

## Scope
Docs-only. Facts verified against `handleUploadBuild` in `packages/relay/src/api/builds.ts`.

## Review
Docs-only → adversarial review skipped per AGENTS.md; record at `.work/reviews/docs__eas-receiver-and-build-api.md` (HEAD 319f5a3). Checks: `pnpm docs:build` pass, ai-tells detect KO/EN grade A, pre-commit typecheck+lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for automating EAS build uploads with webhooks.
  * Included a Node/Express receiver example and a GitHub Actions alternative.
  * Clarified webhook signature handling and secret configuration.
  * Updated build upload API documentation to identify required and optional fields.
  * Expanded iOS artifact guidance to support simulator `.tar.gz` and `.tgz` files, while documenting unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->