### PR TITLE
fix(android): restore emulator-encoder exec bit so gRPC audio + host-mute work (M3)

### DIFF
--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -46,6 +46,7 @@
     "access": "public"
   },
   "scripts": {
+    "postinstall": "node -e \"if (process.platform === 'darwin') { try { require('fs').chmodSync('bin/emulator-encoder', 0o755) } catch {} }\"",
     "build": "tsc -b",
     "typecheck": "tsc -b",
     "test": "vitest run",

--- a/packages/android-agent/src/__tests__/EmulatorVideo.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorVideo.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { EmulatorVideo, detectCornerRadius, type EncoderProcess } from '../emulator/EmulatorVideo'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { EmulatorVideo, detectCornerRadius, ensureExecutable, type EncoderProcess } from '../emulator/EmulatorVideo'
 import { EmulatorGrpcClient, type RawEmulatorController } from '../emulator/EmulatorGrpcClient'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 
@@ -202,5 +205,44 @@ describe('EmulatorVideo', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+// followups M3: emulator-encoder ships without the exec bit on installs that skip the
+// postinstall (--ignore-scripts), so the gRPC video/audio path fails with EACCES and
+// silently falls back to scrcpy (no audio, no host-mute). ensureExecutable self-heals it.
+describe('ensureExecutable', () => {
+  it('restores the exec bit on a non-executable binary', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-encoder-'))
+    const bin = path.join(dir, 'emulator-encoder')
+    try {
+      fs.writeFileSync(bin, '#!/bin/sh\n')
+      fs.chmodSync(bin, 0o644) // no exec bit — mimics a --ignore-scripts install
+      expect(() => fs.accessSync(bin, fs.constants.X_OK)).toThrow()
+
+      ensureExecutable(bin)
+
+      expect(() => fs.accessSync(bin, fs.constants.X_OK)).not.toThrow()
+      expect(fs.statSync(bin).mode & 0o111).not.toBe(0)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is a no-op (no throw) when the binary is already executable', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-encoder-'))
+    const bin = path.join(dir, 'emulator-encoder')
+    try {
+      fs.writeFileSync(bin, '#!/bin/sh\n')
+      fs.chmodSync(bin, 0o755)
+      expect(() => ensureExecutable(bin)).not.toThrow()
+      expect(() => fs.accessSync(bin, fs.constants.X_OK)).not.toThrow()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not throw when the binary is missing (spawn will surface the real error)', () => {
+    expect(() => ensureExecutable('/no/such/emulator-encoder')).not.toThrow()
   })
 })

--- a/packages/android-agent/src/__tests__/EmulatorVideo.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorVideo.test.ts
@@ -208,9 +208,7 @@ describe('EmulatorVideo', () => {
   })
 })
 
-// followups M3: emulator-encoder ships without the exec bit on installs that skip the
-// postinstall (--ignore-scripts), so the gRPC video/audio path fails with EACCES and
-// silently falls back to scrcpy (no audio, no host-mute). ensureExecutable self-heals it.
+// followups M3: a lost encoder exec bit makes spawn EACCES → silent scrcpy fallback (no audio/host-mute); ensureExecutable self-heals it.
 describe('ensureExecutable', () => {
   it('restores the exec bit on a non-executable binary', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-encoder-'))

--- a/packages/android-agent/src/emulator/EmulatorVideo.ts
+++ b/packages/android-agent/src/emulator/EmulatorVideo.ts
@@ -11,10 +11,7 @@ const logger = createLogger('android-agent:emulator-video')
 // The Swift VT encoder, two levels up in both src/ (tsx) and dist/ (build).
 const ENCODER_BIN = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'bin', 'emulator-encoder')
 
-// Defense-in-depth for the postinstall chmod: installs that skip scripts (--ignore-scripts,
-// some CI/security setups) leave emulator-encoder without the exec bit → spawn EACCES → silent
-// scrcpy fallback with no gRPC audio or host-mute. Restore it before spawning; a read-only prefix
-// just falls through to the real spawn error (unchanged scrcpy fallback).
+// Restore the encoder's exec bit before spawning: if it was lost in the install path, spawn would EACCES → silent scrcpy fallback with no gRPC audio/host-mute. Best-effort — a read-only fs falls through to the real spawn error.
 export function ensureExecutable(bin: string): void {
   try {
     fs.accessSync(bin, fs.constants.X_OK)

--- a/packages/android-agent/src/emulator/EmulatorVideo.ts
+++ b/packages/android-agent/src/emulator/EmulatorVideo.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
+import fs from 'node:fs'
 import { createLogger } from '@tapflowio/agent-core'
 import { EmulatorGrpcClient } from './EmulatorGrpcClient.js'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo.js'
@@ -9,6 +10,21 @@ const logger = createLogger('android-agent:emulator-video')
 
 // The Swift VT encoder, two levels up in both src/ (tsx) and dist/ (build).
 const ENCODER_BIN = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'bin', 'emulator-encoder')
+
+// Defense-in-depth for the postinstall chmod: installs that skip scripts (--ignore-scripts,
+// some CI/security setups) leave emulator-encoder without the exec bit → spawn EACCES → silent
+// scrcpy fallback with no gRPC audio or host-mute. Restore it before spawning; a read-only prefix
+// just falls through to the real spawn error (unchanged scrcpy fallback).
+export function ensureExecutable(bin: string): void {
+  try {
+    fs.accessSync(bin, fs.constants.X_OK)
+  } catch {
+    try {
+      fs.chmodSync(bin, 0o755)
+      logger.info(`restored exec bit on ${bin} (postinstall likely skipped)`)
+    } catch { /* read-only fs — spawn surfaces EACCES and we fall back to scrcpy as before */ }
+  }
+}
 
 export interface EmulatorVideoInfo {
   width: number
@@ -77,7 +93,7 @@ export class EmulatorVideo {
   /** Spawns the encoder and starts capture; resolves once the first frame fixes the dimensions. */
   async start(): Promise<EmulatorVideoInfo> {
     const fps = this.options.fps ?? 30
-    const spawnEncoder = this.options.spawnEncoder ?? ((f: number) => spawn(ENCODER_BIN, [String(f)]))
+    const spawnEncoder = this.options.spawnEncoder ?? ((f: number) => { ensureExecutable(ENCODER_BIN); return spawn(ENCODER_BIN, [String(f)]) })
     this.encoder = spawnEncoder(fps)
     this.encoder.stderr.on('data', (d: Buffer) => logger.info(`encoder: ${d.toString().trim()}`))
     this.encoder.stdout.on('data', (chunk: Buffer) => this.onEncoderOutput(chunk))


### PR DESCRIPTION
## Summary

Fixes **followups M3** — with the dashboard and Android agent on **separate Macs**, the emulator's audio came out of the *agent* Mac and never reached the dashboard.

Root cause is a **packaging bug, not the mute logic**. On a fresh install the android-agent's `bin/emulator-encoder` (a Swift VideoToolbox H.264 encoder) came without an executable bit → the encoder spawn failed with `EACCES` → the gRPC video backend fell back to scrcpy. Because gRPC `streamAudio` capture **and** the #341 host-mute tap are only set up on the gRPC path, that fallback silently killed **both**:

- dashboard got no audio (no gRPC `streamAudio` capture)
- the agent Mac played the emulator's audio (host-mute never ran)

Diagnosed from the agent log on a 2-Mac repro: `emulator-encoder … EACCES … gRPC backend failed … falling back to scrcpy` (with no `host-mute:` line, because that path never runs `startHostMute`).

Why it hid until now: on **one Mac** the local emulator playback masked it, and dev runs use the repo's already-executable binary. **iOS was unaffected** — its `.muted` Core Audio tap captures + mutes in a single step, so the two can't diverge.

## Fix

- **`ensureExecutable()`** restores the exec bit right before spawning the encoder — the load-bearing runtime safety net that self-heals **however** the bit was lost (including `--ignore-scripts` installs that skip the postinstall).
- **`postinstall`** chmods `bin/emulator-encoder` to `0o755` at install time, matching `ios-agent` / `audiotap-helper`.

> Note: `npm pack` preserves the `0o755` bit in the published tarball, so the bit was dropped somewhere in the install path (global-install layer / extraction tooling / package-manager store), not by the tarball itself. `ensureExecutable` is the piece that stands on its own.

## Follow-up (not this PR)

Audio + host-mute die silently on **any** gRPC→scrcpy fallback, not just this EACCES — worth a user-visible degraded-audio signal, or wiring host-mute/audio independent of the video backend.

## Verification

- New tests: `ensureExecutable` restores the bit / no-ops when already set / doesn't throw on a missing binary (exercises the real exported function).
- android-agent suite **176** green; `pnpm typecheck` + lint clean.
- **Adversarial review** by an independent context: no BLOCKER/MAJOR, safe to merge; one MINOR (narrative precision) fixed by amending the commit. Record: `.work/reviews/fix__android-encoder-exec-bit.md`.

> This is a published-package bug, so the fix reaches users on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android emulator video startup by best-effort restoring executable permissions for the encoder to prevent permission errors.
  * Added a macOS installation safeguard to automatically set the required permissions.
  * Updated behavior to handle cases where the encoder is already executable or the target is missing without breaking existing fallback handling.
* **Tests**
  * Added coverage for executable-permission restoration, including no-op and missing-binary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->