### PR TITLE
feat(mcp): truthful input acks for tap/swipe/press_key/press_button (H-F)

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -126,10 +126,7 @@ interface DeviceState {
   sessionId: string
   deviceId: string
   touchHelper: AndroidTouchHelper | null
-  // Whether this session's device is booted, for truthful input acks. Set when the
-  // device is ready, cleared on shutdown. Starts false after a reconnect (state is
-  // recreated) even if the emulator is still up — the input-ack path verifies once
-  // via adb and caches the result here.
+  // Device-booted flag for truthful input acks — set on device:ready, cleared on shutdown; false after a reconnect until the ack path re-verifies once via adb.
   booted: boolean
   streamWs: WebSocket | null
   scrcpySession: ScrcpySession | null
@@ -851,10 +848,7 @@ export class AndroidAgent implements DeviceAgent {
     }))
   }
 
-  // Ack a terminal input (tap/swipe/key/button) — mirrors ios-agent.ackInput.
-  // input:done means the input was dispatched to a booted device (not a guarantee it
-  // physically landed); input:error means there was no live pointer channel or the
-  // device wasn't booted, so nothing was dispatched.
+  // Ack a terminal input (mirrors ios-agent.ackInput): input:done = dispatched to a booted device (not a landing guarantee); input:error = no live pointer channel / not booted.
   private async ackInput(state: DeviceState, dispatched: boolean): Promise<void> {
     const booted = dispatched && (state.booted || (await this.isBooted(state.deviceId)))
     if (booted) state.booted = true // cache the post-reconnect verify so later inputs skip adb

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -126,6 +126,11 @@ interface DeviceState {
   sessionId: string
   deviceId: string
   touchHelper: AndroidTouchHelper | null
+  // Whether this session's device is booted, for truthful input acks. Set when the
+  // device is ready, cleared on shutdown. Starts false after a reconnect (state is
+  // recreated) even if the emulator is still up — the input-ack path verifies once
+  // via adb and caches the result here.
+  booted: boolean
   streamWs: WebSocket | null
   scrcpySession: ScrcpySession | null
   emulatorVideo: EmulatorVideo | null
@@ -314,6 +319,7 @@ export class AndroidAgent implements DeviceAgent {
         sessionId,
         deviceId,
         touchHelper: null,
+        booted: false,
         streamWs: null,
         scrcpySession: null,
         emulatorVideo: null,
@@ -410,6 +416,7 @@ export class AndroidAgent implements DeviceAgent {
     state.cornerRadius = 0
     state.touchHelper?.stop()
     state.touchHelper = null
+    state.booted = false
     state.streamWs?.close()
     state.streamWs = null
   }
@@ -812,6 +819,7 @@ export class AndroidAgent implements DeviceAgent {
           cornerRadius: state.cornerRadius,
         },
       }))
+      state.booted = true
       this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: avdId } }))
     } catch (e) {
       if (seq !== state.bootSeq) return
@@ -841,6 +849,27 @@ export class AndroidAgent implements DeviceAgent {
       sessionId,
       payload: { deviceId: avdId },
     }))
+  }
+
+  // Ack a terminal input (tap/swipe/key/button) — mirrors ios-agent.ackInput.
+  // input:done means the input was dispatched to a booted device (not a guarantee it
+  // physically landed); input:error means there was no live pointer channel or the
+  // device wasn't booted, so nothing was dispatched.
+  private async ackInput(state: DeviceState, dispatched: boolean): Promise<void> {
+    const booted = dispatched && (state.booted || (await this.isBooted(state.deviceId)))
+    if (booted) state.booted = true // cache the post-reconnect verify so later inputs skip adb
+    this.ws?.send(JSON.stringify(
+      booted
+        ? { type: 'input:done', sessionId: state.sessionId }
+        : { type: 'input:error', sessionId: state.sessionId, message: dispatched ? 'device not booted' : 'input channel not ready' },
+    ))
+  }
+
+  private async isBooted(deviceId: string): Promise<boolean> {
+    try {
+      const devices = await this.adb.listDevices()
+      return devices.find((d) => d.id === deviceId)?.status === 'booted'
+    } catch { return false }
   }
 
   private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
@@ -942,6 +971,7 @@ export class AndroidAgent implements DeviceAgent {
         } else {
           state.touchHelper?.touchEnd()
         }
+        void this.ackInput(state, pc !== null || state.touchHelper !== null) // terminal of a tap/swipe → ack the gesture
         break
       }
       case 'input:pinch:start': {
@@ -981,6 +1011,7 @@ export class AndroidAgent implements DeviceAgent {
         } else {
           state.touchHelper?.pinchEnd()
         }
+        void this.ackInput(state, pc !== null || state.touchHelper !== null)
         break
       }
       case 'input:rotate': {
@@ -999,9 +1030,10 @@ export class AndroidAgent implements DeviceAgent {
       }
       case 'input:button': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
+        if (!state) break
         const { name } = msg.payload as { name: string }
-        state.touchHelper.pressButton(name)
+        state.touchHelper?.pressButton(name)
+        void this.ackInput(state, state.touchHelper !== null)
         break
       }
       case 'stream:request-idr': {
@@ -1055,10 +1087,11 @@ export class AndroidAgent implements DeviceAgent {
       }
       case 'input:key': {
         const state = this.deviceStates.get(msg.sessionId!)
-        const serial = state ? this.adb.getSerial(state.deviceId) : undefined
-        if (!serial) break
+        if (!state) break
+        const serial = this.adb.getSerial(state.deviceId)
         const { code, modifiers } = msg.payload as { code: string; modifiers: number }
-        this.handleKeyInput(serial, code, modifiers).catch(() => {})
+        if (serial) this.handleKeyInput(serial, code, modifiers).catch(() => {})
+        void this.ackInput(state, serial !== undefined)
         break
       }
       case 'screenshot:request': {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -731,6 +731,15 @@ describe('AndroidAgent', () => {
         // last px from start: 0.1*1080 = 108, 0.2*2400 = 480
         expect(control.touchUp).toHaveBeenCalledWith(0, 108, 480)
       })
+
+      // followups H-F: the terminal of a tap acks input:done when dispatched to a
+      // booted device (pointer channel present + adb reports booted).
+      it('acks input:done on touch:end for a booted session', async () => {
+        const done = waitForType(browser, 'input:done')
+        browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+        browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+        expect((await done).sessionId).toBe(agent.sessionId)
+      })
     })
 
     describe('input — pinch', () => {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -732,8 +732,7 @@ describe('AndroidAgent', () => {
         expect(control.touchUp).toHaveBeenCalledWith(0, 108, 480)
       })
 
-      // followups H-F: the terminal of a tap acks input:done when dispatched to a
-      // booted device (pointer channel present + adb reports booted).
+      // followups H-F: touch:end acks input:done when dispatched to a booted device (pointer channel present + adb reports booted).
       it('acks input:done on touch:end for a booted session', async () => {
         const done = waitForType(browser, 'input:done')
         browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -76,6 +76,11 @@ interface DeviceState {
   sessionId: string
   deviceId: string
   touchHelper: TouchHelper | null
+  // Whether this session's device is booted, for truthful input acks. Set on a
+  // successful device:boot, cleared on shutdown. Starts false after a reconnect
+  // (state is recreated) even though the sim may still be booted — the input-ack
+  // path verifies once via simctl and caches the result here.
+  booted: boolean
   streamWs: WebSocket | null
   streamReader: ReadableStreamDefaultReader<StreamFrame> | null
   // Current capture streamer (ScreenCaptureStreamer path only) — lets the relay
@@ -255,6 +260,7 @@ export class IOSAgent implements DeviceAgent {
         sessionId,
         deviceId,
         touchHelper: null,
+        booted: false,
         streamWs: null,
         streamReader: null,
         captureStreamer: null,
@@ -347,6 +353,7 @@ export class IOSAgent implements DeviceAgent {
     state.audioPids = null
     state.touchHelper?.stop()
     state.touchHelper = null
+    state.booted = false
     state.streamWs?.close()
     state.streamWs = null
   }
@@ -478,6 +485,7 @@ export class IOSAgent implements DeviceAgent {
     state.captureStreamer = null // reader.cancel() kills the helper proc; drop the ref so a stale requestKeyframe() no-ops
     state.touchHelper?.stop()
     state.touchHelper = null
+    state.booted = false
     state.streamWs?.close()
     state.streamWs = null
 
@@ -516,6 +524,7 @@ export class IOSAgent implements DeviceAgent {
       // Opt-in audio output: stand up the loopback server and start the whole-sim tap now. Best-effort
       // — never blocks/affects the video path.
       if (this.audioEnabled()) this.startAudioCapture(state, streamWs, deviceId)
+      state.booted = true
       this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId } }))
 
       // Sync AppleKeyboards after ready — fire-and-forget so streaming isn't delayed.
@@ -557,6 +566,7 @@ export class IOSAgent implements DeviceAgent {
     state.captureStreamer = null // reader.cancel() kills the helper proc; drop the ref so a stale requestKeyframe() no-ops
     state.touchHelper?.stop()
     state.touchHelper = null
+    state.booted = false
     state.streamWs?.close()
     state.streamWs = null
     this.lastBundleIds.delete(deviceId)
@@ -582,6 +592,29 @@ export class IOSAgent implements DeviceAgent {
     if (state.touchHelper) return
     state.touchHelper = new TouchHelper(state.deviceId)
     state.touchHelper.start()
+  }
+
+  // Ack a terminal input (tap/swipe/key/button). input:done means the input was
+  // dispatched to a booted device — NOT a guarantee the tap physically landed (HID
+  // injection is fire-and-forget), same "agent handled it" semantics as the other
+  // :done acks. input:error means there was no live touch channel or the device
+  // wasn't booted, so nothing was dispatched. Runs off the sync injection path, so
+  // it never affects touch start/end pairing.
+  private async ackInput(state: DeviceState, dispatched: boolean): Promise<void> {
+    const booted = dispatched && (state.booted || (await this.isBooted(state.deviceId)))
+    if (booted) state.booted = true // cache the post-reconnect verify so later inputs skip simctl
+    this.ws?.send(JSON.stringify(
+      booted
+        ? { type: 'input:done', sessionId: state.sessionId }
+        : { type: 'input:error', sessionId: state.sessionId, message: dispatched ? 'device not booted' : 'input channel not ready' },
+    ))
+  }
+
+  private async isBooted(deviceId: string): Promise<boolean> {
+    try {
+      const devices = await this.simctl.listDevices()
+      return devices.find((d) => d.id === deviceId)?.status === 'booted'
+    } catch { return false }
   }
 
   private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
@@ -646,7 +679,9 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'input:touch:end': {
         const state = this.deviceStates.get(msg.sessionId!)
-        state?.touchHelper?.touchEnd()
+        if (!state) break
+        state.touchHelper?.touchEnd()
+        void this.ackInput(state, state.touchHelper !== null) // terminal of a tap/swipe → ack the gesture
         break
       }
       case 'input:pinch:start': {
@@ -666,8 +701,9 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'input:pinch:end': {
         const state = this.deviceStates.get(msg.sessionId!)
-        if (!state?.touchHelper) break
-        state.touchHelper.pinchEnd()
+        if (!state) break
+        state.touchHelper?.pinchEnd()
+        void this.ackInput(state, state.touchHelper !== null)
         break
       }
       case 'input:rotate': {
@@ -743,7 +779,10 @@ export class IOSAgent implements DeviceAgent {
         this.ensureTouchHelper(state)
         const { code, modifiers } = msg.payload as { code: string; modifiers?: number }
         const usage = KEY_CODE_MAP[code]
-        if (usage === undefined) break
+        if (usage === undefined) {
+          this.ws?.send(JSON.stringify({ type: 'input:error', sessionId: msg.sessionId, message: `unknown key code: ${code}` }))
+          break
+        }
         if (state.softKeyboardVisible) {
           // Hide the SW keyboard first so iOS re-initialises the HW keyboard
           // context. Skipping this causes input-source desync (qks / ㅂㅏㄴ symptoms).
@@ -757,6 +796,7 @@ export class IOSAgent implements DeviceAgent {
         } else {
           state.touchHelper?.sendKey(usage, modifiers ?? 0)
         }
+        void this.ackInput(state, state.touchHelper !== null)
         break
       }
       case 'input:button': {
@@ -780,6 +820,7 @@ export class IOSAgent implements DeviceAgent {
             else state.touchHelper?.pressButton(btn.usagePage, btn.usage)
           }
         }
+        void this.ackInput(state, state.touchHelper !== null)
         break
       }
       case 'open-url': {

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -76,10 +76,7 @@ interface DeviceState {
   sessionId: string
   deviceId: string
   touchHelper: TouchHelper | null
-  // Whether this session's device is booted, for truthful input acks. Set on a
-  // successful device:boot, cleared on shutdown. Starts false after a reconnect
-  // (state is recreated) even though the sim may still be booted — the input-ack
-  // path verifies once via simctl and caches the result here.
+  // Device-booted flag for truthful input acks — set on device:boot, cleared on shutdown; false after a reconnect until the ack path re-verifies once via simctl.
   booted: boolean
   streamWs: WebSocket | null
   streamReader: ReadableStreamDefaultReader<StreamFrame> | null
@@ -594,12 +591,7 @@ export class IOSAgent implements DeviceAgent {
     state.touchHelper.start()
   }
 
-  // Ack a terminal input (tap/swipe/key/button). input:done means the input was
-  // dispatched to a booted device — NOT a guarantee the tap physically landed (HID
-  // injection is fire-and-forget), same "agent handled it" semantics as the other
-  // :done acks. input:error means there was no live touch channel or the device
-  // wasn't booted, so nothing was dispatched. Runs off the sync injection path, so
-  // it never affects touch start/end pairing.
+  // Ack a terminal input: input:done = dispatched to a booted device (not a landing guarantee — HID is fire-and-forget); input:error = no live channel / not booted. Off the sync inject path, so start/end pairing is unaffected.
   private async ackInput(state: DeviceState, dispatched: boolean): Promise<void> {
     const booted = dispatched && (state.booted || (await this.isBooted(state.deviceId)))
     if (booted) state.booted = true // cache the post-reconnect verify so later inputs skip simctl

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -355,14 +355,24 @@ describe('IOSAgent', () => {
       browser.close()
     })
 
-    it('acks input:error when the device is not booted (dispatched but simctl reports shutdown)', async () => {
+    it('acks input:error after the device is shut down (booted then shutdown)', async () => {
       const browser = new WebSocket(`ws://localhost:${port}`)
       await waitForOpen(browser)
-      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(false)) // simctl reports shutdown
+      const simctl = mockSimctl(true)
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      // no device:boot → booted flag stays false; the ack path verifies via simctl
+      // Boot first (per the device:boot guideline → booted flag true, TouchHelper set up).
+      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:ready')
+
+      // Power the device off: shutdown clears the booted flag, and simctl now reports it shut down.
+      ;(simctl.listDevices as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'shutdown', osVersion: 'iOS 18.3' },
+      ])
+      browser.send(JSON.stringify({ type: 'device:shutdown', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:shutdown-done')
 
       const errored = waitForType(browser, 'input:error')
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -333,6 +333,49 @@ describe('IOSAgent', () => {
     })
   })
 
+  describe('input acks (followups H-F)', () => {
+    beforeEach(() => { MockTouchHelper.mockClear() })
+
+    it('acks input:done after a tap on a booted session', async () => {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:ready')
+
+      const done = waitForType(browser, 'input:done')
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      expect((await done).sessionId).toBe(agent.sessionId)
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('acks input:error when the device is not booted (dispatched but simctl reports shutdown)', async () => {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(false)) // simctl reports shutdown
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+      // no device:boot → booted flag stays false; the ack path verifies via simctl
+
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      const e = await errored
+      expect(e.sessionId).toBe(agent.sessionId)
+      expect(e.message).toBe('device not booted')
+
+      agent.disconnect()
+      browser.close()
+    })
+  })
+
   describe('pinch relay messages', () => {
     beforeEach(() => { MockTouchHelper.mockClear() })
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -2,22 +2,35 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { WebSocketServer, WebSocket } from 'ws'
 import { TapflowClient } from '../client.js'
 
+// inputAck models the agent's H-F terminal-input ack: 'done' = a new agent that
+// acks a booted device, 'error' = the agent rejects (not booted / no channel),
+// 'none' = an older agent that never acks (degradation path).
 function createMockRelay(): {
   wss: WebSocketServer
   port: number
   lastClient: () => WebSocket
   send: (msg: Record<string, unknown>) => void
+  setInputAck: (mode: 'done' | 'error' | 'none') => void
   sentMessages: () => Record<string, unknown>[]
   close: () => Promise<void>
 } {
   const wss = new WebSocketServer({ port: 0 })
   const received: Record<string, unknown>[] = []
   let conn: WebSocket | null = null
+  let inputAck: 'done' | 'error' | 'none' = 'done'
+  const TERMINAL = new Set(['input:touch:end', 'input:key', 'input:button'])
 
   wss.on('connection', (ws) => {
     conn = ws
     ws.on('message', (data) => {
-      try { received.push(JSON.parse(data.toString()) as Record<string, unknown>) } catch { /* ignore */ }
+      let msg: Record<string, unknown>
+      try { msg = JSON.parse(data.toString()) as Record<string, unknown> } catch { return }
+      received.push(msg)
+      if (inputAck !== 'none' && TERMINAL.has(msg['type'] as string)) {
+        ws.send(JSON.stringify(inputAck === 'error'
+          ? { type: 'input:error', sessionId: msg['sessionId'], message: 'device not booted' }
+          : { type: 'input:done', sessionId: msg['sessionId'] }))
+      }
     })
   })
 
@@ -28,6 +41,7 @@ function createMockRelay(): {
     port,
     lastClient: () => conn!,
     send: (msg) => conn?.send(JSON.stringify(msg)),
+    setInputAck: (mode) => { inputAck = mode },
     sentMessages: () => received,
     close: () => new Promise((resolve) => wss.close(() => resolve())),
   }
@@ -163,11 +177,20 @@ describe('TapflowClient', () => {
 
   describe('tap', () => {
     it('sends touch:start then touch:end with coordinates', async () => {
-      client.tap('sess-1', 100, 200)
-      await waitForMessage(relay, 'input:touch:end')
+      await client.tap('sess-1', 100, 200)
       const msgs = relay.sentMessages()
       expect(msgs[0]).toMatchObject({ type: 'input:touch:start', sessionId: 'sess-1', payload: { x: 100, y: 200 } })
       expect(msgs[1]).toMatchObject({ type: 'input:touch:end', sessionId: 'sess-1', payload: { x: 100, y: 200 } })
+    })
+
+    it('throws when the agent acks input:error (device not booted)', async () => {
+      relay.setInputAck('error')
+      await expect(client.tap('sess-1', 1, 2)).rejects.toThrow('device not booted')
+    })
+
+    it('resolves optimistically when an older agent never acks (degradation)', async () => {
+      relay.setInputAck('none')
+      await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
     })
   })
 
@@ -198,20 +221,20 @@ describe('TapflowClient', () => {
 
   describe('pressKey', () => {
     it('sends the agent contract { code, modifiers } — not { key }', async () => {
-      client.pressKey('sess-1', 'Enter')
+      await client.pressKey('sess-1', 'Enter')
       const msg = await waitForMessage(relay, 'input:key')
       expect(msg).toMatchObject({ type: 'input:key', sessionId: 'sess-1', payload: { code: 'Enter', modifiers: 0 } })
       expect((msg as { payload: Record<string, unknown> }).payload).not.toHaveProperty('key')
     })
 
     it('maps the Return alias to Enter (no platform maps "Return")', async () => {
-      client.pressKey('sess-1', 'Return')
+      await client.pressKey('sess-1', 'Return')
       const msg = await waitForMessage(relay, 'input:key')
       expect(msg).toMatchObject({ payload: { code: 'Enter', modifiers: 0 } })
     })
 
     it('passes other KeyboardEvent.code names through unchanged', async () => {
-      client.pressKey('sess-1', 'Backspace')
+      await client.pressKey('sess-1', 'Backspace')
       const msg = await waitForMessage(relay, 'input:key')
       expect(msg).toMatchObject({ payload: { code: 'Backspace', modifiers: 0 } })
     })
@@ -219,7 +242,7 @@ describe('TapflowClient', () => {
 
   describe('pressButton', () => {
     it('sends the agent contract { name } — not { button }', async () => {
-      client.pressButton('sess-1', 'home')
+      await client.pressButton('sess-1', 'home')
       const msg = await waitForMessage(relay, 'input:button')
       expect(msg).toMatchObject({ type: 'input:button', sessionId: 'sess-1', payload: { name: 'home' } })
       expect((msg as { payload: Record<string, unknown> }).payload).not.toHaveProperty('button')

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { WebSocketServer, WebSocket } from 'ws'
 import { TapflowClient } from '../client.js'
 
-// inputAck models the agent's H-F terminal-input ack: 'done' = a new agent that
-// acks a booted device, 'error' = the agent rejects (not booted / no channel),
-// 'none' = an older agent that never acks (degradation path).
+// inputAck models the agent's terminal-input ack: 'done' = new agent (booted), 'error' = rejects (not booted / no channel), 'none' = older agent that never acks (degradation).
 function createMockRelay(): {
   wss: WebSocketServer
   port: number
@@ -191,6 +189,13 @@ describe('TapflowClient', () => {
     it('resolves optimistically when an older agent never acks (degradation)', async () => {
       relay.setInputAck('none')
       await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
+    })
+
+    it('rejects (not optimistic) when the relay connection drops mid-input', async () => {
+      relay.setInputAck('none') // no ack will arrive
+      const p = client.tap('sess-1', 1, 2)
+      relay.lastClient().close() // drop the connection while awaiting the ack
+      await expect(p).rejects.toThrow(/closed/i)
     })
   })
 

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -169,10 +169,36 @@ export class TapflowClient {
     )
   }
 
-  tap(sessionId: string, x: number, y: number): void {
+  // Awaits the agent's terminal-input ack (sent on the gesture's last message).
+  // input:error → the device wasn't booted / no input channel, so the gesture was
+  // dropped: surface it as a failure. A timeout means an older agent/relay that
+  // doesn't ack input — fall back to optimistic success so tap/swipe keep working
+  // (additive protocol, graceful degradation).
+  private async awaitInputAck(sessionId: string): Promise<void> {
+    let msg: RelayMsg
+    try {
+      msg = await this.waitFor(
+        (m) =>
+          (m['type'] === 'input:done' || m['type'] === 'input:error') &&
+          m['sessionId'] === sessionId,
+        // Short window: a booted device acks in ms; the reconnect-verify path adds
+        // one simctl/adb call (~sub-second). If it lapses, an older agent/relay
+        // doesn't ack input — assume dispatched rather than stall each gesture.
+        2_000,
+      )
+    } catch {
+      return // no ack within the window → older agent/relay; assume dispatched
+    }
+    if (msg['type'] === 'input:error') {
+      throw new Error((msg['message'] as string) ?? 'Input failed')
+    }
+  }
+
+  async tap(sessionId: string, x: number, y: number): Promise<void> {
     const payload = { x, y }
     this.send({ type: 'input:touch:start', sessionId, payload })
     this.send({ type: 'input:touch:end', sessionId, payload })
+    await this.awaitInputAck(sessionId)
   }
 
   async swipe(
@@ -203,6 +229,7 @@ export class TapflowClient {
     }
     await delay(interval)
     this.send({ type: 'input:touch:end', sessionId, payload: { x: endX, y: endY } })
+    await this.awaitInputAck(sessionId)
   }
 
   // Awaits the agent's ack so a following input (e.g. pressKey Enter) is sent
@@ -222,16 +249,18 @@ export class TapflowClient {
 
   // Agents consume KeyboardEvent.code names ({ code, modifiers }) on input:key.
   // 'Return' is accepted as an alias — neither platform maps it, 'Enter' is the code.
-  pressKey(sessionId: string, key: string): void {
+  async pressKey(sessionId: string, key: string): Promise<void> {
     const code = key === 'Return' ? 'Enter' : key
     this.send({ type: 'input:key', sessionId, payload: { code, modifiers: 0 } })
+    await this.awaitInputAck(sessionId)
   }
 
   // Agents consume { name, phase? } on input:button; a phase-less message is a
   // single press on both platforms (iOS 'home' is legacy-pressed once, chrome
   // buttons and Android BUTTON_KEY_MAP names resolve by name).
-  pressButton(sessionId: string, button: string): void {
+  async pressButton(sessionId: string, button: string): Promise<void> {
     this.send({ type: 'input:button', sessionId, payload: { name: button } })
+    await this.awaitInputAck(sessionId)
   }
 
   async openUrl(sessionId: string, url: string): Promise<void> {

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -181,13 +181,14 @@ export class TapflowClient {
         (m) =>
           (m['type'] === 'input:done' || m['type'] === 'input:error') &&
           m['sessionId'] === sessionId,
-        // Short window: a booted device acks in ms; the reconnect-verify path adds
-        // one simctl/adb call (~sub-second). If it lapses, an older agent/relay
-        // doesn't ack input — assume dispatched rather than stall each gesture.
+        // Short window: acks are near-instant (the reconnect-verify adds one sub-second simctl/adb call); a lapse means an older agent/relay that never acks → optimistic (see catch below).
         2_000,
       )
-    } catch {
-      return // no ack within the window → older agent/relay; assume dispatched
+    } catch (e) {
+      // Only a timeout means an older agent/relay that never acks → assume dispatched.
+      // A WebSocket close (or any other error) means the input was NOT dispatched — surface it.
+      if (e instanceof Error && e.message === 'Request timed out') return
+      throw e
     }
     if (msg['type'] === 'input:error') {
       throw new Error((msg['message'] as string) ?? 'Input failed')

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -286,7 +286,7 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
     },
     async ({ sessionId, x, y, screenshotWidth, screenshotHeight }) => {
       try {
-        client.tap(sessionId, x / screenshotWidth, y / screenshotHeight)
+        await client.tap(sessionId, x / screenshotWidth, y / screenshotHeight)
         return ok(JSON.stringify({ tapped: true, x, y }))
       } catch (e) {
         return err(`tap failed: ${(e as Error).message}`)
@@ -361,7 +361,7 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
     },
     async ({ sessionId, key }) => {
       try {
-        client.pressKey(sessionId, key)
+        await client.pressKey(sessionId, key)
         return ok(JSON.stringify({ pressed: true, key }))
       } catch (e) {
         return err(`press_key failed: ${(e as Error).message}`)
@@ -383,7 +383,7 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
     },
     async ({ sessionId, button }) => {
       try {
-        client.pressButton(sessionId, button)
+        await client.pressButton(sessionId, button)
         return ok(JSON.stringify({ pressed: true, button }))
       } catch (e) {
         return err(`press_button failed: ${(e as Error).message}`)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -90,7 +90,7 @@ const AGENT_MSG_TYPES = new Set([
   'session:chrome', 'session:deviceInfo',
   'app:install-done', 'app:install-error', 'app:launch-done', 'app:launch-error',
   'open-url:done', 'open-url:error', 'keyboard:toggled',
-  'input:type-done', 'input:type-error',
+  'input:type-done', 'input:type-error', 'input:done', 'input:error',
   // stream:register binds a session's stream socket — agent-only, or a browser
   // (view PAT / cookie) could hijack an existing session's video feed.
   'stream:register',
@@ -614,6 +614,8 @@ export class RelayServer {
       case 'app:clear-state-error':
       case 'input:type-done':
       case 'input:type-error':
+      case 'input:done':
+      case 'input:error':
       case 'keyboard:toggled': {
         const session = this.sessions.get(msg.sessionId!)
         if (session?.browserSocket?.readyState === WebSocket.OPEN) {

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -82,6 +82,11 @@ const RESOURCE_THRESHOLD = Number.isFinite(_parsedThreshold) ? _parsedThreshold 
 
 // Messages that only agents are allowed to send. Authenticated browser sockets
 // that send any of these are disconnected immediately.
+// Terminal input messages the MCP client awaits an ack for — if the agent is offline
+// the relay replies input:error so the client fails truthfully (non-terminal moves/starts
+// expect no ack and are dropped silently).
+const TERMINAL_INPUT_TYPES = new Set<string>(['input:touch:end', 'input:pinch:end', 'input:key', 'input:button'])
+
 const AGENT_MSG_TYPES = new Set([
   'agent:register', 'agent:resources', 'screenshot:done', 'screenshot:error',
   'ui:tree:response', 'ui:tree:error',
@@ -672,6 +677,11 @@ export class RelayServer {
         const session = this.sessions.get(msg.sessionId!)
         if (session?.agentSocket.readyState === WebSocket.OPEN) {
           session.agentSocket.send(JSON.stringify(msg))
+        } else if (TERMINAL_INPUT_TYPES.has(msg.type) && ws.readyState === WebSocket.OPEN) {
+          // Agent offline or session evicted: a terminal input can't be dispatched.
+          // Reply to the sender (the MCP/browser socket) so it fails truthfully
+          // instead of falling through to its optimistic 2s timeout.
+          ws.send(JSON.stringify({ type: 'input:error', sessionId: msg.sessionId, message: 'agent offline' }))
         }
         break
       }

--- a/packages/relay/src/__tests__/clearState.test.ts
+++ b/packages/relay/src/__tests__/clearState.test.ts
@@ -83,6 +83,20 @@ describe('app:clear-state relay routing', () => {
     browser.close()
   })
 
+  it('replies input:error to the sender when a terminal input arrives after the agent is gone', async () => {
+    const { agent, browser, sessionId } = await setup()
+    const agentClosed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await agentClosed
+
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    const err = await waitForType(browser, 'input:error')
+    expect(err.sessionId).toBe(sessionId)
+    expect(err.message).toBe('agent offline')
+
+    browser.close()
+  })
+
   it('forwards the error reply back to the browser', async () => {
     const { agent, browser, sessionId } = await setup()
 

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -40,6 +40,8 @@ export type MessageType =
   | 'input:type'
   | 'input:type-done'
   | 'input:type-error'
+  | 'input:done'
+  | 'input:error'
   | 'input:button'
   | 'input:rotate'
   | 'input:keyboard:toggle'


### PR DESCRIPTION
## Summary

Fixes **followups H-F** — MCP input tools were fire-and-forget. The client sent `input:touch:*` / `input:key` / `input:button` and the tool fabricated `{tapped:true}` regardless of what the agent did. On a session whose device isn't booted, the input was silently dropped but reported as success — a false positive that also makes parallel test results untrustworthy (the trustworthiness prerequisite in the AI Automation maturity plan).

## Change (4 layers, reuses the existing request/response convention)

Adds a terminal-input ack with the same shape as `input:type-done` / `screenshot:done`:

- **agents (ios + android)** — on a gesture's terminal message (`input:touch:end`, `input:pinch:end`, `input:key`, `input:button`) send `input:done` if the input was dispatched to a booted device, else `input:error`. `input:done` means *dispatched* (agent handled it), **not a landing guarantee** — same semantics as the sibling `:done` acks (HID injection is fire-and-forget). Truthfulness uses a cached `DeviceState.booted` flag (set on `device:ready`, cleared on shutdown) and, only when the flag is false (post-reconnect / dead sim), one `simctl`/`adb` verify. Injection stays **synchronous**, so a tap's start/end pairing (H-E) is unaffected — the ack runs off that path.
- **relay** — forward `input:done` / `input:error` to the browser socket (allowlist + `MessageType` + forward switch), mirroring `input:type-done`.
- **mcp-server** — `tap` / `swipe` / `press_key` / `press_button` await the ack and surface `input:error` as a tool failure.

## Backward compatibility

**Additive + graceful degradation — not a breaking change for real (matched-version) users.** An older agent/relay that never acks lapses a short 2s window and the client falls back to optimistic success. All four packages release together (fixed changeset group), so skew is transient.

- The `run_flow` driver shares this client, so its input becomes truthful too; the flow-runner **CLI** (separate `RelayClient`) is a follow-up.
- Also resolves the H-E review MINOR#1 (input:type false-success on a shut-down sim is now covered by the ack family).

## Verification

- New tests: client ack round-trip (**done → success, error → throw, no-ack → optimistic**), ios-agent `input:done`/`input:error` acks, android-agent `input:done` ack. Relay forwarding is covered end-to-end (agent tests drive a real `RelayServer` and receive the ack on the browser socket).
- Full suites green — relay 480, mcp-server 38, ios-agent 229, android-agent 173. `pnpm typecheck` + lint clean.
- **Adversarial review** by an independent context: no BLOCKER/MAJOR, ship-able; 3 non-blocking notes (stale-ack NIT, 2s×N skew penalty by-design, iOS unknown-key now surfaced). Record: `.work/reviews/feat__mcp-input-ack.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input actions now acknowledge `done` vs `error` based on per-session device readiness.
  * Terminal input acknowledgements are forwarded so the client can reliably confirm completion.

* **Bug Fixes**
  * Improved acknowledgements for touch, pinch, key, and button inputs during boot/shutdown and after reconnects.
  * Clear errors now returned for agent-offline sessions and unknown key codes.

* **Tests**
  * Added/updated tests covering booted vs not-booted acknowledgements, client ack-wait behavior, and agent-offline error responses.

* **Documentation**
  * No user-facing documentation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->