### PR TITLE
test(cli): wait for the relay listening line so the smoke test stops flaking

### DIFF
--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -53,23 +53,21 @@ describe('CLI smoke tests', () => {
         else resolve()
       }
 
-      // Wait for the "Relay started on …" line rather than sampling stdout after a fixed
-      // delay: a cold tsx start plus relay boot can outlast any fixed window on a loaded
-      // CI runner, which made this test flaky.
+      // Wait for the readiness line: a cold tsx start can outlast any fixed window on CI.
       proc.stdout.on('data', (d: Buffer) => {
         stdout += d.toString()
         if (listening || !stdout.includes('localhost:14321')) return
         listening = true
-        // Keep watching for the ~2s the fixed window used to cover, so a relay that prints
-        // and then dies still trips the early-exit guard below; never wait less than 500ms
-        // when a slow runner pushed the line out late.
+        // Keep the ~2s of liveness the fixed window used to observe, floored at 500ms.
         grace = setTimeout(finish, Math.max(500, 2_000 - (Date.now() - startedAt)))
       })
       proc.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
 
-      // 즉시 종료하면 실패
-      proc.on('exit', (code) => {
-        if (code !== null) finish(new Error(`relay start exited early (code ${code})\n${stderr}`))
+      // 즉시 종료하면 실패 (a signal kill reports code === null, so check both)
+      proc.on('exit', (code, signal) => {
+        if (code !== null || signal !== null) {
+          finish(new Error(`relay start exited early (code ${code}, signal ${signal})\n${stderr}`))
+        }
       })
 
       deadline = setTimeout(() => {

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -35,25 +35,46 @@ describe('CLI smoke tests', () => {
         env: { ...process.env, TAPFLOW_DATA_DIR: dataDir },
       })
 
+      const startedAt = Date.now()
       let stdout = ''
       let stderr = ''
-      proc.stdout.on('data', (d: Buffer) => { stdout += d.toString() })
+      let listening = false
+      let settled = false
+      let deadline: ReturnType<typeof setTimeout>
+      let grace: ReturnType<typeof setTimeout>
+
+      const finish = (err?: Error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(deadline)
+        clearTimeout(grace)
+        proc.kill()
+        if (err) reject(err)
+        else resolve()
+      }
+
+      // Wait for the "Relay started on …" line rather than sampling stdout after a fixed
+      // delay: a cold tsx start plus relay boot can outlast any fixed window on a loaded
+      // CI runner, which made this test flaky.
+      proc.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString()
+        if (listening || !stdout.includes('localhost:14321')) return
+        listening = true
+        // Keep watching for the ~2s the fixed window used to cover, so a relay that prints
+        // and then dies still trips the early-exit guard below; never wait less than 500ms
+        // when a slow runner pushed the line out late.
+        grace = setTimeout(finish, Math.max(500, 2_000 - (Date.now() - startedAt)))
+      })
       proc.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
 
       // 즉시 종료하면 실패
       proc.on('exit', (code) => {
-        if (code !== null) reject(new Error(`relay start exited early (code ${code})\n${stderr}`))
+        if (code !== null) finish(new Error(`relay start exited early (code ${code})\n${stderr}`))
       })
 
-      setTimeout(() => {
-        proc.kill()
-        try {
-          expect(stdout).toContain('localhost:14321')
-          resolve()
-        } catch (e) {
-          reject(e)
-        }
-      }, 2000)
+      deadline = setTimeout(() => {
+        finish(new Error(`relay start never reported listening within 15s\nstdout: ${stdout}\nstderr: ${stderr}`))
+      }, 15_000)
     })
-  }, 10_000)
+  }, 20_000)
 })


### PR DESCRIPTION
## Summary

`tapflow relay start` smoke test is flaky on CI. It killed the spawned process after a **fixed 2000ms** and only *then* asserted stdout contained `localhost:14321`. On a loaded runner a cold `tsx` start plus relay boot outlasts that window, so the assertion ran against a stdout that stopped at the JWT-secret line.

The test timeout was already 10s — the 2s sample never used that headroom.

## Evidence it is flakiness, not a break

- Failing run: https://github.com/jo-duchan/tapflow/actions/runs/30166954214 (PR #413, commit `1385b29`). That commit's whole diff is **2 added lines in `packages/android-agent/src/__tests__/AndroidAgent.test.ts`** — nothing touches the cli package.
- Parent commit `0ffc082` passed; re-running the same failing run succeeded.
- Locally the relay prints the line at **+383ms** warm, **+451ms** with a cleared `tsx` cache — healthy, just not guaranteed inside 2s on a cold CI runner.

## Fix

Settle as soon as the `Relay started on …` line appears, bounded by a **15s deadline** (test timeout raised to 20s).

The original test also implicitly checked "does not exit immediately" by observing ~1.6s of post-print liveness. To keep that, the observation window still runs to **~2s from spawn** — `max(500ms, 2000ms - elapsed)` — so it only shortens when a slow runner already spent the budget. The pre-existing early-exit guard then still catches a relay that prints and dies.

## Verification

- 5 consecutive local runs green; full cli suite **246** pass; typecheck + lint + a11y-lens clean; no zombie vitest.
- **Negative tests — the test still fails for the right reasons:**
  - line never printed → `relay start never reported listening within 15s`
  - relay exits immediately → `exited early (code 0)` at 391ms
  - relay prints then dies at +700ms (injected `setTimeout(() => process.exit(0), 700)` into `relay-start.ts`) → `exited early (code 0)` at 1123ms. `relay-start.ts` restored byte-for-byte after the experiment.
- **Adversarial review** by an independent context: 1 MAJOR (the first revision's flat 500ms grace let the +700ms death pass — fixed, then re-verified with the reviewer's own injection), 3 MINOR (2 fixed, 1 skipped with reason), 2 NIT (out of scope, recorded). Record: `.work/reviews/fix__cli-smoke-relay-banner-wait.md`.

Side effect: the smoke file drops from ~3.5s to ~1.8s in the fast path, since it no longer sleeps a flat 2s when the relay is already up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked the CLI smoke test to wait for an explicit “listening” signal by incrementally monitoring process output, instead of using a fixed startup delay.
  * Improved failure handling with a longer overall timeout, a hard deadline if the listening line isn’t observed, and clearer error details (including captured stderr) when the process exits early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->