### PR TITLE
docs: fix README demo video 404 for logged-out viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   </p>
 </div>
 
-<video src="https://github.com/user-attachments/assets/75652346-93cb-4261-9210-6a24b883d44a" controls width="100%"></video>
+<video src="https://github.com/user-attachments/assets/dbba8bde-74b6-4fb9-bdb6-3919bc4295c4" controls width="100%"></video>
 
 <p align="center"><em>Streams over H.264 with a zero-buffer decoder (no MSE) — <a href="contributing/streaming-latency-log.md">latency measurements ↗</a></em></p>
 


### PR DESCRIPTION
## Problem

The README demo video rendered for the repo owner but **404'd for logged-out / external viewers** (console: `Failed to load resource: 404` on `user-attachments/assets/…6a24b883d44a`). The asset was uploaded into an unsubmitted/draft context, so it was only accessible to the uploader — never finalized as public content.

## Fix

Re-hosted the video via a **submitted** public comment (#397), which mints a publicly accessible attachment, and swapped the new URL into `README.md:39`.

## Verification (anonymous, no auth)

```
new: 302 → 200 · content-type video/mp4 · ~5.9 MB   ✓ public
old: 404                                            (the bug)
```

Docs-only (one line). Review record: `.work/reviews/docs__fix-readme-demo-video.md`. Closes the manual step in #397 (that issue can be closed once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README demo video to use a refreshed media asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->