### PR TITLE
test(ios-agent): sync on the streamer, not on a replayed device:ready

### DIFF
--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -296,7 +296,9 @@ browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId 
 await waitForType(browser, 'session:joined')
 browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
 await waitForType(browser, 'device:ready')
-// MockTouchHelper.mock.results[0].value is now accessible
+// device:ready alone does not mean the mock exists yet — see below. Sync on the mock itself.
+await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterThan(0))
+const touchHelper = MockTouchHelper.mock.results[0].value
 ```
 
 `mockSimctl(true)` (booted=true) → skips `device:booting` and delivers `device:ready` immediately.

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -300,3 +300,5 @@ await waitForType(browser, 'device:ready')
 ```
 
 `mockSimctl(true)` (booted=true) → skips `device:booting` and delivers `device:ready` immediately.
+
+**`device:ready` is not a sync point.** With `booted=true` the relay registers the session as already booted and **replays a `device:ready` on `session:start`** (browser-reconnect support), so `waitForType(browser, 'device:ready')` can latch that stale ack rather than the one this boot emits — before any streamer or helper exists. Always `vi.waitFor` on the mock you are about to read (`MockCapture`, `MockTouchHelper`, …), never on the message alone. This is what made the codec-negotiation test flake at ~2/10 suite runs.

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -402,8 +402,9 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
-      // device:ready is sent after TouchHelper is created, but the mock recording
-      // occasionally lags a microtask behind the message delivery — wait explicitly
+      // device:ready is sent after TouchHelper is created, but the relay also replays a
+      // device:ready on session:start for an already-booted device, so this may have latched
+      // the stale one — wait for the helper itself. (A vi.fn call log never lags.)
       await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
       const thInstance = MockTouchHelper.mock.results[0].value
       return { browser, agent, thInstance }
@@ -1016,6 +1017,11 @@ describe('IOSAgent', () => {
         payload: { deviceId: 'dev-1', ...bootPayload },
       }))
       await waitForType(browser, 'device:ready')
+      // mockSimctl(true) registers the device as already booted, so the relay replays a
+      // device:ready on session:start — waitForType can latch that stale ack instead of this
+      // boot's, and the mock read then saw zero calls (`undefined` vs the expected codec).
+      // Sync on the streamer itself, which is what this test actually asserts.
+      await vi.waitFor(() => expect(MockCapture.mock.calls.length).toBeGreaterThan(0), { timeout: 2000 })
       const calls = MockCapture.mock.calls
       const codec = calls[calls.length - 1]?.[2] as string
       agent.disconnect()


### PR DESCRIPTION
## Summary

The ios-agent codec-negotiation tests flake at roughly **2 in 10 full-suite runs**, failing with `AssertionError: expected undefined to be 'h264'` (or `'jpeg'`). Test-only fix.

`bootAndGetCodec` read `MockCapture.mock.calls` immediately after awaiting `device:ready`, and sometimes observed zero calls.

## Cause

Not what it looks like. There is **no async gap in `handleDeviceBoot`** — `startBinaryStream` is synchronous and runs at `IOSAgent.ts:520`, before the ack at `:525`, so the real `device:ready` can never precede the streamer.

The stale ack comes from the relay. `SessionManager.create` seeds `deviceStatus` from the device list, and `RelayServer.ts:780-782` **replays a `device:ready` on `session:start`** when it says `booted` — that exists so a browser reconnect re-syncs. `mockSimctl(true)` makes every such session look booted, so `waitForType` can latch the replay instead of this boot's ack, before any streamer exists.

Proven by the reviewer with **no `device:boot` ever sent**:

```
PROOF-A messages=["session:joined","device:ready"] screenCaptureCalls=0   # mockSimctl(true)
PROOF-B messages=["session:joined"]                                        # mockSimctl(false)
PROOF-C N=200 observedStaleReady=3 rate=1.5%
```

## Fix

Wait for the streamer mock — the thing the test actually asserts — instead of trusting the message. Also corrects a comment a few hundred lines up that blamed the same symptom on a "mock recording lagging a microtask" (a `vi.fn` call log is recorded synchronously and cannot lag), and documents the trap in `packages/ios-agent/AGENTS.md`, which presented `device:ready` as a reliable sync point and is how the pattern spread.

## Verification

- **Reproduced and fixed**: 2/25 full-suite runs failed before, 0/25 after — measured independently by the reviewer, matching my own 2/10 → 0/20.
- **Does not hide regressions**: breaking the codec selection turns the tests red (`expected 'h264' to be 'jpeg'`); making `startBinaryStream` return early fails 5 tests at ~2.18s each with `expected 0 to be greater than 0`. The 2000ms wait **fails cleanly rather than hanging**.
- Every other `waitForType(browser, 'device:ready')` in both agent suites was surveyed; the rest already `vi.waitFor` on their mocks or use `mockSimctl(false)`, where no replay happens.
- **Adversarial review** in an isolated worktree: 1 MAJOR — my original commit message and comment stated a false root cause (the non-existent async gap), now rewritten. Record: `.work/reviews/fix__ios-codec-test-flake.md`.

Found while running the full suite for the clipboard-bridge work; kept separate since it is an unrelated pre-existing test defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for reliable synchronization in iOS streaming tests.
  * Clarified why readiness events may be replayed when devices are already booted, and how to avoid flakes by waiting for the specific helper/streamer activity.
* **Tests**
  * Improved synchronization for pinch-session setup.
  * Strengthened codec-negotiation assertions by waiting until the relevant streamer is actually engaged before validating captured values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->