### PR TITLE
feat(mcp): add shutdown_device tool to power a device down (H-G)

### DIFF
--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -99,6 +99,7 @@ Any MCP-compatible client can use tapflow. Add the following to your MCP config 
 | `connect_device` | Join a session (required before controlling a device) |
 | `disconnect_device` | End a session |
 | `boot_device` | Boot a simulator or emulator |
+| `shutdown_device` | Power the device down (frees resources; forces a cold boot next time) |
 | `screenshot` | Capture the current screen (PNG or JPEG) |
 | `query_ui_tree` | Read the on-screen UI as a structured accessibility tree (role, label, identifier, frame) |
 | `tap` | Tap at a coordinate |

--- a/docs/ko/guide/mcp-server.md
+++ b/docs/ko/guide/mcp-server.md
@@ -99,6 +99,7 @@ MCP를 지원하는 클라이언트라면 모두 tapflow를 사용할 수 있습
 | `connect_device` | 세션 참여 (제어 전 필수) |
 | `disconnect_device` | 세션 종료 |
 | `boot_device` | 시뮬레이터·에뮬레이터 부팅 |
+| `shutdown_device` | 기기 전원 종료 (리소스 반납·다음 콜드 부팅 강제) |
 | `screenshot` | 현재 화면 캡처 (PNG 또는 JPEG) |
 | `query_ui_tree` | 화면 UI를 구조화된 접근성 트리로 조회 (role·label·identifier·frame) |
 | `tap` | 좌표 터치 |

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -27,7 +27,9 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 
 ### Available tools
 
-`list_devices`, `connect_device`, `disconnect_device`, `boot_device`, `screenshot`, `query_ui_tree`, `run_flow`, `tap`, `swipe`, `type_text`, `press_key`, `press_button`, `install_app`, `launch_app`, `list_builds`
+`list_devices`, `connect_device`, `disconnect_device`, `boot_device`, `shutdown_device`, `screenshot`, `query_ui_tree`, `run_flow`, `tap`, `swipe`, `type_text`, `press_key`, `press_button`, `install_app`, `launch_app`, `list_builds`
+
+`disconnect_device` only leaves the session (`session:leave`) — the device stays booted. `shutdown_device` powers the device down (`device:shutdown` → agent runs simctl/adb shutdown → `device:shutdown-done`); use it to free resources or force a cold boot.
 
 `run_flow` replays a `@tapflowio/flow-runner` YAML flow deterministically (no LLM at replay time) over this process's existing relay connection — it shares the session joined via `connect_device`, so it never opens a second WebSocket or hits "Session busy".
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -138,6 +138,29 @@ describe('TapflowClient', () => {
     })
   })
 
+  describe('shutdownDevice', () => {
+    it('sends device:shutdown (with payload.deviceId) and resolves on device:shutdown-done', async () => {
+      setTimeout(() => relay.send({ type: 'device:shutdown-done', sessionId: 'sess-1' }), 10)
+      await expect(client.shutdownDevice('sess-1', 'dev-1')).resolves.toBeUndefined()
+      const msg = await waitForMessage(relay, 'device:shutdown')
+      // deviceId must be in the payload — the agent handler destructures msg.payload.deviceId.
+      expect(msg).toMatchObject({ type: 'device:shutdown', sessionId: 'sess-1', payload: { deviceId: 'dev-1' } })
+    })
+
+    it('does not resolve on a different session\'s shutdown-done, only the matching one', async () => {
+      const p = client.shutdownDevice('sess-1', 'dev-1')
+      relay.send({ type: 'device:shutdown-done', sessionId: 'OTHER' })
+      // A different session's completion must leave the promise pending.
+      const outcome = await Promise.race([
+        p.then(() => 'resolved'),
+        new Promise<string>((r) => setTimeout(() => r('pending'), 40)),
+      ])
+      expect(outcome).toBe('pending')
+      relay.send({ type: 'device:shutdown-done', sessionId: 'sess-1' })
+      await expect(p).resolves.toBeUndefined()
+    })
+  })
+
   describe('tap', () => {
     it('sends touch:start then touch:end with coordinates', async () => {
       client.tap('sess-1', 100, 200)

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -158,6 +158,17 @@ export class TapflowClient {
     }
   }
 
+  // Powers the session's booted device down (agent runs simctl/adb shutdown, replies device:shutdown-done).
+  // payload carries deviceId, matching the agent handler and the relay's own shutdown path. There is no
+  // shutdown-error message: Android replies done regardless, iOS surfaces a failed shutdown as a wait timeout.
+  async shutdownDevice(sessionId: string, deviceId: string): Promise<void> {
+    this.send({ type: 'device:shutdown', sessionId, payload: { deviceId } })
+    await this.waitFor(
+      (m) => m['type'] === 'device:shutdown-done' && m['sessionId'] === sessionId,
+      30_000,
+    )
+  }
+
   tap(sessionId: string, x: number, y: number): void {
     const payload = { x, y }
     this.send({ type: 'input:touch:start', sessionId, payload })

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -133,6 +133,28 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
   )
 
   server.registerTool(
+    'shutdown_device',
+    {
+      description:
+        'Shut the session\'s booted simulator/emulator down — powers the device off to free resources or force a ' +
+        'cold boot next time. Unlike disconnect_device (which only leaves the session, leaving the device running), ' +
+        'this actually stops the device. Requires connect_device first. Waits up to 30 seconds.',
+      inputSchema: {
+        sessionId: z.string().describe('Session ID from list_devices'),
+        deviceId: z.string().describe('Device ID from list_devices'),
+      },
+    },
+    async ({ sessionId, deviceId }) => {
+      try {
+        await client.shutdownDevice(sessionId, deviceId)
+        return ok(JSON.stringify({ shutdown: true, sessionId, deviceId }))
+      } catch (e) {
+        return err(`shutdown_device failed: ${(e as Error).message}`)
+      }
+    },
+  )
+
+  server.registerTool(
     'query_ui_tree',
     {
       description:


### PR DESCRIPTION
## Problem

MCP had `boot_device` but no way to shut a device down. `disconnect_device` only sends `session:leave` (the controller leaves; the simulator/emulator stays **booted** and keeps holding resources), so an agent couldn't free the device or force a cold boot — the only options were the dashboard's 5-min idle-shutdown or Ctrl+C on the agent.

## Fix

The relay already forwards a client-sent `device:shutdown` to the agent and the agent replies `device:shutdown-done`. This adds:
- `TapflowClient.shutdownDevice(sessionId, deviceId)` — sends `device:shutdown` with `payload: { deviceId }`, awaits `device:shutdown-done` (30s).
- `shutdown_device` MCP tool (sessionId + deviceId), distinct from `disconnect_device`.

`deviceId` rides in the payload to match the agent handlers' `msg.payload.deviceId` destructure — the same shape the dashboard and the relay's own auto-shutdown already send. No `device:shutdown-error` exists: Android replies `done` regardless, iOS surfaces a failed shutdown as a wait timeout.

## Tests

`client.test.ts`: `shutdownDevice` sends `device:shutdown` **with `payload.deviceId`** and resolves on `device:shutdown-done`; wrong-session `done` is ignored. mcp-server 32 pass, typecheck + lint + docs build green. AGENTS + docs (EN/KO) tool tables updated.

## Adversarial review

Independent context, refute-first. **Found a BLOCKER** on the first pass: the initial version sent `device:shutdown` *without* `payload.deviceId`, so both agents would `TypeError` on the destructure (swallowed by the relay message try/catch) → no `device:shutdown-done` → 30s timeout, no actual shutdown — and the test was Potemkin (`toMatchObject` didn't assert the payload). Fixed (add `deviceId` param + payload, assert `payload.deviceId`, correct the comment) and **re-verified RESOLVED** by the same independent context. Record: `.work/reviews/feat__mcp-shutdown-device.md` @ HEAD `0adea9114d486da1ea978c6bf538067d90efd544`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `shutdown_device` tool to power down connected devices, release resources, and force a cold boot the next time they are started.
  * Shutdown requests now report success or failure through the tool response.
* **Documentation**
  * Updated English and Korean guides with the new tool and clarified the difference between disconnecting and shutting down a device.
* **Tests**
  * Added coverage for successful shutdown completion and correct handling of session-specific shutdown confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->