### PR TITLE
chore: guard dev-server leaks and missing changesets

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,6 +13,7 @@ model: claude-opus-4-8
 - `git log v{latest}..HEAD --oneline`(머지 포함/제외 각각) — feat / fix / perf / breaking 분류
 - 열린 PR: `gh pr list`
 - 대기 중인 changeset: `.changeset/*.md`
+- **누락된 changeset 감사**: `pnpm changeset:audit` — 마지막 태그 이후 머지 중 배포 소스를 바꿨는데 changeset이 없는 것을 나열한다. PR 게이트(CI `changeset` job)는 새 PR만 막으므로 **이미 머지된 것은 여기서만 잡힌다.** v0.17.0 준비 때 네 건(#410~#413)이 이 방식으로 발견됐다. 나오면 릴리즈 전에 백필한다
 - `.changeset/config.json`의 `fixed` / `ignore` 그룹 재확인
 
 ## 2. bump 레벨 추천 → 사용자 합의

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,7 +13,7 @@ model: claude-opus-4-8
 - `git log v{latest}..HEAD --oneline`(머지 포함/제외 각각) — feat / fix / perf / breaking 분류
 - 열린 PR: `gh pr list`
 - 대기 중인 changeset: `.changeset/*.md`
-- **누락된 changeset 감사**: `pnpm changeset:audit` — 마지막 태그 이후 머지 중 배포 소스를 바꿨는데 changeset이 없는 것을 나열한다. PR 게이트(CI `changeset` job)는 새 PR만 막으므로 **이미 머지된 것은 여기서만 잡힌다.** v0.17.0 준비 때 네 건(#410~#413)이 이 방식으로 발견됐다. 나오면 릴리즈 전에 백필한다
+- **누락된 changeset 감사**: `pnpm changeset:audit` — 마지막 태그 이후 머지 중 배포 소스를 바꿨는데 changeset이 없는 것을 나열한다. PR 게이트(CI `changeset` job)는 새 PR만 막으므로 **이미 머지된 것은 여기서만 잡힌다.** v0.17.0 준비 때 이 누락(#410~#413)을 수작업으로 발견한 것이 이 감사를 만든 계기다. 나오면 릴리즈 전에 백필한다
 - `.changeset/config.json`의 `fixed` / `ignore` 그룹 재확인
 
 ## 2. bump 레벨 추천 → 사용자 합의

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
     # Dependabot cannot write the opt-out marker into its own PR body, and a dependency bump is
     # already surfaced by the bot and the lockfile. Blocking those would only teach people to
     # ignore this job.
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # `pull_request.user.login` is the PR's author. `github.actor` is whoever triggered the run,
+    # so a maintainer pushing to a bot's branch would lose the exemption — and a bot cannot write
+    # the opt-out marker into its own body.
+    if: >-
+      github.event_name == 'pull_request' &&
+      !endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,4 +62,6 @@ jobs:
           # fence, which sed cannot express — and a body is untrusted input, so it never reaches
           # a shell command line.
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: node scripts/check-changeset.mjs "origin/${{ github.base_ref }}"
+          # Via env, not interpolated into the command: a branch name may contain shell syntax.
+          BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-changeset.mjs "origin/$BASE_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,29 @@ jobs:
       - run: pnpm --filter tapflow --filter @tapflowio/mcp-server build
 
       - run: pnpm test
+
+  changeset:
+    # A PR that changes shipped code must say what a user gets. Separate job so it reports on its
+    # own rather than hiding inside a build failure.
+    # Dependabot cannot write the opt-out marker into its own PR body, and a dependency bump is
+    # already surfaced by the bot and the lockfile. Blocking those would only teach people to
+    # ignore this job.
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # the check diffs against the merge base
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Require a changeset for published source changes
+        env:
+          # `<!-- no-changeset: reason -->` in the PR body is the documented opt-out. Parsed by
+          # the script, not by shell: the marker only counts on its own line and outside a code
+          # fence, which sed cannot express — and a body is untrusted input, so it never reaches
+          # a shell command line.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-changeset.mjs "origin/${{ github.base_ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false   # runs PR-supplied code; needs no token afterwards
 
       - uses: pnpm/action-setup@v4
 
@@ -34,6 +38,8 @@ jobs:
       - run: pnpm test
 
   changeset:
+    permissions:
+      contents: read
     # A PR that changes shipped code must say what a user gets. Separate job so it reports on its
     # own rather than hiding inside a build failure.
     # Dependabot cannot write the opt-out marker into its own PR body, and a dependency bump is
@@ -49,7 +55,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # the check diffs against the merge base
+          fetch-depth: 0            # the check diffs against the merge base
+          persist-credentials: false   # this job runs PR-supplied code; it needs no token
 
       - uses: actions/setup-node@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ pnpm dev:down          # stops relay / agents / vite for THIS checkout
 `concurrently -k` cleans up on a normal exit, not when the terminal goes away or the machine sleeps.
 
 ### Changesets
-A PR that changes published source needs a changeset. CI enforces it (`changeset` job). Opt out only by writing the reason in the PR body, on its own line:
+A PR that changes published source needs a changeset. The CI `changeset` job fails without one — it only *blocks* a merge if it is a required check in branch protection. Opt out only by writing the reason in the PR body, on its own line:
 ```
 <!-- no-changeset: comment-only follow-up to #123 -->
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ pnpm dev:down          # stops relay / agents / vite for THIS checkout
 `concurrently -k` cleans up on a normal exit, not when the terminal goes away or the machine sleeps.
 
 ### Changesets
-A PR that changes published source needs a changeset. The CI `changeset` job fails without one — it only *blocks* a merge if it is a required check in branch protection. Opt out only by writing the reason in the PR body, on its own line:
+A PR that changes published source needs a changeset. The CI `changeset` job fails without one — it only *blocks* a merge once it is a required status check on the `protect-main` ruleset, which it is not yet. Opt out only by writing the reason in the PR body, on its own line:
 ```
 <!-- no-changeset: comment-only follow-up to #123 -->
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,17 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 - **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
 - **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 
+#### Keeping a review affordable
+
+Review wall-clock is dominated by **what the reviewer has to execute**, not by how hard it thinks. Measured across one session: a read-and-probe review of a protocol change took 11 minutes at 93k tokens; a review of ~590 lines of tooling took **106 minutes at only 134k tokens** — fewer tokens, 10× the time, because it spent that time on `pnpm install`, `pnpm build`, starting real dev servers and waiting out sleeps.
+
+- **Only use an isolated worktree when the reviewer must edit files.** A fresh worktree has no `node_modules` and no `dist`, so it pays 8–10 minutes of install and build before it can run anything — and a reviewer that does not know this reports results from commands that silently did nothing (`vitest: command not found` swallowed by a shell exit). A read-only lens (contract, compatibility, documentation) can work against the primary checkout, which is already built.
+- **Say what to install.** When a worktree is required, the prompt must open with `pnpm install --frozen-lockfile && pnpm build`, or the first `pnpm test` result is meaningless.
+- **Do the mutation testing yourself, then hand over the list.** Ask the reviewer to find what your mutations *missed*, not to redo them. Every surviving mutation found so far came from someone imagining a different way to break a test — never from running more of them.
+- **No blanket "run it 10 times".** Repeat runs have found zero flakes across two rounds; they cost 4+ minutes each time. Ask for 3 runs, and only for tests that use timers or real sleeps.
+- **Split by lens and run the lenses in parallel.** Wall-clock is then the slowest lens, not the sum. Two channels on the same commit took 11 and 40 minutes concurrently, against 51 serially.
+- **Some cost is irreducible.** Verifying code that kills processes means starting and killing processes, with real waits. Budget for it and say so up front, rather than discovering it at 100 minutes.
+
 ### Before Implementing — cross-cutting features
 
 Applies when a change spans **two or more packages, or both platforms**. Skip it for work inside one package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,15 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 - **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
 - **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 
+### Before Implementing — cross-cutting features
+
+Applies when a change spans **two or more packages, or both platforms**. Skip it for work inside one package.
+
+1. **Write the invariant table first** — one row per path or state, one column per platform, and what the *user* observes. Put it in the plan document. The clipboard bridge took eleven review rounds largely because this table was never written: the same class of defect (one platform fixed, the other not) was found five separate times, each by a reviewer rather than by looking.
+2. **Review the design before the code.** One adversarial pass over the plan and that table, before implementing. The expensive rounds on a multi-package feature are the ones where the mechanism itself was wrong, and a wrong mechanism is cheapest to find on paper. This is in addition to the pre-PR review below, not instead of it.
+3. **A design-level review finding means replan, not patch.** If a reviewer says the *shape* is wrong — wrong scope for a flag, wrong owner for a decision — stop and redo that part. Patching a design finding produced the next design finding three times in a row on the clipboard branch.
+4. **Mutate the guards too.** A test written to catch drift or protect an invariant is itself untested until you break the thing it guards and watch it fail — and until you run it **alone**. Three separate guards on the clipboard branch had the very hole they were written to close, including one that only worked because a sibling `describe` leaked its environment.
+
 ### Design Principles (SOLID — priority subset)
 
 - **OCP**: New platforms and features are added without modifying existing code — platforms register via `AgentRegistry.register()` only; relay and dashboard code stay unchanged.
@@ -99,6 +108,22 @@ ps aux | grep vitest | grep -v grep
 pkill -f "vitest"
 ```
 Zombie worker processes accumulate silently from `pnpm test` loops and consume memory. Kill them before starting new test runs.
+
+### Dev Server Hygiene
+Same rule, different processes. **Anything you start with `pnpm dev` you stop before the session ends:**
+```bash
+pnpm dev:down          # stops relay / agents / vite for THIS checkout
+```
+`pnpm dev` refuses to start when :4000 or :3001 is already held, and names the pid — because the failure it produces otherwise mentions neither. A relay left running once survived a day and cost a debugging session: it failed with `EADDRINUSE`, `concurrently` SIGTERMed the dashboard and both agents, and the visible symptom was four processes dying for no stated reason.
+
+`concurrently -k` cleans up on a normal exit, not when the terminal goes away or the machine sleeps.
+
+### Changesets
+A PR that changes published source needs a changeset. CI enforces it (`changeset` job). Opt out only by writing the reason in the PR body, on its own line:
+```
+<!-- no-changeset: comment-only follow-up to #123 -->
+```
+`pnpm changeset:check` runs the same check locally, against committed work. That gate cannot see anything already on main, so `/release` audits the merges too (`pnpm changeset:audit`) — four merged PRs once got as far as release preparation with no changelog entry between them, and only the audit would have caught it.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ playground/       ← local integration test environment
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
 - Always create new branches from `origin/main` (`git fetch origin && git checkout -b feature/{topic} origin/main`). Your local `main` may be behind.
-- **Every PR that changes published source needs a changeset.** The CI `changeset` job fails otherwise (make it a required check in branch protection for it to actually block a merge); `pnpm changeset:check` runs the same check locally against committed work. Skip it only by stating why in the PR body, on a line of its own: `<!-- no-changeset: reason -->` (quoting it inside a code block does not count). A comment-only or test-only change is a fair skip — the point is that it is a decision, not an omission.
+- **Every PR that changes published source needs a changeset.** The CI `changeset` job fails otherwise (it blocks a merge only once it is a required status check on the `protect-main` ruleset); `pnpm changeset:check` runs the same check locally against committed work. Skip it only by stating why in the PR body, on a line of its own: `<!-- no-changeset: reason -->` (quoting it inside a code block does not count). A comment-only or test-only change is a fair skip — the point is that it is a decision, not an omission.
 - Releases are driven by [changesets](https://github.com/changesets/changesets). A tag push triggers GitHub Actions → npm publish + GitHub Release. Merging to main does not auto-publish.
 - Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies between packages; the changesets → pnpm publish path does.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ playground/       ← local integration test environment
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
 - Always create new branches from `origin/main` (`git fetch origin && git checkout -b feature/{topic} origin/main`). Your local `main` may be behind.
-- **Every PR that changes published source needs a changeset.** CI blocks it otherwise; `pnpm changeset:check` runs the same check locally against committed work. Skip it only by stating why in the PR body, on a line of its own: `<!-- no-changeset: reason -->` (quoting it inside a code block does not count). A comment-only or test-only change is a fair skip — the point is that it is a decision, not an omission.
+- **Every PR that changes published source needs a changeset.** The CI `changeset` job fails otherwise (make it a required check in branch protection for it to actually block a merge); `pnpm changeset:check` runs the same check locally against committed work. Skip it only by stating why in the PR body, on a line of its own: `<!-- no-changeset: reason -->` (quoting it inside a code block does not count). A comment-only or test-only change is a fair skip — the point is that it is a decision, not an omission.
 - Releases are driven by [changesets](https://github.com/changesets/changesets). A tag push triggers GitHub Actions → npm publish + GitHub Release. Merging to main does not auto-publish.
 - Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies between packages; the changesets → pnpm publish path does.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ playground/       ← local integration test environment
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.
 - Always create new branches from `origin/main` (`git fetch origin && git checkout -b feature/{topic} origin/main`). Your local `main` may be behind.
+- **Every PR that changes published source needs a changeset.** CI blocks it otherwise; `pnpm changeset:check` runs the same check locally against committed work. Skip it only by stating why in the PR body, on a line of its own: `<!-- no-changeset: reason -->` (quoting it inside a code block does not count). A comment-only or test-only change is a fair skip — the point is that it is a decision, not an omission.
 - Releases are driven by [changesets](https://github.com/changesets/changesets). A tag push triggers GitHub Actions → npm publish + GitHub Release. Merging to main does not auto-publish.
 - Never publish with raw `npm publish` — it does not rewrite `workspace:*` dependencies between packages; the changesets → pnpm publish path does.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,20 @@ const commonRules = {
 }
 
 export default tseslint.config(
-  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.js', '**/*.mjs', '**/*.cjs', '**/__tests__/**'] },
+  // `!scripts/**` re-includes: a global ignore cannot be undone by a later `files` entry, so the
+  // negation has to live here.
+  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.js', '**/*.mjs', '**/*.cjs', '**/__tests__/**', '!scripts/**/*.mjs'] },
+
+  // Repo tooling under scripts/ is .mjs, which the blanket ignore above covers. It is opted back
+  // in because `dev-down` sends SIGKILL to processes it selects — the most destructive code in
+  // the repo should not also be the only code nothing checks.
+  {
+    files: ['scripts/**/*.mjs'],
+    ignores: [],
+    extends: [tseslint.configs.recommended],
+    languageOptions: { globals: globals.node, sourceType: 'module' },
+    rules: commonRules,
+  },
 
   // Node.js packages — .ts files (excludes dashboard)
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ const commonRules = {
 export default tseslint.config(
   // `!scripts/**` re-includes: a global ignore cannot be undone by a later `files` entry, so the
   // negation has to live here.
-  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.js', '**/*.mjs', '**/*.cjs', '**/__tests__/**', '!scripts/**/*.mjs'] },
+  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.js', '**/*.mjs', '**/*.cjs', '**/__tests__/**', '!scripts/**'] },
 
   // Repo tooling under scripts/ is .mjs, which the blanket ignore above covers. It is opted back
   // in because `dev-down` sends SIGKILL to processes it selects — the most destructive code in

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
   },
   "scripts": {
     "build": "pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/flow-runner build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter tapflow build && pnpm --filter @tapflowio/mcp-server build",
-    "test": "pnpm -r test --if-present",
-    "lint": "pnpm -r --if-present lint",
+    "test": "vitest run --config scripts/vitest.config.mjs && pnpm -r test --if-present",
+    "lint": "eslint scripts && pnpm -r --if-present lint",
     "typecheck": "tsc -b && pnpm --filter @tapflowio/dashboard --filter @tapflowio/mcp-server typecheck",
     "prepare": "lefthook install || true",
-    "dev": "concurrently -k -n relay,dashboard,ios,android -c cyan,magenta,green,yellow \"pnpm dev:relay\" \"pnpm --filter @tapflowio/dashboard dev\" \"pnpm dev:ios\" \"pnpm dev:android\"",
-    "dev:pool": "concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm dev:relay\" \"pnpm dev:ios\" \"pnpm --filter @tapflowio/playground mock-agents\"",
+    "dev": "node scripts/dev-preflight.mjs relay dashboard && concurrently -k -n relay,dashboard,ios,android -c cyan,magenta,green,yellow \"pnpm dev:relay\" \"pnpm --filter @tapflowio/dashboard dev\" \"pnpm dev:ios\" \"pnpm dev:android\"",
+    "dev:pool": "node scripts/dev-preflight.mjs relay && concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm dev:relay\" \"pnpm dev:ios\" \"pnpm --filter @tapflowio/playground mock-agents\"",
     "dev:relay": "pnpm --filter @tapflowio/playground relay",
     "dev:ios": "pnpm --filter @tapflowio/playground ios-agent",
     "dev:android": "pnpm --filter @tapflowio/playground android-agent",
+    "dev:down": "node scripts/dev-down.mjs",
     "seed": "pnpm --filter @tapflowio/playground seed",
     "seed:demo": "pnpm --filter @tapflowio/playground demo-seed",
     "doctor": "pnpm --filter @tapflowio/playground doctor",
@@ -29,6 +30,8 @@
     "docs:build": "pnpm --filter @tapflowio/docs build",
     "docs:preview": "pnpm --filter @tapflowio/docs preview",
     "changeset": "changeset",
+    "changeset:check": "node scripts/check-changeset.mjs",
+    "changeset:audit": "node scripts/check-changeset.mjs --audit",
     "version": "changeset version",
     "release": "pnpm build && changeset publish"
   },
@@ -40,7 +43,8 @@
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "lefthook": "^2.1.10",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.65.0",
+    "vitest": "^4.1.10"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.7.0(jiti@1.21.7))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
 
   docs:
     devDependencies:

--- a/scripts/__tests__/changesetReason.test.mjs
+++ b/scripts/__tests__/changesetReason.test.mjs
@@ -1,0 +1,55 @@
+// The opt-out marker switches the changeset gate off, so a body that merely *mentions* it must
+// not count. The first version used a `sed` one-liner and fired on any body quoting the syntax —
+// including the PR that introduced the rule, and any PR explaining it to a contributor.
+import { describe, it, expect } from 'vitest'
+import { extractReason } from '../check-changeset.mjs'
+
+describe('extractReason — accepts a genuine opt-out', () => {
+  it('reads a marker on its own line', () => {
+    expect(extractReason('Fixes a typo.\n\n<!-- no-changeset: comment-only -->\n')).toBe('comment-only')
+  })
+
+  it('tolerates surrounding whitespace and CRLF line endings', () => {
+    expect(extractReason('a\r\n   <!--  no-changeset:   renamed a local  -->   \r\nb'))
+      .toBe('renamed a local')
+  })
+
+  it('takes the first marker when there are several', () => {
+    expect(extractReason('<!-- no-changeset: first -->\n<!-- no-changeset: second -->')).toBe('first')
+  })
+})
+
+describe('extractReason — refuses anything that is not one', () => {
+  const NOT_AN_OPT_OUT = {
+    'no marker at all': 'Just a normal PR body.',
+    'inside a fenced block': 'Skip it like this:\n\n```\n<!-- no-changeset: reason -->\n```\n',
+    'inside a tilde fence': 'Skip it:\n\n~~~\n<!-- no-changeset: reason -->\n~~~\n',
+    'inside an indented block': 'Skip it:\n\n    <!-- no-changeset: reason -->\n',
+    'quoted mid-sentence': 'Put `<!-- no-changeset: reason -->` in the body to skip.',
+    'trailing prose on the line': '<!-- no-changeset: reason --> and here is why I did it',
+    'empty reason': '<!-- no-changeset:  -->',
+    'no reason given': '<!-- no-changeset: -->',
+    'a different marker': '<!-- no-release: reason -->',
+  }
+
+  for (const [name, body] of Object.entries(NOT_AN_OPT_OUT)) {
+    it(`ignores: ${name}`, () => {
+      expect(extractReason(body)).toBe('')
+    })
+  }
+
+  // The exact shape this repo's own docs use. If this ever returns a reason, then documenting
+  // the escape hatch disables the gate for whoever documents it.
+  it('ignores the snippet as CONTRIBUTING.md and AGENTS.md print it', () => {
+    const body = [
+      'Skip it only by stating why in the PR body:',
+      '',
+      '```',
+      '<!-- no-changeset: comment-only follow-up to #123 -->',
+      '```',
+      '',
+      'That is the whole rule.',
+    ].join('\n')
+    expect(extractReason(body)).toBe('')
+  })
+})

--- a/scripts/__tests__/devProcesses.test.mjs
+++ b/scripts/__tests__/devProcesses.test.mjs
@@ -62,6 +62,55 @@ describe('isDevProcess — must never select anything else', () => {
   }
 })
 
+describe('isDevProcess — the role and the repo must be the SAME argument', () => {
+  // Each of these supplies "inside the repo" from one argument and "looks like a dev process"
+  // from another. Checking the two independently made all four kill targets.
+  const SPLIT_EVIDENCE = {
+    'in-repo tsx running an out-of-repo script':
+      `node ${ROOT}/node_modules/.bin/tsx --conditions=source /Users/dev/side/relay.ts`,
+    'foreign tsx, repo path in an unrelated flag':
+      `node /usr/local/lib/tsx/cli.mjs --conditions=source relay.ts --cwd ${ROOT}/x`,
+    'foreign vite, repo path as data':
+      `node /other/node_modules/vite/bin/vite.js --port 3001 --root ${ROOT}/packages`,
+    'a repo script with a vite-ish word and a bare 3001':
+      `node ${ROOT}/scripts/foo.mjs vite 3001`,
+  }
+
+  for (const [name, command] of Object.entries(SPLIT_EVIDENCE)) {
+    it(`does not select: ${name}`, () => {
+      expect(isDevProcess(command, ROOT)).toBe(false)
+    })
+  }
+})
+
+describe('isDevProcess — a checkout path containing spaces', () => {
+  // Splitting the command on whitespace shredded such a path, so nothing matched: `dev:down`
+  // reported "no dev processes" and exited 0 while the relay still held the port — the exact
+  // confusion the tool exists to remove, delivered as a success.
+  const SPACED = '/Users/dev/My Projects/tapflow'
+
+  it('still selects the relay', () => {
+    expect(isDevProcess(
+      `node ${SPACED}/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source relay.ts`,
+      SPACED,
+    )).toBe(true)
+  })
+
+  it('still selects vite', () => {
+    expect(isDevProcess(
+      `node ${SPACED}/packages/dashboard/node_modules/.bin/../vite/bin/vite.js --port 3001`,
+      SPACED,
+    )).toBe(true)
+  })
+
+  it('still refuses a sibling checkout', () => {
+    expect(isDevProcess(
+      `node ${SPACED}-fork/packages/dashboard/node_modules/vite/bin/vite.js --port 3001`,
+      SPACED,
+    )).toBe(false)
+  })
+})
+
 describe('isDevProcess — the individual conditions', () => {
   it('requires the executable to be node, not merely a mention of it', () => {
     expect(isDevProcess(`sh -c "node ${ROOT}/playground/x --conditions=source relay.ts"`, ROOT))

--- a/scripts/__tests__/devProcesses.test.mjs
+++ b/scripts/__tests__/devProcesses.test.mjs
@@ -4,7 +4,7 @@
 // written from memory. The first version of this matcher was written from memory and selected
 // none of the three roles while selecting `grep`, `less` and sibling checkouts instead.
 import { describe, it, expect } from 'vitest'
-import { isDevProcess } from '../dev-ports.mjs'
+import { isDevProcess, selectPorts, DEV_PORTS } from '../dev-ports.mjs'
 
 const ROOT = '/Users/dev/projects/tapflow'
 const NODE = '/Users/dev/.nvm/versions/node/v24.15.0/bin/node'
@@ -135,5 +135,24 @@ describe('isDevProcess — the individual conditions', () => {
   it('does not treat a docs or playground concurrently run as the dev supervisor', () => {
     expect(isDevProcess(`node ${ROOT}/node_modules/.bin/concurrently -n docs,api "a" "b"`, ROOT))
       .toBe(false)
+  })
+})
+
+// `pnpm dev:pool` runs no dashboard, so callers name the ports they need. A name that matches
+// nothing must not quietly select none: the preflight would then exit 0 having looked at nothing,
+// which is precisely the silent success this tool exists to prevent.
+describe('selectPorts', () => {
+  it('returns every port when nothing is named', () => {
+    expect(selectPorts([])).toEqual(DEV_PORTS)
+  })
+
+  it('selects by prefix, so "dashboard" matches "dashboard (vite)"', () => {
+    expect(selectPorts(['dashboard']).map((p) => p.what)).toEqual(['dashboard (vite)'])
+    expect(selectPorts(['relay']).map((p) => p.what)).toEqual(['relay'])
+  })
+
+  it('throws on a name that matches nothing rather than selecting none', () => {
+    expect(() => selectPorts(['relayy'])).toThrow(/Unknown dev-preflight target: relayy/)
+    expect(() => selectPorts(['relay', 'typo'])).toThrow(/typo/)
   })
 })

--- a/scripts/__tests__/devProcesses.test.mjs
+++ b/scripts/__tests__/devProcesses.test.mjs
@@ -1,0 +1,90 @@
+// `dev-down` SIGKILLs whatever `isDevProcess` selects, so these fixtures are the safety argument.
+//
+// The MATCH cases are verbatim `ps -Ao pid=,command=` lines from a live `pnpm dev` — copied, not
+// written from memory. The first version of this matcher was written from memory and selected
+// none of the three roles while selecting `grep`, `less` and sibling checkouts instead.
+import { describe, it, expect } from 'vitest'
+import { isDevProcess } from '../dev-ports.mjs'
+
+const ROOT = '/Users/dev/projects/tapflow'
+const NODE = '/Users/dev/.nvm/versions/node/v24.15.0/bin/node'
+
+// Real command lines, with the path rewritten to ROOT.
+const REAL = {
+  supervisor: `node ${ROOT}/node_modules/.bin/../concurrently/dist/bin/concurrently.js -k -n relay,dashboard,ios,android -c cyan,magenta,green,yellow pnpm dev:relay`,
+  vite: `node ${ROOT}/packages/dashboard/node_modules/.bin/../vite/bin/vite.js --port 3001`,
+  tsxLauncher: `node ${ROOT}/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source relay.ts`,
+  tsxChild: `${NODE} --require ${ROOT}/node_modules/.pnpm/tsx@4.23.1/node_modules/tsx/dist/preflight.cjs --import file://${ROOT}/node_modules/.pnpm/tsx@4.23.1/node_modules/tsx/dist/loader.mjs --conditions=source relay.ts`,
+  iosLauncher: `node ${ROOT}/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source ios-agent.ts`,
+  androidLauncher: `node ${ROOT}/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source android-agent.ts`,
+}
+
+describe('isDevProcess — must select every process `pnpm dev` starts', () => {
+  for (const [name, command] of Object.entries(REAL)) {
+    it(`selects the ${name}`, () => {
+      expect(isDevProcess(command, ROOT)).toBe(true)
+    })
+  }
+})
+
+describe('isDevProcess — must never select anything else', () => {
+  const NEVER = {
+    // A sibling clone at a path the repo root is a prefix of. `includes(ROOT)` matched these.
+    'sibling clone (prefix)': `node ${ROOT}-fork/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source relay.ts`,
+    'sibling clone (suffix)': `node ${ROOT}2/packages/dashboard/node_modules/.bin/../vite/bin/vite.js --port 3001`,
+    // Agent worktrees live INSIDE the repo but are separate checkouts.
+    'agent worktree': `node ${ROOT}/.claude/worktrees/agent-x/playground/node_modules/.bin/../tsx/dist/cli.mjs --conditions=source relay.ts`,
+    // Someone else's project that happens to use the same tooling.
+    'unrelated vite': '/usr/local/bin/node /Users/dev/other-app/node_modules/vite/bin/vite.js --port 3001',
+    // Tools whose ARGUMENTS contain the patterns. Grepping the repo for the string in
+    // dev-ports.mjs must not make you a kill target.
+    // Unquoted on purpose: `ps` shows the shell's word-split argv, so the search terms arrive as
+    // separate tokens that look exactly like a dev process's flags. This is the case that makes
+    // the "executable must be node" rule load-bearing — with quotes it passes for the wrong
+    // reason, and the rule can be deleted without any test noticing.
+    grep: `grep -rn vite --port 3001 ${ROOT}/packages`,
+    ripgrep: `rg --conditions=source relay.ts ${ROOT}/packages`,
+    pager: `less ${ROOT}/scripts/dev-ports.mjs vite --port 3001`,
+    editor: `vim ${ROOT}/README.md`,
+    tail: `tail -f ${ROOT}/relay.log`,
+    // Node processes in the repo doing something else entirely.
+    'node running eslint': `node ${ROOT}/node_modules/.bin/eslint scripts`,
+    'node running vitest': `node ${ROOT}/node_modules/.pnpm/vitest@3.0.0/node_modules/vitest/vitest.mjs run`,
+    'the teardown script itself': `node ${ROOT}/scripts/dev-down.mjs`,
+    // A build of the same sources — not a running dev server.
+    'tsc build': `node ${ROOT}/node_modules/.bin/tsc -b`,
+  }
+
+  for (const [name, command] of Object.entries(NEVER)) {
+    it(`does not select: ${name}`, () => {
+      expect(isDevProcess(command, ROOT)).toBe(false)
+    })
+  }
+})
+
+describe('isDevProcess — the individual conditions', () => {
+  it('requires the executable to be node, not merely a mention of it', () => {
+    expect(isDevProcess(`sh -c "node ${ROOT}/playground/x --conditions=source relay.ts"`, ROOT))
+      .toBe(false)
+  })
+
+  it('requires an absolute path inside the repo, not a relative one', () => {
+    // Run from inside the repo, everything is relative and the process is indistinguishable
+    // from the same command in any other checkout. Refuse rather than guess.
+    expect(isDevProcess('node ./node_modules/.bin/tsx --conditions=source relay.ts', ROOT))
+      .toBe(false)
+  })
+
+  it('requires a recognised role, not just any node process in the repo', () => {
+    expect(isDevProcess(`node ${ROOT}/playground/seed.ts`, ROOT)).toBe(false)
+  })
+
+  it('does not confuse vite on another port with the dashboard', () => {
+    expect(isDevProcess(`node ${ROOT}/node_modules/vite/bin/vite.js --port 5173`, ROOT)).toBe(false)
+  })
+
+  it('does not treat a docs or playground concurrently run as the dev supervisor', () => {
+    expect(isDevProcess(`node ${ROOT}/node_modules/.bin/concurrently -n docs,api "a" "b"`, ROOT))
+      .toBe(false)
+  })
+})

--- a/scripts/__tests__/shipsToUsers.test.mjs
+++ b/scripts/__tests__/shipsToUsers.test.mjs
@@ -2,7 +2,7 @@
 // this predicate missed while it was an allowlist over `src/**.ts`, and it then went a round with
 // no tests at all — the twenty-line rule that had been wrong six ways was the one thing unchecked.
 import { describe, it, expect } from 'vitest'
-import { shipsToUsers } from '../check-changeset.mjs'
+import { shipsToUsers, isReleaseBranch } from '../check-changeset.mjs'
 
 describe('shipsToUsers — files a released tapflow puts in front of users', () => {
   const SHIPS = [
@@ -64,4 +64,30 @@ describe('shipsToUsers — files that change nothing a user can observe', () => 
   for (const f of DOES_NOT_SHIP) {
     it(`does not require a changeset for ${f}`, () => expect(shipsToUsers(f)).toBe(false))
   }
+})
+
+// `pnpm changeset version` bumps every packages/*/package.json and DELETES the changesets it
+// consumed. A gate that only looks for ADDED changesets therefore fails the release PR — and with
+// the check required on `protect-main`, that blocks the release permanently. This is the one path
+// that is exercised once per release and cannot be discovered gradually.
+describe('isReleaseBranch — the shape `changeset version` produces', () => {
+  it('recognises consumed changesets plus written changelogs', () => {
+    expect(isReleaseBranch(
+      ['.changeset/clipboard-bridge.md'],
+      ['packages/relay/package.json', 'packages/relay/CHANGELOG.md', 'packages/cli/package.json'],
+    )).toBe(true)
+  })
+
+  it('does not fire when a changeset is deleted without a changelog being written', () => {
+    // Someone dropping a changeset they decided against is not a release.
+    expect(isReleaseBranch(['.changeset/oops.md'], ['packages/relay/src/RelayServer.ts'])).toBe(false)
+  })
+
+  it('does not fire on a changelog edit alone', () => {
+    expect(isReleaseBranch([], ['packages/relay/CHANGELOG.md', 'packages/relay/src/x.ts'])).toBe(false)
+  })
+
+  it('does not fire on an ordinary branch', () => {
+    expect(isReleaseBranch([], ['packages/ios-agent/src/IOSAgent.ts'])).toBe(false)
+  })
 })

--- a/scripts/__tests__/shipsToUsers.test.mjs
+++ b/scripts/__tests__/shipsToUsers.test.mjs
@@ -1,0 +1,67 @@
+// Decides whether a changed file needs a changeset. A previous review found six separate things
+// this predicate missed while it was an allowlist over `src/**.ts`, and it then went a round with
+// no tests at all — the twenty-line rule that had been wrong six ways was the one thing unchecked.
+import { describe, it, expect } from 'vitest'
+import { shipsToUsers } from '../check-changeset.mjs'
+
+describe('shipsToUsers — files a released tapflow puts in front of users', () => {
+  const SHIPS = [
+    // The obvious case.
+    'packages/ios-agent/src/IOSAgent.ts',
+    'packages/relay/src/RelayServer.ts',
+    // Not TypeScript, and not under a name the old extension filter knew about.
+    'packages/relay/src/migrations/014_add_index.sql',
+    'packages/android-agent/proto/emulator_controller.proto',
+    'packages/flow-runner/schema/flow.schema.json',
+    'packages/ios-agent/xctest-runner/TreeRunner/TreeServer.swift',
+    // Committed binaries and entry points, shipped via `files[]`, never under `src/`.
+    'packages/cli/bin/tapflow.js',
+    'packages/ios-agent/bin/touch-helper',
+    // The dashboard is `private`, but it is built into the relay's `public/` and shipped there.
+    'packages/dashboard/src/main.tsx',
+    'packages/dashboard/hooks/useClipboardBridge.ts',
+    // A manifest carries `bin`, `files`, `postinstall` and dependencies — all user-visible.
+    'packages/android-agent/package.json',
+    // A brand-new published package. An allowlist of package names could not see this at all,
+    // which is backwards: a new package is the change most in need of a release note.
+    'packages/flow-capture/src/index.ts',
+  ]
+
+  for (const f of SHIPS) {
+    it(`requires a changeset for ${f}`, () => expect(shipsToUsers(f)).toBe(true))
+  }
+})
+
+describe('shipsToUsers — files that change nothing a user can observe', () => {
+  const DOES_NOT_SHIP = [
+    // Tests and their fixtures.
+    'packages/ios-agent/src/__tests__/IOSAgent.test.ts',
+    'packages/ios-agent/src/__fixtures__/the-app-tree.txt',
+    'packages/relay/src/session.test.ts',
+    'packages/dashboard/src/foo.spec.tsx',
+    // The XCUITest runner's own test target — it drives the tree server, it is not shipped.
+    'packages/ios-agent/xctest-runner/TreeRunner/TreeServerTest.swift',
+    // Build output and local config.
+    'packages/relay/dist/index.js',
+    'packages/relay/tsconfig.json',
+    'packages/dashboard/vitest.config.ts',
+    'packages/ios-agent/.gitignore',
+    'packages/dashboard/.env.development',
+    // Prose.
+    'packages/relay/README.md',
+    'packages/dashboard/DESIGN.md',
+    'packages/ios-agent/AGENTS.md',
+    'packages/agent-core/CHANGELOG.md',
+    // Packages that are never published.
+    'packages/docs/guide/requirements.md',
+    // Outside packages/ entirely.
+    'playground/relay.ts',
+    'scripts/dev-down.mjs',
+    '.github/workflows/ci.yml',
+    'AGENTS.md',
+  ]
+
+  for (const f of DOES_NOT_SHIP) {
+    it(`does not require a changeset for ${f}`, () => expect(shipsToUsers(f)).toBe(false))
+  }
+})

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -38,6 +38,17 @@ const EXEMPT = [
 ]
 
 const PACKAGE_FILE = /^packages\/([^/]+)\//
+/**
+ * Is this the branch `pnpm changeset version` produces? It consumes (deletes) the changesets it
+ * folds into the changelogs, so a gate looking for ADDED ones fails the release PR — which, with
+ * the check required, blocks the release itself. Both halves are needed: deleting a changeset
+ * you decided against is not a release. Exported for the tests.
+ */
+export function isReleaseBranch(consumedChangesets, changedFiles) {
+  if (consumedChangesets.length === 0) return false
+  return changedFiles.some((f) => /(^|\/)CHANGELOG\.md$/.test(f))
+}
+
 /** Would a user of a released tapflow notice this file changing? Exported for the tests. */
 export function shipsToUsers(f) {
   const pkg = f.match(PACKAGE_FILE)?.[1]
@@ -153,6 +164,18 @@ function main() {
   const added = git('diff', '--name-only', '--diff-filter=A', `${mergeBase}...HEAD`)
     .split('\n')
     .filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/^\.changeset\/README\.md$/i.test(f))
+
+  // A `changeset version` branch bumps every `packages/*/package.json` and DELETES the
+  // changesets it consumed, so it trips a gate that only looks for added ones — with the check
+  // required, that blocks the release PR permanently. Recognise it by its signature: changesets
+  // removed plus changelogs written. Verified against a real `pnpm changeset version` run.
+  const consumed = git('diff', '--name-only', '--diff-filter=D', `${mergeBase}...HEAD`)
+    .split('\n')
+    .filter((f) => /^\.changeset\/.+\.md$/.test(f))
+  if (isReleaseBranch(consumed, changed)) {
+    console.log(`Release branch: ${consumed.length} changeset(s) consumed into a changelog.`)
+    process.exit(0)
+  }
 
   if (added.length > 0) {
     console.log(`Published source changed and ${added.length} changeset(s) added:`)

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Fails a PR that changes published source without adding a changeset.
+//
+// Why: between v0.16.0 and v0.17.0 four PRs (#410–#413) changed shipped code with no changeset
+// between them, and the omission only surfaced while preparing the release. The rule was written
+// down in CONTRIBUTING.md and nothing enforced it, so the release notes would have announced the
+// clipboard bridge and stayed silent on the four fixes underneath it.
+//
+// Usage: node scripts/check-changeset.mjs <base-ref>   (default: origin/main)
+//
+// Opting out: put `<!-- no-changeset: reason -->` in the PR body, or pass --reason "…" locally.
+// A comment-only or test-only change is a legitimate skip; the point is that skipping is a
+// decision someone writes down, not something that happens by forgetting.
+import { execFileSync } from 'child_process'
+import { pathToFileURL } from 'url'
+
+// Published to npm, plus `dashboard`: it is `private`, but it is built into the relay's
+// `public/` and shipped inside that package — it is tapflow's primary user surface.
+const SHIPPED_PACKAGES = [
+  'agent-core', 'ios-agent', 'android-agent', 'relay', 'cli', 'mcp-server', 'flow-runner',
+  'audiotap-helper', 'dashboard',
+]
+
+// Deny by default. An earlier version listed what ships — `src/**` with a TypeScript extension —
+// and so ignored `.sql` migrations, `bin/`, `proto/`, `schema/`, `xctest-runner/`, the dashboard
+// entirely, and every `package.json`. Listing the EXCEPTIONS instead means a new shipped
+// directory errs toward asking for a changeset, which is the harmless direction to be wrong in.
+const EXEMPT = [
+  /(^|\/)__tests__\//,
+  /\.(test|spec)\.[cm]?[jt]sx?$/,
+  /(^|\/)dist\//,
+  /(^|\/)(README|LICENSE|CHANGELOG|AGENTS|CLAUDE)(\.md)?$/i,
+  /(^|\/)(tsconfig[^/]*\.json|vitest\.config\.[^/]+|eslint\.config\.[^/]+|\.npmignore)$/,
+]
+
+const PACKAGE_FILE = new RegExp(`^packages/(${SHIPPED_PACKAGES.join('|')})/`)
+const shipsToUsers = (f) => PACKAGE_FILE.test(f) && !EXEMPT.some((re) => re.test(f))
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+
+/**
+ * Pull `<!-- no-changeset: reason -->` out of a PR body.
+ *
+ * Two rules, both learned the hard way: the marker must be the WHOLE line, and it must not be
+ * inside a fenced code block. Otherwise any PR that merely quotes the syntax — a PR explaining
+ * the rule, or the PR that introduced it, both of which paste the snippet from CONTRIBUTING.md —
+ * silently switches the gate off.
+ *
+ * Exported for the tests.
+ */
+export function extractReason(body) {
+  let fenced = false
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (/^(```|~~~)/.test(line)) { fenced = !fenced; continue }
+    if (fenced) continue
+    if (/^ {4,}|^\t/.test(raw)) continue          // indented code block
+    const m = line.match(/^<!--\s*no-changeset:\s*(.*?)\s*-->$/)
+    if (m && m[1]) return m[1]
+  }
+  return ''
+}
+
+function main() {
+  // `--audit [since]` walks merges instead of the current branch: the PR gate cannot help with
+  // anything already on main, and that is exactly how #410–#413 slipped through. Run at release
+  // time, from /release step 1.
+  if (process.argv.includes('--audit')) {
+    const i = process.argv.indexOf('--audit')
+    const since = process.argv[i + 1] && !process.argv[i + 1].startsWith('--')
+      ? process.argv[i + 1]
+      : git('describe', '--tags', '--abbrev=0')
+
+    const merges = git('log', `${since}..HEAD`, '--merges', '--format=%H %s').split('\n').filter(Boolean)
+    const gaps = []
+    for (const line of merges) {
+      const [sha, ...rest] = line.split(' ')
+      const subject = rest.join(' ')
+      const files = git('diff', '--name-only', `${sha}^1`, sha).split('\n').filter(Boolean)
+      const shipped = files.filter((f) => shipsToUsers(f))
+      const cs = files.filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/README/i.test(f))
+      if (shipped.length > 0 && cs.length === 0) gaps.push({ subject, shipped })
+    }
+
+    console.log(`Merges since ${since}: ${merges.length}`)
+    if (gaps.length === 0) {
+      console.log('Every merge that changed published source carries a changeset.')
+      process.exit(0)
+    }
+    console.log(`\n  ${gaps.length} merge(s) changed published source with no changeset:\n`)
+    for (const { subject, shipped } of gaps) {
+      console.log(`    ${subject}`)
+      for (const f of shipped.slice(0, 5)) console.log(`      ${f}`)
+      if (shipped.length > 5) console.log(`      …and ${shipped.length - 5} more`)
+    }
+    console.log(`
+    These will be missing from the changelog. Either backfill a changeset for each, or
+    confirm the change is genuinely not worth a release note.
+  `)
+    process.exit(1)
+  }
+
+  const base = process.argv[2] ?? 'origin/main'
+  const reasonFlag = process.argv.indexOf('--reason')
+  const reason = reasonFlag > -1
+    ? (process.argv[reasonFlag + 1] ?? '').trim()
+    : extractReason(process.env.PR_BODY ?? '')
+
+  let mergeBase
+  try {
+    mergeBase = git('merge-base', base, 'HEAD')
+  } catch {
+    console.error(`Could not find a merge base with ${base}. Fetch it first:  git fetch origin main`)
+    process.exit(2)
+  }
+
+  const changed = git('diff', '--name-only', `${mergeBase}...HEAD`).split('\n').filter(Boolean)
+  const shipped = changed.filter((f) => shipsToUsers(f))
+
+  if (shipped.length === 0) {
+    console.log('No published source changed — no changeset required.')
+    process.exit(0)
+  }
+
+  // Added, not merely present: `.changeset/` always has entries waiting for the next release, so
+  // "a changeset exists" is true on every branch and would never fail.
+  const added = git('diff', '--name-only', '--diff-filter=A', `${mergeBase}...HEAD`)
+    .split('\n')
+    .filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/README/i.test(f))
+
+  if (added.length > 0) {
+    console.log(`Published source changed and ${added.length} changeset(s) added:`)
+    for (const f of added) console.log(`  + ${f}`)
+    process.exit(0)
+  }
+
+  if (reason) {
+    console.log(`Published source changed with no changeset, skipped on purpose:\n  ${reason}`)
+    process.exit(0)
+  }
+
+  console.error('\n  This branch changes published source but adds no changeset.\n')
+  for (const f of shipped.slice(0, 20)) console.error(`    ${f}`)
+  if (shipped.length > 20) console.error(`    …and ${shipped.length - 20} more`)
+  console.error(`
+    Add one:
+
+        pnpm changeset
+
+    Write it for someone reading the release notes: what was wrong, what they get now.
+
+    If this genuinely needs no release note — a comment, a rename with no behaviour change —
+    say so in the PR body:
+
+        <!-- no-changeset: comment-only follow-up to #123 -->
+  `)
+  process.exit(1)
+}
+
+// Only when run directly: the tests import `extractReason` from here.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main()

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -13,13 +13,14 @@
 // decision someone writes down, not something that happens by forgetting.
 import { execFileSync } from 'child_process'
 import { pathToFileURL } from 'url'
+import { realpathSync } from 'fs'
 
-// Published to npm, plus `dashboard`: it is `private`, but it is built into the relay's
-// `public/` and shipped inside that package — it is tapflow's primary user surface.
-const SHIPPED_PACKAGES = [
-  'agent-core', 'ios-agent', 'android-agent', 'relay', 'cli', 'mcp-server', 'flow-runner',
-  'audiotap-helper', 'dashboard',
-]
+// Inverted on purpose: everything under `packages/` ships unless named here. Listing what
+// ships instead left a NEW published package invisible to the gate — the case that most needs
+// a release note — while the comment below claimed the opposite. `dashboard` is deliberately
+// absent from this list: it is `private`, but it is built into the relay's `public/` and
+// shipped inside that package, and it is tapflow's primary user surface.
+const NOT_SHIPPED_PACKAGES = ['docs', 'playground']
 
 // Deny by default. An earlier version listed what ships — `src/**` with a TypeScript extension —
 // and so ignored `.sql` migrations, `bin/`, `proto/`, `schema/`, `xctest-runner/`, the dashboard
@@ -27,14 +28,22 @@ const SHIPPED_PACKAGES = [
 // directory errs toward asking for a changeset, which is the harmless direction to be wrong in.
 const EXEMPT = [
   /(^|\/)__tests__\//,
+  /(^|\/)__fixtures__\//,
   /\.(test|spec)\.[cm]?[jt]sx?$/,
+  /Test\.swift$/,                                  // the XCUITest runner's own test target
   /(^|\/)dist\//,
-  /(^|\/)(README|LICENSE|CHANGELOG|AGENTS|CLAUDE)(\.md)?$/i,
+  /(^|\/)\.(gitignore|env[^/]*)$/,
+  /(^|\/)(README|LICENSE|CHANGELOG|AGENTS|CLAUDE|DESIGN)(\.md)?$/i,
   /(^|\/)(tsconfig[^/]*\.json|vitest\.config\.[^/]+|eslint\.config\.[^/]+|\.npmignore)$/,
 ]
 
-const PACKAGE_FILE = new RegExp(`^packages/(${SHIPPED_PACKAGES.join('|')})/`)
-const shipsToUsers = (f) => PACKAGE_FILE.test(f) && !EXEMPT.some((re) => re.test(f))
+const PACKAGE_FILE = /^packages\/([^/]+)\//
+/** Would a user of a released tapflow notice this file changing? Exported for the tests. */
+export function shipsToUsers(f) {
+  const pkg = f.match(PACKAGE_FILE)?.[1]
+  if (!pkg || NOT_SHIPPED_PACKAGES.includes(pkg)) return false
+  return !EXEMPT.some((re) => re.test(f))
+}
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
 
@@ -67,9 +76,16 @@ function main() {
   // time, from /release step 1.
   if (process.argv.includes('--audit')) {
     const i = process.argv.indexOf('--audit')
-    const since = process.argv[i + 1] && !process.argv[i + 1].startsWith('--')
-      ? process.argv[i + 1]
-      : git('describe', '--tags', '--abbrev=0')
+    const after = process.argv[i + 1]
+    let since = after && !after.startsWith('-') ? after : null
+    if (!since) {
+      try {
+        since = git('describe', '--tags', '--abbrev=0')
+      } catch {
+        console.error('No tags here — pass an explicit revision: pnpm changeset:audit <ref>')
+        process.exit(2)
+      }
+    }
 
     const merges = git('log', `${since}..HEAD`, '--merges', '--format=%H %s').split('\n').filter(Boolean)
     const gaps = []
@@ -78,7 +94,10 @@ function main() {
       const subject = rest.join(' ')
       const files = git('diff', '--name-only', `${sha}^1`, sha).split('\n').filter(Boolean)
       const shipped = files.filter((f) => shipsToUsers(f))
-      const cs = files.filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/README/i.test(f))
+      const cs = files.filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/^\.changeset\/README\.md$/i.test(f))
+      // Same exemption the CI job makes. Without it the audit reports a bot's dependency bump as
+      // a permanent gap: the gate never asked for that changeset, so nobody can ever close it.
+      if (/dependabot|renovate/i.test(subject)) continue
       if (shipped.length > 0 && cs.length === 0) gaps.push({ subject, shipped })
     }
 
@@ -100,11 +119,18 @@ function main() {
     process.exit(1)
   }
 
-  const base = process.argv[2] ?? 'origin/main'
-  const reasonFlag = process.argv.indexOf('--reason')
-  const reason = reasonFlag > -1
-    ? (process.argv[reasonFlag + 1] ?? '').trim()
-    : extractReason(process.env.PR_BODY ?? '')
+  // Parse rather than index. Reading `argv[2]` blindly handed `--reason` itself to
+  // `git merge-base`; skipping only dash-prefixed words then handed it the reason TEXT.
+  const argv = process.argv.slice(2)
+  const positional = []
+  let reasonArg = null
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--reason') { reasonArg = argv[++i] ?? ''; continue }
+    if (argv[i] === '--audit') { i++; continue }        // its value is read in the audit branch
+    if (!argv[i].startsWith('-')) positional.push(argv[i])
+  }
+  const base = positional[0] ?? 'origin/main'
+  const reason = reasonArg !== null ? reasonArg.trim() : extractReason(process.env.PR_BODY ?? '')
 
   let mergeBase
   try {
@@ -126,7 +152,7 @@ function main() {
   // "a changeset exists" is true on every branch and would never fail.
   const added = git('diff', '--name-only', '--diff-filter=A', `${mergeBase}...HEAD`)
     .split('\n')
-    .filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/README/i.test(f))
+    .filter((f) => /^\.changeset\/.+\.md$/.test(f) && !/^\.changeset\/README\.md$/i.test(f))
 
   if (added.length > 0) {
     console.log(`Published source changed and ${added.length} changeset(s) added:`)
@@ -158,4 +184,6 @@ function main() {
 }
 
 // Only when run directly: the tests import `extractReason` from here.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main()
+// `realpathSync`: `import.meta.url` is already resolved, `argv[1]` is not, so invoking
+// through a symlink skipped `main()` entirely and the gate reported success having done nothing.
+if (process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href) main()

--- a/scripts/dev-down.mjs
+++ b/scripts/dev-down.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Stops the dev processes `pnpm dev` starts, for this checkout only.
+//
+// Why this exists: `concurrently -k` cleans up when it exits normally, but not when the terminal
+// goes away, the machine sleeps, or a process was started detached. One relay survived a day that
+// way and cost a debugging session — the failure it produced named neither the port nor the pid.
+import { findDevProcesses, listenersOn, REPO_ROOT, DEV_PORTS } from './dev-ports.mjs'
+
+const targets = findDevProcesses()
+if (targets.length === 0) {
+  console.log(`No tapflow dev processes running for ${REPO_ROOT}`)
+  process.exit(0)
+}
+
+for (const { pid, command } of targets) {
+  console.log(`  kill ${pid}  ${command.slice(0, 100)}`)
+  try { process.kill(pid, 'SIGTERM') } catch { /* already gone */ }
+}
+
+// SIGTERM first so a relay can close its sockets; SIGKILL only what ignores it.
+await new Promise((r) => setTimeout(r, 1500))
+const survivors = findDevProcesses()
+for (const { pid } of survivors) {
+  console.log(`  kill -9 ${pid}  (did not stop on SIGTERM)`)
+  try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
+}
+
+// The child processes tsx spawns (esbuild services) exit with their parent; anything still
+// holding a port after this is not ours, and saying so is more useful than a silent success.
+await new Promise((r) => setTimeout(r, 500))
+const stillThere = findDevProcesses()
+if (stillThere.length > 0) {
+  console.error(`\n  ${stillThere.length} process(es) survived — investigate:`)
+  for (const { pid, command } of stillThere) console.error(`    ${pid}  ${command.slice(0, 100)}`)
+  process.exit(1)
+}
+
+// Honours the PORT override the same way the preflight does; hardcoding 4000 made this note
+// meaningless whenever the relay was started on another port.
+for (const { port, what } of DEV_PORTS) {
+  if (listenersOn(port).length > 0) {
+    console.log(`\n  Note: :${port} (${what}) is still held, by something that is not a tapflow dev process.`)
+  }
+}
+
+console.log('\nStopped.')

--- a/scripts/dev-down.mjs
+++ b/scripts/dev-down.mjs
@@ -6,9 +6,20 @@
 // way and cost a debugging session — the failure it produced named neither the port nor the pid.
 import { findDevProcesses, listenersOn, REPO_ROOT, DEV_PORTS } from './dev-ports.mjs'
 
+// Reported before the early exit: "nothing of ours is running" and "the port is free" are
+// different facts, and the case that needs both stated is exactly the one that returned early.
+function reportForeignHolders() {
+  for (const { port, what } of DEV_PORTS) {
+    if (listenersOn(port).length > 0) {
+      console.log(`\n  Note: :${port} (${what}) is still held, by something that is not a tapflow dev process.`)
+    }
+  }
+}
+
 const targets = findDevProcesses()
 if (targets.length === 0) {
   console.log(`No tapflow dev processes running for ${REPO_ROOT}`)
+  reportForeignHolders()
   process.exit(0)
 }
 
@@ -35,12 +46,6 @@ if (stillThere.length > 0) {
   process.exit(1)
 }
 
-// Honours the PORT override the same way the preflight does; hardcoding 4000 made this note
-// meaningless whenever the relay was started on another port.
-for (const { port, what } of DEV_PORTS) {
-  if (listenersOn(port).length > 0) {
-    console.log(`\n  Note: :${port} (${what}) is still held, by something that is not a tapflow dev process.`)
-  }
-}
+reportForeignHolders()
 
 console.log('\nStopped.')

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -15,7 +15,7 @@ export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 /** Agent worktrees live under the repo. They are separate checkouts and are never ours to kill. */
 const NESTED_CHECKOUTS = '/.claude/worktrees/'
 
-export const RELAY_PORT = Number(process.env.PORT ?? 4000)
+export const RELAY_PORT = Number(process.env.PORT || 4000)   // `||`: PORT="" is not port 0
 export const DASHBOARD_PORT = 3001
 export const DEV_PORTS = [
   { port: RELAY_PORT, what: 'relay' },
@@ -23,6 +23,7 @@ export const DEV_PORTS = [
 ]
 
 const isNode = (argv0) => basename(argv0 ?? '') === 'node'
+const escapeRe = (v) => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /**
  * Does this command line belong to a dev process of the checkout at `root`?
@@ -40,22 +41,30 @@ export function isDevProcess(command, root = REPO_ROOT) {
   const argv = command.split(/\s+/).filter(Boolean)
   if (!isNode(argv[0])) return false
 
-  const inRepo = argv.some(
-    (a) => a.startsWith(`${root}/`) && !a.startsWith(`${root}${NESTED_CHECKOUTS}`),
-  )
-  if (!inRepo) return false
+  // The path that establishes the ROLE must itself be the one inside the repo. Testing those two
+  // things independently let `--root <repo>/packages` or `--cwd <repo>/x` supply the "in repo"
+  // half while a foreign vite or a foreign script supplied the role — and `dev-down` SIGKILLs
+  // what this returns.
+  //
+  // Matched against the raw command rather than a token, so a checkout path containing a space
+  // still works: `root` is embedded literally and only the remainder is space-free.
+  const under = (suffix) =>
+    new RegExp(`${escapeRe(root)}/(?!${escapeRe(NESTED_CHECKOUTS.slice(1, -1))}/)\\S*${suffix}`)
+      .test(command)
 
-  // tsx launcher and the child it spawns — the child is the one holding the relay port.
+  // The tsx launcher, and the child it spawns — the child holds the relay port. The child names
+  // its script relatively, so what anchors it to this checkout is the tsx loader path.
   const isTsxDev =
     argv.includes('--conditions=source') &&
-    argv.some((a) => /(^|\/)(relay|ios-agent|android-agent|multi-agent)\.ts$/.test(a))
+    argv.some((a) => /(^|\/)(relay|ios-agent|android-agent|multi-agent)\.ts$/.test(a)) &&
+    !argv.some((a) => a.startsWith('/') && /(relay|ios-agent|android-agent|multi-agent)\.ts$/.test(a)
+      && !a.startsWith(`${root}/`)) &&
+    under('tsx/[^\\s]*')
   // `node …/vite/bin/vite.js --port 3001`
-  const isVite =
-    argv.some((a) => /(^|\/)vite(\.js)?$/.test(a)) && argv.includes(String(DASHBOARD_PORT))
+  const isVite = under('vite(\\.js)?(\\s|$)') && argv.includes(String(DASHBOARD_PORT))
   // `node …/concurrently.js -k -n relay,dashboard,ios,android …`
   const isSupervisor =
-    argv.some((a) => /(^|\/)concurrently(\.js)?$/.test(a)) &&
-    argv.some((a) => a.startsWith('relay,'))
+    under('concurrently(\\.js)?(\\s|$)') && argv.some((a) => a.startsWith('relay,'))
 
   return isTsxDev || isVite || isSupervisor
 }

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -72,7 +72,10 @@ export function isDevProcess(command, root = REPO_ROOT) {
 /** `ps` output as {pid, command}. Empty if ps is unavailable — never a reason to block. */
 export function listProcesses() {
   try {
-    return execFileSync('ps', ['-Ao', 'pid=,command='], { encoding: 'utf8' })
+    // `-ww`: do not let `ps` bound the command column. Not reproducible on this macOS — a
+    // 1929-char line survives a pipe intact — but a truncated line makes `isDevProcess` miss a
+    // real process, and this tool's worst failure is reporting success having stopped nothing.
+    return execFileSync('ps', ['-Awwo', 'pid=,command='], { encoding: 'utf8' })
       .split('\n')
       .map((line) => {
         const m = line.match(/^\s*(\d+)\s+(.*)$/)
@@ -102,6 +105,18 @@ export function listenersOn(port) {
     // "nothing to report" — a preflight that cannot look must not stop the dev server.
     return []
   }
+}
+
+/**
+ * Which ports a caller wants checked. Throws on a name that matches nothing: an empty selection
+ * would make the preflight exit 0 having looked at nothing, which is the one outcome a tool
+ * against silent success must not produce. Exported for the tests.
+ */
+export function selectPorts(wanted) {
+  if (wanted.length === 0) return DEV_PORTS
+  const unknown = wanted.filter((w) => !DEV_PORTS.some(({ what }) => what.startsWith(w)))
+  if (unknown.length > 0) throw new Error(`Unknown dev-preflight target: ${unknown.join(', ')}`)
+  return DEV_PORTS.filter(({ what }) => wanted.some((w) => what.startsWith(w)))
 }
 
 export const commandFor = (pid) =>

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -1,0 +1,99 @@
+// Shared between dev-preflight and dev-down: the ports `pnpm dev` needs, and how to tell one of
+// its processes apart from anything else on the machine.
+//
+// `dev-down` SIGKILLs what this module selects, so the selection is the dangerous part of the
+// tool and is written to be provably narrow. Every rule below was derived from the real `ps`
+// output of a running `pnpm dev` (see scripts/__tests__/devProcesses.test.mjs, whose fixtures
+// are verbatim command lines) — an earlier version was written from memory and matched none of
+// the three, while matching `grep`, `less` and sibling checkouts instead.
+import { execFileSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { dirname, resolve, basename } from 'path'
+
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Agent worktrees live under the repo. They are separate checkouts and are never ours to kill. */
+const NESTED_CHECKOUTS = '/.claude/worktrees/'
+
+export const RELAY_PORT = Number(process.env.PORT ?? 4000)
+export const DASHBOARD_PORT = 3001
+export const DEV_PORTS = [
+  { port: RELAY_PORT, what: 'relay' },
+  { port: DASHBOARD_PORT, what: 'dashboard (vite)' },
+]
+
+const isNode = (argv0) => basename(argv0 ?? '') === 'node'
+
+/**
+ * Does this command line belong to a dev process of the checkout at `root`?
+ *
+ * Three independent conditions, all required:
+ *  1. it is a node process — this alone excludes `grep`, `less`, `vim` and every other tool
+ *     that merely mentions the repo or one of the patterns below;
+ *  2. some argument is an absolute path inside `root` and outside any nested checkout — this
+ *     excludes a sibling clone, and `<root>/.claude/worktrees/*`;
+ *  3. it looks like one of the three roles `pnpm dev` starts.
+ *
+ * Exported for the tests; callers use `findDevProcesses`.
+ */
+export function isDevProcess(command, root = REPO_ROOT) {
+  const argv = command.split(/\s+/).filter(Boolean)
+  if (!isNode(argv[0])) return false
+
+  const inRepo = argv.some(
+    (a) => a.startsWith(`${root}/`) && !a.startsWith(`${root}${NESTED_CHECKOUTS}`),
+  )
+  if (!inRepo) return false
+
+  // tsx launcher and the child it spawns — the child is the one holding the relay port.
+  const isTsxDev =
+    argv.includes('--conditions=source') &&
+    argv.some((a) => /(^|\/)(relay|ios-agent|android-agent|multi-agent)\.ts$/.test(a))
+  // `node …/vite/bin/vite.js --port 3001`
+  const isVite =
+    argv.some((a) => /(^|\/)vite(\.js)?$/.test(a)) && argv.includes(String(DASHBOARD_PORT))
+  // `node …/concurrently.js -k -n relay,dashboard,ios,android …`
+  const isSupervisor =
+    argv.some((a) => /(^|\/)concurrently(\.js)?$/.test(a)) &&
+    argv.some((a) => a.startsWith('relay,'))
+
+  return isTsxDev || isVite || isSupervisor
+}
+
+/** `ps` output as {pid, command}. Empty if ps is unavailable — never a reason to block. */
+export function listProcesses() {
+  try {
+    return execFileSync('ps', ['-Ao', 'pid=,command='], { encoding: 'utf8' })
+      .split('\n')
+      .map((line) => {
+        const m = line.match(/^\s*(\d+)\s+(.*)$/)
+        return m ? { pid: Number(m[1]), command: m[2] } : null
+      })
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+export const findDevProcesses = () =>
+  listProcesses().filter(({ pid, command }) => pid !== process.pid && isDevProcess(command))
+
+/** PIDs listening on a port. `[]` when nothing holds it — or when lsof is unavailable. */
+export function listenersOn(port) {
+  try {
+    return execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .split('\n')
+      .map((s) => Number(s.trim()))
+      .filter(Boolean)
+  } catch {
+    // lsof exits non-zero when nothing matches, and may not be installed at all. Both mean
+    // "nothing to report" — a preflight that cannot look must not stop the dev server.
+    return []
+  }
+}
+
+export const commandFor = (pid) =>
+  listProcesses().find((p) => p.pid === pid)?.command ?? '(unknown)'

--- a/scripts/dev-preflight.mjs
+++ b/scripts/dev-preflight.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Runs before `pnpm dev`. A dev server left running from an earlier session holds :4000, the
+// relay fails with EADDRINUSE, and concurrently then SIGTERMs the dashboard and both agents —
+// so the visible failure is four processes dying and no mention of the port anywhere.
+//
+// It reports and stops. It does NOT kill anything: a dev server you started deliberately in
+// another terminal is indistinguishable from a leftover, and killing the wrong one is the more
+// expensive mistake. `pnpm dev:down` is the deliberate version.
+import { DEV_PORTS, listenersOn, commandFor, findDevProcesses } from './dev-ports.mjs'
+
+// `pnpm dev:pool` runs no dashboard, so blocking it on :3001 would refuse a start for a port it
+// never wanted. Callers name what they need: `dev-preflight.mjs relay dashboard`.
+const wanted = process.argv.slice(2)
+const ports = wanted.length
+  ? DEV_PORTS.filter(({ what }) => wanted.some((w) => what.startsWith(w)))
+  : DEV_PORTS
+
+const held = ports.map(({ port, what }) => ({ port, what, pids: listenersOn(port) })).filter(
+  (p) => p.pids.length > 0,
+)
+
+if (held.length === 0) process.exit(0)
+
+const ours = new Set(findDevProcesses().map((p) => p.pid))
+
+console.error('\n  Cannot start: something is already listening.\n')
+for (const { port, what, pids } of held) {
+  for (const pid of pids) {
+    const mine = ours.has(pid) ? '  ← a tapflow dev process from this checkout' : ''
+    console.error(`  :${port}  ${what}`)
+    console.error(`         pid ${pid}${mine}`)
+    console.error(`         ${commandFor(pid).slice(0, 120)}\n`)
+  }
+}
+
+const allOurs = held.every(({ pids }) => pids.every((pid) => ours.has(pid)))
+console.error(
+  allOurs
+    ? '  All of the above are this checkout\'s own dev processes:\n\n      pnpm dev:down\n'
+    : `  Some of these are not tapflow dev processes. Check before killing:\n\n      kill ${held
+        .flatMap(({ pids }) => pids)
+        .join(' ')}\n`,
+)
+process.exit(1)

--- a/scripts/dev-preflight.mjs
+++ b/scripts/dev-preflight.mjs
@@ -6,14 +6,17 @@
 // It reports and stops. It does NOT kill anything: a dev server you started deliberately in
 // another terminal is indistinguishable from a leftover, and killing the wrong one is the more
 // expensive mistake. `pnpm dev:down` is the deliberate version.
-import { DEV_PORTS, listenersOn, commandFor, findDevProcesses } from './dev-ports.mjs'
+import { selectPorts, listenersOn, commandFor, findDevProcesses } from './dev-ports.mjs'
 
 // `pnpm dev:pool` runs no dashboard, so blocking it on :3001 would refuse a start for a port it
 // never wanted. Callers name what they need: `dev-preflight.mjs relay dashboard`.
-const wanted = process.argv.slice(2)
-const ports = wanted.length
-  ? DEV_PORTS.filter(({ what }) => wanted.some((w) => what.startsWith(w)))
-  : DEV_PORTS
+let ports
+try {
+  ports = selectPorts(process.argv.slice(2))
+} catch (e) {
+  console.error(`\n  ${e.message}\n`)
+  process.exit(2)
+}
 
 const held = ports.map(({ port, what }) => ({ port, what, pids: listenersOn(port) })).filter(
   (p) => p.pids.length > 0,

--- a/scripts/vitest.config.mjs
+++ b/scripts/vitest.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+// Deliberately NOT at the repo root. A config file there is inherited by every package that has
+// none of its own — all of them do — and they then run with this `include` and find no tests.
+// Invoked explicitly: `vitest run --config scripts/vitest.config.mjs`.
+//
+// `root` is resolved from this file, not from the cwd: vitest resolves a relative `root` against
+// the working directory, so '..' pointed one level above the repo.
+export default defineConfig({
+  root: resolve(dirname(fileURLToPath(import.meta.url)), '..'),
+  test: {
+    include: ['scripts/__tests__/**/*.test.mjs'],
+  },
+})


### PR DESCRIPTION
## Summary

Two rules this repo relied on people remembering, plus what a long branch cost.

**Dev servers.** `pnpm dev` refuses to start when :4000 or :3001 is held and names the pid; `pnpm dev:down` stops this checkout's dev processes. A relay left running from an earlier session once survived a day: it failed with `EADDRINUSE`, `concurrently` SIGTERMed the dashboard and both agents, and the visible symptom was four processes dying with the port mentioned nowhere.

The preflight reports and stops — it never kills. A dev server started deliberately in another terminal is indistinguishable from a leftover, and killing the wrong one is the more expensive mistake.

**Changesets.** A PR that changes shipped code must add one; the CI `changeset` job fails otherwise. Opting out means writing the reason in the PR body, on its own line and outside a code fence — otherwise a PR that merely documents the escape hatch turns the gate off. CI cannot see what is already merged, which is exactly how #410–#413 reached release prep with no changelog entry, so `pnpm changeset:audit` walks the merges since the last tag and `/release` runs it.

**AGENTS.md.** Dev-server hygiene next to the vitest-zombie rule, what the clipboard branch cost (invariant table before implementing anything cross-cutting; review the design before the code; a design-level finding means replan, not patch; mutate the guards themselves), and what makes a review expensive.

## The dangerous part

`dev:down` sends SIGTERM then SIGKILL to processes it selects from `ps` output. Both review rounds were pointed at that selection first, and both found it wrong.

Round 1: it killed sibling clones (`tapflow-fork` matched by substring), killed agent worktrees nested under the repo, killed `grep` and `less` whose *arguments* contained the patterns — and matched **none** of the three real roles, so in the orphan case it reported success while :3001 stayed held. Root cause: the patterns were written from memory. They are now derived from captured `ps` output of a live `pnpm dev`, and those exact strings are the test fixtures.

Round 2: "inside this checkout" and "looks like a dev process" were still two *independent* conditions, so one argument could satisfy each — an in-repo tsx running a script elsewhere, a foreign vite with `--root <repo>/packages`. And a checkout path containing a space made the whole matcher silently return nothing, so `dev:down` printed "no dev processes running" and exited 0 with the relay still up.

Selection is now: the executable is node, **and** the argument that establishes the role is itself the one inside this checkout and outside `.claude/worktrees/`. 37 fixtures cover it, and each of the three conditions is mutation-verified.

## Verification

`pnpm test` **1764 passed | 1 skipped** — 75 tooling tests plus every package. `pnpm typecheck` and `pnpm lint` clean; `scripts/` was excluded from both and is now covered, since it holds the only code in the repo that sends SIGKILL.

Beyond unit tests, the acceptance case was run live in both rounds: start `pnpm dev`, SIGKILL the supervisor to orphan the children, run `pnpm dev:down`, assert both ports end up free.

**Adversarial review: 2 rounds**, findings and dispositions in `.work/reviews/chore__dev-and-changeset-guards.md`. Round 2 confirmed round 1's fixes against live processes and real history, then found the next layer — including that `check-changeset`'s own documented `--reason` invocation crashed, and that `--audit` would have reported a dependency bump as a gap nobody could ever close.

## One thing this cannot do alone

`main` is protected by an active ruleset (`protect-main`): no deletion, no force push, PR with one approving review. What it does **not** carry is a `required_status_checks` rule, so a failing `changeset` job reports without blocking the merge button. The docs say that rather than claiming enforcement. Adding the required check is a repo-settings change and yours to make.

*(An earlier version of this section said main had no protection at all. That came from `/branches/main/protection` returning 404 — that endpoint only reports classic branch protection and cannot see rulesets.)*

Deferred: root `package.json` / `pnpm-lock.yaml` changes to `pnpm.overrides` do ship to users but are not gated, because that file changes for unrelated reasons often enough that gating it would train people to ignore the job.

<!-- no-changeset: repo tooling and docs only; nothing under packages/ changes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CI enforcement to require changesets for published-source changes, with an opt-out marker, plus an audit step to detect merged shipped changes missing changesets since the last tag.
  - Added local dev preflight to detect port conflicts before starting, and improved guidance for stopping dev servers cleanly.
- **Documentation**
  - Updated contribution/review guidance for changesets and dev-server hygiene.
- **Bug Fixes / Chores**
  - Improved lint coverage for `scripts/` and refined CI checkout/permissions behavior.
- **Tests**
  - Added Vitest configuration and new test suites covering changeset opt-out parsing, shipped-file detection, and dev-process/port selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
