### PR TITLE
chore(dashboard,ios-agent): lint the whole dashboard source, drop the dead Simulator hide

### DIFF
--- a/.changeset/dead-simulator-hide.md
+++ b/.changeset/dead-simulator-hide.md
@@ -2,4 +2,6 @@
 "@tapflowio/ios-agent": patch
 ---
 
-Remove the dead `Simulator.app` hide from `SimctlWrapper.boot`. On the supported Xcode (26.x) `simctl boot` does not open Simulator.app, so the `osascript` call failed with `-10006` on every boot while its callback swallowed the error — it hid nothing, and its silence meant nobody would notice if the assumption changed back. The occlusion throttle it was guarding against only applies to a window that is on screen.
+Remove the dead `Simulator.app` hide from `SimctlWrapper.boot`. On the supported Xcode (26.x) `simctl boot` does not open Simulator.app, so the `osascript` call failed with `-10006` on every boot while its callback swallowed the error — it hid nothing, and its silence meant nobody would notice if the assumption changed back. The occlusion throttle it was guarding against only applies to a window that is on screen. Verified by quitting Simulator.app entirely and booting from the dashboard: no Simulator process appears.
+
+Also make `SimctlWrapper.shutdown` tolerate an already-stopped device, mirroring the guard `boot` has had. Tearing down a session whose device is already `Shutdown` raised `code=405 / Unable to shutdown device in current state: Shutdown`, so a routine teardown logged `shutdown failed` and became indistinguishable from a device that genuinely refused to stop.

--- a/.changeset/dead-simulator-hide.md
+++ b/.changeset/dead-simulator-hide.md
@@ -1,0 +1,5 @@
+---
+"@tapflowio/ios-agent": patch
+---
+
+Remove the dead `Simulator.app` hide from `SimctlWrapper.boot`. On the supported Xcode (26.x) `simctl boot` does not open Simulator.app, so the `osascript` call failed with `-10006` on every boot while its callback swallowed the error — it hid nothing, and its silence meant nobody would notice if the assumption changed back. The occlusion throttle it was guarding against only applies to a window that is on screen.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,12 @@ export default tseslint.config(
   // structure we do not own and would have to re-fix on every upstream sync. Only that hint is
   // waived — every correctness rule still applies here, which is what caught the `Math.random()`
   // during render in sidebar.tsx.
+  //
+  // The scope is the directory, not the file's origin, and `ui/` also holds a few of our own
+  // components (`search-input`, `tech-label`). They export a single component today so the rule
+  // would not fire on them anyway — but the cost of this shortcut is that adding a hand-written
+  // file here that exports a component *and* a helper loses the hint silently. Put such a file in
+  // `components/` rather than `components/ui/`.
   {
     files: ['packages/dashboard/components/ui/**/*.{ts,tsx}'],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,4 +54,16 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
+
+  // shadcn primitives are generated and re-synced from upstream, and their convention is to export
+  // a `*Variants` helper next to the component. That trips the Fast Refresh hint in five files for a
+  // structure we do not own and would have to re-fix on every upstream sync. Only that hint is
+  // waived — every correctness rule still applies here, which is what caught the `Math.random()`
+  // during render in sidebar.tsx.
+  {
+    files: ['packages/dashboard/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 )

--- a/packages/dashboard/components/CommentPanel.tsx
+++ b/packages/dashboard/components/CommentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -57,13 +57,13 @@ export function CommentPanel({ buildId }: Props) {
   const fileRef = useRef<HTMLInputElement>(null)
   const commentRefs = useRef<Record<number, HTMLDivElement | null>>({})
 
-  function load() {
+  const load = useCallback(() => {
     fetch(`/api/v1/comments?build_id=${buildId}`, { credentials: 'include' })
       .then((r) => r.ok ? r.json() : [])
       .then(setComments)
-  }
+  }, [buildId])
 
-  useEffect(() => { load() }, [buildId])
+  useEffect(() => { load() }, [load])
 
   useEffect(() => {
     const hash = window.location.hash

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -120,6 +120,10 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
         description: 'Go back and select a different Mac.',
       })
     }
+    // `resetMode` is missing from the deps below on purpose. Adding it changes what `device:boot`
+    // sends, which is a behaviour fix (a stale mode can be sent after a reconnect) tracked in #439 —
+    // not part of widening the lint scope. Remove this suppression when #439 lands.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, deviceId, buildId]);
 
   const handleBinaryFrame = useCallback((data: ArrayBuffer) => {

--- a/packages/dashboard/components/UploadBuildDialog.tsx
+++ b/packages/dashboard/components/UploadBuildDialog.tsx
@@ -7,7 +7,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   Select,

--- a/packages/dashboard/components/UserAvatar.tsx
+++ b/packages/dashboard/components/UserAvatar.tsx
@@ -1,18 +1,4 @@
-const PALETTE_SIZE = 6;
-
-function hashName(name: string): number {
-  let hash = 0;
-  for (const c of name) hash = (hash * 31 + c.charCodeAt(0)) & 0xffffffff;
-  return Math.abs(hash);
-}
-
-export function avatarColors(name: string): { bg: string; fg: string } {
-  const i = (hashName(name) % PALETTE_SIZE) + 1;
-  return {
-    bg: `hsl(var(--avatar-${i}-bg))`,
-    fg: `hsl(var(--avatar-${i}-fg))`,
-  };
-}
+import { avatarColors } from '@/lib/avatar';
 
 type Props = {
   name: string;

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -180,7 +180,7 @@ export function AndroidViewer({
       }
     }
     ctx.restore()
-  }, [])
+  }, [recordCanvasRef])
 
   const handleScreenshot = useCallback(() => {
     const src = decoderRef.current?.surface; const size = videoSizeRef.current
@@ -208,7 +208,7 @@ export function AndroidViewer({
     } else if (recordState === 'recording') {
       stopClientRecording()
     }
-  }, [recordState, startClientRecording, stopClientRecording, composeFrame])
+  }, [recordState, startClientRecording, stopClientRecording, composeFrame, recordCanvasRef])
 
   const handleRotate = useCallback(() => {
     send({ type: 'input:rotate', sessionId })
@@ -429,6 +429,12 @@ export function AndroidViewer({
   // display naturally (any landscape direction stays upright — scrcpy mirrors the real display).
   const isLandscapeContent = effectiveSize ? effectiveSize.width > effectiveSize.height : false;
   const needsCSSRotation = userWantsLandscape && !isLandscapeContent;
+  // react-hooks/immutability false positive: needsCSSRotationRef is only *read*, inside callbacks
+  // (lines 204 and 293), is never passed to a hook or listed in a deps array, and is not exposed via
+  // forwardRef — so writing it from an effect is the standard pattern the rule exists to allow. The
+  // rule counts a closure capture as an argument. Restructuring would touch the rotation path below,
+  // whose display behaviour no test covers, for no correctness gain.
+  // eslint-disable-next-line react-hooks/immutability
   useLayoutEffect(() => { needsCSSRotationRef.current = needsCSSRotation }, [needsCSSRotation])
   // Container uses landscape dims; canvas inside rotated 90° to show portrait content in landscape shell
   const containerW = needsCSSRotation ? androidDisplayH : androidDisplayW;

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -186,7 +186,7 @@ export function IOSViewer({
   useEffect(() => {
     const rc = recordCanvasRef.current; const container = containerRef.current
     if (rc && container) { rc.width = container.clientWidth; rc.height = container.clientHeight }
-  }, [chrome])
+  }, [chrome, recordCanvasRef])
 
   // ── Recording (composeFrame only — state/refs/lifecycle in useClientRecording) ──
   const composeFrame = useCallback(() => {
@@ -252,7 +252,7 @@ export function IOSViewer({
       }
       ctx.restore()
     }
-  }, [])
+  }, [recordCanvasRef])
 
   const handleScreenshot = useCallback(() => {
     const src = canvasRef.current; if (!src) return
@@ -276,7 +276,7 @@ export function IOSViewer({
     } else if (recordState === 'recording') {
       stopClientRecording()
     }
-  }, [recordState, startClientRecording, stopClientRecording, composeFrame])
+  }, [recordState, startClientRecording, stopClientRecording, composeFrame, recordCanvasRef])
 
   const handleRotate = useCallback(() => {
     send({ type: 'input:rotate', sessionId }); setIsLandscape(prev => !prev)
@@ -399,7 +399,7 @@ export function IOSViewer({
     const fc = canvasRef.current; const rc = recordCanvasRef.current
     if (fc && fc.clientWidth > 0) return { x: fc.offsetLeft + norm.x * fc.clientWidth, y: fc.offsetTop + norm.y * fc.clientHeight }
     return { x: norm.x * (rc?.width ?? 1), y: norm.y * (rc?.height ?? 1) }
-  }, [])
+  }, [recordCanvasRef])
 
   // ── Pointer interaction ───────────────────────────────────────────────────
   const handlePointerDown = useCallback((e: React.PointerEvent) => {

--- a/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
+++ b/packages/dashboard/components/device/shared/SimulatorInfoCard.tsx
@@ -5,11 +5,8 @@ import { ScanLine } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
 import { performanceMode } from '@/lib/decoders/pickDecoder';
-import {
-  PerformanceModeNotice,
-  shouldAutoShowPerfNotice,
-  PERF_NOTICE_KEY,
-} from '@/components/perf/PerformanceModeNotice';
+import { PerformanceModeNotice } from '@/components/perf/PerformanceModeNotice';
+import { shouldAutoShowPerfNotice, PERF_NOTICE_KEY } from '@/lib/perfNotice';
 
 // init wizard와 같은 프로파일 용어로 — 디코더 jargon(WebCodecs/WASM) 대신.
 const MODE_LABEL: Record<string, string | null> = {

--- a/packages/dashboard/components/perf/PerformanceModeNotice.tsx
+++ b/packages/dashboard/components/perf/PerformanceModeNotice.tsx
@@ -9,15 +9,8 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import type { PerformanceMode } from '@/lib/decoders/pickDecoder';
 
-export const PERF_NOTICE_KEY = 'tapflow.perfModeNoticeDismissed';
 const DOCS_HTTPS_URL = 'https://www.tapflow.dev/reference/configuration#https-secure-context';
-
-// Auto-show only in Standard mode and only if not dismissed before (once per browser).
-export function shouldAutoShowPerfNotice(mode: PerformanceMode, dismissed: boolean): boolean {
-  return mode === 'standard' && !dismissed;
-}
 
 export function PerformanceModeNotice({
   open,

--- a/packages/dashboard/components/ui/sidebar.tsx
+++ b/packages/dashboard/components/ui/sidebar.tsx
@@ -662,6 +662,12 @@ const SidebarMenuSkeleton = React.forwardRef<
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
+    // shadcn upstream code. The width is randomised once per mount so skeleton rows differ; both
+    // useMemo and a lazy initializer run during render, so neither satisfies react-hooks/purity, and
+    // the only structural alternative — computing it in an effect — would make the width jump after
+    // first paint. SidebarMenuSkeleton is currently unused, so suppressing costs nothing today and
+    // avoids handing a visible jump to whoever adopts it.
+    // eslint-disable-next-line react-hooks/purity
     return `${Math.floor(Math.random() * 40) + 50}%`
   }, [])
 

--- a/packages/dashboard/hooks/useBreadcrumb.tsx
+++ b/packages/dashboard/hooks/useBreadcrumb.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable react-refresh/only-export-components --
+   The Provider and its consumer hook are one unit; splitting them across two files to satisfy
+   Fast Refresh would spread a 19-line module for no reader benefit. */
 import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
 
 type ContextValue = {

--- a/packages/dashboard/hooks/useClientRecording.ts
+++ b/packages/dashboard/hooks/useClientRecording.ts
@@ -31,10 +31,12 @@ export function useClientRecording({ sessionId, buildId, onRecordingUploaded }: 
   // Stable ref wrapper so RAF always calls the latest composeFrame without recreating the loop
   const composeFrameRef = useRef<(() => void) | null>(null)
 
-  const rafLoop = useCallback(() => {
+  // Named function expression so the recursive schedule refers to itself, not to the `rafLoop`
+  // binding that is still uninitialised while useCallback runs.
+  const rafLoop = useCallback(function loop() {
     if (!recordingRef.current) return
     composeFrameRef.current?.()
-    rafIdRef.current = requestAnimationFrame(rafLoop)
+    rafIdRef.current = requestAnimationFrame(loop)
   }, [])
 
   // Caller must set recordCanvasRef.current.width/height before calling this.

--- a/packages/dashboard/hooks/useDecoderStream.ts
+++ b/packages/dashboard/hooks/useDecoderStream.ts
@@ -34,9 +34,13 @@ interface UseDecoderStreamOptions {
  */
 export function useDecoderStream(opts: UseDecoderStreamOptions): void {
   const { binaryFrameHandlerRef, perfHookRef, frameCount } = opts
-  // Keep the latest callbacks without re-running the (mount-once) effect.
+  // Keep the latest callbacks without re-running the (mount-once) effect. Written after commit
+  // rather than during render — the mount effect below reads it only from async decode/frame
+  // callbacks, and a render-time write is lost when a concurrent render is discarded.
   const cbRef = useRef(opts)
-  cbRef.current = opts
+  useEffect(() => {
+    cbRef.current = opts
+  }, [opts])
 
   useEffect(() => {
     let decoder: Decoder | null = null

--- a/packages/dashboard/hooks/useDecoderStream.ts
+++ b/packages/dashboard/hooks/useDecoderStream.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
 import { pickDecoder } from '@/lib/decoders/pickDecoder'
 import { WASMDecoder } from '@/lib/decoders/WASMDecoder'
@@ -34,11 +34,12 @@ interface UseDecoderStreamOptions {
  */
 export function useDecoderStream(opts: UseDecoderStreamOptions): void {
   const { binaryFrameHandlerRef, perfHookRef, frameCount } = opts
-  // Keep the latest callbacks without re-running the (mount-once) effect. Written after commit
-  // rather than during render — the mount effect below reads it only from async decode/frame
-  // callbacks, and a render-time write is lost when a concurrent render is discarded.
+  // Keep the latest callbacks without re-running the (mount-once) effect. Written in a layout
+  // effect for the same reason as `useRelay`: a render-time write is lost when a concurrent render
+  // is discarded, and a passive effect runs after paint, leaving a window in which an arriving
+  // frame still reaches the previous callbacks.
   const cbRef = useRef(opts)
-  useEffect(() => {
+  useLayoutEffect(() => {
     cbRef.current = opts
   }, [opts])
 

--- a/packages/dashboard/hooks/useDeviceSelector.ts
+++ b/packages/dashboard/hooks/useDeviceSelector.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { AgentDevice, SessionInfo } from '@/lib/types'
+import type { SessionInfo } from '@/lib/types'
 
 export function useDeviceSelector(
   selectedSession: SessionInfo | undefined,

--- a/packages/dashboard/hooks/useRelay.ts
+++ b/packages/dashboard/hooks/useRelay.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { RelayMessage } from '@/lib/types'
 
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -11,12 +11,14 @@ export function useRelay(
 ) {
   const ws = useRef<WebSocket | null>(null)
   const [connected, setConnected] = useState(false)
-  // Latest-callback refs, written after commit instead of during render. The socket handlers below
-  // only run from events — i.e. after the effects have flushed — so a post-commit write is soon
-  // enough, while a write during render is lost when a concurrent render is discarded.
+  // Latest-callback refs. Written in a layout effect, not during render (lost when a concurrent
+  // render is discarded) and not in a passive effect: `useEffect` runs after paint, leaving a gap
+  // in which a socket message can still reach the previous callbacks — misrouting a frame right
+  // after `sessionId` or `deviceId` changes. A layout effect runs synchronously on commit, so no
+  // task can interleave.
   const onMessageRef = useRef(onMessage)
   const onBinaryFrameRef = useRef(onBinaryFrame)
-  useEffect(() => {
+  useLayoutEffect(() => {
     onMessageRef.current = onMessage
     onBinaryFrameRef.current = onBinaryFrame
   }, [onMessage, onBinaryFrame])

--- a/packages/dashboard/hooks/useRelay.ts
+++ b/packages/dashboard/hooks/useRelay.ts
@@ -11,10 +11,15 @@ export function useRelay(
 ) {
   const ws = useRef<WebSocket | null>(null)
   const [connected, setConnected] = useState(false)
+  // Latest-callback refs, written after commit instead of during render. The socket handlers below
+  // only run from events — i.e. after the effects have flushed — so a post-commit write is soon
+  // enough, while a write during render is lost when a concurrent render is discarded.
   const onMessageRef = useRef(onMessage)
-  onMessageRef.current = onMessage
   const onBinaryFrameRef = useRef(onBinaryFrame)
-  onBinaryFrameRef.current = onBinaryFrame
+  useEffect(() => {
+    onMessageRef.current = onMessage
+    onBinaryFrameRef.current = onBinaryFrame
+  }, [onMessage, onBinaryFrame])
 
   useEffect(() => {
     let cancelled = false

--- a/packages/dashboard/lib/avatar.ts
+++ b/packages/dashboard/lib/avatar.ts
@@ -1,0 +1,18 @@
+// Deterministic avatar colour from a display name. Lives here rather than in UserAvatar.tsx so the
+// component file exports only components — a module that mixes the two breaks Vite's Fast Refresh
+// for every consumer of the file.
+const PALETTE_SIZE = 6;
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (const c of name) hash = (hash * 31 + c.charCodeAt(0)) & 0xffffffff;
+  return Math.abs(hash);
+}
+
+export function avatarColors(name: string): { bg: string; fg: string } {
+  const i = (hashName(name) % PALETTE_SIZE) + 1;
+  return {
+    bg: `hsl(var(--avatar-${i}-bg))`,
+    fg: `hsl(var(--avatar-${i}-fg))`,
+  };
+}

--- a/packages/dashboard/lib/perfNotice.ts
+++ b/packages/dashboard/lib/perfNotice.ts
@@ -1,0 +1,11 @@
+import type { PerformanceMode } from '@/lib/decoders/pickDecoder';
+
+// The auto-show policy for the performance-mode notice. Kept out of the component file so that file
+// exports only components — mixing the two breaks Vite's Fast Refresh for its consumers — and so the
+// policy stays unit-testable without importing the dialog.
+export const PERF_NOTICE_KEY = 'tapflow.perfModeNoticeDismissed';
+
+// Auto-show only in Standard mode and only if not dismissed before (once per browser).
+export function shouldAutoShowPerfNotice(mode: PerformanceMode, dismissed: boolean): boolean {
+  return mode === 'standard' && !dismissed;
+}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --noEmit && vite build && rm -rf ../relay/public && mkdir -p ../relay/public && cp -r dist/. ../relay/public/",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "lint": "eslint src",
+    "lint": "eslint src hooks components lib",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --noEmit && vite build && rm -rf ../relay/public && mkdir -p ../relay/public && cp -r dist/. ../relay/public/",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "lint": "eslint src hooks components lib",
+    "lint": "eslint src hooks components lib *.config.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/dashboard/src/__tests__/performanceModeNotice.test.ts
+++ b/packages/dashboard/src/__tests__/performanceModeNotice.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldAutoShowPerfNotice } from '@/components/perf/PerformanceModeNotice'
+import { shouldAutoShowPerfNotice } from '@/lib/perfNotice'
 
 describe('shouldAutoShowPerfNotice — 자동 1회 노출 정책', () => {
   it('standard + 미해제 → true', () => {

--- a/packages/dashboard/src/pages/Invite.tsx
+++ b/packages/dashboard/src/pages/Invite.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Pencil } from 'lucide-react'
-import { avatarColors } from '@/components/UserAvatar'
+import { avatarColors } from '@/lib/avatar'
 
 const schema = z.object({
   displayName: z.string().optional(),

--- a/packages/dashboard/src/pages/settings/Default.tsx
+++ b/packages/dashboard/src/pages/settings/Default.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { toast } from 'sonner'
 import { Pencil } from 'lucide-react'
-import { avatarColors } from '@/components/UserAvatar'
+import { avatarColors } from '@/lib/avatar'
 import { useAuth } from '@/hooks/useAuth'
 
 type App = { id: number; name: string; bundle_id_key: string; platform: string }

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -129,7 +129,16 @@ export class SimctlWrapper {
   }
 
   async shutdown(deviceId: string): Promise<void> {
-    await this.runner.exec('shutdown', deviceId)
+    try {
+      await this.runner.exec('shutdown', deviceId)
+    } catch (err: unknown) {
+      const stderr = (err as { stderr?: string }).stderr ?? ''
+      // already shut down is not an error — the mirror of the guard in boot(). Without it a normal
+      // teardown of an already-stopped device logs `shutdown failed`, which is indistinguishable
+      // from a device that genuinely refused to stop.
+      if (stderr.includes('Unable to shutdown device in current state: Shutdown')) return
+      throw err
+    }
   }
 
   async erase(deviceId: string): Promise<void> {

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -126,9 +126,6 @@ export class SimctlWrapper {
       if (stderr.includes('Unable to boot device in current state: Booted')) return
       throw err
     }
-    // Xcode 14+ auto-opens Simulator.app on `simctl boot`.
-    // Quitting kills the simulator runtime, so just hide the app window instead.
-    execFile('osascript', ['-e', 'tell application "Simulator" to set visible to false'], () => {})
   }
 
   async shutdown(deviceId: string): Promise<void> {

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -77,6 +77,7 @@ describe('SimctlWrapper', () => {
         exec: vi.fn().mockRejectedValue(
           Object.assign(new Error(), { stderr: 'Unable to boot device in current state: Booted' })
         ),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -86,6 +87,7 @@ describe('SimctlWrapper', () => {
     it('rethrows unexpected errors', async () => {
       const runner: SimctlRunner = {
         exec: vi.fn().mockRejectedValue(new Error('xcrun not found')),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -106,6 +108,7 @@ describe('SimctlWrapper', () => {
         exec: vi.fn().mockRejectedValue(
           Object.assign(new Error(), { stderr: 'Unable to shutdown device in current state: Shutdown' })
         ),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -115,6 +118,7 @@ describe('SimctlWrapper', () => {
     it('rethrows unexpected errors', async () => {
       const runner: SimctlRunner = {
         exec: vi.fn().mockRejectedValue(new Error('xcrun not found')),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -192,6 +196,7 @@ describe('SimctlWrapper', () => {
           .mockResolvedValueOnce('(\n    "ko-KR",\n    "en-US"\n)')  // defaults read
           .mockResolvedValue(''),                                       // write + kickstart
         execBinary: vi.fn(),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -211,6 +216,7 @@ describe('SimctlWrapper', () => {
           .mockResolvedValueOnce('(\n    "ko-KR"\n)')
           .mockResolvedValue(''),
         execBinary: vi.fn(),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -226,6 +232,7 @@ describe('SimctlWrapper', () => {
       const runner: SimctlRunner = {
         exec: vi.fn().mockRejectedValue(new Error('Domain does not exist')),
         execBinary: vi.fn(),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -242,6 +249,7 @@ describe('SimctlWrapper', () => {
           .mockResolvedValueOnce('')                    // write
           .mockRejectedValueOnce(new Error('kbd not found')), // kickstart fails
         execBinary: vi.fn(),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
       const wrapper = new SimctlWrapper(runner)
@@ -259,6 +267,7 @@ describe('SimctlWrapper', () => {
 
       const runner: SimctlRunner = {
         exec: vi.fn().mockResolvedValue(''),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -100,6 +100,26 @@ describe('SimctlWrapper', () => {
       await wrapper.shutdown('device-1')
       expect(runner.exec).toHaveBeenCalledWith('shutdown', 'device-1')
     })
+
+    it('does not throw if device is already shut down', async () => {
+      const runner: SimctlRunner = {
+        exec: vi.fn().mockRejectedValue(
+          Object.assign(new Error(), { stderr: 'Unable to shutdown device in current state: Shutdown' })
+        ),
+        execWithOpts: vi.fn().mockResolvedValue(''),
+      }
+      const wrapper = new SimctlWrapper(runner)
+      await expect(wrapper.shutdown('device-1')).resolves.toBeUndefined()
+    })
+
+    it('rethrows unexpected errors', async () => {
+      const runner: SimctlRunner = {
+        exec: vi.fn().mockRejectedValue(new Error('xcrun not found')),
+        execWithOpts: vi.fn().mockResolvedValue(''),
+      }
+      const wrapper = new SimctlWrapper(runner)
+      await expect(wrapper.shutdown('device-1')).rejects.toThrow('xcrun not found')
+    })
   })
 
   describe('installApp', () => {


### PR DESCRIPTION
Closes #423
Closes #431

## Why

`packages/dashboard`'s lint script was `eslint src`, and `hooks/`, `components/` and `lib/` are siblings of `src/`. So **83 of its 123 source files were never linted**, while tsconfig type-checked all four directories. #423 reported the `hooks/` half; measuring first showed the hole was three times wider and hid two errors in `components/` nobody had seen.

## What changed

**Gate** — `lint` now covers `src hooks components lib *.config.ts`, matching what tsconfig already checks. `eslint.config.mjs` needed no rule changes; only the CLI argument was narrow.

**hooks (6 findings)** — render-time ref writes moved into effects (`useRelay`, `useDecoderStream`); the recursive `rafLoop` became a named function expression; an unused import; one Fast Refresh suppression with its reason.

**components (18 findings)** — 6 missing `recordCanvasRef` deps (a stable `useRef` return, so the effect cadence is unchanged); `load` wrapped in `useCallback` so its effect dependency is honest — listing it as-is would have refetched on every render; an unused import; and two false positives suppressed per line with the evidence recorded rather than restructured.

**`lib/` extraction** — `avatarColors` and the perf-notice policy moved out of their component files. The Fast Refresh warning was pointing at a real structure problem: a test was importing a component file to reach one of them.

**shadcn** — `react-refresh/only-export-components` is waived for `components/ui/**` only. Every correctness rule still applies there, which is what caught a `Math.random()` during render in `sidebar.tsx`.

**ios-agent** — `SimctlWrapper.boot` ended with an `osascript` call to hide Simulator.app whose callback swallowed every error. On the only supported Xcode (26.x, per `docs/guide/requirements.md`) `simctl boot` does not open Simulator.app. Also added the mirror guard to `shutdown`, which had none: tearing down an already-stopped device logged `shutdown failed` and was indistinguishable from a device that genuinely refused to stop.

## Deliberately not fixed here

`DeviceViewer` can send a stale `resetMode` after a reconnect. Adding the dep is a behaviour fix, not a lint fix, and it is unreproduced — tracked in **#439**, suppressed on that one line with a pointer.

## Verification

- dashboard lint clean across all 123 files; root lint / typecheck / test green (dashboard 236, ios-agent 275, cli 246)
- **Gate mutation-tested per directory**: a planted violation in `hooks/`, `components/`, `lib/` and `vite.config.ts` is caught each time; the three per-line suppressions still catch unrelated errors, so none of them over-waives
- `shutdown` guard mutation-tested: removing it fails exactly the new test and leaves the other 33 passing
- **Manual E2E**: iOS and Android streaming, tap/swipe, 10s recording → upload → download, Android rotation. #431 verified the decisive way — quitting Simulator.app entirely and booting from the dashboard produces no Simulator process

## Review

Three passes, recorded in `.work/reviews/chore__lint-hooks-scope-and-dead-simulator-hide.md`: a design review of the plan before implementing (this spans two packages), a diff review of the initial hooks change, and a pre-PR diff review of the full branch across two parallel lenses. No blockers or majors; three minors, all fixed — the last two in `34634c8`.

The design pass changed the plan: two `components/` errors were going to be code edits, and it established that one was a false positive on the Android rotation path and the other sits in an export that never renders. Both became suppressions with recorded reasons.

## Also found while testing

**#440** — build install intermittently fails with `No devices are booted`; re-entering the session succeeds. Two causes: a race against `device:ready` replay, and six `simctl` calls targeting the `booted` alias instead of the session's udid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS simulator shutdowns now complete cleanly when a device is already stopped.
  * Removed an unnecessary simulator-window hiding step that could obscure boot failures.
  * Improved dashboard reliability for comment loading, recording/canvas syncing, and real-time relay updates.

* **Refactor**
  * Centralized avatar color generation and performance-notice auto-show/dismiss behavior for consistent dashboard use.

* **Tests**
  * Expanded coverage for simulator shutdown error handling and performance-notice behavior.

* **Chores**
  * Broadened dashboard lint coverage and clarified code-quality configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->