### PR TITLE
docs(contributing): move the adversarial-review procedure out of root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,30 +77,11 @@ Custom commands: `/work-plan {topic}` · `/deep-research {problem}` · `/qa {tar
 
 The authoring session inherits its own assumptions, so before creating a PR the diff must be refuted by an **independent context** that has NOT seen the working conversation. Docs-only PRs may skip the review itself, but still write the record (with the skip reason) — the gate always requires it.
 
-- **Default reviewer**: a fresh subagent given only the diff, repo access, and a refute-first prompt — "find bugs, contract violations, and missing cases; verify every claim with commands; report findings with severity and evidence, plus a checked-and-cleared list". Do not share the authoring session's reasoning with it.
-- **Escalation**: protocol / public-interface / release-infrastructure changes get a second independent channel (a second subagent with a different lens, or Codex for cross-model independence).
-- **Record**: write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
+- **Record**: findings + dispositions (fixed, or skipped with a reason) go in `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
 - **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
+- **A change spanning two or more packages, or both platforms, needs a second, earlier review — of the design, before the code.** One adversarial pass over the plan, in addition to the pre-PR one.
 
-#### Keeping a review affordable
-
-Review wall-clock is dominated by **what the reviewer has to execute**, not by how hard it thinks. Measured across one session: a read-and-probe review of a protocol change took 11 minutes at 93k tokens; a review of ~590 lines of tooling took **106 minutes at only 134k tokens** — fewer tokens, 10× the time, because it spent that time on `pnpm install`, `pnpm build`, starting real dev servers and waiting out sleeps.
-
-- **Only use an isolated worktree when the reviewer must edit files.** A fresh worktree has no `node_modules` and no `dist`, so it pays 8–10 minutes of install and build before it can run anything — and a reviewer that does not know this reports results from commands that silently did nothing (`vitest: command not found` swallowed by a shell exit). A read-only lens (contract, compatibility, documentation) can work against the primary checkout, which is already built.
-- **Say what to install.** When a worktree is required, the prompt must open with `pnpm install --frozen-lockfile && pnpm build`, or the first `pnpm test` result is meaningless.
-- **Do the mutation testing yourself, then hand over the list.** Ask the reviewer to find what your mutations *missed*, not to redo them. Every surviving mutation found so far came from someone imagining a different way to break a test — never from running more of them.
-- **No blanket "run it 10 times".** Repeat runs have found zero flakes across two rounds; they cost 4+ minutes each time. Ask for 3 runs, and only for tests that use timers or real sleeps.
-- **Split by lens and run the lenses in parallel.** Wall-clock is then the slowest lens, not the sum. Two channels on the same commit took 11 and 40 minutes concurrently, against 51 serially.
-- **Some cost is irreducible.** Verifying code that kills processes means starting and killing processes, with real waits. Budget for it and say so up front, rather than discovering it at 100 minutes.
-
-### Before Implementing — cross-cutting features
-
-Applies when a change spans **two or more packages, or both platforms**. Skip it for work inside one package.
-
-1. **Write the invariant table first** — one row per path or state, one column per platform, and what the *user* observes. Put it in the plan document. The clipboard bridge took eleven review rounds largely because this table was never written: the same class of defect (one platform fixed, the other not) was found five separate times, each by a reviewer rather than by looking.
-2. **Review the design before the code.** One adversarial pass over the plan and that table, before implementing. The expensive rounds on a multi-package feature are the ones where the mechanism itself was wrong, and a wrong mechanism is cheapest to find on paper. This is in addition to the pre-PR review below, not instead of it.
-3. **A design-level review finding means replan, not patch.** If a reviewer says the *shape* is wrong — wrong scope for a flag, wrong owner for a decision — stop and redo that part. Patching a design finding produced the next design finding three times in a row on the clipboard branch.
-4. **Mutate the guards too.** A test written to catch drift or protect an invariant is itself untested until you break the thing it guards and watch it fail — and until you run it **alone**. Three separate guards on the clipboard branch had the very hole they were written to close, including one that only worked because a sibling `describe` leaked its environment.
+**Read [contributing/adversarial-review.md](./contributing/adversarial-review.md) before launching a reviewer.** It covers how to design the channels, how to run the cross-cutting design pass, and how to keep the cost in minutes rather than hours — the same review can take 4 minutes or 106 depending only on what its prompt makes it execute.
 
 ### Design Principles (SOLID — priority subset)
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -72,3 +72,4 @@ Committed *why* behind non-obvious decisions. Read the relevant one **before** c
 | [android-video-streaming-diagnosis.md](./contributing/android-video-streaming-diagnosis.md) | diagnosis | Android emulator streaming issues traced to root cause, one section per issue |
 | [awdl-wifi-latency-diagnosis.md](./contributing/awdl-wifi-latency-diagnosis.md) | diagnosis | Periodic Wi-Fi stream hitch traced to AWDL via ICMP ping — method and evidence |
 | [workshop-lab-fork-observations.md](./contributing/workshop-lab-fork-observations.md) | reference | Third-party workshop-lab fork: independent iOS-sim capacity data (~4 seats/32GB) + where our extension seams stop |
+| [adversarial-review.md](./contributing/adversarial-review.md) | rules | How to run the pre-PR review and the cross-cutting design pass — channel design, prompt skeleton, why the same review costs 4 minutes or 106 |

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -84,6 +84,7 @@ cannot keep true.
 | [android-video-streaming-diagnosis.md](./android-video-streaming-diagnosis.md) | diagnosis | android, video, streaming |
 | [awdl-wifi-latency-diagnosis.md](./awdl-wifi-latency-diagnosis.md) | diagnosis | network, latency, relay, wifi |
 | [workshop-lab-fork-observations.md](./workshop-lab-fork-observations.md) | reference | performance, capacity, extensibility, external-fork |
+| [adversarial-review.md](./adversarial-review.md) | rules | process, review, quality |
 
 ## Adding a record
 

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -1,0 +1,127 @@
+---
+type: rules
+topics: [process, review, quality]
+status: living
+---
+
+# Adversarial review — how to run one, and how to keep it cheap
+
+> The gate itself is stated in the root [AGENTS.md](../AGENTS.md): every code-change PR needs an
+> independent review, recorded in `.work/reviews/<branch>.md` with the full 40-character HEAD hash,
+> and a PreToolUse hook enforces it. **This file is the how.** Read it before launching a reviewer —
+> the difference between a 4-minute review and a 106-minute one is entirely in how the prompt is
+> written.
+
+## Why an independent context
+
+The authoring session inherits its own assumptions. It cannot refute them, because the reasoning that
+produced the diff is the same reasoning that would have to find the hole. So the reviewer must be a
+context that has **not** seen the working conversation — given only the diff, repo access, and a
+refute-first prompt.
+
+Docs-only PRs may skip the review itself, but still write the record with the skip reason. The gate
+always requires the record.
+
+## Channels
+
+- **Default reviewer**: a fresh subagent given only the diff, repo access, and a refute-first prompt —
+  "find bugs, contract violations, and missing cases; verify every claim with commands; report
+  findings with severity and evidence, plus a checked-and-cleared list". Do not share the authoring
+  session's reasoning with it.
+- **Escalation**: protocol / public-interface / release-infrastructure changes get a second
+  independent channel — a second subagent with a different lens, or Codex for cross-model
+  independence.
+
+## Keeping a review affordable
+
+Review wall-clock is dominated by **what the reviewer has to execute**, not by how hard it thinks.
+Measured across one session: a read-and-probe review of a protocol change took 11 minutes at 93k
+tokens; a review of ~590 lines of tooling took **106 minutes at only 134k tokens** — fewer tokens,
+10× the time, because it spent that time on `pnpm install`, `pnpm build`, starting real dev servers
+and waiting out sleeps.
+
+- **Only use an isolated worktree when the reviewer must edit files.** A fresh worktree has no
+  `node_modules` and no `dist`, so it pays 8–10 minutes of install and build before it can run
+  anything — and a reviewer that does not know this reports results from commands that silently did
+  nothing (`vitest: command not found` swallowed by a shell exit). A read-only lens (contract,
+  compatibility, documentation) can work against the primary checkout, which is already built.
+- **Say what to install.** When a worktree is required, the prompt must open with
+  `pnpm install --frozen-lockfile && pnpm build`, or the first `pnpm test` result is meaningless.
+- **Do the mutation testing yourself, then hand over the list.** Ask the reviewer to find what your
+  mutations *missed*, not to redo them. Every surviving mutation found so far came from someone
+  imagining a different way to break a test — never from running more of them.
+- **No blanket "run it 10 times".** Repeat runs have found zero flakes across two rounds; they cost
+  4+ minutes each time. Ask for 3 runs, and only for tests that use timers or real sleeps.
+- **Split by lens and run the lenses in parallel.** Wall-clock is then the slowest lens, not the sum.
+  Two channels on the same commit took 11 and 40 minutes concurrently, against 51 serially.
+- **A design review can be made to execute nothing at all.** This is the cheapest review there is, so
+  there is no excuse for skipping the one the cross-cutting section below requires. Hand the reviewer
+  the measurements you already took and **forbid re-running them**, name the files to read so it does
+  not sweep the tree, list the commands it must not run (`eslint`, `pnpm test`, `tsc`, `pnpm build`),
+  cap the findings (4 is enough), and state a time budget. Two lenses over a plan plus its
+  uncommitted diff came back in **4m30s and 3m25s at 83k / 74k tokens**, wall-clock 4m30s in
+  parallel. The measurements in the prompt were what made it cheap — a reviewer told "src 40 files,
+  hooks 13, components 51, lib 19, and here are the 2 errors" spends its time judging instead of
+  counting.
+- **Verify the reviewer's grounds, not just its verdict.** On that plan a `blocker` rested on correct
+  evidence carrying the wrong weight: the component it flagged is an unused export that never
+  renders, so the regression it predicted could not occur. The conclusion survived and the reason
+  changed — which matters, because the reason is what goes in the record. Grade severity yourself. A
+  finding whose evidence you have not reproduced is a hypothesis, including when it agrees with you.
+- **Some cost is irreducible.** Verifying code that kills processes means starting and killing
+  processes, with real waits. Budget for it and say so up front, rather than discovering it at 100
+  minutes.
+
+### A prompt skeleton that stays cheap
+
+What made the 4m30s pair cheap was structural, not stylistic. Each prompt carried:
+
+1. **One lens, named.** "Your lens is whether the uncommitted diff changes runtime behaviour" — not
+   a list of five concerns.
+2. **The measurements, as premises.** File counts, error counts, config contents, wired-up scripts —
+   whatever you already ran. Followed by: do not re-run these.
+3. **The files to read, listed.** Otherwise the reviewer greps the tree to find them.
+4. **The commands not to run**, by name.
+5. **A findings cap and a time budget.**
+6. **A required "checked and cleared" list**, so coverage is visible when nothing is found.
+
+## Cross-cutting changes — review the design before the code
+
+Applies when a change spans **two or more packages, or both platforms**. Skip it for work inside one
+package.
+
+1. **Write the invariant table first** — one row per path or state, one column per platform, and what
+   the *user* observes. Put it in the plan document. The clipboard bridge took eleven review rounds
+   largely because this table was never written: the same class of defect (one platform fixed, the
+   other not) was found five separate times, each by a reviewer rather than by looking.
+2. **Review the design before the code.** One adversarial pass over the plan and that table, before
+   implementing. The expensive rounds on a multi-package feature are the ones where the mechanism
+   itself was wrong, and a wrong mechanism is cheapest to find on paper. This is **in addition to**
+   the pre-PR review, not instead of it.
+3. **A design-level review finding means replan, not patch.** If a reviewer says the *shape* is wrong
+   — wrong scope for a flag, wrong owner for a decision — stop and redo that part. Patching a design
+   finding produced the next design finding three times in a row on the clipboard branch.
+4. **Mutate the guards too.** A test written to catch drift or protect an invariant is itself untested
+   until you break the thing it guards and watch it fail — and until you run it **alone**. Three
+   separate guards on the clipboard branch had the very hole they were written to close, including
+   one that only worked because a sibling `describe` leaked its environment.
+
+A worked example of the payoff: a two-package chore planned two code edits to satisfy new lint
+errors. The design pass established that one error was a false positive on a load-bearing rotation
+path and the other sat in an export that never renders — both planned edits became suppressions with
+recorded reasons, and the regressions they would have introduced had no test to catch them. Cost: 4
+minutes 30 seconds.
+
+## The record
+
+Write findings + dispositions (fixed, or skipped with a reason) to `.work/reviews/<branch>.md`
+(slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an
+abbreviated hash will not pass the gate). Mention the review in the PR body.
+
+The hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and
+references the current HEAD. **Any commit after the review invalidates the record** until it is
+refreshed against the new diff — including a commit that only fixes what the review found.
+
+Record the dispositions honestly. A finding you skipped needs the reason in writing; a finding whose
+severity you re-graded needs the re-grading and its basis, not a silent downgrade. The record is read
+later by someone deciding whether a defect was known.


### PR DESCRIPTION
<!-- no-changeset: docs-only, no published source changes -->

## Why

The review sections were **32 of root `AGENTS.md`'s 148 lines** — the largest single topic in it — and `CLAUDE.md` loads that file unconditionally. Every session paid for procedure detail (worktree economics, measured wall-clock figures, how to construct a reviewer prompt) that only matters while actually launching a reviewer.

## What changed

Extracted to `contributing/adversarial-review.md` (`type: rules`), which is where committed process and rationale records already live and where `INDEX.md` already routes readers. No new layer was needed — the directory's `type` vocabulary already had `rules` for exactly this.

The root keeps only what must always be visible:

- the review is required before every code-change PR
- the record goes in `.work/reviews/<branch>.md` with the full 40-character HEAD hash
- a PreToolUse hook enforces it
- a change spanning two or more packages needs an earlier design review as well

plus one line pointing at the detail. **148 → 125 lines.**

## New in the extracted file

Two lessons from the session that prompted this:

- **A design review can be built to execute nothing at all.** Hand the reviewer the measurements already taken and forbid re-running them, name the files to read, list the commands not to run, cap the findings, state a time budget. Two lenses over a plan and its diff came back in 4m30s and 3m25s — wall-clock 4m30s in parallel. The same technique on the pre-PR review of #441 gave 3m36s and 11m36s.
- **Verify the reviewer's grounds, not just its verdict.** A `blocker` in that review rested on correct evidence carrying the wrong weight — the component it flagged is an unused export that never renders. The conclusion held and the recorded reason changed, which matters because the reason is what the record keeps.

Also a prompt skeleton listing the six things that made those reviews cheap.

## Verification

Documentation move, so the failure mode is broken references rather than broken behaviour:

- `grep -rln "Before Implementing"` over committed files: **0 remaining references**
- registered in both places the directory's own convention requires (`contributing/README.md` table and `INDEX.md` Documentation section)
- `type: rules` already exists in the schema in `contributing/README.md`
- lefthook (typecheck / lint / a11y-lens) passed

Record: `.work/reviews/docs__adversarial-review-layer.md` — the review itself is skipped per the docs-only allowance, with the reason and the reference checks written down.

## Relation to #441

Independent. #441 is the code change whose session produced these lessons; this PR is only the documentation move and can merge in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for conducting and recording adversarial reviews before code-change submissions.
  * Documented review requirements, escalation paths, cost-conscious practices, cross-cutting design reviews, and verification expectations.
  * Updated contributor and documentation indexes to reference the new review guide.
  * Refined pre-submission review instructions to include an additional review pass for broad or cross-platform changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->