### PR TITLE
feat(mcp): install the build before run_flow replays (L4)

### DIFF
--- a/packages/mcp-server/src/__tests__/tools.run-flow.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.run-flow.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerTools } from '../tools.js'
+import type { TapflowClient } from '../client.js'
+
+type ToolResult = { content: unknown[]; isError?: boolean }
+type Handler = (args: Record<string, unknown>) => Promise<ToolResult>
+
+// Capture the tool handlers registered by registerTools so we can invoke run_flow directly.
+function captureTools(client: TapflowClient): Map<string, Handler> {
+  const handlers = new Map<string, Handler>()
+  const server = {
+    registerTool: (name: string, _config: unknown, handler: Handler) => { handlers.set(name, handler) },
+  }
+  registerTools(server as unknown as McpServer, client)
+  return handlers
+}
+
+function fakeClient(calls: string[]): TapflowClient {
+  return {
+    installApp: vi.fn(async () => { calls.push('install') }),
+    launchApp: vi.fn(async () => { calls.push('launch') }),
+    clearState: vi.fn(async () => { calls.push('clearState') }),
+    queryUITree: vi.fn(async () => []),
+    screenshot: vi.fn(async () => Buffer.from('')),
+    tap: vi.fn(),
+    swipe: vi.fn(async () => {}),
+    typeText: vi.fn(async () => {}),
+    pressKey: vi.fn(),
+    openUrl: vi.fn(async () => {}),
+  } as unknown as TapflowClient
+}
+
+describe('run_flow — install before replay', () => {
+  const runFlowHandler = (client: TapflowClient) => captureTools(client).get('run_flow') as Handler
+
+  it('installs buildId before running the flow (default)', async () => {
+    const calls: string[] = []
+    const client = fakeClient(calls)
+    const res = await runFlowHandler(client)({ sessionId: 's1', flow: 'steps:\n  - launchApp\n', buildId: 5 })
+    expect(res.isError).toBeFalsy()
+    expect(client.installApp).toHaveBeenCalledWith('s1', 5)
+    expect(calls).toEqual(['install', 'launch']) // install strictly before the launchApp step
+  })
+
+  it('install:false skips the install but still launches', async () => {
+    const calls: string[] = []
+    const client = fakeClient(calls)
+    await runFlowHandler(client)({ sessionId: 's1', flow: 'steps:\n  - launchApp\n', buildId: 5, install: false })
+    expect(client.installApp).not.toHaveBeenCalled()
+    expect(calls).toEqual(['launch'])
+  })
+
+  it('no buildId → nothing to install', async () => {
+    const calls: string[] = []
+    const client = fakeClient(calls)
+    await runFlowHandler(client)({ sessionId: 's1', flow: 'steps:\n  - clearState: com.example.app\n' })
+    expect(client.installApp).not.toHaveBeenCalled()
+    expect(calls).toEqual(['clearState'])
+  })
+
+  it('surfaces an install failure as a run_flow error and never runs the flow', async () => {
+    const calls: string[] = []
+    const client = fakeClient(calls)
+    vi.mocked(client.installApp).mockRejectedValueOnce(new Error('device offline'))
+    const res = await runFlowHandler(client)({ sessionId: 's1', flow: 'steps:\n  - launchApp\n', buildId: 5 })
+    expect(res.isError).toBe(true)
+    expect(JSON.stringify(res.content)).toContain('device offline')
+    expect(calls).toEqual([]) // install rejected → launchApp step never reached
+  })
+})

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -163,15 +163,18 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
         'tapping step by step: author the flow once, then replay it idempotently. Pass the YAML inline via "flow", or a ' +
         'file path via "path" (resolved from the MCP server process cwd). Steps: clearState / launchApp / tapOn / ' +
         'inputText / pressKey / swipe / scroll / openUrl / assertVisible / assertNotVisible. launchApp launches the ' +
-        'buildId argument. Returns per-step results; on failure a screenshot is saved to a temp file.',
+        'buildId argument. When buildId is set, the build is installed before replaying (like `tapflow flow run --build`) ' +
+        'so clearState/launchApp have the app present — pass install:false to skip. Returns per-step results; on failure ' +
+        'a screenshot is saved to a temp file.',
       inputSchema: {
         sessionId: z.string().describe('Session ID from list_devices (connect_device first)'),
         flow: z.string().optional().describe('Flow YAML content (inline)'),
         path: z.string().optional().describe('Path to a flow YAML file (alternative to "flow")'),
-        buildId: z.number().optional().describe('Build under test for the launchApp step (from list_builds)'),
+        buildId: z.number().int().optional().describe('Build under test — installed before replay and launched by the launchApp step (from list_builds)'),
+        install: z.boolean().optional().describe('Install buildId before replaying (default: true when buildId is set)'),
       },
     },
-    async ({ sessionId, flow, path: flowPath, buildId }) => {
+    async ({ sessionId, flow, path: flowPath, buildId, install }) => {
       try {
         if ((flow === undefined) === (flowPath === undefined)) {
           return err('run_flow needs exactly one of "flow" (inline YAML) or "path"')
@@ -189,6 +192,10 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
           yamlText = fs.readFileSync(resolved, 'utf-8')
         }
         const parsed = parseFlow(yamlText, flowPath ?? 'inline-flow.yaml')
+        // Install the build before replaying (mirrors `flow run --build`) so clearState/launchApp find the app present; skip with install:false.
+        if (buildId !== undefined && install !== false) {
+          await client.installApp(sessionId, buildId)
+        }
         const driver = makeFlowDriver(client, sessionId, buildId)
         const result = await runFlow(parsed, driver)
 


### PR DESCRIPTION
## Problem (L4)

MCP `run_flow` accepted a `buildId` but only **launched** it via the `launchApp` step — it never **installed** the build, unlike `tapflow flow run --build` which installs before running. A flow whose `clearState` / `launchApp` assumes the app is present then failed on MCP replay when the app was never installed or was removed on session end.

(There is a standalone `install_app` tool, but agents had to remember to call it first — an asymmetry with the CLI.)

## Fix

`run_flow` now installs `buildId` before replaying when it is set, mirroring `flow run --build`:

```
buildId set + install !== false  →  client.installApp(sessionId, buildId)  →  runFlow
```

- New optional `install: false` skips it (mirrors `--no-install`).
- No `buildId` → nothing to install. `install_app` remains for manual use.
- Install is treated as a **pre-run precondition**, not a flow step (flows stay install-agnostic / portable).

Gating is byte-for-byte parity with `flow-run.ts` (`opts.build !== undefined && opts.install !== false`). Backward-compatible: existing buildId callers just get one idempotent install; an install failure surfaces as a clean `run_flow` error.

## Tests

`tools.run-flow.test.ts` (new — first test for `tools.ts`): captures the registered `run_flow` handler and invokes it against a fake `TapflowClient`, asserting install-before-launch ordering, `install:false` skip, no-buildId skip, and clean error on install failure. mcp-server **34 pass**, typecheck + lint green.

## Adversarial review

Independent context, refute-first. **No BLOCKER/MAJOR/MINOR.** CLI parity + backward-compat verified. Record: `.work/reviews/feat__mcp-run-flow-auto-install.md` @ HEAD `360f0b7f6bcc8f38c92cb983b625bc2e6ad9cebc`.

Next in the L cluster: MCP `shutdown_device` tool (plan H-G) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `run_flow` to optionally install the target build before replaying a flow.
  * Added an `install` option (defaults to installing when `buildId` is provided) to control whether installation happens.
* **Bug Fixes**
  * If installation fails, `run_flow` returns an error and does not proceed with any subsequent flow steps.
  * When `buildId` is omitted, installation is not attempted.
* **Tests**
  * Added a Vitest suite covering default install sequencing, skipping installation, missing `buildId`, and installation error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->