### PR TITLE
feat(relay,dashboard): announce a session the agent took with it (#426 stage 1)

### DIFF
--- a/.changeset/session-terminated-notice.md
+++ b/.changeset/session-terminated-notice.md
@@ -1,0 +1,14 @@
+---
+"@tapflowio/protocol": minor
+"@tapflowio/relay": minor
+---
+
+Tell an open dashboard tab when its session ends because the agent went away, instead of leaving it to spin.
+
+Restarting a device agent used to orphan the viewer: the relay deleted the session, the browser kept a live socket addressed to a `sessionId` that no longer existed, and everything it sent was dropped as unknown. The tab sat on `Waiting for first frame...` forever with no message, and only a manual page refresh recovered it.
+
+The relay now sends `session:terminated` (with `reason: 'agent-disconnected'`) to whoever is attached, before removing the session — after removal the socket reference is gone. The viewer reports it upward and the dashboard returns to the Mac list with an explanation, then refreshes the agent list immediately so picking the same Mac again does not try to join the dropped session.
+
+The relay also logs one line when an agent connects and one when it disconnects. It previously printed `Waiting for agents...` at startup and then said nothing either way, so a terminal gave no signal about whether an agent was attached.
+
+This is the first half of the fix. Rebinding the tab to the restarted agent's new session — so a restart is invisible rather than merely announced — is tracked separately.

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { BrowserToRelay } from '@tapflowio/protocol'
+import type { BrowserToRelay, SessionTerminatedReason } from '@tapflowio/protocol'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useRelay } from '@/hooks/useRelay';
 import { usePerfMode } from '@/hooks/usePerfMode';
@@ -23,11 +23,15 @@ interface Props {
   buildId?: number;
   resetMode?: 'app-only' | 'full-erase';
   onRecordingUploaded?: () => void;
+  /** The relay dropped this session (the agent went away). The viewer cannot recover on its own —
+   *  it holds a socket addressed to a sessionId that no longer exists — so it reports upward and
+   *  the parent decides where to go. */
+  onSessionEnded?: (reason: SessionTerminatedReason) => void;
 }
 
 type AndroidChrome = { buttons: AndroidButton[]; streamType: 'h264'; screenWidth?: number; screenHeight?: number; cornerRadius?: number };
 
-export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecordingUploaded }: Props) {
+export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecordingUploaded, onSessionEnded }: Props) {
   const sendRef = useRef<(msg: BrowserToRelay) => void>(() => {});
   const { perfMode, visible: perfVisible } = usePerfMode();
 
@@ -86,6 +90,10 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       // non-secure (LAN-HTTP) → it downscales for the WASM decoder. The relay adds `external`.
       sendRef.current({ type: 'device:boot', sessionId, payload: { deviceId, resetMode, acceptH264: canDecodeH264(), secureContext: window.isSecureContext } });
     }
+    if (msg.type === 'session:terminated') {
+      onSessionEnded?.(msg.reason);
+      return;
+    }
     if (msg.type === 'device:boot-error') {
       setBootError((msg as unknown as { message: string }).message);
     }
@@ -125,7 +133,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     // sends, which is a behaviour fix (a stale mode can be sent after a reconnect) tracked in #439 —
     // not part of widening the lint scope. Remove this suppression when #439 lands.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, deviceId, buildId]);
+  }, [sessionId, deviceId, buildId, onSessionEnded]);
 
   const handleBinaryFrame = useCallback((data: ArrayBuffer) => {
     const envelope = parseEnvelopeHeader(data);

--- a/packages/dashboard/hooks/useAgentSession.ts
+++ b/packages/dashboard/hooks/useAgentSession.ts
@@ -71,6 +71,24 @@ export function useAgentSession(os: string) {
     setSelectedAgent(null)
     setBooting(false)
     setStatus('')
+    send({ type: 'agents:list' })
+  }, [send])
+
+  /**
+   * The relay told us the session is gone (the agent went away). Same destination as
+   * `handleBackToMacs` but deliberately **not** the same function: there is no session left to shut
+   * down, so sending `device:shutdown` would only earn a `Session not found`.
+   *
+   * The immediate `agents:list` matters here. The list otherwise refreshes on a 5s interval, and
+   * this flow puts the user back on it and invites them to pick again straight away — with a stale
+   * list that would mean joining a sessionId the relay has already dropped.
+   */
+  const handleSessionEnded = useCallback(() => {
+    setActiveSessionId(null)
+    setSelectedAgent(null)
+    setBooting(false)
+    setStatus('')
+    send({ type: 'agents:list' })
   }, [send])
 
   return {
@@ -88,5 +106,6 @@ export function useAgentSession(os: string) {
     resetDevice,
     handleBack,
     handleBackToMacs,
+    handleSessionEnded,
   }
 }

--- a/packages/dashboard/hooks/useAgentSession.ts
+++ b/packages/dashboard/hooks/useAgentSession.ts
@@ -76,8 +76,10 @@ export function useAgentSession(os: string) {
 
   /**
    * The relay told us the session is gone (the agent went away). Same destination as
-   * `handleBackToMacs` but deliberately **not** the same function: there is no session left to shut
-   * down, so sending `device:shutdown` would only earn a `Session not found`.
+   * `handleBackToMacs` but deliberately **not** the same function: there is no session left, so a
+   * `device:shutdown` would be addressed to a sessionId the relay has already dropped. The relay
+   * discards it silently (that case has no `else` branch), so nothing breaks — it is simply a
+   * message sent about something that no longer exists.
    *
    * The immediate `agents:list` matters here. The list otherwise refreshes on a 5s interval, and
    * this flow puts the user back on it and invites them to pick again straight away — with a stale

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -1,3 +1,5 @@
+import type { SessionTerminatedReason } from '@tapflowio/protocol'
+
 export interface AgentResources {
   cpuPercent: number
   memUsedMB: number
@@ -143,6 +145,7 @@ export interface ReleaseGroup {
 export type RelayMessage =
   | { type: 'agents:listed'; sessions: SessionInfo[] }
   | { type: 'session:joined'; sessionId: string; capabilities?: string[] }
+  | { type: 'session:terminated'; sessionId: string; reason: SessionTerminatedReason }
   | { type: 'session:chrome'; payload: ChromeData | { buttons: AndroidButton[]; streamType: 'h264' } }
   | { type: 'session:deviceInfo'; payload: DeviceInfo }
   | { type: 'device:booting' }

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useBreadcrumb } from '@/hooks/useBreadcrumb';
 import { useBuildLoader } from '@/hooks/useBuildLoader';
@@ -42,7 +43,7 @@ export function QASession() {
     sessions, selectedAgent, setSelectedAgent,
     activeSessionId, deviceId, booting, status,
     connected, agentGroups,
-    startDevice, resetDevice, handleBack, handleBackToMacs,
+    startDevice, resetDevice, handleBack, handleBackToMacs, handleSessionEnded,
   } = useAgentSession(os);
 
   const selectedSession = agentGroups.find((s) => s.agentName === selectedAgent);
@@ -59,6 +60,16 @@ export function QASession() {
     : '';
 
   const handleRecordingUploaded = useCallback(() => setRecordingsKey((k) => k + 1), []);
+
+  // The relay dropped the session because its agent went away. Say so and go back to the Mac list —
+  // before #426 the tab just sat on "Waiting for first frame..." with no way to know a refresh was
+  // needed.
+  const onSessionEnded = useCallback(() => {
+    toast.error('The agent disconnected — this session ended.', {
+      description: 'Pick the Mac again to start a new session.',
+    });
+    handleSessionEnded();
+  }, [handleSessionEnded]);
 
   const { setNode: setBreadcrumb } = useBreadcrumb();
   useEffect(() => {
@@ -131,6 +142,7 @@ export function QASession() {
                 buildId={build?.id}
                 resetMode={resetMode}
                 onRecordingUploaded={handleRecordingUploaded}
+                onSessionEnded={onSessionEnded}
               />
             </div>
           ) : selectedAgent ? (

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import type { SessionTerminatedReason } from '@tapflowio/protocol';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useBreadcrumb } from '@/hooks/useBreadcrumb';
 import { useBuildLoader } from '@/hooks/useBuildLoader';
@@ -29,6 +30,16 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { SearchInput } from '@/components/ui/search-input';
 import type { AgentDevice, SessionInfo } from '@/lib/types';
 import { getResourceHealth, type ResourceHealth } from '@/lib/resource-health';
+
+// Keyed by the reason so a new one cannot be added without deciding what the user is told. A
+// callback that ignored `reason` would keep showing "the agent disconnected" for every future
+// cause — which is exactly what the literal union exists to prevent.
+const SESSION_ENDED_NOTICE: Record<SessionTerminatedReason, { title: string; description: string }> = {
+  'agent-disconnected': {
+    title: 'The agent disconnected — this session ended.',
+    description: 'Pick the Mac again to start a new session.',
+  },
+};
 
 export function QASession() {
   const [searchParams] = useSearchParams();
@@ -64,10 +75,9 @@ export function QASession() {
   // The relay dropped the session because its agent went away. Say so and go back to the Mac list —
   // before #426 the tab just sat on "Waiting for first frame..." with no way to know a refresh was
   // needed.
-  const onSessionEnded = useCallback(() => {
-    toast.error('The agent disconnected — this session ended.', {
-      description: 'Pick the Mac again to start a new session.',
-    });
+  const onSessionEnded = useCallback((reason: SessionTerminatedReason) => {
+    const notice = SESSION_ENDED_NOTICE[reason];
+    toast.error(notice.title, { description: notice.description });
     handleSessionEnded();
   }, [handleSessionEnded]);
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -132,6 +132,16 @@ export type RelayToAgent =
   | { type: 'screenshot:request'; sessionId: string; requestId: string; format: 'png' | 'jpeg' }
   | { type: 'ui:tree:request'; sessionId: string; requestId: string }
 
+/**
+ * Why a session stopped existing, server-side. A literal union rather than a string so that adding
+ * a case is a compile-time event for every consumer that switches on it.
+ *
+ * Named `session:terminated`, not `session:ended`: `session:end` is already a message the *browser*
+ * sends to ask for shutdown, and the two would sit one letter apart in the same switch. This one
+ * travels the other way and is not an acknowledgement of that request.
+ */
+export type SessionTerminatedReason = 'agent-disconnected'
+
 // ── relay → browser ──────────────────────────────────────────────────────────
 //
 // `stream:registered` goes to a stream socket rather than a viewer. It is grouped here because the
@@ -143,6 +153,7 @@ export type RelayToBrowser =
   | { type: 'agents:listed'; sessions: SessionInfo[] }
   | { type: 'stream:registered' }
   | { type: 'session:joined'; sessionId: string; capabilities: string[] }
+  | { type: 'session:terminated'; sessionId: string; reason: SessionTerminatedReason }
   | { type: 'session:chrome'; payload: ChromePayload }
   | { type: 'session:deviceInfo'; payload: DeviceDetails }
   | { type: 'device:ready'; payload: { deviceId: string } }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -771,8 +771,24 @@ export class RelayServer {
         pending.reject(new Error('Agent disconnected'))
       }
     }
+    // Tell whoever is attached before the session stops existing — after `remove()` the socket
+    // reference is gone. Without this the browser keeps a live socket addressed to a sessionId the
+    // relay no longer knows, so everything it sends is dropped as unknown and nothing streams back:
+    // the tab sits on "Waiting for first frame..." with no explanation (#426).
+    //
+    // `sendTo` skips a socket that is not OPEN, and a session nobody has joined has no
+    // `browserSocket` at all. An attached MCP client does have one and will receive this; its
+    // dispatcher drops messages no waiter matches, so that is harmless.
+    for (const s of agentSessions) {
+      if (s.browserSocket) {
+        this.sendTo(s.browserSocket, {
+          type: 'session:terminated', sessionId: s.id, reason: 'agent-disconnected',
+        })
+      }
+    }
     for (const s of agentSessions) this.sessions.remove(s.id)
     this.sessions.removeResources(ws)
+    logger.info(`agent disconnected — ${agentSessions.length} session(s) ended`)
     return true
   }
 
@@ -798,6 +814,10 @@ export class RelayServer {
       sessionId: sessionIds[i],
     }))
     this.sendTo(ws, { type: 'agent:registered', registeredSessions })
+    // The startup banner prints "Waiting for agents..." once and then the relay says nothing either
+    // way, so a terminal gives no signal about whether an agent is attached. One line per
+    // transition, matching the disconnect line in evictAgentSocket.
+    logger.info(`agent connected: ${msg.agentName ?? msg.agentId ?? 'unknown'} (${msg.platform ?? 'unknown'}) — ${registeredSessions.length} device(s)`)
   }
 
   private handleSessionStart(ws: WebSocket, msg: RelayMessage): void {

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -753,7 +753,12 @@ export class RelayServer {
     socket.send(JSON.stringify(msg))
   }
 
-  private evictAgentSocket(ws: WebSocket): boolean {
+  /**
+   * @param cause  `'disconnect'` — the socket closed. `'replaced'` — the same agent re-registered
+   *   and this is its previous socket. Only affects the log line: a restart otherwise reads as a
+   *   crash followed by a recovery, which is not what happened.
+   */
+  private evictAgentSocket(ws: WebSocket, cause: 'disconnect' | 'replaced' = 'disconnect'): boolean {
     const agentSessions = this.sessions.getAllByAgentSocket(ws)
     if (agentSessions.length === 0) return false
     const agentSessionIds = new Set(agentSessions.map((s) => s.id))
@@ -788,7 +793,9 @@ export class RelayServer {
     }
     for (const s of agentSessions) this.sessions.remove(s.id)
     this.sessions.removeResources(ws)
-    logger.info(`agent disconnected — ${agentSessions.length} session(s) ended`)
+    logger.info(cause === 'replaced'
+      ? `agent re-registered — ${agentSessions.length} previous session(s) replaced`
+      : `agent disconnected — ${agentSessions.length} session(s) ended`)
     return true
   }
 
@@ -804,7 +811,7 @@ export class RelayServer {
         if (old === ws) continue
         // Evict before terminate: the old socket's close fires async, by which point its sessions are
         // gone and its in-flight screenshots would be undiscoverable — reject them here instead.
-        this.evictAgentSocket(old)
+        this.evictAgentSocket(old, 'replaced')
         old.terminate()
       }
     }

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -282,7 +282,7 @@ describe('RelayServer', () => {
     const ended = await endedPromise
 
     expect(ended.sessionId).toBe(sessionId)
-    expect((ended as unknown as { reason: string }).reason).toBe('agent-disconnected')
+    expect(ended.reason).toBe('agent-disconnected')
 
     browser.close()
   })

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -262,6 +262,50 @@ describe('RelayServer', () => {
     browserB.close()
   })
 
+  it('tells an attached viewer its session ended when the agent disconnects (#426)', async () => {
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    // Without the notice the browser keeps a live socket addressed to a sessionId the relay has
+    // dropped: everything it sends is ignored and nothing streams back, with no way to tell.
+    const endedPromise = waitForType(browser, 'session:terminated')
+    agent.close()
+    const ended = await endedPromise
+
+    expect(ended.sessionId).toBe(sessionId)
+    expect((ended as unknown as { reason: string }).reason).toBe('agent-disconnected')
+
+    browser.close()
+  })
+
+  it('handles an agent disconnect with no viewer attached', async () => {
+    const devices = [{ id: 'devSolo', name: 'iPhone Solo', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    await waitForMessage(agent)
+
+    agent.close()
+
+    // The session had no browserSocket, so there is nobody to notify. The relay must skip it
+    // rather than throw — proven by it still answering the next client.
+    const probe = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(probe)
+    probe.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType(probe, 'agents:listed')
+    expect(listed.type).toBe('agents:listed')
+    probe.close()
+  })
+
   it('routes input:touch:start from browser to agent', async () => {
     const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
     const agent = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -294,15 +294,21 @@ describe('RelayServer', () => {
     agent.send(JSON.stringify({ type: 'agent:register', devices }))
     await waitForMessage(agent)
 
+    // Arm the close listener before closing: `agent.close()` returns immediately and the relay's
+    // eviction runs on its own close handler, so querying straight away can observe the session
+    // still present and prove nothing.
+    const agentClosed = new Promise<void>((resolve) => agent.on('close', () => resolve()))
     agent.close()
+    await agentClosed
 
     // The session had no browserSocket, so there is nobody to notify. The relay must skip it
-    // rather than throw — proven by it still answering the next client.
+    // rather than throw — proven by it still answering, and by the session actually being gone.
     const probe = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(probe)
     probe.send(JSON.stringify({ type: 'agents:list' }))
     const listed = await waitForType(probe, 'agents:listed')
-    expect(listed.type).toBe('agents:listed')
+    const solo = (listed.sessions ?? []).filter((s) => s.devices.some((d) => d.id === 'devSolo'))
+    expect(solo).toHaveLength(0)
     probe.close()
   })
 

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -307,8 +307,10 @@ describe('RelayServer', () => {
     await waitForOpen(probe)
     probe.send(JSON.stringify({ type: 'agents:list' }))
     const listed = await waitForType(probe, 'agents:listed')
-    const solo = (listed.sessions ?? []).filter((s) => s.devices.some((d) => d.id === 'devSolo'))
-    expect(solo).toHaveLength(0)
+    // Not `listed.sessions ?? []` — that would also pass if the field went missing entirely, which
+    // is a different bug wearing the same green tick.
+    expect(listed.sessions).toBeDefined()
+    expect(listed.sessions!.filter((s) => s.devices.some((d) => d.id === 'devSolo'))).toHaveLength(0)
     probe.close()
   })
 

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -10,6 +10,7 @@ export type MessageType =
   | 'session:deviceInfo'
   | 'session:end'
   | 'session:leave'
+  | 'session:terminated'
   | 'stream:register'
   | 'stream:registered'
   | 'device:boot'
@@ -64,8 +65,8 @@ export type { AgentResources, UIElement }
 
 // The wire contract lives in @tapflowio/protocol so the relay, the dashboard and mcp-server cannot
 // drift apart. `DeviceInfo` is kept as an alias while call sites move over.
-import type { DeviceSummary } from '@tapflowio/protocol'
-export type { DeviceReport, DeviceSummary } from '@tapflowio/protocol'
+import type { DeviceSummary, SessionTerminatedReason } from '@tapflowio/protocol'
+export type { DeviceReport, DeviceSummary, SessionTerminatedReason } from '@tapflowio/protocol'
 
 export type DeviceInfo = DeviceSummary
 
@@ -104,4 +105,6 @@ export interface RelayMessage {
   format?: 'png' | 'jpeg'
   // ui:tree:response: unified element schema (normalized 0-1 frames), mapped agent-side
   elements?: UIElement[]
+  // session:terminated: why the relay dropped the session
+  reason?: SessionTerminatedReason
 }


### PR DESCRIPTION
Stage 1 of #426.

## The bug

Restart a device agent with a dashboard tab open and that tab never recovers. It shows `Waiting for first frame...` indefinitely, input does nothing, and nothing says why. Only a manual refresh fixes it.

`evictAgentSocket` deletes every session the closing socket owned — and tells no one. The browser keeps a live socket addressed to a `sessionId` the relay no longer knows, so everything it sends is dropped as unknown and nothing streams back.

## What this does

Sends `session:terminated` to whoever is attached, **before** `sessions.remove()` — after removal the socket reference is gone, so the order is a requirement rather than a preference.

The scope stops there deliberately. Rebinding the tab to the restarted agent's new session, so a restart is invisible rather than merely announced, is stage 2. This turns a silent failure into a stated one, which is most of the pain for a fraction of the work.

**Named `session:terminated`, not `session:ended`.** `session:end` already exists as the message a browser sends to *request* shutdown; the two would sit one letter apart in the same switch while meaning opposite things.

## The wiring the plan got wrong

The design review caught this before any code was written, and it would have made the change pointless: `DeviceViewer` opens **its own WebSocket**, so the notice arrives there — but `handleBackToMacs` lives in `useAgentSession`, which `QASession` owns, and `DeviceViewer` had no callback prop to reach it. The message would have arrived somewhere with no way to act on it.

The viewer now reports upward through `onSessionEnded` and the parent decides what to do.

`handleSessionEnded` is deliberately **not** `handleBackToMacs`: there is no session left to shut down. Both now refresh the agent list immediately — it otherwise polls every 5s, and this flow puts the user back on that list and invites them to pick again, where a stale entry means joining a session the relay has already dropped. That path was exercised in manual testing: the agent reappeared and was selected before the next poll.

## Also

The relay logs one line when an agent connects and one when it goes away, distinguishing a re-registration from a disconnect. It previously printed `Waiting for agents...` at startup and then nothing either way — the issue filed that separately, and it paid for itself while testing this.

## Verification

- **Manual**: relay and tab left running, agent restarted → toast shown → returned to the Mac list → reselected and reconnected with no refresh.
- relay tests for both branches (viewer attached, no viewer to notify). Mutation-checked: removing the notice fails the first on a 5s timeout and leaves the rest passing.
- Full gate green: typecheck, lint, build, test (relay 492, dashboard 236).

## Review

Two rounds, recorded in `.work/reviews/fix__session-terminated-notice.md`. The pre-PR pass found no blockers but two majors, both of the same kind — a guard that was not guarding:

- The relay's own `MessageType` never listed `session:terminated`. The tell was in this PR's test: it needed `(ended as unknown as { reason: string })` to read the field. That cast was the compiler reporting the missing type, and it got worked around instead of listened to.
- `SessionTerminatedReason` exists so that adding a case in stage 2 is a compile-time event — but `QASession`'s handler ignored the parameter and hard-coded the message. `() => void` is assignable to `(reason: R) => void`, so a second reason would have compiled and shown the wrong text forever. The copy now lives in a `Record<SessionTerminatedReason, …>`; adding a value fails with `TS2741` until someone decides what the user is told.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notifications when an active session ends because its agent disconnects.
  * The dashboard now explains the interruption, returns to the device list, and refreshes available agents.
  * Relay activity logs now include agent connections and disconnections.
* **Bug Fixes**
  * Prevented the dashboard from retaining stale session references after an agent disconnects.
* **Tests**
  * Added coverage for session termination notifications and cleanup when no viewer is connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->