### PR TITLE
feat(relay): keep a session alive across an agent restart

### DIFF
--- a/.changeset/session-rebind-relay.md
+++ b/.changeset/session-rebind-relay.md
@@ -1,0 +1,21 @@
+---
+"@tapflowio/relay": patch
+---
+
+Keep a session alive across an agent restart — the relay half (#426).
+
+Restarting a device agent ended every session it held: the browser was told `session:terminated` and sent back to the Mac list, losing its navigation for something that should have been invisible. The relay now recognises the restart for what it is on the wire — a second socket registering the same devices under the same identity — and re-points the session at it, keeping the id and telling the viewer with `session:rebound`, which the viewer answers with a fresh `device:boot`.
+
+Only devices the restarted agent still reports are kept. One that is gone gets the old treatment: its session ends and its viewer is told why.
+
+`SessionManager.rebind()` owns the whole move, rather than the call site doing it inline:
+
+- **The index order is load-bearing.** The session's id has to leave the old socket's set *before* `agentSocket` is reassigned. Following the idiom in `remove()` — dereferencing the index through `session.agentSocket` — deletes it from the new set and leaves the old one holding it, so the old socket's close, which the relay itself triggers, evicts the session that was just re-pointed.
+- **Agent-derived fields now have one writer.** `create()` and `rebind()` both take them from a single function, so a field added to a session cannot land on one path only — and `rebind` is the path that would be missed.
+- Capabilities are refreshed, because an upgrade is the usual reason to restart an agent and `session:joined` is only sent once. The device's reported status is refreshed too: left stale, a device that came back down still reads `booted` to the REST guards.
+- `readySent` goes false. Carried across, a browser joining just after the restart would be replayed a `device:ready` for a stream that died with the old process.
+- The old socket's resource entry is dropped. `evictAgentSocket` normally does this, but it returns early when the socket has no sessions left — exactly the case where all of them were rebound — so the map would otherwise keep a dead socket per restart.
+
+Two things that used to be handled by the eviction the rebind now skips: in-flight screenshot and UI-tree requests are rejected outright instead of waiting out their timeout, and a device that gets a new session is left out of `create()` so the same simulator cannot end up behind two of them. `agent:registered` pairs devices with sessions by id rather than by position, which stops holding the moment some devices are rebound and others are new.
+
+Also answers a terminal input the agent would have silently dropped. A restarted agent holds no state for a session until it is asked to boot, and an input for a session it does not know is discarded with no ack — while the relay's existing "agent offline" reply stays quiet, because the socket is open and healthy. The caller was left to time out, which the MCP client reports as success. It now gets `input:error` with `device not ready`.

--- a/.changeset/session-rebind-relay.md
+++ b/.changeset/session-rebind-relay.md
@@ -18,4 +18,4 @@ Only devices the restarted agent still reports are kept. One that is gone gets t
 
 Two things that used to be handled by the eviction the rebind now skips: in-flight screenshot and UI-tree requests are rejected outright instead of waiting out their timeout, and a device that gets a new session is left out of `create()` so the same simulator cannot end up behind two of them. `agent:registered` pairs devices with sessions by id rather than by position, which stops holding the moment some devices are rebound and others are new.
 
-Also answers a terminal input the agent would have silently dropped. A restarted agent holds no state for a session until it is asked to boot, and an input for a session it does not know is discarded with no ack — while the relay's existing "agent offline" reply stays quiet, because the socket is open and healthy. The caller was left to time out, which the MCP client reports as success. It now gets `input:error` with `device not ready`.
+A device named twice in one register payload now gets one session rather than two, one of which the agent was never told about — the same orphan the rebind prevents, arriving by a different door.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -689,6 +689,7 @@ export class RelayServer {
           if (msg.type === 'device:boot' && msg.payload && typeof msg.payload === 'object') {
             (msg.payload as Record<string, unknown>).external = this.wsExternal.get(ws) ?? false
           }
+          if (msg.type === 'device:boot') this.sessions.markBootRequested(session.id)
           session.agentSocket.send(JSON.stringify(msg))
         }
         break
@@ -725,13 +726,21 @@ export class RelayServer {
       case 'input:rotate':
       case 'input:keyboard:toggle': {
         const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
+        const agentUp = session?.agentSocket.readyState === WebSocket.OPEN
+        // An agent that has never been asked to boot this session holds no state for it and drops
+        // the input without acking — so forwarding a terminal input there buys silence. Answering
+        // is the same courtesy as the offline case below, for a cause the caller cannot see: after
+        // a restart the socket is open and healthy, it is simply a different process (#426).
+        if (agentUp && (session.bootRequested || !TERMINAL_INPUT_TYPES.has(msg.type))) {
           session.agentSocket.send(JSON.stringify(msg))
         } else if (TERMINAL_INPUT_TYPES.has(msg.type) && ws.readyState === WebSocket.OPEN) {
           // Agent offline or session evicted: a terminal input can't be dispatched.
           // Reply to the sender (the MCP/browser socket) so it fails truthfully
           // instead of falling through to its optimistic 2s timeout.
-          this.sendTo(ws, { type: 'input:error', sessionId: msg.sessionId!, message: 'agent offline' })
+          this.sendTo(ws, {
+            type: 'input:error', sessionId: msg.sessionId!,
+            message: agentUp ? 'device not ready' : 'agent offline',
+          })
         }
         break
       }
@@ -783,6 +792,23 @@ export class RelayServer {
   }
 
   /**
+   * Settle every in-flight screenshot / UI-tree request belonging to these sessions. Both callers
+   * are moments where the agent that was going to answer them no longer exists — it disconnected,
+   * or it restarted and its session moved to the new process. Left alone these reject on their own
+   * timeout, minutes later, having told the caller nothing in between.
+   */
+  private rejectPending(sessionIds: Set<string>, reason: string): void {
+    for (const pendings of [this.pendingScreenshots, this.pendingUITrees]) {
+      for (const [reqId, pending] of pendings.entries()) {
+        if (!sessionIds.has(pending.sessionId)) continue
+        clearTimeout(pending.timer)
+        pendings.delete(reqId)
+        pending.reject(new Error(reason))
+      }
+    }
+  }
+
+  /**
    * @param cause  `'disconnect'` — the socket closed. `'replaced'` — the same agent re-registered
    *   and this is its previous socket. Only affects the log line: a restart otherwise reads as a
    *   crash followed by a recovery, which is not what happened.
@@ -790,21 +816,7 @@ export class RelayServer {
   private evictAgentSocket(ws: WebSocket, cause: 'disconnect' | 'replaced' = 'disconnect'): boolean {
     const agentSessions = this.sessions.getAllByAgentSocket(ws)
     if (agentSessions.length === 0) return false
-    const agentSessionIds = new Set(agentSessions.map((s) => s.id))
-    for (const [reqId, pending] of this.pendingScreenshots.entries()) {
-      if (agentSessionIds.has(pending.sessionId)) {
-        clearTimeout(pending.timer)
-        this.pendingScreenshots.delete(reqId)
-        pending.reject(new Error('Agent disconnected'))
-      }
-    }
-    for (const [reqId, pending] of this.pendingUITrees.entries()) {
-      if (agentSessionIds.has(pending.sessionId)) {
-        clearTimeout(pending.timer)
-        this.pendingUITrees.delete(reqId)
-        pending.reject(new Error('Agent disconnected'))
-      }
-    }
+    this.rejectPending(new Set(agentSessions.map((s) => s.id)), 'Agent disconnected')
     // Tell whoever is attached before the session stops existing — after `remove()` the socket
     // reference is gone. Without this the browser keeps a live socket addressed to a sessionId the
     // relay no longer knows, so everything it sends is dropped as unknown and nothing streams back:
@@ -835,21 +847,60 @@ export class RelayServer {
     // its socket before creating the new ones. Identity is agentId (unique per Mac) when present,
     // else agentName. (Heartbeat backstop for never-reconnecting agents: #313.)
     const identity = msg.agentId ?? msg.agentName
+    const devices = msg.devices ?? []
+    const agent = {
+      agentId: msg.agentId, agentName: msg.agentName,
+      agentPlatform: msg.platform, agentCapabilities: msg.capabilities,
+    }
+    // deviceId → the session id kept across the restart. Also the guard that a device is rebound at
+    // most once (#426): before rebinding existed, `create()` ran after every old session had been
+    // evicted, so one device could not be behind two sessions. It can now, and `list()` does not
+    // deduplicate — the second card would name a session the agent has never heard of, which is the
+    // symptom this whole change is fixing.
+    const rebound = new Map<string, string>()
     if (identity) {
       for (const old of this.sessions.getAgentSocketsByIdentity(identity, msg.platform)) {
         if (old === ws) continue
+        for (const s of this.sessions.getAllByAgentSocket(old)) {
+          if (rebound.has(s.deviceId)) continue
+          const device = devices.find((d) => d.id === s.deviceId)
+          // The device is gone from this agent's list — unplugged, deleted, renamed away. Leave it
+          // for the eviction below, which tells the browser the session ended.
+          if (!device) continue
+          this.sessions.rebind(s.id, ws, device, agent)
+          rebound.set(s.deviceId, s.id)
+        }
         // Evict before terminate: the old socket's close fires async, by which point its sessions are
         // gone and its in-flight screenshots would be undiscoverable — reject them here instead.
+        // The rebound sessions have already moved off `old`, so this no longer covers them.
         this.evictAgentSocket(old, 'replaced')
         old.terminate()
       }
     }
-    const sessionIds = this.sessions.create(ws, msg.devices ?? [], msg.agentName, msg.platform, msg.agentId, msg.capabilities)
-    const registeredSessions = (msg.devices ?? []).map((d, i) => ({
-      deviceId: d.id,
-      sessionId: sessionIds[i],
-    }))
+    // Their in-flight requests are addressed to a process that is gone, and the eviction above can
+    // no longer see them. Nothing else would ever settle these.
+    if (rebound.size > 0) this.rejectPending(new Set(rebound.values()), 'Agent restarted')
+
+    // Only devices without a surviving session get a new one. Passing all of them here is what
+    // would produce the duplicate card described above.
+    const fresh = devices.filter((d) => !rebound.has(d.id))
+    const freshIds = this.sessions.create(ws, fresh, msg.agentName, msg.platform, msg.agentId, msg.capabilities)
+    const byDeviceId = new Map(rebound)
+    fresh.forEach((d, i) => byDeviceId.set(d.id, freshIds[i]!))
+    // Keyed by deviceId, not by position. The old form paired `msg.devices[i]` with `sessionIds[i]`,
+    // which only held while every device got a session — now that some are rebound, the arrays have
+    // different lengths and index alignment would hand the agent someone else's session id.
+    const registeredSessions = devices.map((d) => ({ deviceId: d.id, sessionId: byDeviceId.get(d.id)! }))
     this.sendTo(ws, { type: 'agent:registered', registeredSessions })
+
+    // After the state is final: the browser answers this with `device:boot` on the same session id.
+    for (const sessionId of rebound.values()) {
+      const s = this.sessions.get(sessionId)
+      if (s?.browserSocket) {
+        this.sendTo(s.browserSocket, { type: 'session:rebound', sessionId, capabilities: msg.capabilities ?? [] })
+      }
+    }
+    if (rebound.size > 0) logger.info(`agent restarted — ${rebound.size} session(s) kept across the restart`)
     // The startup banner prints "Waiting for agents..." once and then the relay says nothing either
     // way, so a terminal gives no signal about whether an agent is attached. One line per
     // transition, matching the disconnect line in evictAgentSocket.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -689,7 +689,6 @@ export class RelayServer {
           if (msg.type === 'device:boot' && msg.payload && typeof msg.payload === 'object') {
             (msg.payload as Record<string, unknown>).external = this.wsExternal.get(ws) ?? false
           }
-          if (msg.type === 'device:boot') this.sessions.markBootRequested(session.id)
           session.agentSocket.send(JSON.stringify(msg))
         }
         break
@@ -726,21 +725,13 @@ export class RelayServer {
       case 'input:rotate':
       case 'input:keyboard:toggle': {
         const session = this.sessions.get(msg.sessionId!)
-        const agentUp = session?.agentSocket.readyState === WebSocket.OPEN
-        // An agent that has never been asked to boot this session holds no state for it and drops
-        // the input without acking — so forwarding a terminal input there buys silence. Answering
-        // is the same courtesy as the offline case below, for a cause the caller cannot see: after
-        // a restart the socket is open and healthy, it is simply a different process (#426).
-        if (agentUp && (session.bootRequested || !TERMINAL_INPUT_TYPES.has(msg.type))) {
+        if (session?.agentSocket.readyState === WebSocket.OPEN) {
           session.agentSocket.send(JSON.stringify(msg))
         } else if (TERMINAL_INPUT_TYPES.has(msg.type) && ws.readyState === WebSocket.OPEN) {
           // Agent offline or session evicted: a terminal input can't be dispatched.
           // Reply to the sender (the MCP/browser socket) so it fails truthfully
           // instead of falling through to its optimistic 2s timeout.
-          this.sendTo(ws, {
-            type: 'input:error', sessionId: msg.sessionId!,
-            message: agentUp ? 'device not ready' : 'agent offline',
-          })
+          this.sendTo(ws, { type: 'input:error', sessionId: msg.sessionId!, message: 'agent offline' })
         }
         break
       }
@@ -847,7 +838,11 @@ export class RelayServer {
     // its socket before creating the new ones. Identity is agentId (unique per Mac) when present,
     // else agentName. (Heartbeat backstop for never-reconnecting agents: #313.)
     const identity = msg.agentId ?? msg.agentName
-    const devices = msg.devices ?? []
+    // Deduplicate first. Everything below is keyed by device id, so a payload naming one device
+    // twice would collapse to a single entry in `registeredSessions` while `create()` had already
+    // made two sessions — leaving one the agent is never told about. That is the same orphan the
+    // rebind exists to prevent, arriving by a different door.
+    const devices = [...new Map((msg.devices ?? []).map((d) => [d.id, d])).values()]
     const agent = {
       agentId: msg.agentId, agentName: msg.agentName,
       agentPlatform: msg.platform, agentCapabilities: msg.capabilities,

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -25,6 +25,13 @@ export interface Session {
    *  starts from the agent's `simctl list` snapshot, so a simulator that was already running has a
    *  session marked `booted` before the agent has done anything for it (#440). */
   readySent: boolean
+  /** Whether the relay has forwarded a `device:boot` for this session to the agent socket it is
+   *  currently pointed at. Until it has, that agent holds no device state for the session and
+   *  drops its input without a word (`IOSAgent.handleRelayMessage`: `if (!state) break`) — so this
+   *  is what lets the relay answer instead of letting the caller time out. Distinct from
+   *  `readySent`, which also goes false when only the stream socket drops; the agent still has its
+   *  state then, and input still works. */
+  bootRequested: boolean
   deviceOsVersion?: string
   chromeData?: ChromePayload
   deviceInfo?: DeviceDetails
@@ -32,6 +39,14 @@ export interface Session {
 }
 
 type RawDevice = { id: string; name: string; platform: string; status: string; osVersion?: string }
+
+/** What an `agent:register` says about the agent itself, as opposed to its devices. */
+export type AgentIdentity = {
+  agentId?: string
+  agentName?: string
+  agentPlatform?: string
+  agentCapabilities?: string[]
+}
 
 const DEFAULT_IDLE_TIMEOUT_MS = parseInt(process.env['IDLE_TIMEOUT_MS'] ?? String(5 * 60 * 1000))
 
@@ -47,25 +62,42 @@ export class SessionManager {
     this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS
   }
 
+  /**
+   * The single place a session's agent-derived fields are computed. `create()` spreads it and
+   * `rebind()` assigns it, so neither one names these fields itself — adding one to `Session` has
+   * exactly one place it can be filled in, instead of two that must be kept in step. The rebind
+   * path is the one that would be forgotten, and nothing checks for it.
+   */
+  private static agentFields(
+    agent: AgentIdentity,
+    device: RawDevice,
+  ): Pick<Session, 'agentId' | 'agentName' | 'agentPlatform' | 'agentCapabilities' | 'deviceName' | 'deviceStatus' | 'deviceOsVersion'> {
+    return {
+      agentId: agent.agentId,
+      agentName: agent.agentName,
+      agentPlatform: agent.agentPlatform,
+      agentCapabilities: agent.agentCapabilities,
+      deviceName: device.name,
+      deviceStatus: device.status as DeviceStatus,
+      deviceOsVersion: device.osVersion,
+    }
+  }
+
   create(agentSocket: WebSocket, devices: RawDevice[] = [], agentName?: string, agentPlatform?: string, agentId?: string, agentCapabilities?: string[]): string[] {
     const agentIds = this.agentSocketIndex.get(agentSocket) ?? new Set<string>()
+    const agent: AgentIdentity = { agentId, agentName, agentPlatform, agentCapabilities }
     return devices.map((d) => {
       const id = randomUUID()
       this.sessions.set(id, {
         id,
-        agentId,
-        agentName,
-        agentPlatform,
-        agentCapabilities,
+        ...SessionManager.agentFields(agent, d),
         agentSocket,
         browserSocket: null,
         streamSocket: null,
         deviceId: d.id,
-        deviceName: d.name,
         devicePlatform: d.platform,
-        deviceStatus: d.status as DeviceStatus,
         readySent: false,
-        deviceOsVersion: d.osVersion,
+        bootRequested: false,
         idleTimer: null,
       })
       agentIds.add(id)
@@ -149,6 +181,51 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Re-point an existing session at the socket of an agent that just restarted, keeping its id.
+   *
+   * Everything a rebind touches lives here rather than at the call site, and that is deliberate:
+   * the index move below has an order requirement that is invisible where it is used, and the
+   * field refresh has to stay in step with `create()`. Written inline in `RelayServer`, the next
+   * field added to `create()` would be missed on this path alone, and silently.
+   */
+  rebind(sessionId: string, agentSocket: WebSocket, device: RawDevice, agent: AgentIdentity): void {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    const old = session.agentSocket
+
+    // Drop from the old socket's set BEFORE reassigning. `remove()` dereferences the index through
+    // `session.agentSocket`, and following that idiom here would delete the id from the *new* set
+    // and leave the old one holding it — so the old socket's close, which fires late after an
+    // unclean drop, would evict the session that was just re-pointed.
+    const oldIds = this.agentSocketIndex.get(old)
+    oldIds?.delete(sessionId)
+    if (oldIds?.size === 0) this.agentSocketIndex.delete(old)
+
+    session.agentSocket = agentSocket
+    const ids = this.agentSocketIndex.get(agentSocket) ?? new Set<string>()
+    ids.add(sessionId)
+    this.agentSocketIndex.set(agentSocket, ids)
+
+    // The stream died with the old process. `old.terminate()` only closes the control socket, so
+    // nothing else would clear this.
+    this.clearStreamSocket(sessionId)
+    // `clearStreamSocket` returns early when there is no stream socket, and a session that was
+    // never streamed has none — so this cannot be left to it.
+    session.readySent = false
+    // The new process has no device state for this session until it is asked to boot.
+    session.bootRequested = false
+
+    Object.assign(session, SessionManager.agentFields(agent, device))
+
+    // Not a carry-over guard — resources are keyed by socket, so re-pointing the session at a new
+    // one already leaves the old reading behind, and every reader goes through
+    // `session.agentSocket`. This is the leak: `evictAgentSocket` drops the entry, but it returns
+    // early when the socket has no sessions left, which is precisely the case where every one of
+    // them was rebound. Without this line the map keeps a dead socket per restart, forever.
+    this.agentResources.delete(old)
+  }
+
   setResources(agentSocket: WebSocket, resources: AgentResources): void {
     this.agentResources.set(agentSocket, resources)
   }
@@ -199,6 +276,11 @@ export class SessionManager {
   setDeviceInfo(sessionId: string, info: { deviceName: string; osVersion: string }): void {
     const session = this.sessions.get(sessionId)
     if (session) session.deviceInfo = info
+  }
+
+  markBootRequested(sessionId: string): void {
+    const session = this.sessions.get(sessionId)
+    if (session) session.bootRequested = true
   }
 
   setReadySent(sessionId: string, value: boolean): void {

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -25,13 +25,6 @@ export interface Session {
    *  starts from the agent's `simctl list` snapshot, so a simulator that was already running has a
    *  session marked `booted` before the agent has done anything for it (#440). */
   readySent: boolean
-  /** Whether the relay has forwarded a `device:boot` for this session to the agent socket it is
-   *  currently pointed at. Until it has, that agent holds no device state for the session and
-   *  drops its input without a word (`IOSAgent.handleRelayMessage`: `if (!state) break`) — so this
-   *  is what lets the relay answer instead of letting the caller time out. Distinct from
-   *  `readySent`, which also goes false when only the stream socket drops; the agent still has its
-   *  state then, and input still works. */
-  bootRequested: boolean
   deviceOsVersion?: string
   chromeData?: ChromePayload
   deviceInfo?: DeviceDetails
@@ -63,21 +56,24 @@ export class SessionManager {
   }
 
   /**
-   * The single place a session's agent-derived fields are computed. `create()` spreads it and
-   * `rebind()` assigns it, so neither one names these fields itself — adding one to `Session` has
-   * exactly one place it can be filled in, instead of two that must be kept in step. The rebind
-   * path is the one that would be forgotten, and nothing checks for it.
+   * The single place a session's fields are computed from an `agent:register`. `create()` spreads
+   * it and `rebind()` assigns it, so neither one names these fields itself — a field added here
+   * reaches both paths, and `rebind` is the one that would otherwise be forgotten.
+   *
+   * What is left out is what a register cannot change: the session's own id and sockets, and
+   * `deviceId`, which is the key the rebind matched on in the first place.
    */
   private static agentFields(
     agent: AgentIdentity,
     device: RawDevice,
-  ): Pick<Session, 'agentId' | 'agentName' | 'agentPlatform' | 'agentCapabilities' | 'deviceName' | 'deviceStatus' | 'deviceOsVersion'> {
+  ): Pick<Session, 'agentId' | 'agentName' | 'agentPlatform' | 'agentCapabilities' | 'deviceName' | 'devicePlatform' | 'deviceStatus' | 'deviceOsVersion'> {
     return {
       agentId: agent.agentId,
       agentName: agent.agentName,
       agentPlatform: agent.agentPlatform,
       agentCapabilities: agent.agentCapabilities,
       deviceName: device.name,
+      devicePlatform: device.platform,
       deviceStatus: device.status as DeviceStatus,
       deviceOsVersion: device.osVersion,
     }
@@ -95,9 +91,7 @@ export class SessionManager {
         browserSocket: null,
         streamSocket: null,
         deviceId: d.id,
-        devicePlatform: d.platform,
         readySent: false,
-        bootRequested: false,
         idleTimer: null,
       })
       agentIds.add(id)
@@ -213,8 +207,12 @@ export class SessionManager {
     // `clearStreamSocket` returns early when there is no stream socket, and a session that was
     // never streamed has none — so this cannot be left to it.
     session.readySent = false
-    // The new process has no device state for this session until it is asked to boot.
-    session.bootRequested = false
+    // Same argument as `readySent`, two fields over: `handleSessionStart` replays both to a browser
+    // that joins now, and both were measured by the process that just died. A viewer's own
+    // `device:boot` would clear them a moment later via `device:booting`, but an MCP-attached
+    // session never boots on its own and would keep them for as long as it lives.
+    session.chromeData = undefined
+    session.deviceInfo = undefined
 
     Object.assign(session, SessionManager.agentFields(agent, device))
 
@@ -276,11 +274,6 @@ export class SessionManager {
   setDeviceInfo(sessionId: string, info: { deviceName: string; osVersion: string }): void {
     const session = this.sessions.get(sessionId)
     if (session) session.deviceInfo = info
-  }
-
-  markBootRequested(sessionId: string): void {
-    const session = this.sessions.get(sessionId)
-    if (session) session.bootRequested = true
   }
 
   setReadySent(sessionId: string, value: boolean): void {

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -371,12 +371,53 @@ describe('SessionManager', () => {
       expect(sm.list()[0].devices[0].busy).toBe(false)
     })
 
-    it('separates sessions from different agents', () => {
+  })
+
+  describe('rebind()', () => {
+    const DEV = { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'booted' }
+    const AGENT = { agentId: 'mac-1', agentName: 'the-mac', agentPlatform: 'ios', agentCapabilities: ['clipboard'] }
+
+    it('moves the session off the old socket entirely', () => {
+      // The end-to-end tests observe the session surviving; this observes the index itself, which is
+      // what the survival rests on. An id left in the old socket's set is reachable by the eviction
+      // that runs on that socket's close.
       const sm = new SessionManager()
-      sm.create(mockSocket(), [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }], 'Mac1')
-      sm.create(mockSocket(), [{ id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' }], 'Mac2')
-      const listed = sm.list()
-      expect(listed).toHaveLength(2)
+      const oldWs = mockSocket()
+      const newWs = mockSocket()
+      const [id] = sm.create(oldWs, [DEV])
+
+      sm.rebind(id!, newWs, DEV, AGENT)
+
+      expect(sm.getAllByAgentSocket(oldWs)).toEqual([])
+      expect(sm.getAllByAgentSocket(newWs).map((x) => x.id)).toEqual([id])
+    })
+
+    it('keeps the other sessions on a socket that only lost one', () => {
+      const sm = new SessionManager()
+      const oldWs = mockSocket()
+      const [idA, idB] = sm.create(oldWs, [DEV, { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'booted' }])
+
+      sm.rebind(idA!, mockSocket(), DEV, AGENT)
+
+      expect(sm.getAllByAgentSocket(oldWs).map((x) => x.id)).toEqual([idB])
+    })
+
+    it('does nothing for a session id that no longer exists', () => {
+      // `handleAgentRegister` reads the sessions before it rebinds them, so a removal in between
+      // would otherwise index into undefined.
+      const sm = new SessionManager()
+      const ws = mockSocket()
+
+      expect(() => sm.rebind('no-such-session', ws, DEV, AGENT)).not.toThrow()
+      expect(sm.getAllByAgentSocket(ws)).toEqual([])
     })
   })
-})
+
+  it('separates sessions from different agents', () => {
+    const sm = new SessionManager()
+    sm.create(mockSocket(), [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }], 'Mac1')
+    sm.create(mockSocket(), [{ id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' }], 'Mac2')
+    const listed = sm.list()
+    expect(listed).toHaveLength(2)
+  })
+  })

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -357,7 +357,7 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
 
     const start = Date.now()
     const res = await httpGet(port, `/api/v1/sessions/${sessionId}/screenshot`, { Cookie: makeAuthCookie() })
-    expect(res.status).toBe(502)                 // rejected as Agent disconnected, not the 504 timeout
+    expect(res.status).toBe(502)                 // rejected outright, not left to the 504 timeout
     expect(Date.now() - start).toBeLessThan(300) // resolved before screenshotTimeoutMs
 
     agent1.close()

--- a/packages/relay/src/__tests__/sessionRebind.test.ts
+++ b/packages/relay/src/__tests__/sessionRebind.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type { RelayMessage } from '../types'
+
+// #426 stage 2. Restarting an agent used to end every session it held: the browser was told
+// `session:terminated` and sent back to the Mac list, losing its navigation for something that
+// should have been invisible. The relay now keeps the session and re-points it at the new socket,
+// telling the viewer with `session:rebound` — which the viewer answers with `device:boot` (PR1).
+//
+// A restart here is exactly what one is on the wire: a second socket registering the same devices
+// under the same identity. Nothing about it announces itself as a restart.
+describe('a session survives its agent restarting (#426)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-session-rebind-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  const DEV_A = { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'booted' }
+  const DEV_B = { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'booted' }
+
+  type Device = { id: string; name: string; platform: string; status: string }
+
+  /** One agent process. `agentId` is the machine identity, so a second call with the same one is
+   *  indistinguishable from a restart — which is the point. */
+  async function register(devices: Device[], capabilities: string[] = ['clipboard']) {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      agentId: 'mac-1', agentName: 'the-mac', platform: 'ios',
+      devices, capabilities,
+    }))
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
+    const byDevice = new Map(reply.registeredSessions!.map((r) => [r.deviceId, r.sessionId]))
+    return { agent, byDevice, registered: reply.registeredSessions! }
+  }
+
+  async function join(sessionId: string) {
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return browser
+  }
+
+  /** The device list as the dashboard sees it, flattened across agents. */
+  async function devices(ws: WebSocket) {
+    ws.send(JSON.stringify({ type: 'agents:list' }))
+    const listed = await waitForType<RelayMessage>(ws, 'agents:listed')
+    return (listed.sessions ?? []).flatMap((s) => s.devices)
+  }
+
+  it('keeps the session id and tells the viewer', async () => {
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browser = await join(sessionId)
+
+    const second = await register([DEV_A])
+
+    const rebound = await waitForType<RelayMessage>(browser, 'session:rebound')
+    expect(rebound.sessionId).toBe(sessionId)
+    // The same id came back to the agent too, or its own bookkeeping would point at a session the
+    // relay has since replaced.
+    expect(second.byDevice.get('devA')).toBe(sessionId)
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('does not tell the viewer its session ended', async () => {
+    // The old behaviour, and the reason the tab lost its place. `session:terminated` would arrive
+    // before `session:rebound`, so ordering cannot hide it.
+    const first = await register([DEV_A])
+    const browser = await join(first.byDevice.get('devA')!)
+
+    const second = await register([DEV_A])
+    await waitForType(browser, 'session:rebound')
+
+    expect(await waitForTypeOrNull(browser, 'session:terminated', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('leaves one card per device, not two', async () => {
+    // A rebound device must be left out of `create()`. `list()` does not deduplicate, so a second
+    // session for the same simulator becomes a second card — and it names an id the agent has never
+    // heard of, so it would never come up. That is the bug this change exists to remove.
+    const first = await register([DEV_A, DEV_B])
+    const second = await register([DEV_A, DEV_B])
+
+    const listed = await devices(second.agent)
+
+    expect(listed.map((d) => d.id).sort()).toEqual(['devA', 'devB'])
+
+    first.agent.close(); second.agent.close()
+  })
+
+  it('pairs every device with its own session id', async () => {
+    // `registeredSessions` used to pair `devices[i]` with `sessionIds[i]`. Once some devices are
+    // rebound the two arrays have different lengths, and position would hand the agent the wrong
+    // session for a device — silently, since both values are well-formed uuids.
+    const first = await register([DEV_A, DEV_B])
+    const keptA = first.byDevice.get('devA')!
+    const keptB = first.byDevice.get('devB')!
+
+    // devA is rebound, devC is new, devB is gone — every case at once. The rebound device goes
+    // *first* on purpose: that is the order where index alignment hands devA the freshly created
+    // session belonging to devC. A well-formed uuid for the wrong device is the failure that hides;
+    // put devA last and the misalignment merely runs off the end of the array and shows up as
+    // undefined.
+    const second = await register([DEV_A, { id: 'devC', name: 'iPhone C', platform: 'ios', status: 'booted' }])
+
+    expect(second.byDevice.get('devA')).toBe(keptA)
+    expect(second.byDevice.get('devC')).not.toBe(keptA)
+    expect(second.byDevice.get('devC')).not.toBe(keptB)
+    expect(second.registered).toHaveLength(2)
+
+    first.agent.close(); second.agent.close()
+  })
+
+  it('survives the old socket closing afterwards', async () => {
+    // The index move has an order requirement. Reassign `session.agentSocket` first and the id is
+    // deleted from the *new* socket's set while the old one keeps it — so this close, which fires
+    // late after an unclean drop, evicts the session that was just re-pointed. The relay terminates
+    // the old socket itself, so this is the ordinary path, not an exotic one.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browser = await join(sessionId)
+
+    const second = await register([DEV_A])
+    await waitForType(browser, 'session:rebound')
+    first.agent.close()
+    // Round-trip the new socket: the close above is processed in order relative to this reply.
+    await barrier(second.agent)
+
+    expect((await devices(second.agent)).map((d) => d.id)).toEqual(['devA'])
+    expect(await waitForTypeOrNull(browser, 'session:terminated', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('ends the session for a device the restarted agent no longer has', async () => {
+    // A rebind is not unconditional. A device that is gone — unplugged, deleted — has no session to
+    // keep, and its viewer has to be told rather than left waiting for a `session:rebound` that is
+    // never coming.
+    const first = await register([DEV_A])
+    const browser = await join(first.byDevice.get('devA')!)
+
+    const second = await register([DEV_B])
+
+    const ended = await waitForType<RelayMessage>(browser, 'session:terminated')
+    expect(ended.reason).toBe('agent-disconnected')
+    expect((await devices(second.agent)).map((d) => d.id)).toEqual(['devB'])
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('keeps the devices that stayed and drops the ones that went', async () => {
+    const first = await register([DEV_A, DEV_B])
+    const keptA = first.byDevice.get('devA')!
+    const browserA = await join(keptA)
+    const browserB = await join(first.byDevice.get('devB')!)
+
+    const second = await register([DEV_A])
+
+    expect((await waitForType<RelayMessage>(browserA, 'session:rebound')).sessionId).toBe(keptA)
+    await waitForType(browserB, 'session:terminated')
+    expect((await devices(second.agent)).map((d) => d.id)).toEqual(['devA'])
+
+    first.agent.close(); second.agent.close(); browserA.close(); browserB.close()
+  })
+
+  it('refreshes what the session records about its agent', async () => {
+    // An upgrade is the usual reason to restart an agent, so its capabilities are exactly what a
+    // restart is likely to change — and `session:joined` is sent once, so the viewer has no other
+    // way to learn the new set. The device's own reported state comes across too: left at the old
+    // value, a device that came back down would still read `booted` to the REST guards.
+    const first = await register([DEV_A], ['clipboard'])
+    const browser = await join(first.byDevice.get('devA')!)
+
+    const second = await register([{ ...DEV_A, name: 'iPhone A (renamed)', status: 'shutdown' }], ['clipboard', 'audio'])
+
+    const rebound = await waitForType<RelayMessage>(browser, 'session:rebound')
+    expect(rebound.capabilities).toEqual(['clipboard', 'audio'])
+    const [devA] = await devices(second.agent)
+    expect(devA!.status).toBe('shutdown')
+    expect(devA!.name).toBe('iPhone A (renamed)')
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('stops claiming the session is streaming', async () => {
+    // `readySent` is what the `device:ready` replay keys off. Carried across a restart, a browser
+    // joining just after would be handed a `device:ready` for a stream that died with the old
+    // process — a frozen frame that looks live, which is the symptom #426 opened with.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browserA = await join(sessionId)
+    first.agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await waitForType(browserA, 'device:ready')
+
+    const second = await register([DEV_A])
+    await waitForType(browserA, 'session:rebound')
+    browserA.close()
+
+    // Re-join: the replay fires here if the relay still believes it announced a stream.
+    const browserB = await join(sessionId)
+    await barrier(browserB)
+    expect(await waitForTypeOrNull(browserB, 'device:ready', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browserB.close()
+  })
+
+  it('does not hold the new agent to the old one\'s resource reading', async () => {
+    // `handleSessionStart` refuses a join when the agent's last resource report is over the
+    // threshold, and an overloaded Mac is a common reason to restart an agent — so this pins that
+    // restarting clears the refusal rather than inheriting it.
+    //
+    // What makes it pass is that resources are keyed by socket and every reader goes through
+    // `session.agentSocket`, so re-pointing the session leaves the old reading behind on its own.
+    // Deleting the old entry is a separate concern (a leak, see `rebind`) and mutating that line
+    // away does not fail this test — measured, not assumed. Kept because the behaviour is worth
+    // holding still whatever implements it.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    first.agent.send(JSON.stringify({
+      type: 'agent:resources',
+      resources: {
+        cpuPercent: 99, memUsedMB: 15_000, memTotalMB: 16_000,
+        slotsAvailable: 0, slotsTotal: 2, reportedAt: 1_754_000_000_000,
+      },
+    }))
+    await barrier(first.agent)
+
+    const refused = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(refused)
+    refused.send(JSON.stringify({ type: 'session:start', sessionId }))
+    expect((await waitForType<RelayMessage>(refused, 'error')).message).toBe('Agent resources exhausted')
+    refused.close()
+
+    const second = await register([DEV_A])
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+
+    await expect(waitForType(browser, 'session:joined')).resolves.toBeTruthy()
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('answers a terminal input the restarted agent would have dropped', async () => {
+    // The new process holds no device state for this session until it is asked to boot, and an
+    // input for a session it does not know is dropped with no ack at all
+    // (`IOSAgent.handleRelayMessage`: `if (!state) break`). The socket is open and healthy, so the
+    // relay's "agent offline" branch does not fire either — the caller just waits, and the MCP
+    // client turns that wait into a reported success.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browser = await join(sessionId)
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
+    await barrier(browser)
+
+    const second = await register([DEV_A])
+    await waitForType(browser, 'session:rebound')
+
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 1, y: 1 } }))
+
+    const err = await waitForType<RelayMessage>(browser, 'input:error')
+    expect(err.message).toBe('device not ready')
+    // ...and the new agent was not sent an input it would have thrown away.
+    expect(await waitForTypeOrNull(second.agent, 'input:touch:end', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+
+  it('goes back to forwarding input once the device is asked for again', async () => {
+    // The scope of the answer above is "this agent has not been asked to boot this session". If it
+    // outlived the rebind it would suppress input for the rest of the session.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browser = await join(sessionId)
+    const second = await register([DEV_A])
+    await waitForType(browser, 'session:rebound')
+
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
+    await waitForType(second.agent, 'device:boot')
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 1, y: 1 } }))
+
+    await expect(waitForType(second.agent, 'input:touch:end')).resolves.toBeTruthy()
+    expect(await waitForTypeOrNull(browser, 'input:error', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browser.close()
+  })
+})

--- a/packages/relay/src/__tests__/sessionRebind.test.ts
+++ b/packages/relay/src/__tests__/sessionRebind.test.ts
@@ -58,12 +58,14 @@ describe('a session survives its agent restarting (#426)', () => {
     return { agent, byDevice, registered: reply.registeredSessions! }
   }
 
+  /** `joined` is handed back because `session:joined` is consumed here — it is the only message
+   *  carrying what the relay has stored about the agent, and a later wait would find it gone. */
   async function join(sessionId: string) {
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
-    await waitForType(browser, 'session:joined')
-    return browser
+    const joined = await waitForType<RelayMessage>(browser, 'session:joined')
+    return Object.assign(browser, { joined })
   }
 
   /** The device list as the dashboard sees it, flattened across agents. */
@@ -140,11 +142,15 @@ describe('a session survives its agent restarting (#426)', () => {
     first.agent.close(); second.agent.close()
   })
 
-  it('survives the old socket closing afterwards', async () => {
-    // The index move has an order requirement. Reassign `session.agentSocket` first and the id is
-    // deleted from the *new* socket's set while the old one keeps it — so this close, which fires
-    // late after an unclean drop, evicts the session that was just re-pointed. The relay terminates
-    // the old socket itself, so this is the ordinary path, not an exotic one.
+  it('leaves the old socket holding nothing', async () => {
+    // The index move has an order requirement, and this is the state that shows it kept: after the
+    // move the old socket owns no session ids, so nothing that walks them can reach the rebound one.
+    //
+    // Not named for a late close. Reversing the order does break this, but the session is already
+    // gone by then — `evictAgentSocket` runs in the same synchronous handler and takes it, so the
+    // failure the wrong order produces is immediate, and `keeps the session id and tells the viewer`
+    // is what catches it. `first.agent.close()` here is a formality: the relay has already called
+    // `terminate()` on that socket.
     const first = await register([DEV_A])
     const sessionId = first.byDevice.get('devA')!
     const browser = await join(sessionId)
@@ -152,13 +158,11 @@ describe('a session survives its agent restarting (#426)', () => {
     const second = await register([DEV_A])
     await waitForType(browser, 'session:rebound')
     first.agent.close()
-    // Round-trip the new socket: the close above is processed in order relative to this reply.
-    await barrier(second.agent)
 
     expect((await devices(second.agent)).map((d) => d.id)).toEqual(['devA'])
     expect(await waitForTypeOrNull(browser, 'session:terminated', 0)).toBeNull()
 
-    first.agent.close(); second.agent.close(); browser.close()
+    second.agent.close(); browser.close()
   })
 
   it('ends the session for a device the restarted agent no longer has', async () => {
@@ -194,21 +198,72 @@ describe('a session survives its agent restarting (#426)', () => {
 
   it('refreshes what the session records about its agent', async () => {
     // An upgrade is the usual reason to restart an agent, so its capabilities are exactly what a
-    // restart is likely to change — and `session:joined` is sent once, so the viewer has no other
-    // way to learn the new set. The device's own reported state comes across too: left at the old
+    // restart is likely to change — and `session:joined` is sent once, so a viewer has no other way
+    // to learn the new set. The device's own reported state comes across too: left at the old
     // value, a device that came back down would still read `booted` to the REST guards.
-    const first = await register([DEV_A], ['clipboard'])
+    const first = await register([DEV_A, DEV_B], ['clipboard'])
     const browser = await join(first.byDevice.get('devA')!)
 
-    const second = await register([{ ...DEV_A, name: 'iPhone A (renamed)', status: 'shutdown' }], ['clipboard', 'audio'])
+    const second = await register(
+      [{ ...DEV_A, name: 'iPhone A (renamed)', status: 'shutdown' }, DEV_B],
+      ['clipboard', 'audio'],
+    )
 
     const rebound = await waitForType<RelayMessage>(browser, 'session:rebound')
     expect(rebound.capabilities).toEqual(['clipboard', 'audio'])
+    // ...but that one only proves the register frame was echoed: the relay copies `msg.capabilities`
+    // into it directly, so it holds even if the session was never updated. `session:joined` is what
+    // reads `session.agentCapabilities`, so joining devB — rebound too, and with no browser on it —
+    // is what observes the stored value.
+    const other = await join(first.byDevice.get('devB')!)
+
     const [devA] = await devices(second.agent)
     expect(devA!.status).toBe('shutdown')
     expect(devA!.name).toBe('iPhone A (renamed)')
 
-    first.agent.close(); second.agent.close(); browser.close()
+    first.agent.close(); second.agent.close(); browser.close(); other.close()
+    // Asserted last so the sockets above are closed even when this is the failure.
+    expect(other.joined.capabilities).toEqual(['clipboard', 'audio'])
+  })
+
+  it('tells the agent about every session it made, even for a repeated device', async () => {
+    // Everything here is keyed by device id, so a payload naming one device twice used to collapse
+    // to a single `registeredSessions` entry while `create()` had already made two sessions —
+    // orphaning one. Agents do not normally send duplicates; the relay does not get to assume it.
+    const { agent, registered } = await register([DEV_A, DEV_A])
+
+    const ids = new Set(registered.map((r) => r.sessionId))
+    expect((await devices(agent)).map((d) => d.id)).toEqual(['devA'])
+    expect(ids.size).toBe(registered.length)
+
+    agent.close()
+  })
+
+  it('does not replay the dead agent\'s geometry to a browser that joins next', async () => {
+    // `handleSessionStart` replays `session:chrome` and `session:deviceInfo` the same way it replays
+    // `device:ready`, and all three were measured by the process that just died. A viewer would
+    // clear them itself a moment later with `device:boot`; an MCP-attached session never boots on
+    // its own, so for it they would simply be wrong for as long as it lives.
+    const first = await register([DEV_A])
+    const sessionId = first.byDevice.get('devA')!
+    const browserA = await join(sessionId)
+    first.agent.send(JSON.stringify({ type: 'session:chrome', sessionId, payload: { tag: 'old-agent' } }))
+    first.agent.send(JSON.stringify({
+      type: 'session:deviceInfo', sessionId, payload: { deviceName: 'stale', osVersion: '17.0' },
+    }))
+    await waitForType(browserA, 'session:deviceInfo')
+
+    const second = await register([DEV_A])
+    await waitForType(browserA, 'session:rebound')
+    browserA.close()
+    await barrier(second.agent)
+
+    const browserB = await join(sessionId)
+    await barrier(browserB)
+    expect(await waitForTypeOrNull(browserB, 'session:chrome', 0)).toBeNull()
+    expect(await waitForTypeOrNull(browserB, 'session:deviceInfo', 0)).toBeNull()
+
+    first.agent.close(); second.agent.close(); browserB.close()
   })
 
   it('stops claiming the session is streaming', async () => {
@@ -270,45 +325,30 @@ describe('a session survives its agent restarting (#426)', () => {
     first.agent.close(); second.agent.close(); browser.close()
   })
 
-  it('answers a terminal input the restarted agent would have dropped', async () => {
-    // The new process holds no device state for this session until it is asked to boot, and an
-    // input for a session it does not know is dropped with no ack at all
-    // (`IOSAgent.handleRelayMessage`: `if (!state) break`). The socket is open and healthy, so the
-    // relay's "agent offline" branch does not fire either — the caller just waits, and the MCP
-    // client turns that wait into a reported success.
-    const first = await register([DEV_A])
-    const sessionId = first.byDevice.get('devA')!
-    const browser = await join(sessionId)
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
-    await barrier(browser)
-
-    const second = await register([DEV_A])
-    await waitForType(browser, 'session:rebound')
-
-    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 1, y: 1 } }))
-
-    const err = await waitForType<RelayMessage>(browser, 'input:error')
-    expect(err.message).toBe('device not ready')
-    // ...and the new agent was not sent an input it would have thrown away.
-    expect(await waitForTypeOrNull(second.agent, 'input:touch:end', 0)).toBeNull()
-
-    first.agent.close(); second.agent.close(); browser.close()
-  })
-
-  it('goes back to forwarding input once the device is asked for again', async () => {
-    // The scope of the answer above is "this agent has not been asked to boot this session". If it
-    // outlived the rebind it would suppress input for the rest of the session.
+  it('forwards input to the restarted agent instead of answering for it', async () => {
+    // A relay-side "the device is not ready" reply was written here and then removed: it was built
+    // on the belief that a restarted agent knows nothing about the session until it is asked to
+    // boot, and drops its input silently. That is false. The relay hands the new socket the kept
+    // session id in `agent:registered`, and the agent seeds a device state for every pair it is
+    // given (`IOSAgent.initDeviceStates`) — so `if (!state) break` never fires, and the agent
+    // answers `input:error: input channel not ready` on its own.
+    //
+    // Answering here instead costs correctness twice over: `input:touch:start` is not a terminal
+    // type, so it would still be forwarded while its `:end` was refused, leaving the device holding
+    // a press that never lifts — and `run_flow` never boots at all, so its first `tapOn` would fail
+    // on a device that is up and working. This pins the forwarding so none of that comes back.
     const first = await register([DEV_A])
     const sessionId = first.byDevice.get('devA')!
     const browser = await join(sessionId)
     const second = await register([DEV_A])
     await waitForType(browser, 'session:rebound')
 
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
-    await waitForType(second.agent, 'device:boot')
+    browser.send(JSON.stringify({ type: 'input:touch:start', sessionId, payload: { x: 1, y: 1 } }))
     browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 1, y: 1 } }))
 
+    await expect(waitForType(second.agent, 'input:touch:start')).resolves.toBeTruthy()
     await expect(waitForType(second.agent, 'input:touch:end')).resolves.toBeTruthy()
+    // Both halves of the gesture, and nothing invented on the session's behalf.
     expect(await waitForTypeOrNull(browser, 'input:error', 0)).toBeNull()
 
     first.agent.close(); second.agent.close(); browser.close()

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -11,6 +11,7 @@ export type MessageType =
   | 'session:end'
   | 'session:leave'
   | 'session:terminated'
+  | 'session:rebound'
   | 'stream:register'
   | 'stream:registered'
   | 'device:boot'


### PR DESCRIPTION
PR2 of #426 stage 2, and the half that turns it on. #456 taught the viewer to handle `session:rebound`; nothing sent it. Now the relay does.

## What a restart looks like from here

Nothing announces itself. A restarted agent is just a second socket registering the same devices under the same identity — which the relay already recognised, and answered by destroying every session the old socket held. The browser got `session:terminated` and went back to the Mac list, losing its navigation for something that should have been invisible.

It now keeps those sessions and re-points them at the new socket. Devices the restarted agent no longer reports still get the old treatment: session ends, viewer told why.

## Where the risk is

`SessionManager.rebind()` owns the whole move rather than the call site doing it inline, because two of these are invisible where they'd be used:

- **The index order is load-bearing.** The session's id must leave the old socket's set *before* `agentSocket` is reassigned. Following the idiom in `remove()` — dereferencing the index through `session.agentSocket` — deletes it from the new set and leaves the old one holding it. Mutating that order fails 12 tests.
- **Agent-derived fields now have a single writer** shared with `create()`, so a field added to a session can't land on one path only. `rebind` is the path that would be missed.
- `readySent` goes false, or a browser joining just after the restart is replayed a `device:ready` for a stream that died with the old process. `chromeData` / `deviceInfo` go with it — same replay, same argument.
- The old socket's resource entry is dropped. `evictAgentSocket` normally does that, but it returns early when the socket has no sessions left, which is exactly the case where all of them were rebound.

Two things the skipped eviction used to do: in-flight screenshot / UI-tree requests are rejected outright rather than waiting out their timeout, and a rebound device is left out of `create()` so one simulator can't end up behind two sessions. `agent:registered` pairs by device id rather than by position — index alignment stops holding the moment some devices are rebound and others are new.

## What the review killed

The plan called for the relay to answer `input:error` on a terminal input after a rebind, on the premise that the restarted agent knows nothing about the session until asked to boot and drops input silently. **That premise is false**, and both review channels found it independently:

`initDeviceStates` seeds a device state for every pair in `registeredSessions`, at handshake — and the relay puts the *kept* session id there. So `if (!state) break` never fires and the agent answers on its own. The plan's own A1/A2 make A9 unnecessary: preserve the id and the agent knows it.

Answering in the relay instead cost correctness twice. `input:touch:start` is not a terminal type, so it stayed forwarded while its `:end` was refused — a press that never lifts. And the flag was false from `create()` too, so it fired on sessions no restart had touched; `run_flow` never boots at all, so its first tap would have failed on a working device.

**An existing test already covered this and I did not see it fail.** ios-agent's `keeps touch start/end paired through lazy setup (no stuck finger)` stands up a real relay and does exactly this. It passed my full run because that suite imports the relay from `dist`, and the build was stale. It failed the moment the pre-commit `tsc -b` refreshed it. Worth knowing generally: a full suite run after a relay source change verifies nothing about that change until a build.

## Tests

13 integration cases plus 3 unit cases for `rebind()`. Twelve mutations killed; two survive knowingly and the record says why — `agentResources.delete(old)` is leak-only with no observable behaviour (a reviewer independently confirmed this, and it also refuted the plan's stated rationale for it), and `devicePlatform` has no reachable scenario because agent platform is already a match filter.

Full suite green against a fresh build: 1889 tests.

## Review

`.work/reviews/feat__session-rebind-relay.md` — two parallel channels, given my mutation list and forbidden from re-running it. Left out of scope with reasons: identity fallback letting a same-hostname host steal sessions rather than evict them (#313, pre-existing semantics but a worse consequence now), same-socket re-registration still doubling a card, and moving `agentResources` to a `WeakMap`.

## Verified on a real simulator — and the trigger is narrower than the issue

Run against an iPhone 15 Pro / iOS 17.2 with FoodTruck installed and navigated to an inner screen.

**Killing the agent process does not reach this code.** Twice, `kill -9` followed by a respawn produced:

```
[relay] agent disconnected — 73 session(s) ended
[relay] agent connected: Duchan-MacBook-Pro-7.local (ios) — 73 device(s)
```

Not `agent restarted — N session(s) kept`. On localhost the socket's close is processed in under 400 ms, while a new agent takes over a second to start — so by the time it registers there is nothing left to re-point. The tab got the stage-1 treatment: red toast, back to the Mac list.

**With the old socket still open it works exactly as designed.** Freezing the agent with `SIGSTOP` reproduces an unclean drop — Wi-Fi loss, a sleeping laptop — where TCP has not torn down. Starting a second agent then gives:

```
[relay] agent restarted — 73 session(s) kept across the restart
```

and on screen: the blue "reconnecting" toast, no bounce to the Mac list, the stream returns on its own, and **FoodTruck is still on the same screen** — the reinstall correctly skipped. Killing the frozen process afterwards logged nothing at all, confirming its socket no longer held any session.

So the machinery is right and the payoff is real, but it only fires while the old socket lingers. The heartbeat gives that up to ~60 s, which covers the network-drop case this relay was built for and not the process restart the issue is named after.

**#426 stays open.** Closing it needs the relay to hold a session briefly after its agent socket closes, so a returning agent can reclaim it, instead of evicting on the spot. That is a lifecycle change with its own risk — during the grace window the Mac card would list devices with no agent behind them — so it wants its own design review rather than being bolted on here.

What this PR is worth on its own: the re-pointing machinery any grace period would have to use, the duplicate-card and orphaned-session fixes, and a real recovery in the unclean-drop case.

## What the tests did not ask

Six design review rounds, two pre-PR review channels and 1889 tests all checked how the rebind behaves. None asked whether its trigger occurs. The integration tests open both sockets at once, which hands the precondition over for free — the one thing the real run had to establish for itself.
