### PR TITLE
docs: harden the relay systemd unit and add a first-run smoke test

### DIFF
--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -411,12 +411,39 @@ EnvironmentFile=/etc/tapflow/relay.env
 ExecStart=/usr/bin/env tapflow relay start
 Restart=on-failure
 RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/tapflow
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+The hardening directives keep the filesystem read-only except for
+`/var/lib/tapflow`, which includes the configured
+`/var/lib/tapflow/.tapflow-data` directory. If you move
+`TAPFLOW_DATA_DIR` outside `/var/lib/tapflow`, add that path to
+`ReadWritePaths` too.
+
 Place `tapflow.config.json` in `/var/lib/tapflow` if you need to customize the port or other settings, because that is the service `WorkingDirectory`.
+
+Run a foreground smoke test before enabling the service. This confirms the
+relay can bind and write to the data directory with the same dedicated user:
+
+```sh
+cd /var/lib/tapflow
+sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+```
+
+In another shell, confirm the relay responds:
+
+```sh
+tapflow status
+```
+
+Stop the foreground relay with Ctrl-C after the status check passes.
 
 Enable and start the service:
 

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -424,35 +424,37 @@ WantedBy=multi-user.target
 The hardening directives keep the filesystem read-only except for
 `/var/lib/tapflow`, which contains the `TAPFLOW_DATA_DIR` set above. The relay
 writes nowhere else, so nothing further needs opening — but if you move
-`TAPFLOW_DATA_DIR` outside `/var/lib/tapflow`, add that path to
-`ReadWritePaths` too.
+`TAPFLOW_DATA_DIR`, add its new path to `ReadWritePaths` too.
 
-`ProtectHome=true` is safe here only because the `tapflow` user's home is
-`/var/lib/tapflow`, as created above. Give that user a home under `/home` and
-the service will not be able to read it.
+With one exception: `ProtectHome=true` makes `/home`, `/root` and `/run/user`
+unreachable outright, and `ReadWritePaths` cannot open a path back up inside
+them. A data directory in any of those is invisible to the service no matter
+what you list. Keep it elsewhere, or switch to `ProtectHome=read-only`. This is
+also why the `tapflow` user is given a home in `/var/lib/tapflow` above rather
+than under `/home`.
 
 Place `tapflow.config.json` in `/var/lib/tapflow` if you need to customize the port or other settings, because that is the service `WorkingDirectory`.
 
-Run a foreground smoke test before enabling the service. Starting it the same
-way systemd will — same user, same data directory — surfaces a permission or
-port problem as a message you can read, instead of a unit that restarts every
-five seconds:
+Run a smoke test before enabling the service, so a problem arrives as a message
+you can read instead of a unit that restarts every five seconds. `systemd-run`
+applies the same sandbox the unit will, which a plain `sudo -u tapflow` would
+not — the directives above are what most often turn out to be the problem:
 
 ```sh
-cd /var/lib/tapflow
-sudo -u tapflow env $(sudo cat /etc/tapflow/relay.env | xargs) tapflow relay start
+sudo systemd-run --pty --unit=tapflow-smoke   --property=User=tapflow --property=Group=tapflow   --property=WorkingDirectory=/var/lib/tapflow   --property=EnvironmentFile=/etc/tapflow/relay.env   --property=NoNewPrivileges=true   --property=ProtectSystem=strict   --property=ProtectHome=true   --property=PrivateTmp=true   --property=ReadWritePaths=/var/lib/tapflow   /usr/bin/env tapflow relay start
 ```
 
-In another shell, confirm the relay answers. Name the URL rather than relying on
-the default: `tapflow status` reads *your* configuration to find the relay, not
-the service's, so a port set in `/var/lib/tapflow/tapflow.config.json` is one
-this shell does not know about.
+In another shell, confirm the relay answers. Give it the URL rather than relying
+on the default: `tapflow status` reads *your* configuration to find the relay,
+not the service's, so a port set in `/var/lib/tapflow/tapflow.config.json` is
+one this shell does not know about. Use the port the relay is actually on, and
+`wss://` if you configured TLS:
 
 ```sh
-tapflow status --relay ws://localhost:4000
+tapflow status --relay ws://localhost:4000   # your port; wss:// with TLS
 ```
 
-Stop the foreground relay with Ctrl-C after the status check passes.
+Stop the foreground relay with Ctrl-C once the status check passes.
 
 Enable and start the service:
 

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -447,11 +447,14 @@ sudo systemd-run --pty --unit=tapflow-smoke   --property=User=tapflow --property
 In another shell, confirm the relay answers. Give it the URL rather than relying
 on the default: `tapflow status` reads *your* configuration to find the relay,
 not the service's, so a port set in `/var/lib/tapflow/tapflow.config.json` is
-one this shell does not know about. Use the port the relay is actually on, and
-`wss://` if you configured TLS:
+one this shell does not know about.
+
+Copy the address the command above printed on startup — `Relay : …`. `--relay`
+accepts it as-is and switches the scheme itself, so a TLS deployment needs no
+edit:
 
 ```sh
-tapflow status --relay ws://localhost:4000   # your port; wss:// with TLS
+tapflow status --relay http://localhost:4000   # whatever `Relay :` said
 ```
 
 Stop the foreground relay with Ctrl-C once the status check passes.

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -422,25 +422,34 @@ WantedBy=multi-user.target
 ```
 
 The hardening directives keep the filesystem read-only except for
-`/var/lib/tapflow`, which includes the configured
-`/var/lib/tapflow/.tapflow-data` directory. If you move
+`/var/lib/tapflow`, which contains the `TAPFLOW_DATA_DIR` set above. The relay
+writes nowhere else, so nothing further needs opening — but if you move
 `TAPFLOW_DATA_DIR` outside `/var/lib/tapflow`, add that path to
 `ReadWritePaths` too.
 
+`ProtectHome=true` is safe here only because the `tapflow` user's home is
+`/var/lib/tapflow`, as created above. Give that user a home under `/home` and
+the service will not be able to read it.
+
 Place `tapflow.config.json` in `/var/lib/tapflow` if you need to customize the port or other settings, because that is the service `WorkingDirectory`.
 
-Run a foreground smoke test before enabling the service. This confirms the
-relay can bind and write to the data directory with the same dedicated user:
+Run a foreground smoke test before enabling the service. Starting it the same
+way systemd will — same user, same data directory — surfaces a permission or
+port problem as a message you can read, instead of a unit that restarts every
+five seconds:
 
 ```sh
 cd /var/lib/tapflow
-sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+sudo -u tapflow env $(sudo cat /etc/tapflow/relay.env | xargs) tapflow relay start
 ```
 
-In another shell, confirm the relay responds:
+In another shell, confirm the relay answers. Name the URL rather than relying on
+the default: `tapflow status` reads *your* configuration to find the relay, not
+the service's, so a port set in `/var/lib/tapflow/tapflow.config.json` is one
+this shell does not know about.
 
 ```sh
-tapflow status
+tapflow status --relay ws://localhost:4000
 ```
 
 Stop the foreground relay with Ctrl-C after the status check passes.

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -411,12 +411,40 @@ EnvironmentFile=/etc/tapflow/relay.env
 ExecStart=/usr/bin/env tapflow relay start
 Restart=on-failure
 RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/tapflow
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+하드닝 지시어는 파일 시스템을 읽기 전용으로 유지하되
+`/var/lib/tapflow`만 쓰기 가능하게 둡니다. 이 경로 안에는 설정한
+`/var/lib/tapflow/.tapflow-data` 데이터 디렉터리가 포함됩니다.
+`TAPFLOW_DATA_DIR`을 `/var/lib/tapflow` 밖으로 옮겼다면 그 경로도
+`ReadWritePaths`에 추가하세요.
+
 기본값이 아닌 포트나 다른 설정이 필요하다면 `tapflow.config.json`을 `WorkingDirectory`인 `/var/lib/tapflow`에 둡니다.
+
+서비스를 활성화하기 전에 포그라운드 스모크 테스트를 먼저 실행하세요.
+전용 사용자로 실행했을 때 릴레이가 바인딩되고 데이터 디렉터리에 쓸 수
+있는지 확인합니다.
+
+```sh
+cd /var/lib/tapflow
+sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+```
+
+다른 셸에서 릴레이가 응답하는지 확인합니다.
+
+```sh
+tapflow status
+```
+
+상태 확인이 끝나면 Ctrl-C로 포그라운드 릴레이를 중지합니다.
 
 서비스를 활성화하고 시작합니다:
 

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -448,11 +448,14 @@ sudo systemd-run --pty --unit=tapflow-smoke   --property=User=tapflow --property
 다른 셸에서 릴레이가 응답하는지 확인합니다. 기본값에 기대지 말고 URL을
 직접 지정하세요. `tapflow status`는 서비스의 설정이 아니라 **그 셸의**
 설정을 읽어 릴레이를 찾으므로, `/var/lib/tapflow/tapflow.config.json`에
-지정한 포트는 이 셸이 알지 못합니다. 실제 릴레이가 떠 있는 포트를 쓰고,
-TLS를 설정했다면 `wss://`를 씁니다.
+지정한 포트는 이 셸이 알지 못합니다.
+
+위 명령이 시작할 때 출력한 주소(`Relay : …`)를 그대로 복사하세요.
+`--relay`는 그 형태를 받아 스킴을 알아서 바꾸므로 TLS 배포에서도 고칠
+것이 없습니다.
 
 ```sh
-tapflow status --relay ws://localhost:4000   # 실제 포트, TLS면 wss://
+tapflow status --relay http://localhost:4000   # `Relay :`에 찍힌 값
 ```
 
 상태 확인이 끝나면 Ctrl-C로 포그라운드 릴레이를 중지합니다.

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -424,32 +424,35 @@ WantedBy=multi-user.target
 하드닝 지시어는 파일 시스템을 읽기 전용으로 유지하되
 `/var/lib/tapflow`만 쓰기 가능하게 둡니다. 이 경로 안에 위에서 설정한
 `TAPFLOW_DATA_DIR`이 들어 있고, 릴레이는 그 밖에 쓰지 않으므로 더 열어줄
-경로는 없습니다. 다만 `TAPFLOW_DATA_DIR`을 `/var/lib/tapflow` 밖으로
-옮겼다면 그 경로도 `ReadWritePaths`에 추가하세요.
+경로는 없습니다. `TAPFLOW_DATA_DIR`을 옮겼다면 새 경로를
+`ReadWritePaths`에 추가하세요.
 
-`ProtectHome=true`가 문제되지 않는 것은 위에서 `tapflow` 사용자의 홈을
-`/var/lib/tapflow`로 만들었기 때문입니다. 홈을 `/home` 아래에 두면 서비스가
-그 경로를 읽지 못합니다.
+예외가 하나 있습니다. `ProtectHome=true`는 `/home`·`/root`·`/run/user`를
+아예 접근 불가로 만들고, `ReadWritePaths`로는 그 안의 경로를 다시 열 수
+없습니다. 데이터 디렉터리를 그 아래에 두면 무엇을 나열하든 서비스가 보지
+못합니다. 다른 곳에 두거나 `ProtectHome=read-only`로 바꾸세요. 위에서
+`tapflow` 사용자의 홈을 `/home`이 아니라 `/var/lib/tapflow`로 만든 것도
+같은 이유입니다.
 
 기본값이 아닌 포트나 다른 설정이 필요하다면 `tapflow.config.json`을 `WorkingDirectory`인 `/var/lib/tapflow`에 둡니다.
 
-서비스를 활성화하기 전에 포그라운드 스모크 테스트를 먼저 실행하세요.
-systemd가 실행할 방식 그대로 — 같은 사용자, 같은 데이터 디렉터리 — 띄우면
-권한이나 포트 문제가 5초마다 재시작하는 유닛이 아니라 읽을 수 있는
-메시지로 드러납니다.
+서비스를 활성화하기 전에 스모크 테스트를 먼저 실행하세요. 문제가 5초마다
+재시작하는 유닛이 아니라 읽을 수 있는 메시지로 드러납니다. `systemd-run`은
+유닛과 같은 샌드박스를 적용합니다 — 그냥 `sudo -u tapflow`로 띄우면 위
+지시어들이 빠지는데, 정작 문제가 되는 것은 대개 그쪽입니다.
 
 ```sh
-cd /var/lib/tapflow
-sudo -u tapflow env $(sudo cat /etc/tapflow/relay.env | xargs) tapflow relay start
+sudo systemd-run --pty --unit=tapflow-smoke   --property=User=tapflow --property=Group=tapflow   --property=WorkingDirectory=/var/lib/tapflow   --property=EnvironmentFile=/etc/tapflow/relay.env   --property=NoNewPrivileges=true   --property=ProtectSystem=strict   --property=ProtectHome=true   --property=PrivateTmp=true   --property=ReadWritePaths=/var/lib/tapflow   /usr/bin/env tapflow relay start
 ```
 
 다른 셸에서 릴레이가 응답하는지 확인합니다. 기본값에 기대지 말고 URL을
 직접 지정하세요. `tapflow status`는 서비스의 설정이 아니라 **그 셸의**
 설정을 읽어 릴레이를 찾으므로, `/var/lib/tapflow/tapflow.config.json`에
-지정한 포트는 이 셸이 알지 못합니다.
+지정한 포트는 이 셸이 알지 못합니다. 실제 릴레이가 떠 있는 포트를 쓰고,
+TLS를 설정했다면 `wss://`를 씁니다.
 
 ```sh
-tapflow status --relay ws://localhost:4000
+tapflow status --relay ws://localhost:4000   # 실제 포트, TLS면 wss://
 ```
 
 상태 확인이 끝나면 Ctrl-C로 포그라운드 릴레이를 중지합니다.

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -422,26 +422,34 @@ WantedBy=multi-user.target
 ```
 
 하드닝 지시어는 파일 시스템을 읽기 전용으로 유지하되
-`/var/lib/tapflow`만 쓰기 가능하게 둡니다. 이 경로 안에는 설정한
-`/var/lib/tapflow/.tapflow-data` 데이터 디렉터리가 포함됩니다.
-`TAPFLOW_DATA_DIR`을 `/var/lib/tapflow` 밖으로 옮겼다면 그 경로도
-`ReadWritePaths`에 추가하세요.
+`/var/lib/tapflow`만 쓰기 가능하게 둡니다. 이 경로 안에 위에서 설정한
+`TAPFLOW_DATA_DIR`이 들어 있고, 릴레이는 그 밖에 쓰지 않으므로 더 열어줄
+경로는 없습니다. 다만 `TAPFLOW_DATA_DIR`을 `/var/lib/tapflow` 밖으로
+옮겼다면 그 경로도 `ReadWritePaths`에 추가하세요.
+
+`ProtectHome=true`가 문제되지 않는 것은 위에서 `tapflow` 사용자의 홈을
+`/var/lib/tapflow`로 만들었기 때문입니다. 홈을 `/home` 아래에 두면 서비스가
+그 경로를 읽지 못합니다.
 
 기본값이 아닌 포트나 다른 설정이 필요하다면 `tapflow.config.json`을 `WorkingDirectory`인 `/var/lib/tapflow`에 둡니다.
 
 서비스를 활성화하기 전에 포그라운드 스모크 테스트를 먼저 실행하세요.
-전용 사용자로 실행했을 때 릴레이가 바인딩되고 데이터 디렉터리에 쓸 수
-있는지 확인합니다.
+systemd가 실행할 방식 그대로 — 같은 사용자, 같은 데이터 디렉터리 — 띄우면
+권한이나 포트 문제가 5초마다 재시작하는 유닛이 아니라 읽을 수 있는
+메시지로 드러납니다.
 
 ```sh
 cd /var/lib/tapflow
-sudo -u tapflow env TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow-data tapflow relay start
+sudo -u tapflow env $(sudo cat /etc/tapflow/relay.env | xargs) tapflow relay start
 ```
 
-다른 셸에서 릴레이가 응답하는지 확인합니다.
+다른 셸에서 릴레이가 응답하는지 확인합니다. 기본값에 기대지 말고 URL을
+직접 지정하세요. `tapflow status`는 서비스의 설정이 아니라 **그 셸의**
+설정을 읽어 릴레이를 찾으므로, `/var/lib/tapflow/tapflow.config.json`에
+지정한 포트는 이 셸이 알지 못합니다.
 
 ```sh
-tapflow status
+tapflow status --relay ws://localhost:4000
 ```
 
 상태 확인이 끝나면 Ctrl-C로 포그라운드 릴레이를 중지합니다.


### PR DESCRIPTION
Carries on @vku2018's #366, which has been open since 3 July with no reply to a follow-up. Their commit is cherry-picked here unchanged and first in the history, so the authorship — and the contribution — stays theirs; my fixes sit on top as a second commit.

**@vku2018's work** adds a sandboxing baseline to the unit example (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `ReadWritePaths`), explains what to open if the data directory moves, and adds a foreground smoke test before `systemctl enable --now` — mirrored on the Korean page. That shape is right and is what #365 asked for.

## What the follow-up changes

Docs that describe a hardened deployment are only worth having if they are true, so I checked each claim against the code.

**The smoke test pointed at a directory the service does not use.** It named `/var/lib/tapflow/.tapflow-data`, but the unit reads `TAPFLOW_DATA_DIR=/var/lib/tapflow/.tapflow/data` from its EnvironmentFile — and `.tapflow-data` is the layout this same page tells you to migrate away from, eight lines earlier. Following it would have tested a different directory than the service runs against, and created a legacy one doing so. It now loads the same env file systemd does.

**`tapflow status` needed a URL.** It resolves the relay from the *caller's* configuration (`config.relay.url ?? ws://localhost:${config.local.port}`), so from a second shell it looks for the default port — not one set in `/var/lib/tapflow/tapflow.config.json`, which the same page recommends doing. A verification step that can fail for a reason unrelated to what it verifies is worse than no verification step. `--relay` already exists.

**Two things worth saying out loud**, since the reader is being asked to trust `ProtectSystem=strict`: the relay writes nowhere outside its data directory (checked — no `os.homedir()` or `os.tmpdir()` writes anywhere in the relay), so `ReadWritePaths` needs nothing further. And `ProtectHome=true` is safe here only because the guide gives the service user a home in `/var/lib/tapflow`; under `/home` it would break, which is not obvious from reading the unit.

## Not verified

I have no Linux host, so this was checked for agreement with the code, not by running the unit. `pnpm --filter @tapflowio/docs build` passes.

Docs-only, so no changeset (`changeset:check` agrees) and the independent review is skipped — the record and the skip reason are in `.work/reviews/docs__systemd-hardening-smoke-test.md`.

Supersedes #366. Closes #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc4pFTHvZBsuDU1ibxT5eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting guides with stronger systemd service security and filesystem access restrictions.
  * Documented how custom data paths affect required permissions.
  * Added a foreground smoke-test procedure, including relay connectivity verification before enabling the service.
  * Added Korean-language documentation covering the same deployment and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->