### PR TITLE
fix(flow-runner): retry transient ui-tree query errors while polling

### DIFF
--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -1,6 +1,20 @@
 import { WebSocket } from 'ws'
 import type { UIElement } from '@tapflowio/agent-core'
 import { PlatformError } from '@tapflowio/agent-core'
+import { TransientQueryError } from './errors.js'
+
+// Carries the HTTP status so ui-tree queries can tell a transient failure (retry) from a permanent one.
+// status 0 marks a network-level failure (fetch rejected before a response).
+class RelayHttpError extends PlatformError {
+  constructor(message: string, readonly status: number, options?: ErrorOptions) {
+    super(message, options)
+  }
+}
+
+// Statuses that won't self-heal by polling: bad request, auth, missing session, device-not-booted
+// (a flow always boots first, so mid-flow 409 is a dead device, not a race). Everything else
+// (agent/foreground-race 502, idle-timeout 504, 5xx, network 0) is retryable.
+const PERMANENT_QUERY_STATUSES = new Set([400, 401, 403, 404, 409])
 
 export interface DeviceInfo {
   id: string
@@ -213,10 +227,16 @@ export class RelayClient {
     return this.relayUrl.replace(/^wss?/, (p) => (p === 'wss' ? 'https' : 'http'))
   }
 
-  private async getJson<T>(path: string, what: string): Promise<T> {
-    const res = await fetch(new URL(path, this.httpBase()).toString(), {
-      headers: this.token ? { Authorization: `Bearer ${this.token}` } : undefined,
-    })
+  private async getJson<T>(path: string, what: string, signal?: AbortSignal): Promise<T> {
+    let res: Response
+    try {
+      res = await fetch(new URL(path, this.httpBase()).toString(), {
+        headers: this.token ? { Authorization: `Bearer ${this.token}` } : undefined,
+        signal,
+      })
+    } catch (e) {
+      throw new RelayHttpError(`${what} failed: ${(e as Error).message}`, 0, { cause: e })
+    }
     if (!res.ok) {
       const text = await res.text().catch(() => '')
       let message = text || `${what} failed: ${res.status}`
@@ -224,14 +244,23 @@ export class RelayClient {
         const body = JSON.parse(text) as { error?: string }
         if (body.error) message = body.error
       } catch { /* keep raw text */ }
-      throw new PlatformError(message)
+      throw new RelayHttpError(message, res.status)
     }
     return (await res.json()) as T
   }
 
-  async queryUITree(sessionId: string): Promise<UIElement[]> {
-    const body = await this.getJson<{ elements?: UIElement[] }>(`/api/v1/sessions/${sessionId}/ui-tree`, 'ui-tree query')
-    return body.elements ?? []
+  async queryUITree(sessionId: string, signal?: AbortSignal): Promise<UIElement[]> {
+    try {
+      const body = await this.getJson<{ elements?: UIElement[] }>(`/api/v1/sessions/${sessionId}/ui-tree`, 'ui-tree query', signal)
+      return body.elements ?? []
+    } catch (e) {
+      // A retryable condition (foreground race, idle timeout, agent blip, network) → let the runner
+      // poll again until the step deadline. Permanent failures keep their type and fail the step now.
+      if (e instanceof RelayHttpError && !PERMANENT_QUERY_STATUSES.has(e.status)) {
+        throw new TransientQueryError(e.message, { cause: e })
+      }
+      throw e
+    }
   }
 
   async screenshot(sessionId: string): Promise<Buffer> {

--- a/packages/flow-runner/src/RelayDriver.ts
+++ b/packages/flow-runner/src/RelayDriver.ts
@@ -11,7 +11,7 @@ export class RelayDriver implements FlowDriver {
     private readonly buildId?: number,
   ) {}
 
-  queryUITree() { return this.client.queryUITree(this.sessionId) }
+  queryUITree(signal?: AbortSignal) { return this.client.queryUITree(this.sessionId, signal) }
 
   async tap(x: number, y: number): Promise<void> {
     this.client.tap(this.sessionId, x, y)

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { RelayClient } from '../RelayClient.js'
+import { TransientQueryError } from '../errors.js'
+
+// Minimal Response stub for the ui-tree GET.
+function jsonResponse(status: number, body: unknown): Response {
+  const text = JSON.stringify(body)
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => JSON.parse(text) as unknown,
+  } as unknown as Response
+}
+
+function client(): RelayClient {
+  return new RelayClient('ws://localhost:4000', 'tok')
+}
+
+describe('RelayClient.queryUITree — transient vs permanent classification', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('200 → returns elements', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(200, { elements: [{ role: 'button', label: 'x', frame: { x: 0, y: 0, width: 1, height: 1 }, enabled: true }] }))
+    const els = await client().queryUITree('s1')
+    expect(els).toHaveLength(1)
+  })
+
+  it.each([502, 504, 500, 503])('%d → TransientQueryError (retryable)', async (status) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(status, { error: 'transient' }))
+    await expect(client().queryUITree('s1')).rejects.toBeInstanceOf(TransientQueryError)
+  })
+
+  it.each([400, 401, 403, 404, 409])('%d → NOT transient (fail-fast)', async (status) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(status, { error: 'nope' }))
+    const err = await client().queryUITree('s1').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(TransientQueryError)
+  })
+
+  it('network failure (fetch rejects) → TransientQueryError, preserving the original cause', async () => {
+    const original = new Error('ECONNREFUSED')
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(original)
+    const err = await client().queryUITree('s1').catch((e: unknown) => e as Error)
+    expect(err).toBeInstanceOf(TransientQueryError)
+    expect((err.cause as Error).cause).toBe(original) // original fetch error chained through the wrappers
+  })
+
+  it('a stalled request aborted by the signal → TransientQueryError (never hangs)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_url, opts) =>
+      new Promise<Response>((_resolve, reject) => {
+        (opts as RequestInit | undefined)?.signal?.addEventListener('abort', () => reject(new DOMException('timed out', 'TimeoutError')))
+      }),
+    )
+    await expect(client().queryUITree('s1', AbortSignal.timeout(10))).rejects.toBeInstanceOf(TransientQueryError)
+  })
+
+  it('carries the server error message', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(502, { error: 'is the app running in the foreground?' }))
+    await expect(client().queryUITree('s1')).rejects.toThrow('is the app running in the foreground?')
+  })
+})

--- a/packages/flow-runner/src/__tests__/engine.test.ts
+++ b/packages/flow-runner/src/__tests__/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { UIElement } from '@tapflowio/agent-core'
 import { runFlow, type FlowDriver } from '../engine.js'
 import { parseFlow } from '../schema.js'
+import { TransientQueryError } from '../errors.js'
 
 const el = (over: Partial<UIElement>): UIElement => ({
   role: 'button',
@@ -84,6 +85,46 @@ describe('runFlow', () => {
     expect(driver.queryUITree).toHaveBeenCalledTimes(3)
   })
 
+  it('retries a transient query error (foreground race), then resolves', async () => {
+    const driver = fakeDriver([[]])
+    let n = 0
+    driver.queryUITree = vi.fn(async () => {
+      if (n++ === 0) throw new TransientQueryError('is the app running in the foreground?')
+      return [el({ label: 'OK' })]
+    })
+    const result = await runFlow(flowOf('steps:\n  - tapOn: "OK"\n'), driver, { ...OPTS, defaultTimeoutMs: 500 })
+    expect(result.status).toBe('passed')
+    expect(driver.queryUITree).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails at the deadline surfacing the last transient query error', async () => {
+    const driver = fakeDriver([[]])
+    driver.queryUITree = vi.fn(async () => { throw new TransientQueryError('is the app running in the foreground?') })
+    const result = await runFlow(flowOf('steps:\n  - tapOn: "OK"\n'), driver, OPTS)
+    expect(result.status).toBe('failed')
+    expect(result.failureMessage).toContain('last query error: is the app running in the foreground?')
+  })
+
+  it('fails immediately on a non-transient query error (no retry)', async () => {
+    const driver = fakeDriver([[]])
+    driver.queryUITree = vi.fn(async () => { throw new Error('Session not found') })
+    const result = await runFlow(flowOf('steps:\n  - tapOn: "OK"\n'), driver, OPTS)
+    expect(result.status).toBe('failed')
+    expect(result.failureMessage).toContain('Session not found')
+    expect(driver.queryUITree).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not hang when a query stalls — the deadline aborts it and the step fails', async () => {
+    const driver = fakeDriver([[]])
+    // The query never resolves on its own; only the engine's deadline AbortSignal ends it.
+    driver.queryUITree = vi.fn((signal?: AbortSignal) => new Promise<UIElement[]>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(new TransientQueryError('query aborted at deadline')))
+    }))
+    const result = await runFlow(flowOf('steps:\n  - tapOn: "OK"\n'), driver, OPTS)
+    expect(result.status).toBe('failed')
+    expect(driver.queryUITree.mock.calls[0][0]).toBeInstanceOf(AbortSignal) // engine passed a bounding signal
+  })
+
   it('fails with a timeout, captures a screenshot, and skips remaining steps', async () => {
     const driver = fakeDriver([[]])
     const result = await runFlow(flowOf('steps:\n  - tapOn: "없는버튼"\n  - pressKey: Enter\n'), driver, OPTS)
@@ -110,6 +151,29 @@ describe('runFlow', () => {
     const driver = fakeDriver([[el({ label: '항목' }), el({ label: '항목' })]])
     const result = await runFlow(flowOf('steps:\n  - assertVisible: "항목"\n'), driver, OPTS)
     expect(result.status).toBe('passed')
+  })
+
+  it('assertVisible retries a transient query error, then passes', async () => {
+    const driver = fakeDriver([[]])
+    let n = 0
+    driver.queryUITree = vi.fn(async () => {
+      if (n++ === 0) throw new TransientQueryError('foreground?')
+      return [el({ label: '항목' })]
+    })
+    const result = await runFlow(flowOf('steps:\n  - assertVisible: "항목"\n'), driver, { ...OPTS, defaultTimeoutMs: 500 })
+    expect(result.status).toBe('passed')
+    expect(driver.queryUITree).toHaveBeenCalledTimes(2)
+  })
+
+  it('assertNotVisible does not treat a transient error as "gone" (element still present)', async () => {
+    const driver = fakeDriver([[]])
+    let n = 0
+    driver.queryUITree = vi.fn(async () => {
+      if (n++ === 0) throw new TransientQueryError('foreground?')
+      return [el({ label: '오류' })] // still present after the transient blip
+    })
+    const result = await runFlow(flowOf('steps:\n  - assertNotVisible: "오류"\n'), driver, OPTS)
+    expect(result.status).toBe('failed') // must not pass on the transient poll
   })
 
   it('maps scroll directions to swipes (direction = where to reveal content)', async () => {

--- a/packages/flow-runner/src/engine.ts
+++ b/packages/flow-runner/src/engine.ts
@@ -1,11 +1,13 @@
 import type { UIElement } from '@tapflowio/agent-core'
 import type { Flow, Selector, Step, ScrollDirection } from './schema.js'
+import { TransientQueryError } from './errors.js'
 
 // Transport-agnostic device surface the engine drives (DIP): the relay-backed
 // implementation lives in RelayDriver, tests use fakes, and mcp-server adapts
 // its own client. All coordinates are normalized 0-1.
 export interface FlowDriver {
-  queryUITree(): Promise<UIElement[]>
+  // Optional AbortSignal so a stalled query can't block the poll loop past the step deadline.
+  queryUITree(signal?: AbortSignal): Promise<UIElement[]>
   tap(x: number, y: number): Promise<void>
   swipe(from: [number, number], to: [number, number], durationMs: number): Promise<void>
   inputText(text: string): Promise<void>
@@ -99,6 +101,23 @@ export function matchSelector(tree: UIElement[], sel: Selector): UIElement[] {
 
 class StepFailure extends Error {}
 
+// Query the tree, surfacing a transient failure (foreground race, idle timeout, agent/network blip)
+// so the polling caller keeps waiting until its deadline. Permanent failures propagate and fail now.
+// The query is bounded by an AbortSignal set to the remaining deadline so a stalled response can't
+// block the loop past the step's timeout.
+async function queryOrRetry(driver: FlowDriver, deadline: number): Promise<{ tree: UIElement[] } | { transient: string }> {
+  try {
+    return { tree: await driver.queryUITree(AbortSignal.timeout(Math.max(1, deadline - Date.now()))) }
+  } catch (e) {
+    if (e instanceof TransientQueryError) return { transient: e.message }
+    throw e
+  }
+}
+
+function withLastError(base: string, lastError: string | undefined): string {
+  return lastError ? `${base} (last query error: ${lastError})` : base
+}
+
 async function resolveOne(
   driver: FlowDriver,
   sel: Selector,
@@ -106,15 +125,22 @@ async function resolveOne(
   pollIntervalMs: number,
 ): Promise<UIElement> {
   const deadline = Date.now() + (sel.timeoutMs ?? timeoutMs)
+  let lastError: string | undefined
   for (;;) {
-    const matches = matchSelector(await driver.queryUITree(), sel)
-    if (matches.length === 1) return matches[0]
-    if (matches.length > 1) {
-      const described = matches.slice(0, 5).map((m) => `${m.role} "${m.label}"${m.identifier ? ` id=${m.identifier}` : ''}`).join(' | ')
-      throw new StepFailure(`${matches.length} elements match ${describeSelector(sel)} — make the selector unique (candidates: ${described})`)
+    const q = await queryOrRetry(driver, deadline)
+    if ('tree' in q) {
+      lastError = undefined // a successful query clears any earlier transient error
+      const matches = matchSelector(q.tree, sel)
+      if (matches.length === 1) return matches[0]
+      if (matches.length > 1) {
+        const described = matches.slice(0, 5).map((m) => `${m.role} "${m.label}"${m.identifier ? ` id=${m.identifier}` : ''}`).join(' | ')
+        throw new StepFailure(`${matches.length} elements match ${describeSelector(sel)} — make the selector unique (candidates: ${described})`)
+      }
+    } else {
+      lastError = q.transient
     }
     if (Date.now() >= deadline) {
-      throw new StepFailure(`no element matched ${describeSelector(sel)} within ${(sel.timeoutMs ?? timeoutMs) / 1000}s`)
+      throw new StepFailure(withLastError(`no element matched ${describeSelector(sel)} within ${(sel.timeoutMs ?? timeoutMs) / 1000}s`, lastError))
     }
     await delay(pollIntervalMs)
   }
@@ -122,10 +148,17 @@ async function resolveOne(
 
 async function waitVisible(driver: FlowDriver, sel: Selector, timeoutMs: number, pollIntervalMs: number): Promise<void> {
   const deadline = Date.now() + (sel.timeoutMs ?? timeoutMs)
+  let lastError: string | undefined
   for (;;) {
-    if (matchSelector(await driver.queryUITree(), sel).length > 0) return
+    const q = await queryOrRetry(driver, deadline)
+    if ('tree' in q) {
+      lastError = undefined // a successful query clears any earlier transient error
+      if (matchSelector(q.tree, sel).length > 0) return
+    } else {
+      lastError = q.transient
+    }
     if (Date.now() >= deadline) {
-      throw new StepFailure(`no element matched ${describeSelector(sel)} within ${(sel.timeoutMs ?? timeoutMs) / 1000}s`)
+      throw new StepFailure(withLastError(`no element matched ${describeSelector(sel)} within ${(sel.timeoutMs ?? timeoutMs) / 1000}s`, lastError))
     }
     await delay(pollIntervalMs)
   }
@@ -133,10 +166,18 @@ async function waitVisible(driver: FlowDriver, sel: Selector, timeoutMs: number,
 
 async function waitNotVisible(driver: FlowDriver, sel: Selector, timeoutMs: number, pollIntervalMs: number): Promise<void> {
   const deadline = Date.now() + (sel.timeoutMs ?? timeoutMs)
+  let lastError: string | undefined
   for (;;) {
-    if (matchSelector(await driver.queryUITree(), sel).length === 0) return
+    const q = await queryOrRetry(driver, deadline)
+    if ('tree' in q) {
+      lastError = undefined // a successful query clears any earlier transient error
+      if (matchSelector(q.tree, sel).length === 0) return
+    } else {
+      // A transient failure means we can't confirm the element is gone — keep polling, don't return.
+      lastError = q.transient
+    }
     if (Date.now() >= deadline) {
-      throw new StepFailure(`element ${describeSelector(sel)} is still visible after ${(sel.timeoutMs ?? timeoutMs) / 1000}s`)
+      throw new StepFailure(withLastError(`element ${describeSelector(sel)} is still visible after ${(sel.timeoutMs ?? timeoutMs) / 1000}s`, lastError))
     }
     await delay(pollIntervalMs)
   }

--- a/packages/flow-runner/src/errors.ts
+++ b/packages/flow-runner/src/errors.ts
@@ -1,0 +1,10 @@
+// A ui-tree query failure the runner should treat as transient — poll again until the step deadline
+// instead of failing the step (e.g. the app isn't in the foreground yet right after launch, or the
+// screen hasn't gone idle). Permanent failures (bad request, auth, missing session) are not wrapped
+// in this and fail the step immediately.
+export class TransientQueryError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'TransientQueryError'
+  }
+}


### PR DESCRIPTION
## Problem (L2)

Wait steps (`tapOn` / `assertVisible` / `assertNotVisible`) failed **immediately** when `queryUITree()` threw — most notably the app not being in the foreground yet right after `launchApp` (`"tree runner returned an unexpected response … is the app running in the foreground?"`, surfaced by the relay as **502**). The poll loops only retried on a *zero-match* result; a thrown query error propagated straight to a step failure. In real E2E this forced a **3s long-press (`from==to` swipe) as a sleep workaround** — an anti-pattern the "no sleep, condition-based waits" design was meant to avoid.

## Fix

The poll loops now distinguish **transient** from **permanent** query failures:

- `RelayClient.queryUITree` preserves the HTTP status (new local `RelayHttpError`) and throws a new `TransientQueryError` for retryable conditions — foreground race (502), idle-timeout (504), 5xx, network. `{400,401,403,404,409}` (bad request / auth / missing session / **not-booted** — a flow always boots first, so mid-flow 409 is a dead device, not a race) stay permanent and fail the step now.
- The engine's poll loops (`resolveOne` / `waitVisible` / `waitNotVisible`) swallow `TransientQueryError` until the step deadline via `queryOrRetry`, then fail with the last query error appended. A successful query clears the stale transient. Non-transient errors propagate immediately (fail-fast, driver called once).

This makes waits truly condition-based and also **softens L3** (idle 504 now retries).

## Scope

`tapflow flow run` (RelayClient) only. MCP `run_flow` uses its own `TapflowClient.queryUITree` which throws plain errors — unaffected (fail-fast as before, no regression); MCP parity is a follow-up.

`FlowDriver` interface unchanged; `TransientQueryError` is internal to flow-runner (not a public API change).

## Tests

`engine.test.ts`: retry-then-resolve, all-transient→deadline-with-last-error, non-transient→fail-fast-no-retry, `assertVisible` retry, `assertNotVisible` must-not-treat-transient-as-gone. `RelayClient.test.ts` (new): status classification boundary (502/504/500/503 → transient; 400/401/403/404/409 → permanent; network → transient; message preserved). flow-runner **47 pass**; cli 246 / mcp-server 30 no regression; typecheck·lint clean.

## Adversarial review

Independent context, refute-first, no authoring context shared. **No BLOCKER/MAJOR.** 3 MINOR fixed (stale last-error label, 409 classification, wait-path test coverage). Record: `.work/reviews/fix__flow-runner-transient-query-retry.md` @ HEAD `53c833792ad5f3812edb3244491f27f81ea4ebaa`.

Part of the **L cluster** (flow-runner/selector usability); L1 (role/nth selectors) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI-tree query handling with HTTP-status-aware transient vs permanent error classification.
  * Automatic retry now applies to transient failures (including network-level issues and server errors), while permanent errors fail fast with the server’s message when available.
  * Visibility assertions and flow timeouts now incorporate the last transient query error message and avoid false pass/fail outcomes.
  * Added support for cancellation via an optional abort signal to prevent stalled queries from hanging.
* **Tests**
  * Added/extended coverage for transient vs fail-fast behavior, retry-driven assertion outcomes, and abort/deadline handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->