### PR TITLE
fix(android): map Cmd/Ctrl clipboard shortcuts to keycodes so copy/paste work (M1)

### DIFF
--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -1167,6 +1167,14 @@ export class AndroidAgent implements DeviceAgent {
       await this.adb.sendKeyEvent(serial, SPECIAL[code])
       return
     }
+    // A Ctrl/Cmd chord is a command, not text. `input text` can't do chords, so map the
+    // clipboard shortcuts to dedicated keycodes (a Mac viewer sends Cmd = meta 0x08; treat
+    // meta and ctrl alike). Any other chord+letter (e.g. Cmd+A) must NOT type the raw letter.
+    if (modifiers & (0x01 | 0x08)) {
+      const CLIP: Record<string, string> = { KeyC: 'KEYCODE_COPY', KeyV: 'KEYCODE_PASTE', KeyX: 'KEYCODE_CUT' }
+      if (CLIP[code]) await this.adb.sendKeyEvent(serial, CLIP[code])
+      return
+    }
     const shift = Boolean(modifiers & 0x02)
     let char: string | null = null
     if (code.startsWith('Key')) {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -835,6 +835,38 @@ describe('AndroidAgent', () => {
         expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', '!')
       })
 
+      // followups M1: a Cmd/Ctrl chord used to be typed as the raw letter (Cmd+C → 'c'), so
+      // copy/paste both silently failed. They must map to the dedicated keycodes instead.
+      it('maps Cmd+C (meta) to KEYCODE_COPY, not a typed "c"', () => {
+        const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
+        const inputSpy = vi.spyOn(adb, 'sendInput')
+        inject({ type: 'input:key', payload: { code: 'KeyC', modifiers: 0x08 } })
+        expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_COPY')
+        expect(inputSpy).not.toHaveBeenCalled()
+      })
+
+      it('maps Cmd+V to KEYCODE_PASTE and Ctrl+X to KEYCODE_CUT', () => {
+        const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
+        inject({ type: 'input:key', payload: { code: 'KeyV', modifiers: 0x08 } })
+        inject({ type: 'input:key', payload: { code: 'KeyX', modifiers: 0x01 } })
+        expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_PASTE')
+        expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_CUT')
+      })
+
+      it('does not type the raw letter for a non-clipboard chord (Cmd+A)', () => {
+        const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
+        const inputSpy = vi.spyOn(adb, 'sendInput')
+        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0x08 } })
+        expect(inputSpy).not.toHaveBeenCalled()
+        expect(keyEvSpy).not.toHaveBeenCalled()
+      })
+
+      it('still types a plain letter with no chord modifier (regression)', () => {
+        const inputSpy = vi.spyOn(adb, 'sendInput')
+        inject({ type: 'input:key', payload: { code: 'KeyC', modifiers: 0 } })
+        expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', 'c')
+      })
+
       it('keyboard:toggle is a client-side no-op (no adb side effect, no throw)', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
         const inputSpy = vi.spyOn(adb, 'sendInput')

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -847,10 +847,12 @@ describe('AndroidAgent', () => {
 
       it('maps Cmd+V to KEYCODE_PASTE and Ctrl+X to KEYCODE_CUT', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
+        const inputSpy = vi.spyOn(adb, 'sendInput')
         inject({ type: 'input:key', payload: { code: 'KeyV', modifiers: 0x08 } })
         inject({ type: 'input:key', payload: { code: 'KeyX', modifiers: 0x01 } })
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_PASTE')
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_CUT')
+        expect(inputSpy).not.toHaveBeenCalled()
       })
 
       it('does not type the raw letter for a non-clipboard chord (Cmd+A)', () => {


### PR DESCRIPTION
## Summary

Fixes the **Android** half of followups **M1** — copy and paste both silently failed on the Android emulator.

`handleKeyInput` ignored the Ctrl/Meta modifier and typed the raw letter via `adb input text`, so a viewer's **Cmd+C / Cmd+V** (the dashboard forwards these as `input:key` with `modifiers: 0x08` = meta) just entered the literal characters **"c" / "v"**.

## Fix

Map a Ctrl/Cmd chord + `C`/`V`/`X` to `KEYCODE_COPY` / `KEYCODE_PASTE` / `KEYCODE_CUT` (a Mac viewer sends Cmd = meta `0x08`; a non-Mac viewer sends Ctrl = `0x01` — treat both as the chord). Any other chord + letter (e.g. Cmd+A) no longer types the raw letter either — a chord is a command, not text.

## Scope

- **Android only.** iOS needs no key-mapping fix: measured on Xcode 26.6 / iOS 26.5, selecting text in the simulator and pressing **Cmd+C through the tapflow dashboard puts the text on the simulator pasteboard** (`xcrun simctl pbpaste <udid>` returned the selected string). The HID Cmd+C path already works, matching the code — copy and paste both go through the same `sendKey(usage, MetaLeft)` HID keyboard.
- The reported iOS "copy is broken" symptom is a **missing sim→viewer clipboard bridge**, not a key bug: the text lands on the *simulator's* pasteboard with no path to the *browser user's* clipboard (there is no `pbpaste` / clipboard-read anywhere in the codebase). The Simulator's automatic pasteboard sync with the host Mac is dead in both directions on 26.6 — with or without Simulator.app running — so it cannot serve as that path either. tapflow already sidesteps this on the host→sim side: `input:type` writes the pasteboard via `simctl setPasteboard` before sending Cmd+V, never relying on auto-sync. Since the direct `simctl pbcopy`/`pbpaste` round-trip does work, it is a viable source for the bridge. Distinct cross-platform feature, out of scope here.
- This fix restores **sim-internal** copy/paste on Android (select → Cmd+C → Cmd+V within the emulator). Surfacing the copied text to the *dashboard user's* clipboard is that separate bridge feature (applies to both platforms).

## Verification

- New tests: Cmd+C→COPY (no typed "c"), Cmd+V→PASTE, Ctrl+X→CUT, Cmd+A types nothing, plain "c" still types. Reverting the fix fails 3 of the 4.
- android-agent suite **180** green; `pnpm typecheck` + lint clean.
- iOS behaviour confirmed on a live simulator (see Scope) — no code change needed on that side.
- **Adversarial review** by an independent context: no BLOCKER/MAJOR; 2 minor/stylistic notes (Ctrl+Shift+C→COPY, keycode names vs numbers), both accepted. CodeRabbit's one actionable note (assert clipboard chords never reach `sendInput`) is fixed in `1385b29`. Record: `.work/reviews/fix__android-clipboard-shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling on Android.
  * Copy, paste, and cut shortcuts now trigger the correct system actions instead of typing letters.
  * Other Ctrl/Cmd shortcuts no longer produce unintended text input.
  * Regular, unmodified letter input continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
