### PR TITLE
docs(changeset): backfill release notes for four merged fixes

### DIFF
--- a/.changeset/android-clipboard-shortcuts.md
+++ b/.changeset/android-clipboard-shortcuts.md
@@ -2,8 +2,8 @@
 "@tapflowio/android-agent": patch
 ---
 
-Fix Cmd/Ctrl+C, +V and +X on Android — they typed the letter instead of copying.
+Fix the copy, paste and cut shortcuts on Android — they typed the letter instead.
 
-The key handler ignored the Ctrl/Meta modifier and typed the raw character, so pressing Cmd+C in the viewer entered a literal `c` into the app and copy and paste both failed silently. A Ctrl/Cmd chord with C, V or X now maps to `KEYCODE_COPY` / `KEYCODE_PASTE` / `KEYCODE_CUT`.
+The key handler ignored the Ctrl/Meta modifier and typed the raw character, so pressing Cmd+C in the viewer entered a literal `c` into the app — copy, paste and cut all failed silently. A Ctrl/Cmd chord with C, V or X now maps to `KEYCODE_COPY` / `KEYCODE_PASTE` / `KEYCODE_CUT`.
 
 Any other chord with a letter — Cmd+A, for one — no longer types that letter either. A chord is a command, not text.

--- a/.changeset/android-clipboard-shortcuts.md
+++ b/.changeset/android-clipboard-shortcuts.md
@@ -1,0 +1,9 @@
+---
+"@tapflowio/android-agent": patch
+---
+
+Fix Cmd/Ctrl+C, +V and +X on Android — they typed the letter instead of copying.
+
+The key handler ignored the Ctrl/Meta modifier and typed the raw character, so pressing Cmd+C in the viewer entered a literal `c` into the app and copy and paste both failed silently. A Ctrl/Cmd chord with C, V or X now maps to `KEYCODE_COPY` / `KEYCODE_PASTE` / `KEYCODE_CUT`.
+
+Any other chord with a letter — Cmd+A, for one — no longer types that letter either. A chord is a command, not text.

--- a/.changeset/android-encoder-exec-bit.md
+++ b/.changeset/android-encoder-exec-bit.md
@@ -2,7 +2,7 @@
 "@tapflowio/android-agent": patch
 ---
 
-Fix missing Android audio, and the emulator's sound playing out of the agent Mac instead.
+Fix missing Android audio in the dashboard, and the emulator's sound playing out of the agent Mac's speakers instead.
 
 On a fresh install the bundled `emulator-encoder` binary lost its executable bit, so spawning it failed and the agent fell back from the emulator's gRPC backend to scrcpy. Audio capture and the host-mute tap only exist on the gRPC path, so that fallback silently took both: the dashboard got no audio, and the Mac running the agent played the emulator's audio out loud.
 

--- a/.changeset/android-encoder-exec-bit.md
+++ b/.changeset/android-encoder-exec-bit.md
@@ -1,0 +1,9 @@
+---
+"@tapflowio/android-agent": patch
+---
+
+Fix missing Android audio, and the emulator's sound playing out of the agent Mac instead.
+
+On a fresh install the bundled `emulator-encoder` binary lost its executable bit, so spawning it failed and the agent fell back from the emulator's gRPC backend to scrcpy. Audio capture and the host-mute tap only exist on the gRPC path, so that fallback silently took both: the dashboard got no audio, and the Mac running the agent played the emulator's audio out loud.
+
+Only visible with the dashboard and the agent on separate Macs — on one Mac the local playback masked it. The agent now restores the bit just before spawning the encoder, so it self-heals however the bit was lost, and an install step sets it explicitly as well.

--- a/.changeset/ios-lazy-touch-helper.md
+++ b/.changeset/ios-lazy-touch-helper.md
@@ -1,0 +1,9 @@
+---
+"@tapflowio/ios-agent": patch
+---
+
+Fix iOS sessions that silently dropped every tap, swipe and keystroke after an agent reconnect.
+
+The input channel was created only during `device:boot`. When an agent reconnected while the simulator stayed booted, the session came back without one, so touch, pinch, key and button input were discarded with no error — the device looked responsive because screenshots and UI-tree reads went through a different path. Input now sets the channel up on demand.
+
+Buttons addressed by name still need a fresh `device:boot`; that is a narrower gap tracked separately.

--- a/.changeset/mcp-truthful-input-acks.md
+++ b/.changeset/mcp-truthful-input-acks.md
@@ -1,0 +1,14 @@
+---
+"@tapflowio/mcp-server": minor
+"@tapflowio/relay": minor
+"@tapflowio/ios-agent": minor
+"@tapflowio/android-agent": minor
+---
+
+MCP input tools now report what actually happened instead of always reporting success.
+
+`tap`, `swipe`, `press_key` and `press_button` were fire-and-forget: the tool answered `{tapped: true}` no matter what the agent did with the input. Against a session whose device is not booted the input was dropped and still reported as success — a false positive that also makes parallel test results untrustworthy.
+
+Agents now acknowledge a gesture's terminal message with `input:done` or `input:error`, and the tools surface that. `done` means the agent dispatched the input to a booted device; as with the existing `input:type-done`, it is not a guarantee the app reacted.
+
+Additive: an agent that does not send the ack is handled as before.


### PR DESCRIPTION
## Summary

Four merged PRs changed published code without a changeset. As it stands, 0.17.0's changelog would describe only the clipboard bridge and say nothing about the fixes underneath it.

| PR | | changeset |
|---|---|---|
| #418 | clipboard bridge | present |
| #413 | Android Cmd/Ctrl+C/V/X typed the letter instead of copying | **missing** |
| #412 | `emulator-encoder` exec bit — no dashboard audio, emulator sound on the agent Mac | **missing** |
| #411 | MCP input tools always reported success | **missing** |
| #410 | iOS input silently dropped after an agent reconnect | **missing** |

The other six merged since v0.16.0 (#417, #415, #414, #409, #408, #407) are docs, chore or test-only and correctly have none.

#413 is the one that stings: it is what made Android clipboard shortcuts work at all, and the bridge in #418 builds directly on it. A user reading the release notes would see the bridge announced and no mention that the shortcuts themselves were broken until now.

## No version change

`npx changeset status` still resolves to **minor → 0.17.0**. The packages are one `fixed` group and the clipboard changeset already requires minor, so these four only add changelog entries.

## Verification

Each entry was written from the originating PR's commit body rather than from the diff summary. One draft claimed #412 restored the executable bit "at startup"; it actually restores it just before spawning the encoder, and the wording was corrected.

Adversarial review skipped — docs-only, no executable code in the diff. Recorded with the reason in `.work/reviews/chore__backfill-changesets.md`, per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Android clipboard shortcuts so Cmd/Ctrl+C/V/X trigger copy/paste/cut correctly without breaking other modifier-key commands.
  - Restored Android emulator audio capture and correct routing after fresh installs.
  - Fixed iOS sessions where tap, swipe, keystroke, and button input could be dropped after an agent reconnect.
- **New Behavior**
  - MCP input tools now report the actual terminal result (acknowledged dispatch success or error) instead of always indicating success.
- **Documentation**
  - Added/updated release notes for these fixes and behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->