### PR TITLE
docs(release): drop the one-time steps that are done, correct the dist-tag one that is not

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -48,13 +48,7 @@ model: claude-opus-4-8
 
 ## 7. 이 레포 전용 수동 단계 (놓치기 가장 쉬움)
 
-- **mcp-server·flow-runner는 2026-07 graduation 이후 fixed 그룹의 정규 멤버다** — experimental 접미사 수동 변경 절차는 폐기됐다. 되살리지 말 것.
-- **flow-runner 첫 발행 전제(1회성, v0.14.0 이전에만 해당)**: `@tapflowio/flow-runner`는 npm에 존재하지 않아 OIDC trusted publishing으로 첫 publish가 불가하다(신규 패키지에는 trusted publisher를 등록할 수 없음). **태그 push 전에** 반드시:
-  1. 로컬에서 seed publish — **반드시 pnpm 경로로**: `pnpm --filter @tapflowio/flow-runner publish --access public --no-git-checks` (raw `npm publish`는 `workspace:*`를 치환하지 않아 설치 불가 tarball이 나간다)
-  2. npmjs.com 패키지 설정에서 trusted publisher 등록: repo `jo-duchan/tapflow`, workflow `release.yml`
-  3. 이걸 건너뛰고 태그를 밀면: 다른 패키지는 발행되고 flow-runner만 실패 → exact pin 의존 때문에 **`npm i tapflow`가 전 사용자에게 깨진다** (복구: 태그 커밋에서 flow-runner 수동 pnpm publish 후 잡 재실행)
-- **graduation 릴리즈(v0.14.0) 태그 전제**: MCP 안정화(Track A — press_key/press_button 수정 + 툴 전수 검증) 머지 완료. `.work/2026-07-05-mcp-followups-plan.md` 확인.
-- **릴리즈 후 1회성**: 구 `experimental` dist-tag가 0.13.0-experimental.1에 고정돼 있어 `@experimental`로 설치한 기존 사용자는 업데이트가 끊긴다 → `npm dist-tag add @tapflowio/mcp-server@X.Y.Z experimental` 로 당겨주거나 태그 제거를 안내한다.
+- **`@experimental` dist-tag**: `@tapflowio/mcp-server`에 `experimental` dist-tag가 남아 있고 **`latest`를 따라가지 않는다**. 2026-07 기준 `experimental: 0.14.0` / `latest: 0.16.0` — 한 번 당겨준 뒤 멈췄다. 그 태그로 설치한 사용자는 업데이트가 끊긴 상태다. 매 릴리즈마다 `npm dist-tag add @tapflowio/mcp-server@X.Y.Z experimental`로 당기거나, 태그를 없애고(`npm dist-tag rm`) 안내하거나 — 둘 중 하나를 정해야 한다. 현재 상태는 "정하지 않음"이고 그게 가장 나쁘다.
 - **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
   - **하단 compare 링크도 함께 갱신**(놓치기 쉬움): `[Unreleased]`를 `vX.Y.Z...HEAD`로 바꾸고, `[X.Y.Z]: .../compare/v{직전}...vX.Y.Z` 링크를 새로 추가한다. 직전 릴리즈 링크가 빠져 있으면 이번에 함께 메운다.
 - **dashboard**: private + `ignore` → 건드리지 않는다.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -48,7 +48,11 @@ model: claude-opus-4-8
 
 ## 7. 이 레포 전용 수동 단계 (놓치기 가장 쉬움)
 
-- **`@experimental` dist-tag**: `@tapflowio/mcp-server`에 `experimental` dist-tag가 남아 있고 **`latest`를 따라가지 않는다**. 2026-07 기준 `experimental: 0.14.0` / `latest: 0.16.0` — 한 번 당겨준 뒤 멈췄다. 그 태그로 설치한 사용자는 업데이트가 끊긴 상태다. 매 릴리즈마다 `npm dist-tag add @tapflowio/mcp-server@X.Y.Z experimental`로 당기거나, 태그를 없애고(`npm dist-tag rm`) 안내하거나 — 둘 중 하나를 정해야 한다. 현재 상태는 "정하지 않음"이고 그게 가장 나쁘다.
+- **`@experimental` dist-tag 정리**: `@tapflowio/mcp-server`는 v0.14.0 graduation 전까지 `X.Y.Z-experimental.N`으로 20개를 발행했고 그 채널이 `experimental` dist-tag였다. graduation 이후 prerelease는 한 번도 나오지 않았다 — **개념은 사라졌고 npm 태그만 남았다.**
+  - 당시 절차는 "새 버전으로 당기거나, 제거를 안내하거나"였고 앞쪽만 수행돼 태그가 `0.14.0`을 가리킨다. **그 1회성 조치가 문제를 재생산했다**: `latest`가 0.16.0으로 가는 동안 태그는 그대로라, 문서가 진단했던 "업데이트가 끊긴다"가 한 버전 뒤에서 그대로 반복됐다. 1회성으로 설계한 것이 원인이지 누가 빠뜨린 것이 아니다.
+  - 지금 태그는 두 가지로 틀렸다: 이름이 가리키는 `0.14.0`은 실험판이 아니라 정식 릴리즈이고, `latest`보다 뒤처져 "최신 실험판"도 아니다.
+  - **제거가 맞다.** 가리킬 prerelease 스트림이 없고, `latest`와 동기화해 유지하면 순수한 별칭이라 잊어버릴 거리만 늘린다. 제거하면 `@experimental` 설치가 소리내어 실패해 사용자가 `latest`로 옮길 신호를 받는다 — 3주 지난 버전을 조용히 설치하는 것보다 낫다.
+  - 사용자에게 영향이 가므로 **실행 전 확인**을 받는다: `npm dist-tag rm @tapflowio/mcp-server experimental`
 - **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
   - **하단 compare 링크도 함께 갱신**(놓치기 쉬움): `[Unreleased]`를 `vX.Y.Z...HEAD`로 바꾸고, `[X.Y.Z]: .../compare/v{직전}...vX.Y.Z` 링크를 새로 추가한다. 직전 릴리즈 링크가 빠져 있으면 이번에 함께 메운다.
 - **dashboard**: private + `ignore` → 건드리지 않는다.


### PR DESCRIPTION
## Summary

Found while running `/release` for v0.17.0. Three of the four items under "repo-specific manual steps" describe work that has already happened. A checklist that describes the past charges attention every release and teaches people to skim it.

| item | why it goes | evidence |
|---|---|---|
| experimental-suffix procedure | retired at graduation; only a "don't revive it" note remained | — |
| flow-runner first publish (one-time, pre-v0.14.0) | it has been on npm since then | `npm view @tapflowio/flow-runner version` → `0.16.0` |
| graduation release (v0.14.0) tag precondition | that release shipped | — |

## The fourth is still live, and its facts were wrong

It said the `experimental` dist-tag is pinned at `0.13.0-experimental.1`. It is not:

```
@tapflowio/mcp-server
  experimental: 0.14.0
  latest:       0.16.0
```

It was pulled forward once and then dropped. Anyone who installed `@tapflowio/mcp-server@experimental` is two versions behind and has no way to know. Rewritten to say that, and to name the decision it has been deferring: pull the tag every release, or retire it. Neither has been chosen, which is worse than either.

`@tapflowio/flow-runner` carries only `latest`, so it is unaffected.

## Not decided here

Whether to keep pulling the tag or remove it. Removing affects whoever installs through it, so that is the maintainer's call — raised after v0.17.0 publishes.

Adversarial review skipped: docs-only, one file, seven lines removed. Recorded with the reason in `.work/reviews/docs__release-command-cleanup.md`.

<!-- no-changeset: command documentation only; nothing under packages/ changes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to clarify that the experimental dist-tag may no longer track the latest release.
  * Removed outdated manual release steps and prerequisite assumptions.
  * Added clear instructions for aligning the experimental tag or removing it when prereleases are not being maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->