### PR TITLE
fix(relay): replay device:ready for a streaming session, not a running device

### DIFF
--- a/.changeset/device-ready-liveness.md
+++ b/.changeset/device-ready-liveness.md
@@ -8,4 +8,4 @@ The relay replays `device:ready` when a browser joins, so a tab that lost its so
 
 The replay now keys off whether this session announced a stream and has not since taken it back, tracked separately from the device's own state. `deviceStatus` is unchanged and still answers "is this device up" for the device list and the REST guards — the two questions were sharing one field.
 
-Also released when a reboot starts: `device:booting` already cleared the cached chrome for the same reason, and a browser joining mid-boot should not be promised a stream that is being torn down.
+Also released when a reboot starts and when the stream socket goes away. `device:booting` already cleared the cached chrome for the same reason, and a browser joining mid-boot should not be promised a stream that is being torn down. The stream socket matters because the agent does not always get to report the end: `handleDeviceShutdown` tears the streamer down before running `simctl shutdown`, and if that throws, no `device:shutdown-done` is ever sent.

--- a/.changeset/device-ready-liveness.md
+++ b/.changeset/device-ready-liveness.md
@@ -1,0 +1,11 @@
+---
+"@tapflowio/relay": patch
+---
+
+Stop telling a viewer a device is ready when nothing is streaming.
+
+The relay replays `device:ready` when a browser joins, so a tab that lost its socket mid-session gets a picture back without waiting for another boot. The condition for that replay was `deviceStatus === 'booted'` — and `deviceStatus` starts life as the agent's `simctl list` snapshot at registration. Since the relay opens a session for every device an agent reports, a simulator somebody left running had a session marked booted before the agent had done anything with it. Joining that session produced a `device:ready` with no stream behind it.
+
+The replay now keys off whether this session announced a stream and has not since taken it back, tracked separately from the device's own state. `deviceStatus` is unchanged and still answers "is this device up" for the device list and the REST guards — the two questions were sharing one field.
+
+Also released when a reboot starts: `device:booting` already cleared the cached chrome for the same reason, and a browser joining mid-boot should not be promised a stream that is being torn down.

--- a/.changeset/device-ready-liveness.md
+++ b/.changeset/device-ready-liveness.md
@@ -8,4 +8,6 @@ The relay replays `device:ready` when a browser joins, so a tab that lost its so
 
 The replay now keys off whether this session announced a stream and has not since taken it back, tracked separately from the device's own state. `deviceStatus` is unchanged and still answers "is this device up" for the device list and the REST guards — the two questions were sharing one field.
 
-Also released when a reboot starts and when the stream socket goes away. `device:booting` already cleared the cached chrome for the same reason, and a browser joining mid-boot should not be promised a stream that is being torn down. The stream socket matters because the agent does not always get to report the end: `handleDeviceShutdown` tears the streamer down before running `simctl shutdown`, and if that throws, no `device:shutdown-done` is ever sent.
+The flag is cleared on three events: `device:shutdown-done`, `device:booting`, and the stream socket closing.
+
+`device:booting` already cleared the cached chrome for the same reason — a browser joining mid-boot should not be promised a stream that is being torn down. The stream socket matters because the agent does not always get to report the end: `handleDeviceShutdown` tears the streamer down before running `simctl shutdown`, and if that throws, no `device:shutdown-done` is ever sent.

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -303,4 +303,6 @@ const touchHelper = MockTouchHelper.mock.results[0].value
 
 `mockSimctl(true)` (booted=true) → skips `device:booting` and delivers `device:ready` immediately.
 
-**`device:ready` is not a sync point.** With `booted=true` the relay registers the session as already booted and **replays a `device:ready` on `session:start`** (browser-reconnect support), so `waitForType(browser, 'device:ready')` can latch that stale ack rather than the one this boot emits — before any streamer or helper exists. Always `vi.waitFor` on the mock you are about to read (`MockCapture`, `MockTouchHelper`, …), never on the message alone. This is what made the codec-negotiation test flake at ~2/10 suite runs.
+**`device:ready` is not a sync point.** It is sent as soon as the stream is handed off, before the helpers a test is usually about to read are observable — so `waitForType(browser, 'device:ready')` returning does not mean `MockCapture` or `MockTouchHelper` has been constructed. Always `vi.waitFor` on the mock you are about to read, never on the message alone.
+
+There used to be a second reason: the relay replayed `device:ready` on `session:start` for any session whose device was up at registration, so the wait could latch an ack that belonged to no boot at all — that is what made the codec-negotiation test flake at ~2/10 suite runs. The replay now keys off whether the session announced a stream (relay `Session.readySent`), so a freshly registered `mockSimctl(true)` session no longer produces one. The `vi.waitFor` rule stands on the first reason alone.

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -459,9 +459,10 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
-      // device:ready is sent after TouchHelper is created, but the relay also replays a
-      // device:ready on session:start for an already-booted device, so this may have latched
-      // the stale one — wait for the helper itself. (A vi.fn call log never lags.)
+      // device:ready is sent as the stream is handed off, which is not the same instant the helper
+      // becomes observable — wait for the helper itself. (A vi.fn call log never lags.)
+      // The relay used to replay a device:ready for any already-booted session too, which could
+      // latch an ack belonging to no boot; that is fixed, but this wait is still the right shape.
       await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
       const thInstance = MockTouchHelper.mock.results[0].value
       return { browser, agent, thInstance }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -616,6 +616,7 @@ export class RelayServer {
         const session = this.sessions.get(msg.sessionId!)
         if (!session) break
         this.sessions.updateDeviceStatus(session.id, 'shutdown')
+        this.sessions.setReadySent(session.id, false)
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -625,6 +626,7 @@ export class RelayServer {
         const session = this.sessions.get(msg.sessionId!)
         if (!session) break
         this.sessions.updateDeviceStatus(session.id, 'booted')
+        this.sessions.setReadySent(session.id, true)
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }
@@ -886,8 +888,11 @@ export class RelayServer {
     if (session.deviceInfo) {
       this.sendTo(ws, { type: 'session:deviceInfo', payload: session.deviceInfo })
     }
-    // Replay device:ready if the device is already booted (browser WS blip reconnect)
-    if (session.deviceStatus === 'booted') {
+    // Replay device:ready only if this session actually announced one (browser WS blip reconnect).
+    // Not `deviceStatus`: that starts from the agent's `simctl list` snapshot, so a session for a
+    // simulator that was already running would fire this before the agent had done anything —
+    // telling the viewer a stream exists when none does (#440).
+    if (session.readySent) {
       this.sendTo(ws, { type: 'device:ready', payload: { deviceId: session.deviceId } })
       // (Re)joining a live stream: ask the agent for an IDR so this viewer gets a decodable
       // keyframe immediately, instead of waiting for the next periodic one — and so it isn't

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -17,7 +17,14 @@ export interface Session {
   deviceId: string
   deviceName: string
   devicePlatform: string
+  /** What simctl/adb reported about the device. Drives the device list and the REST guards —
+   *  "is this device up", which is a different question from the one below. */
   deviceStatus: DeviceStatus
+  /** Whether the relay has told a browser this session is streaming, and has not since taken it
+   *  back. This is what the `device:ready` replay keys off. `deviceStatus` cannot answer it: it
+   *  starts from the agent's `simctl list` snapshot, so a simulator that was already running has a
+   *  session marked `booted` before the agent has done anything for it (#440). */
+  readySent: boolean
   deviceOsVersion?: string
   chromeData?: ChromePayload
   deviceInfo?: DeviceDetails
@@ -57,6 +64,7 @@ export class SessionManager {
         deviceName: d.name,
         devicePlatform: d.platform,
         deviceStatus: d.status as DeviceStatus,
+        readySent: false,
         deviceOsVersion: d.osVersion,
         idleTimer: null,
       })
@@ -159,6 +167,9 @@ export class SessionManager {
     session.chromeData = undefined
     session.deviceInfo = undefined
     session.deviceStatus = 'shutdown'
+    // Called on `device:booting`: whatever we announced before is no longer true, and replaying it
+    // to a browser that joins mid-boot would promise a stream that is being torn down.
+    session.readySent = false
   }
 
   setStreamSocket(sessionId: string, ws: WebSocket): void {
@@ -184,6 +195,11 @@ export class SessionManager {
   setDeviceInfo(sessionId: string, info: { deviceName: string; osVersion: string }): void {
     const session = this.sessions.get(sessionId)
     if (session) session.deviceInfo = info
+  }
+
+  setReadySent(sessionId: string, value: boolean): void {
+    const session = this.sessions.get(sessionId)
+    if (session) session.readySent = value
   }
 
   updateDeviceStatus(sessionId: string, status: DeviceStatus): void {

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -180,11 +180,15 @@ export class SessionManager {
     this.streamSocketIndex.set(ws, session)
   }
 
+  /** The stream socket is the stream. Losing it means whatever we announced is no longer true —
+   *  and this is the only signal for it on the paths where the agent never reports back, such as a
+   *  `simctl shutdown` that throws after the streamer has already been torn down. */
   clearStreamSocket(sessionId: string): void {
     const session = this.sessions.get(sessionId)
     if (!session?.streamSocket) return
     this.streamSocketIndex.delete(session.streamSocket)
     session.streamSocket = null
+    session.readySent = false
   }
 
   setChromeData(sessionId: string, data: ChromePayload): void {

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -1057,13 +1057,19 @@ describe('RelayServer', () => {
     browser.close()
   })
 
-  it('requests an IDR from the agent when a browser joins a booted device', async () => {
+  // The trigger is the agent having announced a stream, not the device having been up at register
+  // time. This used to register with `status: 'booted'` and join — which is the case #440 was
+  // about: a session for an already-running simulator looked ready before the agent touched it.
+  it('requests an IDR from the agent when a browser joins a streaming session', async () => {
     const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'booted' }]
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
     agent.send(JSON.stringify({ type: 'agent:register', devices }))
     const { registeredSessions } = await waitForMessage(agent)
     const sessionId = registeredSessions![0].sessionId
+
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await new Promise((r) => setTimeout(r, 50))
 
     const idrPromise = waitForType(agent, 'stream:request-idr')
     const browser = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -1069,7 +1069,11 @@ describe('RelayServer', () => {
     const sessionId = registeredSessions![0].sessionId
 
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
-    await new Promise((r) => setTimeout(r, 50))
+    // Round-trip on the agent socket rather than a sleep: the browser joins on a different
+    // connection, so nothing orders its session:start against the device:ready above.
+    const listed = waitForType(agent, 'agents:listed')
+    agent.send(JSON.stringify({ type: 'agents:list' }))
+    await listed
 
     const idrPromise = waitForType(agent, 'stream:request-idr')
     const browser = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -19,16 +19,17 @@ const waitForType = (ws: WebSocket, type: string) =>
     ws.on('message', listener)
   })
 
-/** Null after `ms` instead of hanging — used to assert a message does *not* arrive. */
-function typeOrTimeout(ws: WebSocket, type: string, ms = 800) {
-  return new Promise<RelayMessage | null>((resolve) => {
-    const timer = setTimeout(() => { ws.off('message', listener); resolve(null) }, ms)
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) { clearTimeout(timer); ws.off('message', listener); resolve(msg) }
-    }
-    ws.on('message', listener)
+/** Records every message of `type` from the moment it is attached. Paired with a round-trip
+ *  barrier below, this answers "did it arrive" without waiting on a clock: the replay is written
+ *  synchronously alongside `session:joined`, so anything that was coming has already been queued
+ *  by the time a later request completes. */
+function collect(ws: WebSocket, type: string): { got: () => RelayMessage | null } {
+  let seen: RelayMessage | null = null
+  ws.on('message', (data: Buffer) => {
+    const msg = JSON.parse(data.toString()) as RelayMessage
+    if (msg.type === type) seen ??= msg
   })
+  return { got: () => seen }
 }
 
 // #440: the relay replays `device:ready` so a browser that reconnects mid-stream gets a picture
@@ -75,9 +76,13 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
   async function joinAs(sessionId: string) {
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
-    const ready = typeOrTimeout(browser, 'device:ready')
+    const ready = collect(browser, 'device:ready')
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForType(browser, 'session:joined')
+    // Barrier, not a sleep: a completed round-trip after the join means the relay has finished
+    // everything it was going to send for it.
+    browser.send(JSON.stringify({ type: 'agents:list' }))
+    await waitForType(browser, 'agents:listed')
     return { browser, ready }
   }
 
@@ -87,7 +92,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { browser, ready } = await joinAs(sessionId)
 
     // Before this fix the viewer was told the device was ready here, with no stream behind it.
-    expect(await ready).toBeNull()
+    expect(ready.got()).toBeNull()
 
     agent.close(); browser.close()
   })
@@ -98,13 +103,19 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     // would pass the test above.
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
-    await new Promise((r) => setTimeout(r, 50))
 
+    // The IDR request rides the same branch, and it goes out during the join — so the listener has
+    // to exist before it. Asserting it here keeps it covered: moving it out of the replay block
+    // would otherwise be caught by nothing.
+    const idrPromise = waitForType(agent, 'stream:request-idr')
     const { browser, ready } = await joinAs(sessionId)
 
-    const msg = await ready
+    const msg = ready.got()
     expect(msg).not.toBeNull()
     expect((msg!.payload as { deviceId: string }).deviceId).toBe('devA')
+
+    const idr = await idrPromise
+    expect(idr.sessionId).toBe(sessionId)
 
     agent.close(); browser.close()
   })
@@ -113,11 +124,10 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
     agent.send(JSON.stringify({ type: 'device:shutdown-done', sessionId, payload: { deviceId: 'devA' } }))
-    await new Promise((r) => setTimeout(r, 50))
 
     const { browser, ready } = await joinAs(sessionId)
 
-    expect(await ready).toBeNull()
+    expect(ready.got()).toBeNull()
 
     agent.close(); browser.close()
   })
@@ -128,11 +138,33 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
     agent.send(JSON.stringify({ type: 'device:booting', sessionId }))
-    await new Promise((r) => setTimeout(r, 50))
 
     const { browser, ready } = await joinAs(sessionId)
 
-    expect(await ready).toBeNull()
+    expect(ready.got()).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  // The agent does not always get to say the stream ended: `handleDeviceShutdown` tears the
+  // streamer down first and only then runs `simctl shutdown`, which can throw — and then no
+  // `device:shutdown-done` is sent at all. The stream socket closing is the signal that survives
+  // that, and without it a later join is told a stream exists and fires an install into nothing.
+  it('stops replaying when the stream socket goes away', async () => {
+    const { agent, sessionId } = await registerAgent('shutdown')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+
+    const streamWs = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(streamWs)
+    streamWs.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    await waitForType(streamWs, 'stream:registered')
+    const closed = new Promise<void>((r) => streamWs.on('close', () => r()))
+    streamWs.close()
+    await closed
+
+    const { browser, ready } = await joinAs(sessionId)
+
+    expect(ready.got()).toBeNull()
 
     agent.close(); browser.close()
   })

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import type { RelayMessage } from '../types'
+
+const waitForOpen = (ws: WebSocket) =>
+  new Promise<void>((resolve) => ws.once('open', resolve))
+
+const waitForType = (ws: WebSocket, type: string) =>
+  new Promise<RelayMessage>((resolve) => {
+    const listener = (data: Buffer) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === type) { ws.off('message', listener); resolve(msg) }
+    }
+    ws.on('message', listener)
+  })
+
+/** Null after `ms` instead of hanging — used to assert a message does *not* arrive. */
+function typeOrTimeout(ws: WebSocket, type: string, ms = 800) {
+  return new Promise<RelayMessage | null>((resolve) => {
+    const timer = setTimeout(() => { ws.off('message', listener); resolve(null) }, ms)
+    const listener = (data: Buffer) => {
+      const msg = JSON.parse(data.toString()) as RelayMessage
+      if (msg.type === type) { clearTimeout(timer); ws.off('message', listener); resolve(msg) }
+    }
+    ws.on('message', listener)
+  })
+}
+
+// #440: the relay replays `device:ready` so a browser that reconnects mid-stream gets a picture
+// without waiting for the next boot. The condition for that has to be "this session announced a
+// stream", not "the device was up when the agent registered" — the relay opens a session for every
+// device the agent reports, so a simulator someone left running had a session that looked ready
+// before the agent had done anything with it.
+describe('device:ready replay tracks the session, not the device (#440)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-ready-replay-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  /** Registers one device and returns its session. `status` is what the agent reports to the relay
+   *  at register time — 'booted' is an ordinary state for a simulator nobody shut down. */
+  async function registerAgent(status: 'booted' | 'shutdown') {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status }],
+    }))
+    const reply = await waitForType(agent, 'agent:registered')
+    return { agent, sessionId: reply.registeredSessions![0]!.sessionId }
+  }
+
+  async function joinAs(sessionId: string) {
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    const ready = typeOrTimeout(browser, 'device:ready')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return { browser, ready }
+  }
+
+  it('says nothing about readiness when the device merely happened to be running', async () => {
+    const { agent, sessionId } = await registerAgent('booted')
+
+    const { browser, ready } = await joinAs(sessionId)
+
+    // Before this fix the viewer was told the device was ready here, with no stream behind it.
+    expect(await ready).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  it('replays for a session that is actually streaming', async () => {
+    // The reason replay exists: a Wi-Fi blip drops the browser socket mid-session, and the viewer
+    // must not sit blank until the next boot. Without this case, deleting the replay outright
+    // would pass the test above.
+    const { agent, sessionId } = await registerAgent('shutdown')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    const { browser, ready } = await joinAs(sessionId)
+
+    const msg = await ready
+    expect(msg).not.toBeNull()
+    expect((msg!.payload as { deviceId: string }).deviceId).toBe('devA')
+
+    agent.close(); browser.close()
+  })
+
+  it('stops replaying once the device is shut down', async () => {
+    const { agent, sessionId } = await registerAgent('shutdown')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    agent.send(JSON.stringify({ type: 'device:shutdown-done', sessionId, payload: { deviceId: 'devA' } }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    const { browser, ready } = await joinAs(sessionId)
+
+    expect(await ready).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  it('stops replaying while a reboot is in flight', async () => {
+    // `device:booting` clears the cached chrome for the same reason: what was announced is being
+    // torn down, and a browser joining now would be promised a stream that no longer exists.
+    const { agent, sessionId } = await registerAgent('shutdown')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    agent.send(JSON.stringify({ type: 'device:booting', sessionId }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    const { browser, ready } = await joinAs(sessionId)
+
+    expect(await ready).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  it('still reports the real device state in the device list', async () => {
+    // `deviceStatus` answers a different question — "is this device up" — and the dashboard's
+    // Booted badge and the REST guards both read it. Moving them onto the new flag would have made
+    // every device look shut down.
+    const { agent, sessionId } = await registerAgent('booted')
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType(browser, 'agents:listed')
+
+    const device = listed.sessions![0]!.devices.find((d) => d.sessionId === sessionId)
+    expect(device?.status).toBe('booted')
+
+    agent.close(); browser.close()
+  })
+})

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -32,6 +32,16 @@ function collect(ws: WebSocket, type: string): { got: () => RelayMessage | null 
   return { got: () => seen }
 }
 
+/** A round-trip on one socket. WebSocket preserves order within a connection, so once the reply
+ *  lands the relay has finished everything sent before it. The agent and the browser are separate
+ *  connections with no ordering between them, so lifecycle messages sent on the agent socket need
+ *  this before the browser acts on their effect — a sleep would only make that likely. */
+async function barrier(ws: WebSocket): Promise<void> {
+  const done = waitForType(ws, 'agents:listed')
+  ws.send(JSON.stringify({ type: 'agents:list' }))
+  await done
+}
+
 // #440: the relay replays `device:ready` so a browser that reconnects mid-stream gets a picture
 // without waiting for the next boot. The condition for that has to be "this session announced a
 // stream", not "the device was up when the agent registered" — the relay opens a session for every
@@ -79,10 +89,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const ready = collect(browser, 'device:ready')
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForType(browser, 'session:joined')
-    // Barrier, not a sleep: a completed round-trip after the join means the relay has finished
-    // everything it was going to send for it.
-    browser.send(JSON.stringify({ type: 'agents:list' }))
-    await waitForType(browser, 'agents:listed')
+    await barrier(browser)
     return { browser, ready }
   }
 
@@ -103,6 +110,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     // would pass the test above.
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await barrier(agent)
 
     // The IDR request rides the same branch, and it goes out during the join — so the listener has
     // to exist before it. Asserting it here keeps it covered: moving it out of the replay block
@@ -124,6 +132,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
     agent.send(JSON.stringify({ type: 'device:shutdown-done', sessionId, payload: { deviceId: 'devA' } }))
+    await barrier(agent)
 
     const { browser, ready } = await joinAs(sessionId)
 
@@ -138,6 +147,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
     agent.send(JSON.stringify({ type: 'device:booting', sessionId }))
+    await barrier(agent)
 
     const { browser, ready } = await joinAs(sessionId)
 
@@ -153,6 +163,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
   it('stops replaying when the stream socket goes away', async () => {
     const { agent, sessionId } = await registerAgent('shutdown')
     agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await barrier(agent)
 
     const streamWs = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(streamWs)


### PR DESCRIPTION
Closes #440. Last of three PRs; #449 and #450 are merged.

`Session.deviceStatus` was answering two questions with one field.

| Question | Read by | Snapshot answers it |
|---|---|---|
| Is this device up? | device list, REST guards | correctly |
| Did this session announce a stream? | the `device:ready` replay | **no** |

The relay opens a session for **every** device an agent reports, and `deviceStatus` is initialised from the agent's `simctl list` snapshot at registration. So a simulator somebody left running had a session marked `booted` from the moment it registered, and a browser joining it was told the device was ready before the agent had done anything with it.

Observed while writing tests for #450: `session:joined` → **`device:ready`** → (boot sent) → `device:booting` → `device:ready`. The first one meant nothing — no stream, no work done.

## What changed

`readySent` answers the second question. Set when the agent sends `device:ready`; cleared on `device:shutdown-done`, on `device:booting`, and when the stream socket closes.

That last one matters because the agent does not always get to report the end. `handleDeviceShutdown` cancels the stream reader and closes the stream socket *before* `await simctl.shutdown(deviceId)`, and a throw there is only logged — no `device:shutdown-done` is sent. Without the socket signal the relay keeps claiming a stream, and the dashboard, on a replayed `device:ready`, fires an install into nothing.

`deviceStatus` is untouched. There is a test that the device list still reports it: moving the existing readers onto the new flag would have made every device read as shut down.

## Two documents this made false

`packages/ios-agent/AGENTS.md` and a test comment both teach that the relay replays `device:ready` for any already-booted session, and that this is what made the codec-negotiation test flake at ~2/10 runs. That mechanism is what this PR removes. The `vi.waitFor` rule they exist to justify still holds — `device:ready` is sent as the stream is handed off, before the helpers a test is about to read are observable — so they now say that, with the old cause noted as fixed. Caught in review; the PR would otherwise have left contributors defending against a hazard that no longer exists.

## Review

Record: `.work/reviews/fix__device-ready-liveness.md`. One independent pass, lens "what stopped working, or started lying".

Six mutations, all caught. The one worth naming is removing the replay entirely: with only the "does not arrive" assertions it would have been green, and that is the regression where a reconnecting tab never gets a picture back. The reconnect case is what makes the negative ones mean something.

Also from the review: the IDR request rides the replay branch and had lost its independent assertion, and three negative assertions were waiting out 800 ms timers. The replay is written synchronously with `session:joined`, so a round-trip barrier proves the same thing — the file went from 5.5 s to 363 ms.

## Follow-ups, deliberately not here

- The agent's own `device:ready` timing. `simctl boot` returns before the device reaches Booted, and the agent sends ready right after the stream handoff. Whether that is early was impossible to measure while this replay was also firing; it is measurable now.
- Both agents log a failed `simctl shutdown` / `adb emu kill` and tell nobody. This PR stops the relay from being misled by it, but the silence itself remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device readiness notifications during session reconnects.
  - Readiness is now replayed only when an active stream is available, preventing stale notifications for devices that are merely registered or previously connected.
  - Readiness is cleared when a device reboots, shuts down, or its stream disconnects.
  - Device availability status remains accurate independently of stream readiness.

- **Tests**
  - Added coverage for reconnects, shutdowns, reboots, stream disconnections, and related IDR requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->