### PR TITLE
chore: release v0.15.0 — unified .tapflow/ layout + hardened Android build ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-20
+
 ### Added
 
+- `tapflow migrate data-dir` — a one-shot command that moves a legacy `.tapflow-data/` into the unified `.tapflow/data/` layout: atomic rename (no copy, no data loss), repoints `local.dataDir` in `tapflow.config.json` when it pinned the old default, and updates `.gitignore`. Idempotent; conflicting or cross-filesystem states stop with manual guidance.
 - `tapflow setup android` installs Android `build-tools` (pinned `35.0.0`), and `tapflow doctor` gains an `aapt (build-tools)` check — apk metadata extraction needs it.
 
 ### Breaking Changes
@@ -287,7 +290,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic `tapflow.config.json` creation as a side effect of `tapflow start` / `tapflow relay start`.
 
-[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/jo-duchan/tapflow/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/jo-duchan/tapflow/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/jo-duchan/tapflow/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/jo-duchan/tapflow/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/jo-duchan/tapflow/compare/v0.11.1...v0.12.0

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @tapflowio/agent-core
 
+## 0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/agent-core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "DeviceAgent interface, AgentRegistry, and shared utilities for tapflow agents",
   "keywords": [
     "tapflow",

--- a/packages/android-agent/CHANGELOG.md
+++ b/packages/android-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/android-agent
 
+## 0.15.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.15.0
+- @tapflowio/audiotap-helper@0.2.5
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/android-agent",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Android emulator agent for tapflow — ADB control and scrcpy H.264 streaming",
   "keywords": [
     "tapflow",

--- a/packages/audiotap-helper/CHANGELOG.md
+++ b/packages/audiotap-helper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/audiotap-helper
 
+## 0.2.5
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.15.0
+
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/audiotap-helper/package.json
+++ b/packages/audiotap-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/audiotap-helper",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Shared macOS Core Audio process-tap helper for tapflow — iOS simulator audio capture and Android emulator host-mute",
   "keywords": [
     "tapflow",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # tapflow
 
+## 0.15.0
+
+### Minor Changes
+
+- Unify project state under a single `.tapflow/` root and harden Android build ingestion.
+
+  - **Breaking — default data directory moved** from `.tapflow-data/` to `.tapflow/data/`, unifying all project state under one `.tapflow/` root (`data/` runtime, `flows/` committed, `artifacts/` screenshots). Existing installs keep working without action — a pinned `local.dataDir` is honored and a config-less default install keeps reading a pre-existing `.tapflow-data/`. Run `tapflow migrate data-dir` once to unify the layout (atomic rename, no data loss; repoints `local.dataDir` and updates `.gitignore`). Docker: remount your data volume at `/app/.tapflow/data`.
+  - **Breaking — stricter APK ingestion.** `POST /api/v1/builds` now returns `400` for an `.apk` uploaded with `app_id` when the relay can't read the APK's package name (Android build-tools / `aapt` missing, or the archive is unreadable), instead of storing an unversioned build under that app. Install build-tools with `tapflow setup android`, or omit `app_id` to file the build separately.
+  - Added `tapflow migrate data-dir`, an Android `build-tools` install in `tapflow setup android`, and an `aapt (build-tools)` check in `tapflow doctor`.
+  - `tapflow flow run` writes failure screenshots to `.tapflow/artifacts/` by default, matching the `--artifacts` help text.
+  - Fixed: an `.apk` with unreadable metadata is no longer merged into an unrelated app or false-promoted to platform `both`; `tapflow doctor` and the relay now share the same `aapt` search paths.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tapflowio/relay@0.15.0
+  - @tapflowio/android-agent@0.15.0
+  - @tapflowio/ios-agent@0.15.0
+  - @tapflowio/agent-core@0.15.0
+  - @tapflowio/flow-runner@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapflow",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Self-hosted iOS/Android simulator streaming for the whole team",
   "keywords": [
     "ios",

--- a/packages/flow-runner/CHANGELOG.md
+++ b/packages/flow-runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/flow-runner
 
+## 0.15.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/flow-runner/package.json
+++ b/packages/flow-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/flow-runner",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Deterministic YAML flow runner for tapflow — replay UI test flows against simulators/emulators with zero LLM calls",
   "keywords": [
     "tapflow",

--- a/packages/ios-agent/CHANGELOG.md
+++ b/packages/ios-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tapflowio/ios-agent
 
+## 0.15.0
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.15.0
+- @tapflowio/audiotap-helper@0.2.5
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/ios-agent",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "iOS simulator agent for tapflow — xcrun simctl control and screen streaming",
   "keywords": [
     "tapflow",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tapflowio/mcp-server
 
+## 0.15.0
+
+### Patch Changes
+
+- @tapflowio/flow-runner@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/mcp-server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "MCP server for tapflow — lets LLM agents control iOS/Android simulators via Model Context Protocol",
   "keywords": [
     "tapflow",

--- a/packages/relay/CHANGELOG.md
+++ b/packages/relay/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @tapflowio/relay
 
+## 0.15.0
+
+### Minor Changes
+
+- Unify project state under a single `.tapflow/` root and harden Android build ingestion.
+
+  - **Breaking — default data directory moved** from `.tapflow-data/` to `.tapflow/data/`, unifying all project state under one `.tapflow/` root (`data/` runtime, `flows/` committed, `artifacts/` screenshots). Existing installs keep working without action — a pinned `local.dataDir` is honored and a config-less default install keeps reading a pre-existing `.tapflow-data/`. Run `tapflow migrate data-dir` once to unify the layout (atomic rename, no data loss; repoints `local.dataDir` and updates `.gitignore`). Docker: remount your data volume at `/app/.tapflow/data`.
+  - **Breaking — stricter APK ingestion.** `POST /api/v1/builds` now returns `400` for an `.apk` uploaded with `app_id` when the relay can't read the APK's package name (Android build-tools / `aapt` missing, or the archive is unreadable), instead of storing an unversioned build under that app. Install build-tools with `tapflow setup android`, or omit `app_id` to file the build separately.
+  - Added `tapflow migrate data-dir`, an Android `build-tools` install in `tapflow setup android`, and an `aapt (build-tools)` check in `tapflow doctor`.
+  - `tapflow flow run` writes failure screenshots to `.tapflow/artifacts/` by default, matching the `--artifacts` help text.
+  - Fixed: an `.apk` with unreadable metadata is no longer merged into an unrelated app or false-promoted to platform `both`; `tapflow doctor` and the relay now share the same `aapt` search paths.
+
+### Patch Changes
+
+- @tapflowio/agent-core@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapflowio/relay",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "WebSocket relay server for tapflow — NAT traversal, session routing, JWT auth, bundled dashboard",
   "keywords": [
     "tapflow",


### PR DESCRIPTION
Release **v0.15.0** (minor). No source changes — version bumps + CHANGELOG only.

## Versions

| Package | From → To |
|---------|-----------|
| `tapflow`, `@tapflowio/{agent-core,ios-agent,android-agent,relay,flow-runner,mcp-server}` (fixed group) | 0.14.0 → **0.15.0** |
| `@tapflowio/audiotap-helper` | 0.2.4 → **0.2.5** (internal `agent-core` dep update) |
| `@tapflowio/dashboard`, `@tapflowio/playground` | ignored (private) |

## Theme — Unified `.tapflow/` layout + hardened Android build ingestion

### ⚠️ Breaking (with migration)

- **Default data dir moved** `.tapflow-data/` → `.tapflow/data/`. **Existing installs keep working without action** (a pinned `local.dataDir` is honored; a config-less default install keeps reading a pre-existing `.tapflow-data/`). Run `tapflow migrate data-dir` once to unify — atomic rename, no data loss, repoints config + `.gitignore`. **Docker:** remount your volume at `/app/.tapflow/data`.
- **Stricter APK ingestion:** `POST /api/v1/builds` returns `400` for an `.apk` with `app_id` when the relay can't read its package name (missing Android build-tools/`aapt`, or unreadable archive). Fix: `tapflow setup android`, or omit `app_id`.

### Added
`tapflow migrate data-dir` · `tapflow setup android` build-tools install · `tapflow doctor` aapt check.

### Changed
`tapflow flow run` failure screenshots default to `.tapflow/artifacts/`.

## Compatibility (why minor, not major)

0.x convention: breaking changes ride the minor position. Both breaking changes have documented migrations and preserve existing installs. Interface changes (new CLI command, dataDir default, builds 400) are backward-compatible for current users — verified by the shipped PRs' tests (`config.test.ts` precedence, `dataDir.test.ts` read-only fallback, `builds-apk-guard.test.ts`) and their adversarial reviews (#394, #393).

## Release mechanics
- Fixed group bumped together; `audiotap-helper` patch is a correct internal-dep bump. Lockfile unchanged. typecheck·lint·a11y green.
- Adversarial review: skipped (version bump) — record at `.work/reviews/release__v0.15.0.md` @ HEAD `ff96483986a3d86239dc7e481dcab4b8e8cbeb72`. Shipped code was reviewed on #394 / #393.
- **Do not merge from CI** — after merge, a `v0.15.0` tag on the merge commit triggers `release.yml` (changeset publish + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration support for moving project data to `.tapflow/data/`, with optional configuration updates and `.gitignore` changes.
  * Added Android setup and verification guidance, including `aapt` checks through `tapflow doctor`.
  * Failure screenshots now default to `.tapflow/artifacts/`.

* **Bug Fixes**
  * Improved Android APK handling when package metadata cannot be read, preventing incorrect app association.

* **Documentation**
  * Published release notes for version 0.15.0 across supported packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->