### PR TITLE
fix(readme): repair two broken links and realign root/CLI READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 <p align="center"><em>Streams over H.264 with a zero-buffer decoder (no MSE) — <a href="contributing/streaming-latency-log.md">latency measurements ↗</a></em></p>
 
-> **v0.x, actively developed** — backward-compatible by default; breaking changes are rare and always noted in the [changelog](CHANGELOG.md). [Roadmap →](./ROADMAP.md)
+> **v0.x, actively developed** — backward-compatible by default; breaking changes are rare and always noted in the [changelog](CHANGELOG.md). [Roadmap →](ROADMAP.md)
 
 ---
 
@@ -178,7 +178,7 @@ tapflow is self-hosted by design — build files, device streams, and session re
 - **Authenticated by default off-host** — the relay accepts unauthenticated connections only from its own machine (`localhost`). Browsers reaching it from elsewhere sign in; agents on another machine present an `agent`-scope token.
 - **PAT + roles** — Personal Access Tokens carry scopes (`builds:write` for CI uploads, `agent` for remote agents), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
 
-Found a vulnerability? See [SECURITY.md](SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/guide/security).
+Found a vulnerability? See [SECURITY.md](SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/reference/security).
 
 ## Self-Hosting
 
@@ -226,8 +226,8 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 Full docs: **[www.tapflow.dev](https://www.tapflow.dev)**
 
-- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Security & Privacy](https://www.tapflow.dev/guide/security) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
-- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api)
+- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api) · [Security & Privacy](https://www.tapflow.dev/reference/security)
 - **AI Agent** — [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 ## Contributing

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,7 +37,7 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/user-attachments/assets/01914ed2-f35c-4230-ae01-166ffe6af395" target="_blank" rel="noopener noreferrer">
+  <a href="https://github.com/user-attachments/assets/dbba8bde-74b6-4fb9-bdb6-3919bc4295c4" target="_blank" rel="noopener noreferrer">
     <img src="https://raw.githubusercontent.com/jo-duchan/tapflow/main/docs/public/demo-thumbnail.png" alt="tapflow demo — click to play" width="100%" />
   </a>
   <p><em>Click to play</em></p>
@@ -77,7 +77,7 @@ We hit this exact problem, so we built tapflow.
 tapflow connects three parts:
 
 1. A **self-hosted relay** (Linux or Mac) — also serves the dashboard on the same port, so there's no separate web server.
-2. A **macOS agent** that drives the iOS Simulator and Android emulator — it connects _outbound_ to the relay (no inbound firewall rules) and injects iOS touch directly, without WebDriverAgent.
+2. A **macOS agent** that drives the iOS Simulator and Android emulator — it connects *outbound* to the relay (no inbound firewall rules) and injects iOS touch directly, without WebDriverAgent.
 3. A **browser dashboard** for the rest of the team — pick an available device and interact with it in real time while the simulators keep running on your Macs.
 
 ```text
@@ -88,6 +88,8 @@ Browser (your team)  ←─ WebSocket ─→  Relay Server  ←─ WebSocket (ou
 ## What tapflow is not
 
 tapflow doesn't replace native mobile development tools. Mobile developers still use Xcode, Android Studio, and their build tooling. tapflow makes the *running* simulators and emulators accessible to the rest of the team through a browser, and it is not a device farm. It does have an automated QA axis — a deterministic flow runner and an MCP server for LLM agents — but wiring in external automation frameworks like WebDriverAgent or Appium is out of scope; tapflow ships its own minimal runner instead.
+
+Where this is heading is laid out in [VISION.md](https://github.com/jo-duchan/tapflow/blob/main/VISION.md): growing manual QA into automation, only when you need it.
 
 ## Quick Start
 
@@ -181,7 +183,7 @@ tapflow is self-hosted by design — build files, device streams, and session re
 - **Authenticated by default off-host** — the relay accepts unauthenticated connections only from its own machine (`localhost`). Browsers reaching it from elsewhere sign in; agents on another machine present an `agent`-scope token.
 - **PAT + roles** — Personal Access Tokens carry scopes (`builds:write` for CI uploads, `agent` for remote agents), and team roles (Admin / Developer / QA / Viewer) govern dashboard access.
 
-Found a vulnerability? See [SECURITY.md](https://github.com/jo-duchan/tapflow/blob/main/SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/guide/security).
+Found a vulnerability? See [SECURITY.md](https://github.com/jo-duchan/tapflow/blob/main/SECURITY.md). For the full model, read [Security & Privacy](https://www.tapflow.dev/reference/security).
 
 ## Self-Hosting
 
@@ -229,13 +231,13 @@ Full reference → [CLI docs](https://www.tapflow.dev/reference/cli)
 
 Full docs: **[www.tapflow.dev](https://www.tapflow.dev)**
 
-- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Security & Privacy](https://www.tapflow.dev/guide/security) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
-- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api)
+- **Guides** — [Quick Start](https://www.tapflow.dev/guide/getting-started) · [Environment Setup](https://www.tapflow.dev/guide/environment-setup) · [Self-Hosting](https://www.tapflow.dev/guide/self-hosting) · [Uploading Builds (CI/CD)](https://www.tapflow.dev/guide/upload-builds) · [Troubleshooting](https://www.tapflow.dev/guide/troubleshooting)
+- **Reference** — [CLI](https://www.tapflow.dev/reference/cli) · [Configuration](https://www.tapflow.dev/reference/configuration) · [REST API](https://www.tapflow.dev/reference/api) · [Security & Privacy](https://www.tapflow.dev/reference/security)
 - **AI Agent** — [MCP Server](https://www.tapflow.dev/guide/mcp-server)
 
 ## Contributing
 
-tapflow is actively developed and PRs are welcome — see [CONTRIBUTING.md](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md) for branch strategy, commit conventions, and an architecture overview.
+tapflow is actively developed and PRs are welcome — see [CONTRIBUTING.md](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md) for branch strategy, commit conventions, and an architecture overview. For deep dives, the [contributor notes](https://github.com/jo-duchan/tapflow/blob/main/CONTRIBUTING.md#technical-internals) cover the SimulatorKit reverse-engineering and the streaming render pipeline.
 
 **Requirements**: Node.js ≥ 20, pnpm ≥ 9
 


### PR DESCRIPTION
## What

Fixes two broken links in the READMEs and realigns `README.md` with
`packages/cli/README.md`.

### Broken links (user-visible)

- **CLI README demo thumbnail → 404.** It pointed at
  `user-attachments/assets/01914ed2-…`. c5b78b9 ("fix README demo video 404 for
  logged-out viewers") re-hosted the demo and fixed the root README, but left
  `packages/cli/README.md` on the dead asset from ecb34ca. On npmjs.com the
  "Click to play" thumbnail led nowhere. Both files now use `dbba8bde-…`, which
  serves 200.
- **`www.tapflow.dev/guide/security` → 404**, in both READMEs (4 occurrences).
  The page lives at `/reference/security` (`docs/.vitepress/config.ts:70`).
  Fixed, and the entry moved from the **Guides** line to the **Reference** line
  so the README grouping matches the docs sidebar.

### Parity

The CLI copy had drifted from the root README:

- missing the VISION.md sentence
- missing the contributor-notes sentence in Contributing
- `_outbound_` vs `*outbound*`
- stray `./` in the root Roadmap link

After normalizing the CLI copy's absolute URLs back to relative, the two files
now differ **only** in the hero media block — `<video>` (root) vs click-to-play
thumbnail (CLI). That difference is intentional: npm's sanitizer strips
`<video>`.

## Verification

- All **36 absolute links** across both files return 200 (`curl -L`, browser UA).
  Before this PR two returned 404 — exactly the two fixed here.
- All **9 relative targets** in the root README exist on disk.
- `#latency-note` confirmed working on npmjs.com, so the in-page anchors were
  left as-is.
- `pnpm changeset:check` passes; pre-commit typecheck / lint / a11y-lens pass.

## Notes

`packages/cli/README.md` ships in the npm tarball, so the demo-link fix reaches
npmjs.com only on the next publish of `tapflow`. No changeset was added: the
gate reports README changes as non-published-source, and `.changeset/config.json`
puts all seven packages in a `fixed` group, so a patch here would force a
coordinated version bump of every package for a link fix.

Unrelated, found while investigating: README badges stack vertically for
logged-out viewers on **every** repository, because `@layer primer-brand` ships
an unscoped `img,picture{display:block}` reset that leaks into `.markdown-body`.
Reported upstream at https://github.com/primer/brand/issues/1426. No README
change can work around it, so this PR does not attempt one.

## Adversarial review

Skipped — docs-only (two README files, no code, no API/protocol/CLI change).
Record with the reviewed HEAD and the checks run in lieu of the review:
`.work/reviews/docs__readme-root-cli-parity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap, security, and privacy links to point to the correct documentation pages.
  * Reorganized guide and reference navigation for easier discovery.
  * Refreshed the CLI documentation’s demo image and clarified macOS agent connectivity.
  * Added a link to the project vision and updated contributing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->