### PR TITLE
fix(ios-agent): lazily set up TouchHelper so boot-less session input isn't dropped

### DIFF
--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -577,6 +577,19 @@ export class IOSAgent implements DeviceAgent {
     }
   }
 
+  // Ensure the session's touch channel exists. handleDeviceBoot is the normal setup
+  // path, but a session can become active without it — an agent reconnect re-issues
+  // the session (deviceStates recreated with touchHelper=null) while the simulator
+  // stays booted, and the client may send input without a fresh device:boot. Create
+  // the helper lazily so input self-heals instead of being silently dropped. Kept
+  // synchronous so a tap's start+end stay paired: an async setup would let the end
+  // run before the helper exists and drop touchEnd (a stuck finger).
+  private ensureTouchHelper(state: DeviceState): void {
+    if (state.touchHelper) return
+    state.touchHelper = new TouchHelper(state.deviceId)
+    state.touchHelper.start()
+  }
+
   private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
     switch (msg.type) {
       case 'device:boot': {
@@ -624,9 +637,10 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'input:touch:start': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) { logger.error('touch:start — touchHelper not ready'); break }
+        if (!state) break
+        this.ensureTouchHelper(state)
         const { x, y } = msg.payload as { x: number; y: number }
-        state.touchHelper.touchStart(x, y)
+        state.touchHelper?.touchStart(x, y)
         break
       }
       case 'input:touch:move': {
@@ -643,9 +657,10 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'input:pinch:start': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
+        if (!state) break
+        this.ensureTouchHelper(state)
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
-        state.touchHelper.pinchStart(f0.x, f0.y, f1.x, f1.y)
+        state.touchHelper?.pinchStart(f0.x, f0.y, f1.x, f1.y)
         break
       }
       case 'input:pinch:move': {
@@ -696,6 +711,7 @@ export class IOSAgent implements DeviceAgent {
       case 'input:type': {
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
+        if (state) this.ensureTouchHelper(state)
         const { text } = (msg.payload ?? {}) as { text?: string }
         if (!state?.touchHelper) {
           this.ws?.send(JSON.stringify({ type: 'input:type-error', sessionId, message: 'No booted device' }))
@@ -729,7 +745,8 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'input:key': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
+        if (!state) break
+        this.ensureTouchHelper(state)
         const { code, modifiers } = msg.payload as { code: string; modifiers?: number }
         const usage = KEY_CODE_MAP[code]
         if (usage === undefined) break
@@ -744,13 +761,14 @@ export class IOSAgent implements DeviceAgent {
               state.touchHelper?.sendKey(usage, modifiers ?? 0)
             })
         } else {
-          state.touchHelper.sendKey(usage, modifiers ?? 0)
+          state.touchHelper?.sendKey(usage, modifiers ?? 0)
         }
         break
       }
       case 'input:button': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
+        if (!state) break
+        this.ensureTouchHelper(state)
         const { name, phase } = msg.payload as { name: string; phase?: 'down' | 'up' }
         // Map the cross-platform button vocabulary (used by MCP) onto this
         // device's actual chrome button names. Dashboard already sends the raw
@@ -759,13 +777,13 @@ export class IOSAgent implements DeviceAgent {
         if (chromeName === 'home') {
           // Home has no HID down/up split — always a single legacy press. Send once on release
           // (or on a phase-less legacy message) so a down+up pair doesn't fire it twice.
-          if (phase !== 'down') state.touchHelper.pressLegacyButton(0)
+          if (phase !== 'down') state.touchHelper?.pressLegacyButton(0)
         } else {
           const btn = state.loadedChrome?.buttons.find((b) => b.name === chromeName)
           if (btn && btn.usagePage > 0 && btn.usage > 0) {
-            if (phase === 'down') state.touchHelper.pressButtonDown(btn.usagePage, btn.usage)
-            else if (phase === 'up') state.touchHelper.pressButtonUp(btn.usagePage, btn.usage)
-            else state.touchHelper.pressButton(btn.usagePage, btn.usage)
+            if (phase === 'down') state.touchHelper?.pressButtonDown(btn.usagePage, btn.usage)
+            else if (phase === 'up') state.touchHelper?.pressButtonUp(btn.usagePage, btn.usage)
+            else state.touchHelper?.pressButton(btn.usagePage, btn.usage)
           }
         }
         break

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -577,13 +577,7 @@ export class IOSAgent implements DeviceAgent {
     }
   }
 
-  // Ensure the session's touch channel exists. handleDeviceBoot is the normal setup
-  // path, but a session can become active without it — an agent reconnect re-issues
-  // the session (deviceStates recreated with touchHelper=null) while the simulator
-  // stays booted, and the client may send input without a fresh device:boot. Create
-  // the helper lazily so input self-heals instead of being silently dropped. Kept
-  // synchronous so a tap's start+end stay paired: an async setup would let the end
-  // run before the helper exists and drop touchEnd (a stuck finger).
+  // Lazily set up the touch channel: a reconnect re-issues the session with touchHelper=null while the sim stays booted, so input self-heals without a fresh device:boot. Sync so a tap's start+end stay paired (async would drop touchEnd → stuck finger).
   private ensureTouchHelper(state: DeviceState): void {
     if (state.touchHelper) return
     state.touchHelper = new TouchHelper(state.deviceId)

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -285,6 +285,63 @@ describe('IOSAgent', () => {
     })
   })
 
+  describe('input setup — lazy TouchHelper on boot-less session attach', () => {
+    beforeEach(() => { MockTouchHelper.mockClear() })
+
+    // Repro (followups H-E): an agent reconnect re-issues the session, so its
+    // DeviceState is recreated with touchHelper=null while the simulator stays
+    // booted. If the client then sends input without a fresh device:boot, the
+    // input handlers used to drop it silently ("읽기 O / 쓰기 X"). It must
+    // self-heal by setting up the touch channel lazily.
+    it('lazily creates TouchHelper when input arrives on a session that skipped device:boot', async () => {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+      // NO device:boot — this session never runs handleDeviceBoot (the only place
+      // that used to create TouchHelper), so touchHelper starts null.
+      MockTouchHelper.mockClear()
+
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.4, y: 0.6 } }))
+
+      await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
+      const th = MockTouchHelper.mock.results[0].value
+      expect(th.start).toHaveBeenCalled()
+      expect(th.touchStart).toHaveBeenCalledWith(0.4, 0.6)
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    // A tap is input:touch:start + input:touch:end (two messages). The lazy setup
+    // must be synchronous so the end sees the helper the start created — an async
+    // setup would let the end run first and drop touchEnd (a stuck finger).
+    it('keeps touch start/end paired through lazy setup (no stuck finger)', async () => {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+      MockTouchHelper.mockClear()
+
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+
+      await vi.waitFor(() => {
+        expect(MockTouchHelper.mock.results).toHaveLength(1)
+        const th = MockTouchHelper.mock.results[0].value
+        expect(th.touchStart).toHaveBeenCalledTimes(1)
+        expect(th.touchEnd).toHaveBeenCalledTimes(1)
+      }, { timeout: 500 })
+
+      agent.disconnect()
+      browser.close()
+    })
+  })
+
   describe('pinch relay messages', () => {
     beforeEach(() => { MockTouchHelper.mockClear() })
 

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -285,24 +285,23 @@ describe('IOSAgent', () => {
     })
   })
 
-  describe('input setup — lazy TouchHelper on boot-less session attach', () => {
+  describe('input setup — lazy TouchHelper on a null-helper booted session (followups H-E)', () => {
     beforeEach(() => { MockTouchHelper.mockClear() })
 
-    // Repro (followups H-E): an agent reconnect re-issues the session, so its
-    // DeviceState is recreated with touchHelper=null while the simulator stays
-    // booted. If the client then sends input without a fresh device:boot, the
-    // input handlers used to drop it silently ("읽기 O / 쓰기 X"). It must
-    // self-heal by setting up the touch channel lazily.
-    it('lazily creates TouchHelper when input arrives on a session that skipped device:boot', async () => {
+    // A reconnect clears+re-registers deviceStates with touchHelper=null while the sim stays booted (IOSAgent _scheduleReconnect → initDeviceStates); input must self-heal without a fresh device:boot. These tests drive that null-helper-on-booted-sim state directly — skipping device:boot is intentional, since booting would create the helper and bypass the lazy path under test.
+    async function joinBootlessSession() {
       const browser = new WebSocket(`ws://localhost:${port}`)
       await waitForOpen(browser)
-      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true)) // sim booted, session has touchHelper=null (no device:boot)
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      // NO device:boot — this session never runs handleDeviceBoot (the only place
-      // that used to create TouchHelper), so touchHelper starts null.
       MockTouchHelper.mockClear()
+      return { browser, agent }
+    }
+
+    it('lazily creates TouchHelper when input arrives with no device:boot for the session', async () => {
+      const { browser, agent } = await joinBootlessSession()
 
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.4, y: 0.6 } }))
 
@@ -315,17 +314,9 @@ describe('IOSAgent', () => {
       browser.close()
     })
 
-    // A tap is input:touch:start + input:touch:end (two messages). The lazy setup
-    // must be synchronous so the end sees the helper the start created — an async
-    // setup would let the end run first and drop touchEnd (a stuck finger).
+    // A tap is start + end (two messages); sync setup lets the end see the helper the start created (async would drop touchEnd → stuck finger).
     it('keeps touch start/end paired through lazy setup (no stuck finger)', async () => {
-      const browser = new WebSocket(`ws://localhost:${port}`)
-      await waitForOpen(browser)
-      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
-      await agent.connect(`ws://localhost:${port}`)
-      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-      await waitForType(browser, 'session:joined')
-      MockTouchHelper.mockClear()
+      const { browser, agent } = await joinBootlessSession()
 
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
       browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))


### PR DESCRIPTION
## Summary

Fixes **followups H-E** — iOS agent input was silently dropped on a session that never ran `handleDeviceBoot`.

`TouchHelper` was created only in `handleDeviceBoot -> sendChromeData`. When a session becomes active without a fresh `device:boot` — an **agent reconnect re-issues the session** (`deviceStates` recreated with `touchHelper=null`) while the simulator stays booted, and the client sends input — every touch/pinch/key/button was silently dropped. Symptom: **reads work, writes vanish** (UI-tree reads work because the tree runner is udid-keyed and session-independent; input writes are lost).

## Fix

Add synchronous `ensureTouchHelper(state)` and call it at the input entrypoints (`input:touch:start`, `input:pinch:start`, `input:key`, `input:button`, `input:type`). Input self-heals instead of dropping.

**Kept synchronous on purpose**: a tap is `input:touch:start` + `input:touch:end` (two messages). An async setup would let the `end` run before the helper exists, dropping `touchEnd` (a stuck finger). Sync setup means `start` creates the helper before `end` is handled.

## Scope / follow-ups

- Restores the touch channel: **tap / swipe / key / pinch / home button**.
- **Chrome-named buttons** (volume, etc.) additionally need `loadedChrome` (also boot-only) — narrower follow-up, not in this PR.
- **Truthful failure** when input genuinely can't be injected (today's false `{"tapped":true}`, and `input:type` now emitting `input:type-done` on a shut-down sim) is **H-F** — a separate additive input-ack PR, tracked in the AI Automation maturity plan.

## Verification

- Two new reproducing tests (lazy creation on boot-less attach; start/end pairing / no stuck finger) — **fail without the fix, pass with it** (verified by reverting the source).
- Full ios-agent suite **227/227**, `pnpm typecheck` green, lint clean.
- **Adversarial review** by an independent context: sound, no BLOCKER/MAJOR; two MINORs (both inherent tradeoffs of the sync design, deferred to H-F). Record: `.work/reviews/fix__ios-input-lazy-touchhelper.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch, pinch, typing/paste, keyboard key, and button input handling when sessions are reissued after reconnects or when touch support isn’t initialized yet.
  * Prevented lost or stuck touch interactions by lazily initializing missing touch support before dispatching input events.

* **Tests**
  * Added coverage for scenarios where sessions skip initial device setup, verifying touch support is created on first touch input and that touch start/end both dispatch correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->