### PR TITLE
fix(readme): replace hrefless <a name> anchor to prevent reactnative.directory crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ What's included:
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), and Personal Access Tokens.
 - **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
-<a name="latency-note"></a>
+<span id="latency-note"></span>
 > <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [streaming latency log](contributing/streaming-latency-log.md) for the full measurements, conditions, and known limitations.
 
 ## Security & Privacy

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -162,7 +162,7 @@ What's included:
 - **Team management** — invite links, roles (Admin / Developer / QA / Viewer), and Personal Access Tokens.
 - **MCP Server** — `@tapflowio/mcp-server` lets Claude Code and other LLM agents control simulators as native tools.
 
-<a name="latency-note"></a>
+<span id="latency-note"></span>
 > <sup>1</sup> On a real LAN, decode-to-present measures in the low tens of milliseconds (p50 ~11–17 ms with the WASM software decoder; faster with WebCodecs on HTTPS); end-to-end "glass-to-glass" latency adds your network's round trip on top. See the [streaming latency log](https://github.com/jo-duchan/tapflow/blob/main/contributing/streaming-latency-log.md) for the full measurements, conditions, and known limitations.
 
 ## Security & Privacy


### PR DESCRIPTION
## Problem

`reactnative.directory/package/tapflow` shows **"Uh oh, something went wrong ()"** on the Overview tab — the whole package page blanks — while Code/Versions/Score tabs render fine.

Console error:
```
TypeError: Cannot read properties of undefined (reading 'startsWith')
  at MarkdownRenderer.tsx:90
```

Their README renderer's `<a>` handler calls `props.href.startsWith('#')` with no null guard. Our README shipped a **hrefless** `<a name="latency-note"></a>` anchor, so `props.href` is `undefined` → client-side `TypeError` → the page crashes.

The directory fetches the **npm-published** README via unpkg, which is `packages/cli/README.md`. Root `README.md` carried the same anchor and is fixed too for consistency.

## Fix

`<a name="latency-note"></a>` → `<span id="latency-note"></span>` in both READMEs.

The anchor is referenced by a footnote (`<sup>[1](#latency-note)</sup>`), so it can't just be deleted. `<a id>` would still be a hrefless `<a>` (same crash), so a `<span id>` is used — it keeps the `#latency-note` jump working on GitHub while removing the hrefless `<a>` that crashes the directory renderer.

## Verification

- hrefless `<a>` after fix: **0** in both files; anchor ref (1) ↔ target (1) preserved.
- Reproduced the directory's crash condition against a real remark → remark-rehype (`allowDangerousHtml`) → rehype-raw pipeline: **before** = 1 hrefless `<a>` → crash; **after** = 0 → safe (the `[1](#latency-note)` footnote link stays a valid href-bearing `<a>`).
- pre-commit typecheck + lint pass.

## Note

The live directory page only re-scrapes on a new npm publish, so the crash clears once a release ships the fixed `packages/cli/README.md`.

## Review

Docs-only change; adversarial review skipped per AGENTS.md, record at `.work/reviews/fix__readme-hrefless-anchor-directory-crash.md` (HEAD `ed628dfa578557fcb6ace9e7f3497166e907adf7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated latency footnote link targets in the documentation to use modern, compatible markup.
  * Preserved navigation to referenced footnotes in both the main and CLI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->