### PR TITLE
docs: slim agent context files per Claude 5 context-engineering guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,58 +38,28 @@ For the product direction and philosophy behind these — Manual First, Flow Cap
 
 ## Core Principles
 
-Check these four before every task. The cost of violating them — wrong fixes, reverts, rework — always exceeds the cost of following them.
-
-### 1. No guessing — evidence-based
-
-Do not conclude a root cause before verifying it with code, logs, or tests.
-
-- For bugs: reproduce → diagnostic log → validate hypothesis → fix. No jumping to conclusions.
-- When in doubt about package behavior or API signatures, read `package.json`, source code, or runtime output directly.
-- If "this is probably why" comes to mind, stop and verify first.
-- Every hypothesis must come with a validation method (`console.log`, unit test, `git log`, direct invocation, etc.).
-
-### 2. Minimal changes — stay within scope
-
-Only touch lines directly connected to the requested change.
-
-- Do not "improve" adjacent code, comments, or formatting.
-- Follow the file's existing conventions even if they differ from your preferences.
-- Only clean up unused imports or functions introduced by the current change. Leave existing dead code as-is (note it if needed).
-
-### 3. Hypothesis → verifiable goal
-
-Before starting, define in one sentence how success will be measured.
-
-- "Bug fix" → "write a reproducing test → confirm it passes"
-- "Refactor" → "same tests pass before and after"
-- For multi-step tasks, specify the verification method at each step.
-
-### 4. Stop before risky actions
-
-Get user confirmation before any hard-to-reverse operation.
-
-- `git push --force`, `git reset --hard`, sending messages to external systems, DB drops, etc.
-- Only create commits or PRs when the user explicitly requests it.
-- **Do not merge PRs.** Always leave merging to the user — even with `--admin`. Create the PR and stop.
-- **Avoid breaking changes.** If unavoidable, report to the user and get approval before proceeding. Breaking change scope: public API / interface signature changes, DB schema changes, WebSocket message protocol changes, CLI command / flag changes.
+- **Evidence-based**: verify a root cause with code, logs, or tests before fixing — no guess-driven changes.
+- **Minimal changes**: stay within the requested scope; follow the file's existing conventions.
+- **Verifiable goal**: know how success will be measured before starting (a reproducing test, same tests passing after a refactor, etc.).
+- **Stop before risky actions** — get user confirmation before any hard-to-reverse operation (`git push --force`, `git reset --hard`, sending messages to external systems, DB drops, etc.). Specifically:
+  - Only create commits or PRs when the user explicitly requests it.
+  - **Do not merge PRs.** Always leave merging to the user — even with `--admin`. Create the PR and stop.
+  - **Avoid breaking changes.** If unavoidable, report to the user and get approval before proceeding. Breaking change scope: public API / interface signature changes, DB schema changes, WebSocket message protocol changes, CLI command / flag changes.
 
 ---
 
 ## HOW
 
 ### Language & Stack
-- TypeScript throughout. No `any`.
-- Node.js ≥ 20.
-- WebSocket: `ws`. Dashboard: Vite + React 19 + React Router v7. Tests: vitest.
+- TypeScript throughout. No `any`. Node.js ≥ 20. Everything else is in each package's `package.json`.
 
 ### Branches, Commits & Releases
 → [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 Write GitHub PR and issue titles/bodies in **English**, and write new code comments in **English** too. (Conversation and docs follow the existing KO/EN rules.) Code comments default to English so contributors of any language can read and extend them — existing Korean comments stay until the line they sit on is changed.
 
-Before starting any task that requires code changes:
-1. `git checkout main && git pull origin main` — always start from the latest main.
+When starting a **new** task that requires code changes (not when continuing work on an existing branch):
+1. `git checkout main && git pull origin main` — start from the latest main.
 2. `git checkout -b <branch-name>` — work on a new branch, never directly on main.
 
 ### Workflow (Plan → Work → Review → Compound)
@@ -114,14 +84,13 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 
 ### Design Principles (SOLID — priority subset)
 
-- **OCP**: New platforms and features are added without modifying existing code. `AgentRegistry.register()` is the example.
+- **OCP**: New platforms and features are added without modifying existing code — platforms register via `AgentRegistry.register()` only; relay and dashboard code stay unchanged.
 - **ISP**: `DeviceAgent` only contains methods every platform can implement. Platform-specific behavior goes in separate interfaces.
 - **DIP**: Dependencies via constructor injection. Depend on interfaces, not implementations.
 
 ### Code Rules
-- Comments only when the WHY is non-obvious: one line max. Write new comments in English; leave existing Korean comments unless you're already editing that line.
+- Comments only when the WHY is non-obvious. Write new comments in English; leave existing Korean comments unless you're already editing that line.
 - When changing an interface, update `agent-core` first, then align implementations.
-- New platforms are added via `AgentRegistry.register()` only — relay and dashboard code stay unchanged.
 
 ### Test Hygiene
 After running tests (especially repeated or looped runs), always check for zombie vitest processes and kill them:
@@ -137,6 +106,3 @@ Zombie worker processes accumulate silently from `pnpm test` loops and consume m
 
 - Do not write code that sends app data or streams to external services.
 - Do not proactively add features not on the roadmap.
-- Do not pollute the `agent-core` interface with platform-specific logic.
-- Do not write implementation code before tests.
-- Do not make changes based on guesses — no "this is probably the cause" code changes without evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ playground/       ← local integration test environment
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
 - Always create new branches from `origin/main` (`git fetch origin && git checkout -b feature/{topic} origin/main`). Your local `main` may be behind.
 - Releases are driven by [changesets](https://github.com/changesets/changesets). A tag push triggers GitHub Actions → npm publish + GitHub Release. Merging to main does not auto-publish.
+- Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies between packages; the changesets → pnpm publish path does.
 
 ### Versioning (Semver)
 
@@ -59,7 +60,7 @@ Versions follow `MAJOR.MINOR.PATCH`. Determine the bump from the commits since t
 |------|------|
 | `patch` | `fix`, `perf`, `docs`, `chore`, `refactor` — no API change |
 | `minor` | `feat` — new functionality, backward-compatible |
-| `major` | Any breaking change (see [AGENTS.md](./AGENTS.md) Principle 4 for scope) |
+| `major` | Any breaking change (see [AGENTS.md](./AGENTS.md) Core Principles for scope) |
 
 **Before `v1.0.0`:** breaking changes may land in `minor` versions. Once `v1.0.0` is tagged, the table above is strictly enforced.
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -71,26 +71,3 @@ Committed *why* behind non-obvious decisions. Read the relevant one **before** c
 | [streaming-latency-log.md](./contributing/streaming-latency-log.md) | log | Append-only glass-to-glass latency log — pipeline analysis, attempts, decisions |
 | [android-video-streaming-diagnosis.md](./contributing/android-video-streaming-diagnosis.md) | diagnosis | Android emulator streaming issues traced to root cause, one section per issue |
 | [awdl-wifi-latency-diagnosis.md](./contributing/awdl-wifi-latency-diagnosis.md) | diagnosis | Periodic Wi-Fi stream hitch traced to AWDL via ICMP ping — method and evidence |
-
----
-
-## Hierarchy
-
-```text
-AGENTS.md (common rules — WHAT/WHY/HOW/HOW NOT)
-└── INDEX.md (this file — package & doc reference index)
-    ├── packages/agent-core/AGENTS.md
-    ├── packages/ios-agent/AGENTS.md
-    ├── packages/android-agent/AGENTS.md
-    ├── packages/audiotap-helper/AGENTS.md
-    ├── packages/relay/AGENTS.md
-    ├── packages/dashboard/AGENTS.md
-    ├── packages/cli/AGENTS.md
-    ├── packages/mcp-server/AGENTS.md
-    ├── packages/flow-runner/AGENTS.md
-    ├── playground/AGENTS.md
-    ├── .work/CLAUDE.md
-    ├── .internal/marketing/AGENTS.md
-    ├── docs/AGENTS.md
-    └── CONTRIBUTING.md
-```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,18 +11,7 @@ VitePress 1.x 기반 정적 문서 사이트. 작업하면서 겪은 삽질과 �
 
 ## 파일 구조
 
-```
-docs/
-├── .vitepress/
-│   ├── config.ts              # VitePress 설정 (shiki 테마 주입 등)
-│   └── theme/
-│       ├── index.ts           # 테마 진입점
-│       ├── custom.css         # CSS 커스터마이징
-│       ├── tapflow-light.json # shiki 커스텀 테마 (라이트)
-│       └── tapflow-dark.json  # shiki 커스텀 테마 (다크)
-└── reference/
-    └── cli.md                 # CLI 레퍼런스
-```
+VitePress 표준 구조를 따른다. 사이드바·shiki 테마 주입은 `.vitepress/config.ts`, CSS 커스터마이징과 shiki 커스텀 테마는 `.vitepress/theme/`에 있다. 문서 본문은 영어가 `docs/`, 한국어가 `docs/ko/`.
 
 
 ## 문서 작성 규칙

--- a/packages/agent-core/AGENTS.md
+++ b/packages/agent-core/AGENTS.md
@@ -17,7 +17,7 @@ The sole contract that platform implementations (ios-agent, android-agent) depen
 
 ## HOW
 
-- The interface contains only platform-neutral methods: `listDevices`, `boot`, `shutdown`, `installApp`, `launchApp`, `screenshot`, `stream`, `touchStart`, `touchMove`, `touchEnd`, `openUrl`, `queryUITree`.
+- The interface contains only platform-neutral methods every platform can implement — see `DeviceAgent` in `src/` for the current list.
 - `queryUITree` returns the unified `UIElement[]` schema (`role`/`label`/`identifier`/`frame`/`enabled`/`rawRole`); frames are normalized 0-1 in the same coordinate space the touch path consumes. Platform backends (uiautomator, AXUIElement, …) map into this schema on the agent side — relay and mcp-server are pass-through.
 - `AgentRegistry`: platforms self-register via `register(platform, AgentClass, opts?)` (with a `connect` hook and optional `canRun` gate); the CLI drives them through `available()` / `connect(platform, relayUrl, opts)`. `connect`'s `AgentConnectOpts` carries `deviceFilter` and an optional `token` (opaque credential the agent forwards to a remote relay as `Authorization: Bearer`).
 - Interface changes must pass all implementation package tests before merging.
@@ -31,4 +31,4 @@ The sole contract that platform implementations (ios-agent, android-agent) depen
 ## Directory Structure
 
 - `src/` — `DeviceAgent` interface, `AgentRegistry`, shared types, `createLogger` (leveled console logger)
-- `src/utils/` — shared implementation utils for ios-agent, android-agent, and the relay. Currently: `createResourceSampler` (CPU & memory sampling, `resources.ts`); and in `stream.ts`: `registerStreamWs` (stream:register handshake helper), `disableNagle` (TCP_NODELAY — kills the ~40ms Nagle/delayed-ACK stall on small LAN writes), `sendBinaryWithBackpressure` (drop-to-latest), and `createKeyframeAwareSender` (drop-to-keyframe — preserves the H.264 reference chain under backpressure). Not exposed through the `DeviceAgent` interface.
+- `src/utils/` — shared implementation utils for ios-agent, android-agent, and the relay; not exposed through the `DeviceAgent` interface. Non-obvious ones in `stream.ts`: `disableNagle` (TCP_NODELAY — kills the ~40ms Nagle/delayed-ACK stall on small LAN writes) and `createKeyframeAwareSender` (drop-to-keyframe — why: relay AGENTS.md § Compound).

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -13,24 +13,12 @@ status: living
 ## WHAT
 
 `tapflow` CLI: handles local dev environment checks and simulator / relay / agent startup.
-Commands are registered in `src/index.ts`:
+Commands are registered in `src/index.ts`; user-facing reference: [`docs/reference/cli.md`](../../docs/reference/cli.md). Non-obvious contracts:
 
-| Command | Behavior |
-|---------|----------|
-| `init [--tunnel, --force]` | Scaffold `tapflow.config.json` interactively; auto-adds the `.tapflow/` runtime dirs (`data/`, `artifacts/`) to `.gitignore` |
-| `admin init [--relay]` | Create the first admin account on the relay (CLI fallback for headless servers; web `/setup` is the default path) |
-| `start [--device, --platform]` | Local-only shortcut — starts relay + agent together (same Mac) |
-| `relay start [--port, --tunnel]` | Start relay only (for Docker/Linux server) |
-| `agent start [--relay, --device, --platform, --token]` | Start agent only — connects to an existing relay. `--token` (or `TAPFLOW_AGENT_TOKEN`) carries an `agent`-scope PAT, required when the relay is on a different machine; flag wins over env. |
-| `doctor [platform]` | Check system prerequisites (`ios` \| `android`; omit for all): iOS Xcode/simctl/Simulator, Android SDK/adb/AVD |
-| `setup [platform]` | Guided environment setup (`ios` \| `android`; omit to auto-detect): installs/repairs JDK, Android SDK (self-contained at `~/Library/Android/sdk`), simulator runtime / AVDs |
-| `devices` | List available simulators and AVDs |
-| `boot <name>` | Boot a simulator by name or UDID |
-| `reset` | Shut down all simulators and emulators |
-| `status [--relay]` | Show connected agents, devices, and session count (WebSocket `agents:listed`) |
-| `logs [--relay] [--lines]` | Query the relay in-memory log buffer (`GET /api/v1/logs`) |
-| `flow run <files...> [--relay, --token, --session, --device, --build, --no-install, --junit, --artifacts, --timeout]` | Replay YAML flows deterministically via `@tapflowio/flow-runner` (no LLM). Exit codes: `0` passed · `1` flow failed · `2` env/config error. Always sends `device:boot` (idempotent — it initializes the agent's touch/stream state). `--token` needs a `view`-scope PAT; REST (`/ui-tree`, `/screenshot`) requires auth even on localhost. |
-| `migrate <subcommand>` | Migration commands (subcommand: `data-dir`). `migrate data-dir` moves a legacy `.tapflow-data/` into the unified `.tapflow/data/` (atomic rename), repoints `local.dataDir` in `tapflow.config.json` when it pinned the old default, and updates `.gitignore`. Idempotent; the relay itself never moves data (read-only fallback only). |
+- `init` never touches the relay; it scaffolds config and auto-adds the `.tapflow/` runtime dirs to `.gitignore`. `admin init` is the CLI fallback for headless servers (web `/setup` is the default path).
+- `agent start --token` (or `TAPFLOW_AGENT_TOKEN`) carries an `agent`-scope PAT, required when the relay is on a different machine; flag wins over env.
+- `flow run` exit codes: `0` passed · `1` flow failed · `2` env/config error. Always sends `device:boot` (idempotent — it initializes the agent's touch/stream state). `--token` needs a `view`-scope PAT; REST (`/ui-tree`, `/screenshot`) requires auth even on localhost.
+- `migrate data-dir` moves a legacy `.tapflow-data/` into the unified `.tapflow/data/` (atomic rename), repoints `local.dataDir` in `tapflow.config.json` when it pinned the old default, and updates `.gitignore`. Idempotent; the relay itself never moves data (read-only fallback only).
 
 ### Command Design Principles
 
@@ -48,5 +36,4 @@ Each command has exactly one responsibility. `tapflow start` is for local develo
 ## HOW NOT
 
 - Do not add commands that access external systems (cloud, remote infrastructure) — this is a local tool.
-- Do not hardcode credentials or tokens.
 - Only `reset` tears down running state (shutting down simulators/emulators). `setup` may install/configure the local environment (Homebrew packages, JDK, Android SDK, shell rc) but only after explicit consent and only in interactive (TTY) sessions — non-interactive runs print guidance instead. No command deletes user data.

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -49,7 +49,6 @@ The audience is the whole team (PO, PM, designers, backend, QA) — not just QA.
 ## HOW NOT
 
 - Do not reintroduce the `next` package.
-- Do not run as a standalone server — the relay serves it.
 - Do not call the Agent directly from the dashboard — always go through the relay.
 - Do not put platform-specific conditionals (`if platform === 'ios'`) in UI components.
 - Do not send session recording data to external storage.

--- a/packages/flow-runner/AGENTS.md
+++ b/packages/flow-runner/AGENTS.md
@@ -1,3 +1,9 @@
+---
+type: rules
+topics: [flow-runner, yaml, replay]
+status: living
+---
+
 # flow-runner — AGENTS.md
 
 > Common rules: [AGENTS.md](../../AGENTS.md) | Full index: [INDEX.md](../../INDEX.md)
@@ -9,7 +15,7 @@
 `@tapflowio/flow-runner`: deterministic YAML flow engine — the replay half of the automated QA axis.
 Flows are authored once (by an agent via MCP, or by hand) and replayed with **zero LLM calls**: same input → same execution, no API cost in CI.
 
-Published on the standard npm channel and versioned by changesets in the repo-wide fixed group. Never publish with raw `npm publish` — it does not rewrite the `workspace:*` dependency on agent-core; the changesets → pnpm publish path does.
+Published on the standard npm channel and versioned by changesets in the repo-wide fixed group. Publish only via the changesets flow — see [CONTRIBUTING.md § Branches & releases](../../CONTRIBUTING.md#branches--releases).
 
 Consumers: `tapflow flow run` (CLI) and the `run_flow` MCP tool — both drive the same engine, so results never diverge.
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -23,10 +23,9 @@ status: living
 
 ## HOW NOT
 
-- Do not inline `xcrun` commands with business logic.
 - Do not expose iOS-specific methods as public API if they are not in the `DeviceAgent` interface.
 - Do not reintroduce SCStream/ScreenCaptureKit — geometry coordinate mismatches cause double-frame issues.
-- Do not stream JPEG frames over WebRTC DataChannel — the channel silently closes on large messages (~200KB+), and there is no P2P benefit in a relay-intermediary architecture.
+- Do not stream JPEG frames over WebRTC DataChannel — the channel silently closes on large messages (~236KB+; details in "WebSocket Binary streaming — transport choice" below).
 
 ---
 
@@ -226,7 +225,7 @@ snapshot.
 Keyboard injection uses `IndigoHIDMessageForKeyboardArbitrary(usage, op)`.  
 `IndigoHIDMessageForHIDArbitrary(target=0x32, page=0x07, ...)` is the digitizer (touch) path — iOS does not recognize it as a hardware keyboard, so the CapsLock HUD and Korean/English toggle do not work.
 
-→ Detailed analysis (target differences, symptom patterns, SimKeyboardInputController symbols): [`internal/simkit-internals.md` §5](../../internal/simkit-internals.md)
+→ Detailed analysis (target differences, symptom patterns, SimKeyboardInputController symbols): [`contributing/simkit-internals.md` §5](../../contributing/simkit-internals.md)
 
 ---
 

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -14,7 +14,7 @@ status: living
 
 `@tapflowio/mcp-server`: bridges tapflow to LLM agents via the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Published on the standard npm channel and versioned by changesets in the repo-wide fixed group (graduated from the `experimental` dist-tag in 2026-07). Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies (the package depends on `@tapflowio/flow-runner`); the changesets → pnpm publish path does.
+Published on the standard npm channel and versioned by changesets in the repo-wide fixed group (graduated from the `experimental` dist-tag in 2026-07). Publish only via the changesets flow — see [CONTRIBUTING.md § Branches & releases](../../CONTRIBUTING.md#branches--releases).
 
 Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP tools, and exposes them to any MCP-compatible client (Claude Code, Codex, Cursor, etc.) via stdio transport.
 
@@ -25,9 +25,7 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 - Tools: `src/tools.ts` — all MCP tool definitions. One `registerTools(server, client)` call registers everything.
 - Screenshots are saved to a temp file and returned as MCP `image` content with base64 encoding.
 
-### Available tools
-
-`list_devices`, `connect_device`, `disconnect_device`, `boot_device`, `shutdown_device`, `screenshot`, `query_ui_tree`, `run_flow`, `tap`, `swipe`, `type_text`, `press_key`, `press_button`, `install_app`, `launch_app`, `list_builds`
+### Tool semantics (non-obvious)
 
 `disconnect_device` only leaves the session (`session:leave`) — the device stays booted. `shutdown_device` powers the device down (`device:shutdown` → agent runs simctl/adb shutdown → `device:shutdown-done`); use it to free resources or force a cold boot.
 

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -44,18 +44,7 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 
 ### API Endpoints (builds / apps)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/apps` | App list (with latest_build summary) |
-| `POST` | `/api/v1/apps` | Create an app entry |
-| `PATCH` | `/api/v1/apps/:id` | Manually rename an app (Admin/Developer) |
-| `DELETE` | `/api/v1/apps/:id` | Delete an app (and its builds) |
-| `POST` | `/api/v1/builds` | Upload a build (`.app.zip` / `.tar.gz` / `.tgz` / `.apk`) |
-| `GET` | `/api/v1/builds` | Build list (filterable by `app_id`) |
-| `GET` | `/api/v1/builds/:id` | Single build |
-| `PATCH` | `/api/v1/builds/:id` | Update `status_label` / `version_label` |
-| `POST` | `/api/v1/builds/:id/schedule-deletion` | Put the build on the deletion clock (`delete_after = now + TTL`) |
-| `DELETE` | `/api/v1/builds/:id/schedule-deletion` | Cancel a scheduled deletion |
+Routes are registered in `RelayServer.ts`; user-facing reference: [`docs/reference/api.md`](../../docs/reference/api.md).
 
 > **Deletion lifecycle (issue #258)**: review status and deletion are orthogonal. `status_label` (incl. `Done`) is a pure review state and never schedules deletion; purge keys off `delete_after` only, which is set by the explicit schedule-deletion action. `completed_at` is informational.
 

--- a/playground/AGENTS.md
+++ b/playground/AGENTS.md
@@ -43,7 +43,7 @@ pnpm pre-release   # dashboard 빌드 → relay 기동 → localhost:4000
 
 ### Dev/test 스크립트 (모노레포 루트에서 실행)
 
-dev/test 커맨드는 **루트에서** 실행한다. 이 패키지의 스크립트(`relay`·`ios-agent`·`android-agent`·`mock-agents`·`seed`·`demo-seed`·`doctor`·`reset`·`mcp`·`pre-release`)는 루트가 호출하는 구현(leaf)이며, 여기서 직접 타이핑하지 않는다. 전체 목록은 루트 [CONTRIBUTING.md](../CONTRIBUTING.md#dev--test-commands).
+dev/test 커맨드는 **루트에서** 실행한다. 이 패키지의 스크립트는 루트가 호출하는 구현(leaf)이며, 여기서 직접 타이핑하지 않는다. 전체 목록은 루트 [CONTRIBUTING.md](../CONTRIBUTING.md#dev--test-commands).
 
 relay API는 4000, dashboard는 3001(Vite dev server).
 


### PR DESCRIPTION
## Why

Anthropic's [context-engineering guidance for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) reports that ~80% of Claude Code's system prompt was removed with no eval loss: detailed behavioral rules written to protect older models now only add token cost and instruction conflicts, while gotcha-dense, progressively-disclosed context is what pays off.

An independent-context audit of every AGENTS.md/CLAUDE.md in this repo (fresh subagent, no access to the authoring session) concluded the structure is already sound — the contributing/ rationale records and package-level gotchas should stay — but flagged over-constraint in the root file, duplicated instructions, discoverable inventories, and a few accuracy bugs. This PR applies the docs-side findings.

## What changed

**Judgment over rules (root AGENTS.md)**
- Core Principles compressed from four detailed sections (~40 lines) to four bullets. Project-specific gates are preserved verbatim: commits/PRs only on explicit request, never merge PRs, breaking-change scope, confirmation before risky operations.
- Dropped the "one line max" comment rule (the exact pattern the guidance removed); the English-comments policy stays.
- "Always start from latest main" now scoped to *new* tasks, removing the literal conflict with continuing work on an existing branch.

**Deduplication**
- Removed root HOW-NOT lines whose canonical home is elsewhere (tests-first → Workflow, agent-core pollution → agent-core AGENTS.md, no-guessing → Core Principles); AgentRegistry rule stated once; dashboard "no standalone" stated once.
- The near-verbatim `npm publish` warning in mcp-server and flow-runner is now canonical in CONTRIBUTING.md, both packages link to it.

**Accuracy fixes (new findings from the audit)**
- ios-agent: broken link `internal/simkit-internals.md` → `contributing/simkit-internals.md`.
- ios-agent: DataChannel size limit stated as ~200KB in one place and ~236KB in another — unified to the measured ~236KB.
- .work frontmatter phase enum 1–4 → 1–5+ (matches current ROADMAP); stale marketing filename removed with INDEX.md's redundant hierarchy tree.

**Discoverable inventories → source pointers**
- cli command table, relay API endpoint table, mcp-server tool list, agent-core method list, and the docs file tree are replaced by pointers to their sources. Every gotcha that was embedded in those tables (flow-run exit-code contract, `device:boot` idempotency, PAT scopes, `migrate` atomic rename, deletion lifecycle) is preserved as bullets.

All measurement-backed and incident-backed gotchas are untouched. Net: −125/+36 lines across 12 markdown files.

Follow-ups (need code, split out): swiftc helper builds as package.json scripts, a vitest keeping `tapflow-flow.schema.json` in sync with `schema.ts`, hook-automating vitest zombie cleanup, moving ios-agent long-form reference sections to contributing/.

## Review

Docs-only PR — adversarial review skipped per root AGENTS.md; record with skip reason and findings/dispositions at `.work/reviews/docs__context-engineering-slim.md` (HEAD 0c93bbe882ab1607fc4016632b2cbee835858760). The diff itself originates from an independent-context audit, and changed Korean prose passed /ai-tells ko detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution and development guidance across the repository for clearer task scoping, branching, publishing, and code-review practices.
  - Simplified package documentation by replacing lengthy command, API, directory, and interface listings with concise guidance and links to authoritative references.
  - Clarified publishing requirements to use the Changesets workflow.
  - Refined platform-specific rules and documentation links for dashboard, iOS, relay, and flow-runner development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->