### PR TITLE
test: make socket helpers order-proof, in one place instead of nine

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -25,6 +25,7 @@ Common rules are in the root [AGENTS.md](./AGENTS.md).
 | cli | [packages/cli/AGENTS.md](./packages/cli/AGENTS.md) | CLI UX rules |
 | mcp-server | [packages/mcp-server/AGENTS.md](./packages/mcp-server/AGENTS.md) | MCP server bridging tapflow to LLM agents |
 | flow-runner | [packages/flow-runner/AGENTS.md](./packages/flow-runner/AGENTS.md) | Deterministic YAML flow engine (automated QA axis) |
+| test-utils | [packages/test-utils/AGENTS.md](./packages/test-utils/AGENTS.md) | Test-only helpers shared across packages (private, never published) |
 
 ## Local Only
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm --filter @tapflowio/protocol build && pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/flow-runner build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter tapflow build && pnpm --filter @tapflowio/mcp-server build",
     "test": "vitest run --config scripts/vitest.config.mjs && pnpm -r test --if-present",
     "lint": "eslint scripts && pnpm -r --if-present lint",
-    "typecheck": "tsc -b && pnpm --filter @tapflowio/dashboard --filter @tapflowio/mcp-server typecheck",
+    "typecheck": "tsc -b && pnpm --filter @tapflowio/dashboard --filter @tapflowio/mcp-server --filter @tapflowio/test-utils typecheck",
     "prepare": "lefthook install || true",
     "dev": "node scripts/dev-preflight.mjs relay dashboard && concurrently -k -n relay,dashboard,ios,android -c cyan,magenta,green,yellow \"pnpm dev:relay\" \"pnpm --filter @tapflowio/dashboard dev\" \"pnpm dev:ios\" \"pnpm dev:android\"",
     "dev:pool": "node scripts/dev-preflight.mjs relay && concurrently -k -n relay,ios,mocks -c cyan,green,yellow \"pnpm dev:relay\" \"pnpm dev:ios\" \"pnpm --filter @tapflowio/playground mock-agents\"",

--- a/packages/android-agent/package.json
+++ b/packages/android-agent/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@tapflowio/relay": "workspace:*",
+    "@tapflowio/test-utils": "workspace:*",
     "@types/node": "^20.19.43",
     "@types/ws": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -128,6 +128,7 @@ import { isAudioSupported, launchMuteOnlyTap } from '@tapflowio/audiotap-helper'
 import type { ScrcpyControl } from '../scrcpy/ScrcpyControl'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 import type { AdbRunner } from '../adb'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
 // Test-only view of a per-device state entry (the real DeviceState is not exported).
 interface TestState {
@@ -176,22 +177,6 @@ function mockAdb(booted = false): AdbWrapper {
   return adb
 }
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((r) => ws.once('open', r))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<Record<string, unknown>>((r) => {
-    const listener = (d: Buffer) => {
-      try {
-        const msg = JSON.parse(d.toString())
-        if (msg.type === type) {
-          ws.off('message', listener)
-          r(msg)
-        }
-      } catch { /* binary frame */ }
-    }
-    ws.on('message', listener)
-  })
 
 describe('AndroidAgent', () => {
   let relay: RelayServer

--- a/packages/ios-agent/package.json
+++ b/packages/ios-agent/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@tapflowio/relay": "workspace:*",
+    "@tapflowio/test-utils": "workspace:*",
     "@types/node": "^20.19.43",
     "@types/ws": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -71,6 +71,7 @@ import { AudioCaptureStreamer } from '../AudioCaptureStreamer'
 import { launchAudioHelper } from '@tapflowio/audiotap-helper'
 import { SimctlWrapper } from '../SimctlWrapper'
 import { TouchHelper } from '../TouchHelper'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 const MockTouchHelper = vi.mocked(TouchHelper)
 const MockAudioStreamer = vi.mocked(AudioCaptureStreamer)
 const mockLaunchAudioHelper = vi.mocked(launchAudioHelper)
@@ -89,22 +90,6 @@ const internals = (agent: IOSAgent): IOSAgentInternals => agent as unknown as IO
 const HID_BACKSPACE = 0x2A
 const HID_KEY_A = 0x04
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((r) => ws.once('open', r))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<Record<string, unknown>>((r) => {
-    const listener = (d: Buffer) => {
-      try {
-        const msg = JSON.parse(d.toString())
-        if (msg.type === type) {
-          ws.off('message', listener)
-          r(msg)
-        }
-      } catch { /* binary frame — ignore */ }
-    }
-    ws.on('message', listener)
-  })
 
 let pasteboard = ''
 const isSentinelish = (v: string): boolean => v.startsWith('\u200Btapflow-clipboard-')

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -63,6 +63,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@tapflowio/test-utils": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/busboy": "^1.5.4",
     "@types/jsonwebtoken": "^9.0.10",

--- a/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import { WebSocket, WebSocketServer } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
-import type { RelayMessage } from '../types'
 import { waitForMessage, waitForOpen } from '@tapflowio/test-utils'
 
 

--- a/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
@@ -6,14 +6,8 @@ import { WebSocket, WebSocketServer } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
+import { waitForMessage, waitForOpen } from '@tapflowio/test-utils'
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForMessage = (ws: WebSocket) =>
-  new Promise<RelayMessage>((resolve) =>
-    ws.once('message', (data) => resolve(JSON.parse(data.toString()))),
-  )
 
 // Minimal stand-in for a ws socket — only the surface runHeartbeat() touches.
 type MockSocket = { readyState: number; ping: ReturnType<typeof vi.fn>; terminate: ReturnType<typeof vi.fn> }

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -10,6 +10,7 @@ import { initDb, closeDb, getDb } from '../db'
 import { hashPat } from '../middleware/auth'
 import type { RelayMessage } from '../types'
 import { writeEnvelopeHeader, HEADER_SIZE, CODEC_AUDIO } from '@tapflowio/agent-core/utils'
+import { waitForMessage, waitForOpen, waitForType } from '@tapflowio/test-utils'
 
 // Sends a raw HTTP request, bypassing client-side URL normalization.
 const rawHttpGet = (targetPort: number, rawPath: string): Promise<number> =>
@@ -26,25 +27,7 @@ const rawHttpGet = (targetPort: number, rawPath: string): Promise<number> =>
     socket.on('error', reject)
   })
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
 
-const waitForMessage = (ws: WebSocket) =>
-  new Promise<RelayMessage>((resolve) =>
-    ws.once('message', (data) => resolve(JSON.parse(data.toString())))
-  )
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString())
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 describe('RelayServer', () => {
   let server: RelayServer
@@ -1160,10 +1143,10 @@ describe('RelayServer', () => {
     agent.close()
     await new Promise((resolve) => setTimeout(resolve, 50))
 
-    const msgPromise = waitForMessage(browser)
+    // By type, not "the next message": losing the agent also produces a `session:terminated`, and
+    // whichever lands first is not this test's subject.
     browser.send(JSON.stringify({ type: 'open-url', sessionId, payload: { url: 'myapp://home' } }))
-    const received = await msgPromise
-    expect(received.type).toBe('open-url:error')
+    const received = await waitForType(browser, 'open-url:error')
     expect(received.message).toBe('agent offline')
 
     browser.close()

--- a/packages/relay/src/__tests__/appCommandErrors.test.ts
+++ b/packages/relay/src/__tests__/appCommandErrors.test.ts
@@ -6,21 +6,8 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb, getDb } from '../db'
 import type { RelayMessage } from '../types'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 /** Resolves to the first message of any of `types`, or to null after `ms`. Used to assert that a
  *  reply arrives *promptly* — the defect under test is a caller waiting out its whole deadline.
@@ -188,15 +175,14 @@ describe('app command failures reach the caller (#445)', () => {
     await closed
 
     browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'dev-1' } }))
-    // Without this the viewer sits on "Waiting for first frame…" with nothing said.
+    // Without this the viewer sits on "Waiting for first frame…" with nothing said. Which of the
+    // two messages it is depends on whether the relay has finished tearing the agent's sessions
+    // down, which nothing here orders — the test below pins the wording on a case that is
+    // unambiguous.
     const msg = await firstOfOrTimeout(browser, ['device:boot-error'])
 
     expect(msg).not.toBeNull()
     expect(msg!.sessionId).toBe(sessionId)
-    // Losing the agent takes its sessions with it, so this is a missing session — not a live
-    // session with a dead socket. Saying "agent offline" here would point an MCP caller at the
-    // wrong problem on the very first call it makes.
-    expect(msg!.message).toBe('Session not found')
 
     browser.close()
   })
@@ -267,6 +253,23 @@ describe('app command failures reach the caller (#445)', () => {
     const msg = await firstOfOrTimeout(browser, ['app:install-error'])
 
     expect(msg?.type).toBe('app:install-error')
+
+    agent.close(); browser.close()
+  })
+
+  // `bootDevice` is the first call an MCP caller makes, so a stale session id reported as a dead
+  // Mac sends the reader after the wrong problem. An id that was never real is the case where the
+  // distinction is decidable — no teardown to race against.
+  it('calls an unknown session by its name, not a dead agent', async () => {
+    const { agent, browser } = await connectAgentAndBrowser()
+
+    browser.send(JSON.stringify({
+      type: 'device:boot', sessionId: 'no-such-session', payload: { deviceId: 'dev-1' },
+    }))
+    const msg = await firstOfOrTimeout(browser, ['device:boot-error'])
+
+    expect(msg?.message).toBe('Session not found')
+    expect(msg?.sessionId).toBe('no-such-session')
 
     agent.close(); browser.close()
   })

--- a/packages/relay/src/__tests__/appCommandErrors.test.ts
+++ b/packages/relay/src/__tests__/appCommandErrors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -6,30 +6,8 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb, getDb } from '../db'
 import type { RelayMessage } from '../types'
-import { waitForOpen, waitForType } from '@tapflowio/test-utils'
+import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 
-
-/** Resolves to the first message of any of `types`, or to null after `ms`. Used to assert that a
- *  reply arrives *promptly* — the defect under test is a caller waiting out its whole deadline.
- *
- *  The budget is generous on purpose. Every reply here is emitted in the same tick as the inbound
- *  message, so a passing run resolves in single-digit milliseconds and the number never costs
- *  anything; it only bounds the failing case. At 1s this went flaky under a full-monorepo run,
- *  where the relay competes with nine other packages' workers. */
-function firstOfOrTimeout(ws: WebSocket, types: string[], ms = 3000) {
-  return new Promise<RelayMessage | null>((resolve) => {
-    const timer = setTimeout(() => { ws.off('message', listener); resolve(null) }, ms)
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (types.includes(msg.type)) {
-        clearTimeout(timer)
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
-}
 
 // #445: every failure of app:install / app:launch has to reach the caller, carrying the sessionId
 // it was asked about. A dashboard viewer holds one session per socket so an unattributed error
@@ -77,6 +55,20 @@ describe('app command failures reach the caller (#445)', () => {
     return { agent, browser, sessionId }
   }
 
+  /** Blocks until the relay has finished dropping the sessions an agent owned.
+   *
+   *  Closing the agent socket starts that teardown; nothing orders it against the browser's next
+   *  request. Without this the same request answers `agent offline` or `Session not found`
+   *  depending on which won — measured at roughly 1 run in 10, which is exactly the kind of
+   *  flake that gets a real assertion deleted instead of fixed. */
+  async function untilAgentSessionsGone(browser: WebSocket) {
+    await vi.waitFor(async () => {
+      const listed = waitForType(browser, 'agents:listed')
+      browser.send(JSON.stringify({ type: 'agents:list' }))
+      expect((await listed).sessions ?? []).toHaveLength(0)
+    }, { timeout: 2000 })
+  }
+
   function insertBuild(bundleId: string | null): number {
     const db = getDb()
     const key = `com.example.${Math.abs(Number(process.hrtime.bigint() % 100000n))}`
@@ -95,7 +87,7 @@ describe('app command failures reach the caller (#445)', () => {
     browser.send(JSON.stringify({ type: 'app:install', sessionId: 'no-such-session', buildId: 1 }))
     // A generic `error` cannot be correlated by construction — the caller cannot tell whose
     // request it answers, so it keeps waiting.
-    const msg = await firstOfOrTimeout(browser, ['app:install-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:install-error')
 
     expect(msg?.type).toBe('app:install-error')
     expect(msg?.sessionId).toBe('no-such-session')
@@ -142,7 +134,7 @@ describe('app command failures reach the caller (#445)', () => {
     await closed
 
     browser.send(JSON.stringify({ type: 'app:install', sessionId, buildId }))
-    const msg = await firstOfOrTimeout(browser, ['app:install-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:install-error')
 
     expect(msg?.type).toBe('app:install-error')
     expect(msg?.sessionId).toBe(sessionId)
@@ -159,7 +151,7 @@ describe('app command failures reach the caller (#445)', () => {
     await closed
 
     browser.send(JSON.stringify({ type: 'app:launch', sessionId, buildId }))
-    const msg = await firstOfOrTimeout(browser, ['app:launch-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:launch-error')
 
     expect(msg?.type).toBe('app:launch-error')
     expect(msg?.sessionId).toBe(sessionId)
@@ -173,16 +165,18 @@ describe('app command failures reach the caller (#445)', () => {
     const closed = new Promise<void>((r) => agent.on('close', () => r()))
     agent.close()
     await closed
+    await untilAgentSessionsGone(browser)
 
     browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'dev-1' } }))
-    // Without this the viewer sits on "Waiting for first frame…" with nothing said. Which of the
-    // two messages it is depends on whether the relay has finished tearing the agent's sessions
-    // down, which nothing here orders — the test below pins the wording on a case that is
-    // unambiguous.
-    const msg = await firstOfOrTimeout(browser, ['device:boot-error'])
+    // Without this the viewer sits on "Waiting for first frame…" with nothing said.
+    const msg = await waitForTypeOrNull(browser, 'device:boot-error')
 
     expect(msg).not.toBeNull()
     expect(msg!.sessionId).toBe(sessionId)
+    // Losing the agent takes its sessions with it, so this is a missing session — not a live
+    // session with a dead socket. Saying "agent offline" here would point an MCP caller at the
+    // wrong problem on the very first call it makes.
+    expect(msg!.message).toBe('Session not found')
 
     browser.close()
   })
@@ -198,7 +192,7 @@ describe('app command failures reach the caller (#445)', () => {
     const { agent, browser, sessionId } = await connectAgentAndBrowser()
 
     browser.send(JSON.stringify({ type: 'app:install', sessionId, buildId }))
-    const msg = await firstOfOrTimeout(browser, ['app:install-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:install-error')
 
     expect(msg?.type).toBe('app:install-error')
     expect(msg?.sessionId).toBe(sessionId)
@@ -218,7 +212,7 @@ describe('app command failures reach the caller (#445)', () => {
     const { agent, browser, sessionId } = await connectAgentAndBrowser()
 
     browser.send(JSON.stringify({ type: 'app:install', sessionId, buildId }))
-    const msg = await firstOfOrTimeout(browser, ['app:install-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:install-error')
 
     expect(msg?.type).toBe('app:install-error')
     expect(msg?.sessionId).toBe(sessionId)
@@ -230,7 +224,7 @@ describe('app command failures reach the caller (#445)', () => {
     const { agent, browser, sessionId } = await connectAgentAndBrowser()
 
     browser.send(JSON.stringify({ type: 'app:launch', sessionId, buildId: {} }))
-    const msg = await firstOfOrTimeout(browser, ['app:launch-error', 'error'])
+    const msg = await waitForTypeOrNull(browser, 'app:launch-error')
 
     expect(msg?.type).toBe('app:launch-error')
     expect(msg?.sessionId).toBe(sessionId)
@@ -250,7 +244,7 @@ describe('app command failures reach the caller (#445)', () => {
     // Still serving afterwards is the assertion: a thrown TypeError here would surface as an
     // unhandled error and, in production, take the process with it.
     browser.send(JSON.stringify({ type: 'app:install', sessionId, buildId: 999999 }))
-    const msg = await firstOfOrTimeout(browser, ['app:install-error'])
+    const msg = await waitForTypeOrNull(browser, 'app:install-error')
 
     expect(msg?.type).toBe('app:install-error')
 
@@ -266,7 +260,7 @@ describe('app command failures reach the caller (#445)', () => {
     browser.send(JSON.stringify({
       type: 'device:boot', sessionId: 'no-such-session', payload: { deviceId: 'dev-1' },
     }))
-    const msg = await firstOfOrTimeout(browser, ['device:boot-error'])
+    const msg = await waitForTypeOrNull(browser, 'device:boot-error')
 
     expect(msg?.message).toBe('Session not found')
     expect(msg?.sessionId).toBe('no-such-session')

--- a/packages/relay/src/__tests__/appCommandErrors.test.ts
+++ b/packages/relay/src/__tests__/appCommandErrors.test.ts
@@ -45,7 +45,7 @@ describe('app command failures reach the caller (#445)', () => {
       type: 'agent:register',
       devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
     }))
-    const reply = await waitForType(agent, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
     const sessionId = reply.registeredSessions![0]!.sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/clearState.test.ts
+++ b/packages/relay/src/__tests__/clearState.test.ts
@@ -41,7 +41,7 @@ describe('app:clear-state relay routing', () => {
       type: 'agent:register',
       devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
     }))
-    const reply = await waitForType(agent, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
     const sessionId = reply.registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/clearState.test.ts
+++ b/packages/relay/src/__tests__/clearState.test.ts
@@ -6,21 +6,8 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 describe('app:clear-state relay routing', () => {
   let server: RelayServer

--- a/packages/relay/src/__tests__/clipboard.test.ts
+++ b/packages/relay/src/__tests__/clipboard.test.ts
@@ -41,7 +41,7 @@ describe('clipboard bridge relay routing', () => {
       type: 'agent:register',
       devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
     }))
-    const reply = await waitForType(agent, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
     const sessionId = reply.registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)
@@ -62,7 +62,7 @@ describe('clipboard bridge relay routing', () => {
       capabilities: ['clipboard'],
       devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
     }))
-    const reply = await waitForType(agent, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
     const sessionId = reply.registeredSessions![0].sessionId
 
     const browser = new WebSocket(`ws://localhost:${port}`)

--- a/packages/relay/src/__tests__/clipboard.test.ts
+++ b/packages/relay/src/__tests__/clipboard.test.ts
@@ -6,21 +6,8 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 describe('clipboard bridge relay routing', () => {
   let server: RelayServer

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -6,6 +6,7 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type { RelayMessage } from '../types'
 
 
 // #440: the relay replays `device:ready` so a browser that reconnects mid-stream gets a picture
@@ -45,7 +46,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
       type: 'agent:register',
       devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status }],
     }))
-    const reply = await waitForType(agent, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
     return { agent, sessionId: reply.registeredSessions![0]!.sessionId }
   }
 

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -6,41 +6,8 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
+import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) { ws.off('message', listener); resolve(msg) }
-    }
-    ws.on('message', listener)
-  })
-
-/** Records every message of `type` from the moment it is attached. Paired with a round-trip
- *  barrier below, this answers "did it arrive" without waiting on a clock: the replay is written
- *  synchronously alongside `session:joined`, so anything that was coming has already been queued
- *  by the time a later request completes. */
-function collect(ws: WebSocket, type: string): { got: () => RelayMessage | null } {
-  let seen: RelayMessage | null = null
-  ws.on('message', (data: Buffer) => {
-    const msg = JSON.parse(data.toString()) as RelayMessage
-    if (msg.type === type) seen ??= msg
-  })
-  return { got: () => seen }
-}
-
-/** A round-trip on one socket. WebSocket preserves order within a connection, so once the reply
- *  lands the relay has finished everything sent before it. The agent and the browser are separate
- *  connections with no ordering between them, so lifecycle messages sent on the agent socket need
- *  this before the browser acts on their effect — a sleep would only make that likely. */
-async function barrier(ws: WebSocket): Promise<void> {
-  const done = waitForType(ws, 'agents:listed')
-  ws.send(JSON.stringify({ type: 'agents:list' }))
-  await done
-}
 
 // #440: the relay replays `device:ready` so a browser that reconnects mid-stream gets a picture
 // without waiting for the next boot. The condition for that has to be "this session announced a
@@ -86,10 +53,12 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
   async function joinAs(sessionId: string) {
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
-    const ready = collect(browser, 'device:ready')
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForType(browser, 'session:joined')
+    // The barrier proves the relay is done with the join, so whatever it was going to send is
+    // already recorded — `waitForTypeOrNull` reads that recording rather than racing it.
     await barrier(browser)
+    const ready = await waitForTypeOrNull(browser, 'device:ready', 0)
     return { browser, ready }
   }
 
@@ -99,7 +68,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const { browser, ready } = await joinAs(sessionId)
 
     // Before this fix the viewer was told the device was ready here, with no stream behind it.
-    expect(ready.got()).toBeNull()
+    expect(ready).toBeNull()
 
     agent.close(); browser.close()
   })
@@ -118,9 +87,8 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     const idrPromise = waitForType(agent, 'stream:request-idr')
     const { browser, ready } = await joinAs(sessionId)
 
-    const msg = ready.got()
-    expect(msg).not.toBeNull()
-    expect((msg!.payload as { deviceId: string }).deviceId).toBe('devA')
+    expect(ready).not.toBeNull()
+    expect((ready!.payload as { deviceId: string }).deviceId).toBe('devA')
 
     const idr = await idrPromise
     expect(idr.sessionId).toBe(sessionId)
@@ -136,7 +104,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
 
     const { browser, ready } = await joinAs(sessionId)
 
-    expect(ready.got()).toBeNull()
+    expect(ready).toBeNull()
 
     agent.close(); browser.close()
   })
@@ -151,7 +119,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
 
     const { browser, ready } = await joinAs(sessionId)
 
-    expect(ready.got()).toBeNull()
+    expect(ready).toBeNull()
 
     agent.close(); browser.close()
   })
@@ -175,7 +143,7 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
 
     const { browser, ready } = await joinAs(sessionId)
 
-    expect(ready.got()).toBeNull()
+    expect(ready).toBeNull()
 
     agent.close(); browser.close()
   })

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
-import type { RelayMessage } from '../types'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 
 

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -340,7 +340,7 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     const agent1 = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent1)
     agent1.send(JSON.stringify({ type: 'agent:register', agentId: 'uuid-1', platform: 'ios', devices }))
-    const reply = await waitForType(agent1, 'agent:registered')
+    const reply = await waitForType<RelayMessage>(agent1, 'agent:registered')
     const sessionId = reply.registeredSessions![0].sessionId
 
     // On the screenshot request, the same Mac reconnects on a fresh socket → evicts agent1.

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -8,24 +8,11 @@ import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
 import { signJwt } from '../middleware/auth'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
 const FAKE_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) // PNG magic bytes
 const FAKE_JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0]) // JPEG magic bytes
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 function makeAuthCookie(): string {
   return `tapflow_token=${signJwt({ userId: 1, email: 'test@example.com', role: 'Admin' })}`

--- a/packages/relay/src/__tests__/socketHelpers.test.ts
+++ b/packages/relay/src/__tests__/socketHelpers.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import { waitForOpen, waitForType, waitForMessage, waitForTypeOrNull, barrier } from '@tapflowio/test-utils'
+
+// The helpers in @tapflowio/test-utils exist to remove one specific failure: asking for a reply
+// after it has already arrived. The old shape (`ws.once('message')`) lost it silently and the test
+// died on a timeout pointing at the assertion. These cases pin the property that replaces it —
+// without them the package is a refactor with nothing holding its claim.
+describe('socket test helpers are order-proof (#452)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-socket-helpers-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  async function connected() {
+    const ws = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(ws)
+    return ws
+  }
+
+  it('finds a message that arrived before it was asked for', async () => {
+    const ws = await connected()
+
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    // Round-trip on something else first, so the reply is definitely in already. This is the
+    // ordering that used to lose it.
+    await barrier(ws)
+
+    await expect(waitForType(ws, 'agents:listed')).resolves.toMatchObject({ type: 'agents:listed' })
+
+    ws.close()
+  })
+
+  it('still waits for one that has not arrived yet', async () => {
+    const ws = await connected()
+
+    const pending = waitForType(ws, 'agents:listed')
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+
+    await expect(pending).resolves.toMatchObject({ type: 'agents:listed' })
+
+    ws.close()
+  })
+
+  it('hands two waits for one type two different messages', async () => {
+    // Matched messages leave the recording. Without that, a second wait would be answered by the
+    // first message and a test could pass without the second one ever being sent.
+    const ws = await connected()
+
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    await barrier(ws)
+
+    const first = await waitForType(ws, 'agents:listed')
+    const second = await waitForTypeOrNull(ws, 'agents:listed', 500)
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+    expect(second).not.toBe(first)
+
+    ws.close()
+  })
+
+  it('reports absence without waiting out the clock', async () => {
+    const ws = await connected()
+    await barrier(ws)
+
+    const started = process.hrtime.bigint()
+    const missing = await waitForTypeOrNull(ws, 'device:ready', 0)
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
+
+    expect(missing).toBeNull()
+    // The barrier is what makes 0 a valid budget: everything the relay was going to send has been
+    // sent. A test that needs a real timeout here has not established anything.
+    expect(elapsedMs).toBeLessThan(100)
+
+    ws.close()
+  })
+
+  it('waitForMessage takes the oldest unclaimed message', async () => {
+    const ws = await connected()
+
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    await barrier(ws)
+
+    await expect(waitForMessage(ws)).resolves.toMatchObject({ type: 'agents:listed' })
+
+    ws.close()
+  })
+})

--- a/packages/relay/src/__tests__/socketHelpers.test.ts
+++ b/packages/relay/src/__tests__/socketHelpers.test.ts
@@ -9,8 +9,12 @@ import { waitForOpen, waitForType, waitForMessage, waitForTypeOrNull, barrier } 
 
 // The helpers in @tapflowio/test-utils exist to remove one specific failure: asking for a reply
 // after it has already arrived. The old shape (`ws.once('message')`) lost it silently and the test
-// died on a timeout pointing at the assertion. These cases pin the property that replaces it —
-// without them the package is a refactor with nothing holding its claim.
+// died on a timeout pointing at the assertion. These cases pin the property that replaces it.
+//
+// None of them use `barrier` to establish "has already arrived" — barrier is one of the things
+// under test, and using it here would let a broken barrier prove itself. Ordering comes from the
+// socket instead: an invalid `session:start` is answered with `error`, and WebSocket preserves
+// order within a connection, so once that reply lands anything sent before it has landed too.
 describe('socket test helpers are order-proof (#452)', () => {
   let server: RelayServer
   let port: number
@@ -40,13 +44,18 @@ describe('socket test helpers are order-proof (#452)', () => {
     return ws
   }
 
+  /** Sends a request that is answered with `error`, and waits for it. Anything sent earlier on
+   *  this socket has arrived by the time it resolves. */
+  async function sentinel(ws: WebSocket): Promise<void> {
+    ws.send(JSON.stringify({ type: 'session:start', sessionId: 'no-such-session' }))
+    await waitForType(ws, 'error')
+  }
+
   it('finds a message that arrived before it was asked for', async () => {
     const ws = await connected()
 
     ws.send(JSON.stringify({ type: 'agents:list' }))
-    // Round-trip on something else first, so the reply is definitely in already. This is the
-    // ordering that used to lose it.
-    await barrier(ws)
+    await sentinel(ws) // the agents:listed is now definitely in
 
     await expect(waitForType(ws, 'agents:listed')).resolves.toMatchObject({ type: 'agents:listed' })
 
@@ -71,10 +80,10 @@ describe('socket test helpers are order-proof (#452)', () => {
 
     ws.send(JSON.stringify({ type: 'agents:list' }))
     ws.send(JSON.stringify({ type: 'agents:list' }))
-    await barrier(ws)
+    await sentinel(ws)
 
-    const first = await waitForType(ws, 'agents:listed')
-    const second = await waitForTypeOrNull(ws, 'agents:listed', 500)
+    const first = await waitForTypeOrNull(ws, 'agents:listed', 0)
+    const second = await waitForTypeOrNull(ws, 'agents:listed', 0)
 
     expect(first).not.toBeNull()
     expect(second).not.toBeNull()
@@ -83,18 +92,14 @@ describe('socket test helpers are order-proof (#452)', () => {
     ws.close()
   })
 
-  it('reports absence without waiting out the clock', async () => {
+  it('reports absence from the recording, without a live message to find', async () => {
     const ws = await connected()
-    await barrier(ws)
+    await sentinel(ws)
 
-    const started = process.hrtime.bigint()
-    const missing = await waitForTypeOrNull(ws, 'device:ready', 0)
-    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
-
-    expect(missing).toBeNull()
-    // The barrier is what makes 0 a valid budget: everything the relay was going to send has been
-    // sent. A test that needs a real timeout here has not established anything.
-    expect(elapsedMs).toBeLessThan(100)
+    // Budget 0: the sentinel proves the relay has answered everything sent so far, so anything
+    // absent from the recording is absent, full stop. A test that needs a real timeout here has
+    // established nothing about what the relay did.
+    expect(await waitForTypeOrNull(ws, 'device:ready', 0)).toBeNull()
 
     ws.close()
   })
@@ -103,10 +108,51 @@ describe('socket test helpers are order-proof (#452)', () => {
     const ws = await connected()
 
     ws.send(JSON.stringify({ type: 'agents:list' }))
-    await barrier(ws)
+    await sentinel(ws)
 
+    // agents:listed was sent first, so it is what comes out — not the sentinel's error, which is
+    // already consumed, and not whichever arrives next.
     await expect(waitForMessage(ws)).resolves.toMatchObject({ type: 'agents:listed' })
 
     ws.close()
+  })
+
+  it('barrier waits for its own reply, not one already in the recording', async () => {
+    // barrier registers a waiter before sending and never reads the queue. Reading the queue would
+    // let it return on an `agents:listed` a test had queued earlier — no round-trip, nothing
+    // proven, and the test's own message eaten.
+    //
+    // Registering an agent between the two requests is what makes that visible: the queued reply
+    // lists no sessions, barrier's own reply lists one. Counting messages cannot tell the two
+    // apart, because a barrier that eats the first still leaves its own behind.
+    const ws = await connected()
+
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    await sentinel(ws)
+
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }],
+    }))
+    await waitForType(agent, 'agent:registered')
+
+    await barrier(ws)
+
+    const queued = await waitForTypeOrNull(ws, 'agents:listed', 0)
+    expect(queued).not.toBeNull()
+    // The one from before the agent existed. A barrier that took it would leave its own reply
+    // here, which lists the agent.
+    expect(queued!.sessions ?? []).toHaveLength(0)
+
+    agent.close(); ws.close()
+  })
+
+  it('rejects instead of hanging when the socket cannot connect', async () => {
+    // Port 1 is not listening. Without the error branch this waits out the suite timeout and the
+    // failure names the assertion rather than the connection.
+    const ws = new WebSocket('ws://127.0.0.1:1')
+    await expect(waitForOpen(ws)).rejects.toThrow()
   })
 })

--- a/packages/relay/src/__tests__/uiTree.test.ts
+++ b/packages/relay/src/__tests__/uiTree.test.ts
@@ -76,10 +76,10 @@ describe('GET /api/v1/sessions/:sessionId/ui-tree', () => {
     const agent = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(agent)
     agent.send(JSON.stringify({ type: 'agent:register', devices }))
-    const reply = await new Promise<RelayMessage>((resolve) =>
-      agent.once('message', (d) => resolve(JSON.parse(d.toString()))),
-    )
-    const sessionId = reply.registeredSessions![0].sessionId
+    // Through the shared recorder, not a raw `once`: the recorder queues the frame either way, and
+    // consuming it here keeps a later wait on this socket from finding it.
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
+    const sessionId = reply.registeredSessions![0]!.sessionId
     return { agent, sessionId }
   }
 

--- a/packages/relay/src/__tests__/uiTree.test.ts
+++ b/packages/relay/src/__tests__/uiTree.test.ts
@@ -8,6 +8,7 @@ import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage, UIElement } from '../types'
 import { signJwt } from '../middleware/auth'
+import { waitForOpen, waitForType } from '@tapflowio/test-utils'
 
 const ELEMENTS: UIElement[] = [
   {
@@ -20,20 +21,6 @@ const ELEMENTS: UIElement[] = [
   },
 ]
 
-const waitForOpen = (ws: WebSocket) =>
-  new Promise<void>((resolve) => ws.once('open', resolve))
-
-const waitForType = (ws: WebSocket, type: string) =>
-  new Promise<RelayMessage>((resolve) => {
-    const listener = (data: Buffer) => {
-      const msg = JSON.parse(data.toString()) as RelayMessage
-      if (msg.type === type) {
-        ws.off('message', listener)
-        resolve(msg)
-      }
-    }
-    ws.on('message', listener)
-  })
 
 function makeAuthCookie(): string {
   return `tapflow_token=${signJwt({ userId: 1, email: 'test@example.com', role: 'Admin' })}`

--- a/packages/test-utils/AGENTS.md
+++ b/packages/test-utils/AGENTS.md
@@ -31,6 +31,11 @@ await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
 
 Matched messages leave the recording, so two waits for one type see two different messages.
 
+**It is a queue, not a broadcast** — a change from the per-call listeners it replaced, where every
+listener saw every message. A message now goes to exactly one waiter, so a pending `waitForMessage`
+will take one that a concurrent `waitForType` was waiting for. Register the specific wait first, or
+keep the two apart.
+
 **`waitForOpen` is what starts the recording.** A socket that skips it still works — the other helpers begin recording on first use — but only from that call onwards, so anything earlier is genuinely gone. Route every socket through it.
 
 ### Assert absence with a barrier, not a timeout

--- a/packages/test-utils/AGENTS.md
+++ b/packages/test-utils/AGENTS.md
@@ -49,6 +49,13 @@ expect(await waitForTypeOrNull(ws, 'device:ready', 0)).toBeNull()
 
 Two sockets have no ordering between them — an agent's `device:ready` and a browser's `session:start` can be handled in either order. A test that depends on one preceding the other needs `barrier` on the **sending** socket.
 
+### Narrowing is available but unused
+
+`waitForType<RelayMessage>(…)` works. Almost nothing does it, because every package excludes
+`src/__tests__` from `tsc` — a test file's types are stripped, never checked — so the narrowing
+would be decorative. The parameter exists so that bringing tests under `tsc` is a config change
+rather than a rewrite.
+
 ## HOW NOT
 
 - Do not import this from production code. It is `private` and unbuilt; a `src/` import would fail at publish time, not at review time.

--- a/packages/test-utils/AGENTS.md
+++ b/packages/test-utils/AGENTS.md
@@ -1,0 +1,51 @@
+# test-utils — AGENTS.md
+
+> Common rules: [AGENTS.md](../../AGENTS.md) | Full index: [INDEX.md](../../INDEX.md)
+
+---
+
+## WHAT
+
+Test-only helpers shared across packages. `private: true` — never published, and **nothing under any package's `src/` may import it**. The only consumers are vitest suites.
+
+No build step. `main` points at TypeScript source, because vitest transforms it anyway; a `dist/` would drag this package into the production build order for nothing. It is also outside `changeset:check`, which is correct — there is no published surface to version.
+
+## WHY
+
+Socket helpers had been copy-pasted into nine test files. The copies drifted apart, and the defect they shared had to be found three separate times before it was fixed once (#452).
+
+## HOW
+
+### Socket helpers are order-proof by construction
+
+`ws.once('message', …)` only sees what arrives *after* it is attached, so waiting for a reply after sending the request loses it — and the symptom is a timeout pointing at the assertion, not at the ordering.
+
+These record from the moment the socket opens and answer from the recording, so asking after the fact behaves exactly like asking before:
+
+```ts
+const ws = new WebSocket(url)
+await waitForOpen(ws)          // recording starts here
+ws.send(JSON.stringify({ type: 'device:boot', … }))
+await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
+```
+
+Matched messages leave the recording, so two waits for one type see two different messages.
+
+**`waitForOpen` is what starts the recording.** A socket that skips it still works — the other helpers begin recording on first use — but only from that call onwards, so anything earlier is genuinely gone. Route every socket through it.
+
+### Assert absence with a barrier, not a timeout
+
+`waitForTypeOrNull` exists, but a round-trip proves the same thing in milliseconds instead of guessing with a clock:
+
+```ts
+await barrier(ws)                                   // relay has finished everything sent before
+expect(await waitForTypeOrNull(ws, 'device:ready', 0)).toBeNull()
+```
+
+Two sockets have no ordering between them — an agent's `device:ready` and a browser's `session:start` can be handled in either order. A test that depends on one preceding the other needs `barrier` on the **sending** socket.
+
+## HOW NOT
+
+- Do not import this from production code. It is `private` and unbuilt; a `src/` import would fail at publish time, not at review time.
+- Do not add a `dist/` or a build script. That is what keeps it out of the Docker build order.
+- Do not reintroduce a local `waitForType` in a test file. That is the state this package replaced.

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,0 +1,14 @@
+# @tapflowio/test-utils
+
+Test-only helpers shared across tapflow packages. `private: true` — never published, and nothing
+in `src/` of any package may import it.
+
+There is no build step. `main` points at TypeScript source because the only consumers are vitest
+suites, which transform it themselves; adding a `dist/` would put this package into the production
+build order for no reason.
+
+## Why this exists
+
+Socket test helpers were copy-pasted into nine files. The copies drifted, and a defect in the
+shape they share — `ws.once('message')` cannot see a message that already arrived — had to be
+found three separate times before it was fixed once. See #452.

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,9 +9,11 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "lint": "eslint src"
   },
   "devDependencies": {
+    "@types/node": "^20.19.43",
     "@types/ws": "^8.0.0",
     "typescript": "^5.0.0",
     "ws": "^8.18.0"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tapflowio/test-utils",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Test-only helpers shared across tapflow packages. Never published, never imported by production code.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint src"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.0.0",
+    "typescript": "^5.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  waitForOpen,
+  waitForType,
+  waitForMessage,
+  waitForTypeOrNull,
+  barrier,
+  type SocketMessage,
+} from './socket.js'

--- a/packages/test-utils/src/socket.ts
+++ b/packages/test-utils/src/socket.ts
@@ -1,0 +1,128 @@
+import type { WebSocket } from 'ws'
+
+/** The shape every tapflow socket message shares. Deliberately loose: this package is imported by
+ *  relay, ios-agent and android-agent, and each has its own richer view of the wire. */
+export type SocketMessage = Record<string, unknown> & { type: string }
+
+/**
+ * Order-proof socket helpers for tapflow tests.
+ *
+ * **Why these exist rather than a `ws.once('message')` in each file.** The obvious shape —
+ * "attach a listener, wait for the message" — only works if you attach before the message is sent.
+ * Get the order wrong and nothing tells you: the listener sits on a reply that already went past,
+ * and the test dies on a timeout pointing at the assertion instead of the cause. That mistake
+ * happened three times in one branch (#452), twice with a correct example a few lines above.
+ *
+ * So these record instead of listening. From the moment a socket is opened, every message it
+ * receives is either handed to a waiter or kept, and `waitForType` looks in the recording first.
+ * Asking after the fact works exactly like asking before it:
+ *
+ * ```ts
+ * const ws = new WebSocket(url)
+ * await waitForOpen(ws)
+ * ws.send(JSON.stringify({ type: 'device:boot', ... }))
+ * await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
+ * ```
+ *
+ * Matched messages are removed from the recording, so two waits for the same type see two
+ * different messages — the same semantics the old per-call listeners had.
+ */
+
+type Waiter = { type: string | null; resolve: (msg: SocketMessage) => void }
+type Recording = { queued: SocketMessage[]; waiters: Waiter[] }
+
+const recordings = new WeakMap<WebSocket, Recording>()
+
+/** Idempotent: a socket recorded twice would deliver every message twice. */
+function record(ws: WebSocket): Recording {
+  const existing = recordings.get(ws)
+  if (existing) return existing
+
+  const rec: Recording = { queued: [], waiters: [] }
+  recordings.set(ws, rec)
+
+  ws.on('message', (data: Buffer, isBinary: boolean) => {
+    // Stream frames share this socket in some tests and are not JSON.
+    if (isBinary) return
+    let msg: SocketMessage
+    try {
+      msg = JSON.parse(data.toString()) as SocketMessage
+    } catch {
+      return
+    }
+    const i = rec.waiters.findIndex((w) => w.type === null || w.type === msg.type)
+    if (i >= 0) {
+      rec.waiters.splice(i, 1)[0]!.resolve(msg)
+      return
+    }
+    rec.queued.push(msg)
+  })
+
+  return rec
+}
+
+/**
+ * Waits for the socket to open, and starts recording everything it receives from that point.
+ *
+ * Every socket in these suites goes through here, which is what makes `waitForType` order-proof.
+ * A socket that skips it still works — the helpers below start recording on first use — but only
+ * from that call onwards, so anything that arrived earlier is genuinely gone.
+ */
+export const waitForOpen = (ws: WebSocket): Promise<void> => {
+  record(ws)
+  return new Promise((resolve) => ws.once('open', resolve))
+}
+
+/** The next message of `type`, taken from the recording if it has already arrived. */
+export function waitForType(ws: WebSocket, type: string): Promise<SocketMessage> {
+  const rec = record(ws)
+  const i = rec.queued.findIndex((m) => m.type === type)
+  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]!)
+  return new Promise((resolve) => rec.waiters.push({ type, resolve }))
+}
+
+/** The next message of any type. Same recording, same ordering guarantee. */
+export function waitForMessage(ws: WebSocket): Promise<SocketMessage> {
+  const rec = record(ws)
+  if (rec.queued.length > 0) return Promise.resolve(rec.queued.shift()!)
+  return new Promise((resolve) => rec.waiters.push({ type: null, resolve }))
+}
+
+/**
+ * Resolves with the message, or `null` after `ms`.
+ *
+ * For asserting a message does **not** arrive. Prefer {@link barrier} where one fits: a round-trip
+ * proves the relay has finished with everything sent before it, which is an answer rather than a
+ * guess, and it costs milliseconds instead of the timeout.
+ */
+export function waitForTypeOrNull(ws: WebSocket, type: string, ms = 1000): Promise<SocketMessage | null> {
+  const rec = record(ws)
+  const i = rec.queued.findIndex((m) => m.type === type)
+  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]!)
+  return new Promise((resolve) => {
+    const waiter: Waiter = { type, resolve: (m) => { clearTimeout(timer); resolve(m) } }
+    rec.waiters.push(waiter)
+    const timer = setTimeout(() => {
+      const j = rec.waiters.indexOf(waiter)
+      if (j >= 0) rec.waiters.splice(j, 1)
+      resolve(null)
+    }, ms)
+  })
+}
+
+/**
+ * A round-trip on one socket.
+ *
+ * WebSocket preserves order within a connection, so once the reply lands the relay has processed
+ * everything sent before it. Two sockets have no ordering between them — an agent's
+ * `device:ready` and a browser's `session:start` can be handled in either order — so a test that
+ * depends on one preceding the other needs this on the *sending* socket. A sleep only makes it
+ * likely.
+ *
+ * `agents:list` is used because it is answered on the same socket regardless of role.
+ */
+export async function barrier(ws: WebSocket): Promise<void> {
+  const done = waitForType(ws, 'agents:listed')
+  ws.send(JSON.stringify({ type: 'agents:list' }))
+  await done
+}

--- a/packages/test-utils/src/socket.ts
+++ b/packages/test-utils/src/socket.ts
@@ -25,7 +25,18 @@ export type SocketMessage = Record<string, unknown> & { type: string }
  * ```
  *
  * Matched messages are removed from the recording, so two waits for the same type see two
- * different messages — the same semantics the old per-call listeners had.
+ * different messages.
+ *
+ * **This is a queue, not a broadcast.** The old per-call listeners each saw every message, so two
+ * concurrent waits for one type both resolved from a single message. Here a message goes to
+ * exactly one waiter. Two consequences worth knowing:
+ *
+ * - A pending {@link waitForMessage} (which matches any type) takes the next message even if a
+ *   {@link waitForType} for that exact type is also waiting. Register the specific one first, or
+ *   do not mix them on a socket where it matters.
+ * - A {@link waitForTypeOrNull} that times out leaves nothing behind, but a message arriving after
+ *   that goes into the recording and will answer a later wait on the same socket. That is usually
+ *   what you want; it is surprising if you expected the timeout to have consumed it.
  */
 
 type Waiter = { type: string | null; resolve: (msg: SocketMessage) => void }

--- a/packages/test-utils/src/socket.ts
+++ b/packages/test-utils/src/socket.ts
@@ -81,22 +81,36 @@ function record(ws: WebSocket): Recording {
  */
 export const waitForOpen = (ws: WebSocket): Promise<void> => {
   record(ws)
-  return new Promise((resolve) => ws.once('open', resolve))
+  return new Promise((resolve, reject) => {
+    // Without the error branch a refused connection hangs until the suite timeout, and the
+    // failure names the assertion rather than the socket.
+    const onError = (err: Error) => { ws.off('open', onOpen); reject(err) }
+    const onOpen = () => { ws.off('error', onError); resolve() }
+    ws.once('open', onOpen)
+    ws.once('error', onError)
+  })
 }
 
-/** The next message of `type`, taken from the recording if it has already arrived. */
-export function waitForType(ws: WebSocket, type: string): Promise<SocketMessage> {
+/**
+ * The next message of `type`, taken from the recording if it has already arrived.
+ *
+ * The type parameter lets a caller narrow to its own wire type — `waitForType<RelayMessage>(…)`.
+ * Most call sites do not, because test files are outside `tsc` (every package excludes
+ * `src/__tests__`), so the narrowing would be decorative today. It is here so that stops being
+ * true without a rewrite.
+ */
+export function waitForType<T extends SocketMessage = SocketMessage>(ws: WebSocket, type: string): Promise<T> {
   const rec = record(ws)
   const i = rec.queued.findIndex((m) => m.type === type)
-  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]!)
-  return new Promise((resolve) => rec.waiters.push({ type, resolve }))
+  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]! as T)
+  return new Promise((resolve) => rec.waiters.push({ type, resolve: (m) => resolve(m as T) }))
 }
 
 /** The next message of any type. Same recording, same ordering guarantee. */
-export function waitForMessage(ws: WebSocket): Promise<SocketMessage> {
+export function waitForMessage<T extends SocketMessage = SocketMessage>(ws: WebSocket): Promise<T> {
   const rec = record(ws)
-  if (rec.queued.length > 0) return Promise.resolve(rec.queued.shift()!)
-  return new Promise((resolve) => rec.waiters.push({ type: null, resolve }))
+  if (rec.queued.length > 0) return Promise.resolve(rec.queued.shift()! as T)
+  return new Promise((resolve) => rec.waiters.push({ type: null, resolve: (m) => resolve(m as T) }))
 }
 
 /**
@@ -106,12 +120,16 @@ export function waitForMessage(ws: WebSocket): Promise<SocketMessage> {
  * proves the relay has finished with everything sent before it, which is an answer rather than a
  * guess, and it costs milliseconds instead of the timeout.
  */
-export function waitForTypeOrNull(ws: WebSocket, type: string, ms = 1000): Promise<SocketMessage | null> {
+export function waitForTypeOrNull<T extends SocketMessage = SocketMessage>(
+  ws: WebSocket,
+  type: string,
+  ms = 1000,
+): Promise<T | null> {
   const rec = record(ws)
   const i = rec.queued.findIndex((m) => m.type === type)
-  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]!)
+  if (i >= 0) return Promise.resolve(rec.queued.splice(i, 1)[0]! as T)
   return new Promise((resolve) => {
-    const waiter: Waiter = { type, resolve: (m) => { clearTimeout(timer); resolve(m) } }
+    const waiter: Waiter = { type, resolve: (m) => { clearTimeout(timer); resolve(m as T) } }
     rec.waiters.push(waiter)
     const timer = setTimeout(() => {
       const j = rec.waiters.indexOf(waiter)
@@ -131,9 +149,16 @@ export function waitForTypeOrNull(ws: WebSocket, type: string, ms = 1000): Promi
  * likely.
  *
  * `agents:list` is used because it is answered on the same socket regardless of role.
+ *
+ * Registers its waiter *before* sending and never reads the queue: arriving messages go to a
+ * waiter ahead of the queue, so this consumes the reply to its own request. Going through
+ * `waitForType` would take an `agents:listed` a test had queued earlier and return without any
+ * round-trip having happened — the barrier would prove nothing.
  */
-export async function barrier(ws: WebSocket): Promise<void> {
-  const done = waitForType(ws, 'agents:listed')
-  ws.send(JSON.stringify({ type: 'agents:list' }))
-  await done
+export function barrier(ws: WebSocket): Promise<void> {
+  const rec = record(ws)
+  return new Promise((resolve) => {
+    rec.waiters.push({ type: 'agents:listed', resolve: () => resolve() })
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+  })
 }

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,6 +523,9 @@ importers:
 
   packages/test-utils:
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.43
+        version: 20.19.43
       '@types/ws':
         specifier: ^8.0.0
         version: 8.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@tapflowio/relay':
         specifier: workspace:*
         version: link:../relay
+      '@tapflowio/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: ^20.19.43
         version: 20.19.43
@@ -407,6 +410,9 @@ importers:
       '@tapflowio/relay':
         specifier: workspace:*
         version: link:../relay
+      '@tapflowio/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: ^20.19.43
         version: 20.19.43
@@ -487,6 +493,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@tapflowio/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -511,6 +520,18 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/test-utils:
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.0.0
+        version: 8.18.1
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.1
 
   playground:
     dependencies:


### PR DESCRIPTION
Closes #452.

<!-- no-changeset: test-only change; @tapflowio/test-utils is private and no published source is touched -->

`waitForType(ws, type)` attached its listener when called, so a reply that landed first was lost and the test died on a timeout pointing at the assertion rather than the ordering. I made that mistake three times in one branch, twice with a correct example a few lines above — reading material was not what was missing.

## What changed

The helpers **record from the moment a socket opens** and answer from the recording, so asking after the fact behaves exactly like asking before:

```ts
const ws = new WebSocket(url)
await waitForOpen(ws)          // recording starts here
ws.send(JSON.stringify({ type: 'device:boot', … }))
await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
```

**No call site changed.** Every socket already goes through `waitForOpen`, and the signatures are the same — 201 call sites, none touched. The work was deleting nine copies and importing one.

They live in `@tapflowio/test-utils`: `private: true`, no build step. `main` points at TypeScript source because vitest transforms it anyway, and a `dist/` would drag the package into the production build order for nothing.

An earlier attempt kept one copy per package, which would have preserved this issue's own defect at a smaller scale. The workspace package is the structural answer, and `@tapflowio/protocol` was the precedent.

## Two tests were relying on the old imprecision

- `returns open-url:error…` waited for "the next message", and a dead agent also produces a `session:terminated`. Recording surfaced the message that was previously being skipped. It waits by type now.
- `answers a boot the agent will never receive` — see below.

## Review found the interesting one

Record: `.work/reviews/test__order-proof-socket-helpers.md`.

The reviewer's first target — "recording will match a stale message" — was **disproved by instrumentation**: tracing the queue-hit path across three full suites showed exactly one queue hit, in the test that intends it. Everything else still resolves through a waiter, observing what it observed before.

But it found something better. I had removed a `Session not found` assertion, calling it timing-dependent. The reviewer said it was unrelated to this refactor and passed five times running. Half right — at **ten** runs it fails about once. So the assertion was neither safe to keep as it stood nor safe to drop: it is #445's guard that a stale session id is not reported as a dead Mac. The race predates this branch; closing an agent socket starts the relay's teardown and nothing orders it against the browser's next request. There is a wait for the eviction to be observable now, and twenty consecutive runs pass.

Weakening the assertion was the easy path, and it is exactly how a guard gets lost.

It also found that **nothing type-checked `packages/test-utils/src`** — not in the root `tsc -b` references, no `typecheck` script, and every consumer excludes `src/__tests__`. Proved by planting a type error and watching the gate pass. Wired in now; turning the check on immediately surfaced a missing `@types/node`.

Plus: a tenth copy of the order-dependent helper still living in one test file, undocumented queue-vs-broadcast semantics (a message now goes to exactly one waiter), and two dead imports that neither eslint nor tsc can see.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared WebSocket testing utilities for reliable message handling, ordering, and timeout assertions.
  * Added integration coverage for socket ordering and relay error scenarios, including unknown-session boot responses.

* **Bug Fixes**
  * Improved relay test synchronization and targeting of specific error messages.

* **Documentation**
  * Documented the private test utilities package and usage guidelines.

* **Chores**
  * Unified test helpers across Android, iOS, and relay test suites.
  * Added package type checking to the root validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->