### PR TITLE
fix(scripts): make the changeset gates answer for the right commits

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -48,11 +48,29 @@ model: claude-opus-4-8
 
 ## 7. 이 레포 전용 수동 단계 (놓치기 가장 쉬움)
 
-- **`@experimental` dist-tag 정리**: `@tapflowio/mcp-server`는 v0.14.0 graduation 전까지 `X.Y.Z-experimental.N`으로 20개를 발행했고 그 채널이 `experimental` dist-tag였다. graduation 이후 prerelease는 한 번도 나오지 않았다 — **개념은 사라졌고 npm 태그만 남았다.**
-  - 당시 절차는 "새 버전으로 당기거나, 제거를 안내하거나"였고 앞쪽만 수행돼 태그가 `0.14.0`을 가리킨다. **그 1회성 조치가 문제를 재생산했다**: `latest`가 0.16.0으로 가는 동안 태그는 그대로라, 문서가 진단했던 "업데이트가 끊긴다"가 한 버전 뒤에서 그대로 반복됐다. 1회성으로 설계한 것이 원인이지 누가 빠뜨린 것이 아니다.
-  - 지금 태그는 두 가지로 틀렸다: 이름이 가리키는 `0.14.0`은 실험판이 아니라 정식 릴리즈이고, `latest`보다 뒤처져 "최신 실험판"도 아니다.
-  - **제거가 맞다.** 가리킬 prerelease 스트림이 없고, `latest`와 동기화해 유지하면 순수한 별칭이라 잊어버릴 거리만 늘린다. 제거하면 `@experimental` 설치가 소리내어 실패해 사용자가 `latest`로 옮길 신호를 받는다 — 3주 지난 버전을 조용히 설치하는 것보다 낫다.
-  - 사용자에게 영향이 가므로 **실행 전 확인**을 받는다: `npm dist-tag rm @tapflowio/mcp-server experimental`
+- **떠도는 dist-tag 훑기**: 배포 패키지 전부의 dist-tag를 나열하고 `latest`가 **아닌** 것을 찾는다.
+
+  ```sh
+  for n in tapflow @tapflowio/protocol @tapflowio/relay @tapflowio/agent-core \
+           @tapflowio/ios-agent @tapflowio/android-agent @tapflowio/flow-runner \
+           @tapflowio/mcp-server @tapflowio/audiotap-helper; do
+    printf '%-30s ' "$n"; npm view "$n" dist-tags --json 2>/dev/null | tr -d '\n '; echo
+  done
+  ```
+
+  **이 항목이 훑기인 이유**: 이전 판은 `@tapflowio/mcp-server`의 `experimental` 태그 하나를 이름으로 지목했다. 그 문단은 "1회성으로 설계한 것이 원인"이라고 스스로 진단해놓고, 특정 패키지와 태그를 박은 **또 하나의 1회성 조치**를 적었다. 결과는 예측대로였다 — 2026-08-03 v0.18.0 준비 때 그 태그는 이미 없어 항목이 no-op이었고, 대신 문서가 모르는 세 개가 살아 있었다:
+
+  | 태그 | 가리킨 버전 | 그때 `latest`와 차이 |
+  |---|---|---|
+  | `tapflow@alpha` | `0.1.0-alpha.8` (2026-05-20) | 2개월, 16 minor |
+  | `tapflow@next` | `0.8.1-next.0` (2026-06-11) | 6주, 9 minor |
+  | `@tapflowio/relay@next` | `0.8.1-next.0` (2026-06-11) | 6주, 9 minor |
+
+  `next`는 사람들이 관습적으로 시도하는 이름이라 `experimental`보다 나빴다. **이름을 박지 말고 매번 훑는다.**
+
+- **판정 기준**: `latest`가 아닌 태그는 그것을 먹여주는 prerelease 스트림이 **지금도 흐르는지**만 본다. 흐르면 최신 prerelease로 당긴다. 아니면 제거한다 — `latest`와 동기화해 유지하는 것은 순수한 별칭이라 잊어버릴 거리만 늘리고, 방치하면 매 릴리즈마다 격차가 벌어진다. 제거하면 그 설치가 소리내어 실패해 사용자가 옮길 신호를 받는다. 버전 자체는 지워지지 않으므로 `pkg@1.2.3-next.0` 직접 설치는 계속 동작한다.
+- 사용자에게 영향이 가므로 **실행 전 확인**을 받는다: `npm dist-tag rm <pkg> <tag>`
+  - **2FA 계정에서는 이 명령이 `EOTP`로 실패한다** — 브라우저 인증이 필요해 자동화할 수 없다. 사용자에게 명령을 넘긴다.
 - **루트 `CHANGELOG.md`**: changeset 관리 밖(Keep a Changelog 수동) → `[Unreleased]`를 `[X.Y.Z] - YYYY-MM-DD`(오늘 날짜)로 승격하고 Added/Changed/Fixed를 채운다.
   - **하단 compare 링크도 함께 갱신**(놓치기 쉬움): `[Unreleased]`를 `vX.Y.Z...HEAD`로 바꾸고, `[X.Y.Z]: .../compare/v{직전}...vX.Y.Z` 링크를 새로 추가한다. 직전 릴리즈 링크가 빠져 있으면 이번에 함께 메운다.
 - **dashboard**: private + `ignore` → 건드리지 않는다.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -51,18 +51,23 @@ model: claude-opus-4-8
 - **떠도는 dist-tag 훑기**: 배포 패키지 전부의 dist-tag를 나열하고 `latest`가 **아닌** 것을 찾는다.
 
   ```sh
-  pnpm list -r --depth -1 --json \
-    | python3 -c 'import json,sys; print("\n".join(p["name"] for p in json.load(sys.stdin) if p.get("name") and not p.get("private")))' \
-    | while read -r n; do
-        tags=$(npm view "$n" dist-tags --json) || { echo "npm view $n failed"; exit 1; }
-        printf '%-30s %s\n' "$n" "$(printf '%s' "$tags" | tr -d '\n ')"
-      done
+  set -o pipefail
+  pkgs=$(pnpm list -r --depth -1 --json \
+    | python3 -c 'import json,sys; print("\n".join(p["name"] for p in json.load(sys.stdin) if p.get("name") and not p.get("private")))')
+  [ "$(printf '%s' "$pkgs" | grep -c .)" -ge 2 ] || { echo "workspace discovery returned $(printf '%s' "$pkgs" | grep -c .) package(s) — refusing to report on that"; exit 1; }
+  printf '%s\n' "$pkgs" | while read -r n; do
+    tags=$(npm view "$n" dist-tags --json) || { echo "npm view $n failed"; exit 1; }
+    printf '%-30s %s\n' "$n" "$(printf '%s' "$tags" | tr -d '\n ')"
+  done
   ```
 
   Two things this deliberately does **not** do, both learned by getting them wrong here:
 
   - **The package list is derived, not typed.** An earlier version of this step listed the nine names — in a paragraph whose whole point is that hardcoded inventories go stale. A package added after the list is written is a package this step cannot see, and a new package is exactly when a forgotten tag does damage.
-  - **A registry failure is not silence.** `npm view … 2>/dev/null` prints nothing and leaves the loop exiting 0, so an outage or a typo'd name reads identically to "no stray tags" — the one answer this step must never guess at.
+  - **A failure at any stage is not silence.** Three ways this reported "clean" while checking nothing, each found the same way — by breaking it on purpose:
+    - `npm view … 2>/dev/null` prints nothing and leaves the loop exiting 0, so an outage or a typo'd name reads identically to "no stray tags".
+    - Without `pipefail`, `pnpm list` or the parser dying leaves the `while` with no input: zero iterations, **exit 0**. Measured.
+    - `pipefail` alone still does not catch a stage that succeeds while returning nothing, so the package count is checked before anything is reported. Fewer than two published packages in this workspace means discovery broke, not that the repo shrank.
 
   **이 항목이 훑기인 이유**: 이전 판은 `@tapflowio/mcp-server`의 `experimental` 태그 하나를 이름으로 지목했다. 그 문단은 "1회성으로 설계한 것이 원인"이라고 스스로 진단해놓고, 특정 패키지와 태그를 박은 **또 하나의 1회성 조치**를 적었다. 결과는 예측대로였다 — 2026-08-03 v0.18.0 준비 때 그 태그는 이미 없어 항목이 no-op이었고, 대신 문서가 모르는 세 개가 살아 있었다:
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -51,12 +51,18 @@ model: claude-opus-4-8
 - **떠도는 dist-tag 훑기**: 배포 패키지 전부의 dist-tag를 나열하고 `latest`가 **아닌** 것을 찾는다.
 
   ```sh
-  for n in tapflow @tapflowio/protocol @tapflowio/relay @tapflowio/agent-core \
-           @tapflowio/ios-agent @tapflowio/android-agent @tapflowio/flow-runner \
-           @tapflowio/mcp-server @tapflowio/audiotap-helper; do
-    printf '%-30s ' "$n"; npm view "$n" dist-tags --json 2>/dev/null | tr -d '\n '; echo
-  done
+  pnpm list -r --depth -1 --json \
+    | python3 -c 'import json,sys; print("\n".join(p["name"] for p in json.load(sys.stdin) if p.get("name") and not p.get("private")))' \
+    | while read -r n; do
+        tags=$(npm view "$n" dist-tags --json) || { echo "npm view $n failed"; exit 1; }
+        printf '%-30s %s\n' "$n" "$(printf '%s' "$tags" | tr -d '\n ')"
+      done
   ```
+
+  Two things this deliberately does **not** do, both learned by getting them wrong here:
+
+  - **The package list is derived, not typed.** An earlier version of this step listed the nine names — in a paragraph whose whole point is that hardcoded inventories go stale. A package added after the list is written is a package this step cannot see, and a new package is exactly when a forgotten tag does damage.
+  - **A registry failure is not silence.** `npm view … 2>/dev/null` prints nothing and leaves the loop exiting 0, so an outage or a typo'd name reads identically to "no stray tags" — the one answer this step must never guess at.
 
   **이 항목이 훑기인 이유**: 이전 판은 `@tapflowio/mcp-server`의 `experimental` 태그 하나를 이름으로 지목했다. 그 문단은 "1회성으로 설계한 것이 원인"이라고 스스로 진단해놓고, 특정 패키지와 태그를 박은 **또 하나의 1회성 조치**를 적었다. 결과는 예측대로였다 — 2026-08-03 v0.18.0 준비 때 그 태그는 이미 없어 항목이 no-op이었고, 대신 문서가 모르는 세 개가 살아 있었다:
 

--- a/scripts/__tests__/auditIntegration.test.mjs
+++ b/scripts/__tests__/auditIntegration.test.mjs
@@ -227,4 +227,58 @@ describe('audit --audit against real git history', () => {
     mergePr(104, 'dependabot/npm/foo', { 'packages/relay/package.json': '{"a":1}\n' })
     expect(audit().code).toBe(0)
   })
+
+  // Three shapes the audit reported as gaps during the v0.18.0 release, none of them real. Each
+  // was diagnosed by hand there; these are what stop the next release paying for it again.
+
+  it('ignores main being merged back into a feature branch', () => {
+    // Not a PR landing — someone refreshing their branch. It rides onto main inside their PR, and
+    // diffed against its first parent it shows everything main did since the fork, all of which
+    // already had changesets. One such commit reported 32 files.
+    // The branch has to fork BEFORE main moves, or the back-merge carries nothing and the test
+    // passes with or without the fix — measured, that is exactly what a first attempt did.
+    git('checkout', '-q', '-b', 'long-running')
+    writeFileSync(join(repo, 'README.md'), 'notes\n')
+    git('add', '-A'); git('commit', '-q', '-m', 'docs while main moved on')
+    git('checkout', '-q', 'main')
+
+    mergePr(201, 'shipped', {
+      'packages/relay/src/a.ts': 'export const a = 1\n',
+      '.changeset/a.md': CHANGESET('Ships a.'),
+    })
+    // …and released, so the changeset that covered it is gone by the time the back-merge happens.
+    // That is the real shape: the back-merge carries the source without the note.
+    git('rm', '-q', '.changeset/a.md')
+    writeFileSync(join(repo, 'packages/relay/CHANGELOG.md'), '# relay\n\n## 0.2.0\n')
+    git('add', '-A'); git('commit', '-q', '-m', 'chore: release v0.2.0')
+
+    git('checkout', '-q', 'long-running')
+    git('merge', '--no-ff', '-q', 'main', '-m', "Merge remote-tracking branch 'origin/main' into long-running")
+    git('checkout', '-q', 'main')
+    git('merge', '--no-ff', '-q', 'long-running', '-m', 'Merge pull request #202 from me/long-running')
+
+    expect(audit().code).toBe(0)
+  })
+
+  it('ignores a merge that only touched a private package', () => {
+    // A test-only helper nobody installs. The PR gate got this right and the audit did not, which
+    // is how one repository came to hold two answers about the same commit.
+    mergePr(203, 'helpers', {
+      'packages/test-utils/package.json': '{"name":"@tapflowio/test-utils","private":true}\n',
+      'packages/test-utils/src/socket.ts': 'export const wait = () => {}\n',
+    })
+    expect(audit().code).toBe(0)
+  })
+
+  it('still reports a new published package, which has no manifest to judge it by yet', () => {
+    // The direction that must not be traded away for the two above: a package appearing for the
+    // first time is the case that most needs a release note.
+    mergePr(204, 'new-pkg', {
+      'packages/flow-capture/package.json': '{"name":"@tapflowio/flow-capture"}\n',
+      'packages/flow-capture/src/index.ts': 'export const capture = () => {}\n',
+    })
+    const { code, out } = audit()
+    expect(code).toBe(1)
+    expect(out).toContain('#204')
+  })
 })

--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { packagesNamedIn, mixedChangesets, manifestChangeShips, shipsToUsers, packagePublishesAt } from '../check-changeset.mjs'
+
+const IGNORED = new Set(['@tapflowio/dashboard', '@tapflowio/playground'])
+const cs = (body) => `---\n${body}\n---\n\nsome note.\n`
+
+describe('changeset frontmatter', () => {
+  it('reads the packages a changeset bumps', () => {
+    expect(packagesNamedIn(cs('"@tapflowio/relay": patch\n"@tapflowio/protocol": minor')))
+      .toEqual(['@tapflowio/relay', '@tapflowio/protocol'])
+  })
+  it('returns nothing for a file with no frontmatter', () => {
+    expect(packagesNamedIn('just prose\n')).toEqual([])
+  })
+})
+
+describe('mixing an ignored package with a published one', () => {
+  // What stopped the v0.18.0 release. `changeset version` rejects it outright, and until this
+  // check the PR gate never opened a changeset to notice.
+  const read = (f) => ({
+    'mixed.md': cs('"@tapflowio/protocol": patch\n"@tapflowio/dashboard": patch'),
+    'clean.md': cs('"@tapflowio/protocol": patch\n"@tapflowio/relay": patch'),
+    'only-ignored.md': cs('"@tapflowio/dashboard": patch'),
+  })[f]
+
+  it('flags the mix, naming both sides', () => {
+    const [hit] = mixedChangesets(['mixed.md'], IGNORED, read)
+    expect(hit.file).toBe('mixed.md')
+    expect(hit.ignored).toEqual(['@tapflowio/dashboard'])
+    expect(hit.published).toEqual(['@tapflowio/protocol'])
+  })
+  it('leaves a published-only changeset alone', () => {
+    expect(mixedChangesets(['clean.md'], IGNORED, read)).toEqual([])
+  })
+  it('leaves an ignored-only changeset alone — changesets accepts it', () => {
+    expect(mixedChangesets(['only-ignored.md'], IGNORED, read)).toEqual([])
+  })
+})
+
+describe('a package.json edit that ships', () => {
+  const withDev = (dev) => JSON.stringify({ name: 'x', version: '1.0.0', dependencies: { a: '1' }, devDependencies: dev })
+  it('ignores a devDependencies-only change', () => {
+    // #453: wiring a private test helper into three consumers. The audit called it a missing
+    // changeset while the PR gate had said the opposite about the same commit.
+    expect(manifestChangeShips(withDev({}), withDev({ '@tapflowio/test-utils': 'workspace:*' }))).toBe(false)
+  })
+  it('catches a real dependency change', () => {
+    const before = JSON.stringify({ name: 'x', dependencies: { a: '1' } })
+    const after = JSON.stringify({ name: 'x', dependencies: { a: '2' } })
+    expect(manifestChangeShips(before, after)).toBe(true)
+  })
+  it('treats an added or unparseable manifest as shipping', () => {
+    expect(manifestChangeShips(null, withDev({}))).toBe(true)
+    expect(manifestChangeShips('{ not json', withDev({}))).toBe(true)
+  })
+
+  it('still says shipping when BOTH sides are unparseable', () => {
+    // The case the two above miss. Have the failure fall back to a placeholder instead of null
+    // and they keep passing — the placeholder differs from the parsed side, so the comparison is
+    // "changed" for the wrong reason. Only when both sides collapse to the same placeholder does
+    // the answer flip to "nothing shipped", which is the dangerous direction. Measured.
+    expect(manifestChangeShips('{ not json', 'also { not json')).toBe(true)
+  })
+})
+
+describe('which packages ship', () => {
+  // Read at a revision, never from disk: the audit walks history, so a package deleted since —
+  // or introduced by the merge being examined — has to be judged as it was then. Reading the
+  // working tree instead made every package that does not exist today look unpublished, which
+  // broke eight existing cases at once, the new-package one among them.
+  const manifest = (obj) => () => obj === null ? null : JSON.stringify(obj)
+
+  it('excludes a private package', () => {
+    expect(packagePublishesAt(manifest({ name: '@tapflowio/test-utils', private: true }), 'test-utils')).toBe(false)
+  })
+  it('includes the dashboard, which ships inside relay', () => {
+    expect(packagePublishesAt(manifest({ name: '@tapflowio/dashboard', private: true }), 'dashboard')).toBe(true)
+  })
+  it('includes an ordinary published package', () => {
+    expect(packagePublishesAt(manifest({ name: '@tapflowio/relay' }), 'relay')).toBe(true)
+  })
+  it('assumes a package it cannot read publishes — a new one must stay visible', () => {
+    expect(packagePublishesAt(manifest(null), 'flow-capture')).toBe(true)
+    expect(packagePublishesAt(() => '{ not json', 'relay')).toBe(true)
+  })
+
+  it('still excludes a directory under packages/ that is not a package', () => {
+    expect(shipsToUsers('packages/docs/guide/requirements.md')).toBe(false)
+  })
+})

--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -54,6 +54,22 @@ describe('a package.json edit that ships', () => {
     expect(manifestChangeShips('{ not json', withDev({}))).toBe(true)
   })
 
+  it('ignores a pure key reordering', () => {
+    // A formatter or `npm pkg set` can rewrite a manifest without changing a value. Compared as
+    // raw JSON text those differ, and the gate would ask for a changeset nothing earned — the same
+    // spurious signal this file exists to remove, arriving from the other side.
+    const a = JSON.stringify({ name: 'x', version: '1', dependencies: { b: '1', a: '1' } })
+    const b = JSON.stringify({ dependencies: { a: '1', b: '1' }, version: '1', name: 'x' })
+    expect(manifestChangeShips(a, b)).toBe(false)
+  })
+
+  it('still sees a nested value change under reordered keys', () => {
+    // Sorting must not be allowed to hide a real edit that happens to travel with a reorder.
+    const a = JSON.stringify({ name: 'x', dependencies: { b: '1', a: '1' } })
+    const b = JSON.stringify({ dependencies: { a: '2', b: '1' }, name: 'x' })
+    expect(manifestChangeShips(a, b)).toBe(true)
+  })
+
   it('still says shipping when BOTH sides are unparseable', () => {
     // The case the two above miss. Have the failure fall back to a placeholder instead of null
     // and they keep passing — the placeholder differs from the parsed side, so the comparison is

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -71,11 +71,20 @@ const PACKAGE_FILE = /^packages\/([^/]+)\//
  * Anything unreadable counts as shipping: a manifest we cannot parse is not one to wave through.
  */
 export function manifestChangeShips(before, after) {
+  // Key order is not content. `JSON.stringify` preserves insertion order, so a formatter or a
+  // `npm pkg set` that rewrites the manifest without changing a value would compare as different
+  // and ask for a changeset that nothing earned — the same spurious signal this file exists to
+  // remove, arriving from the other side.
+  const stable = (v) =>
+    v === null || typeof v !== 'object' ? v
+      : Array.isArray(v) ? v.map(stable)
+        : Object.fromEntries(Object.keys(v).sort().map((k) => [k, stable(v[k])]))
+
   const strip = (raw) => {
     if (raw === null) return null                    // added or deleted outright — that ships
     try {
       const { devDependencies: _drop, ...rest } = JSON.parse(raw)
-      return JSON.stringify(rest)
+      return JSON.stringify(stable(rest))
     } catch { return null }
   }
   const a = strip(before)

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -13,14 +13,36 @@
 // decision someone writes down, not something that happens by forgetting.
 import { execFileSync } from 'child_process'
 import { pathToFileURL } from 'url'
-import { realpathSync } from 'fs'
+import { readFileSync, realpathSync } from 'fs'
 
 // Inverted on purpose: everything under `packages/` ships unless named here. Listing what
 // ships instead left a NEW published package invisible to the gate — the case that most needs
-// a release note — while the comment below claimed the opposite. `dashboard` is deliberately
-// absent from this list: it is `private`, but it is built into the relay's `public/` and
-// shipped inside that package, and it is tapflow's primary user surface.
+// a release note. These two are directories that are not packages at all.
 const NOT_SHIPPED_PACKAGES = ['docs', 'playground']
+
+// `dashboard` is `private` yet reaches users: it is built into the relay's `public/` and ships
+// inside that package. Every other private package ships nothing, which `packagePublishesAt`
+// reads from the manifest rather than from a list — the list this replaced still named `docs`
+// and `playground`, which have not been under `packages/` for some time, while
+// `@tapflowio/test-utils`, added later, was absent and so counted as shipped.
+const SHIPS_DESPITE_PRIVATE = ['@tapflowio/dashboard']
+
+/**
+ * Whether `packages/<dir>` published anything, judged by its manifest **at `rev`**.
+ *
+ * At `rev`, not on disk: the audit walks history, and a package deleted since — or added by the
+ * very merge under examination — must be judged as it was then. Absent or unreadable counts as
+ * publishing, so the gate asks rather than waves through; that is also what keeps a brand-new
+ * package visible, which is the case that most needs a release note.
+ */
+export function packagePublishesAt(readManifest, dir) {
+  const raw = readManifest(dir)
+  if (raw === null) return true
+  try {
+    const m = JSON.parse(raw)
+    return !m.private || SHIPS_DESPITE_PRIVATE.includes(m.name)
+  } catch { return true }
+}
 
 // Deny by default. An earlier version listed what ships — `src/**` with a TypeScript extension —
 // and so ignored `.sql` migrations, `bin/`, `proto/`, `schema/`, `xctest-runner/`, the dashboard
@@ -38,6 +60,29 @@ const EXEMPT = [
 ]
 
 const PACKAGE_FILE = /^packages\/([^/]+)\//
+
+/**
+ * Whether a `package.json` edit can reach a user. `package.json` is deliberately not in EXEMPT —
+ * `dependencies`, `exports`, `bin` and `files` all ship — but `devDependencies` never does, and
+ * wiring up a private test helper touches every consumer's manifest. At v0.18.0 the audit called
+ * #453 a missing changeset on the strength of four such lines, while the PR-time gate had already
+ * (correctly) said no changeset was required. Two gates, two answers, same repository.
+ *
+ * Anything unreadable counts as shipping: a manifest we cannot parse is not one to wave through.
+ */
+export function manifestChangeShips(before, after) {
+  const strip = (raw) => {
+    if (raw === null) return null                    // added or deleted outright — that ships
+    try {
+      const { devDependencies: _drop, ...rest } = JSON.parse(raw)
+      return JSON.stringify(rest)
+    } catch { return null }
+  }
+  const a = strip(before)
+  const b = strip(after)
+  if (a === null || b === null) return true
+  return a !== b
+}
 /**
  * PR number of a merge commit, from its subject. `null` for anything else (a hand-made merge,
  * a squash). Exported for the tests.
@@ -90,6 +135,27 @@ export function shipsToUsers(f) {
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
 
+/** File content at a revision, or null when it does not exist there. */
+const blobAt = (rev, file) => {
+  // stderr silenced: "exists on disk, but not in <rev>" is the answer to a question, not a
+  // failure, and git says it straight to the console on the way to throwing.
+  try { return execFileSync('git', ['show', `${rev}:${file}`], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }) }
+  catch { return null }
+}
+
+/**
+ * `shipsToUsers`, plus the one question a path cannot answer: a `package.json` whose only change
+ * is under `devDependencies` ships nothing. Both call sites go through this so the audit and the
+ * PR gate cannot give different answers about the same commit again.
+ */
+function shipsBetween(file, before, after) {
+  if (!shipsToUsers(file)) return false
+  const pkg = file.match(PACKAGE_FILE)?.[1]
+  if (pkg && !packagePublishesAt((d) => blobAt(after, `packages/${d}/package.json`), pkg)) return false
+  if (!/(^|\/)package\.json$/.test(file)) return true
+  return manifestChangeShips(blobAt(before, file), blobAt(after, file))
+}
+
 /**
  * Pull `<!-- no-changeset: reason -->` out of a PR body.
  *
@@ -136,6 +202,36 @@ export function extractReason(body) {
   return ''
 }
 
+/**
+ * Packages `changeset version` refuses to see. A changeset that names one of these ALONGSIDE a
+ * published package is rejected outright — "Mixed changesets that contain both ignored and not
+ * ignored packages are not allowed" — and nothing catches it until release day, because the gate
+ * below only asks whether a changeset exists and never opens one. Four such changesets stopped
+ * the v0.18.0 release, written across four different PRs that all went green.
+ */
+function ignoredPackages() {
+  try {
+    return new Set(JSON.parse(readFileSync('.changeset/config.json', 'utf8')).ignore ?? [])
+  } catch { return new Set() }
+}
+
+/** The package names a changeset's frontmatter bumps. */
+export function packagesNamedIn(source) {
+  const front = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)
+  if (!front) return []
+  return [...front[1].matchAll(/^\s*["']([^"']+)["']\s*:\s*(major|minor|patch)\s*$/gm)].map((m) => m[1])
+}
+
+/** Changesets that mix an ignored package with a published one, as `{file, ignored, published}`. */
+export function mixedChangesets(files, ignored, read) {
+  return files.flatMap((f) => {
+    const named = packagesNamedIn(read(f))
+    const inIgnore = named.filter((n) => ignored.has(n))
+    const rest = named.filter((n) => !ignored.has(n))
+    return inIgnore.length && rest.length ? [{ file: f, ignored: inIgnore, published: rest }] : []
+  })
+}
+
 function main() {
   // `--audit [since]` walks merges instead of the current branch: the PR gate cannot help with
   // anything already on main, and that is exactly how #410–#413 slipped through. Run at release
@@ -156,7 +252,12 @@ function main() {
     let mergeLog
     try {
       // stderr silenced so git's own "ambiguous argument" dump does not precede our message.
-      mergeLog = execFileSync('git', ['log', `${since}..HEAD`, '--merges', '--format=%H %s'],
+      // `--first-parent`: only merges that landed ONTO main. Without it, a `Merge remote-tracking
+      // branch 'origin/main' into <feature>` — someone refreshing their branch — is counted as a
+      // merge of its own, and it is diffed `^1..sha` where `^1` is the branch tip and `^2` is
+      // main. That diff is everything main did since the branch forked, each part of which
+      // already had its own changeset. One such commit reported 32 files at v0.18.0.
+      mergeLog = execFileSync('git', ['log', `${since}..HEAD`, '--first-parent', '--merges', '--format=%H %s'],
         { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
     } catch {
       // Exit 2, not 1: a typo'd revision must not look like a finding.
@@ -225,7 +326,7 @@ function main() {
     }
 
     const gaps = []
-    for (const { subject, files, touched, consumed, index } of perMerge) {
+    for (const { sha, subject, files, touched, consumed, index } of perMerge) {
       // Same exemption the CI job makes. Without it the audit reports a bot's dependency bump as
       // a permanent gap: the gate never asked for that changeset, so nobody can ever close it.
       if (/dependabot|renovate/i.test(subject)) continue
@@ -236,7 +337,7 @@ function main() {
       const pr = prNumberOf(subject)
       const claimedAt = pr === null ? undefined : claims.get(pr)
       if (claimedAt !== undefined && claimedAt < index) continue
-      const shipped = files.filter((f) => shipsToUsers(f))
+      const shipped = files.filter((f) => shipsBetween(f, `${sha}^1`, sha))
       if (shipped.length > 0 && touched.length === 0) gaps.push({ subject, shipped })
     }
 
@@ -285,7 +386,7 @@ function main() {
   }
 
   const changed = git('diff', '--name-only', `${mergeBase}...HEAD`).split('\n').filter(Boolean)
-  const shipped = changed.filter((f) => shipsToUsers(f))
+  const shipped = changed.filter((f) => shipsBetween(f, mergeBase, 'HEAD'))
 
   if (shipped.length === 0) {
     console.log('No published source changed — no changeset required.')
@@ -308,6 +409,20 @@ function main() {
   if (isReleaseBranch(consumed, changed)) {
     console.log(`Release branch: ${consumed.length} changeset(s) consumed into a changelog.`)
     process.exit(0)
+  }
+
+  const mixed = mixedChangesets(added, ignoredPackages(), (f) => readFileSync(f, 'utf8'))
+  if (mixed.length > 0) {
+    console.error('Changeset names an ignored package alongside a published one:\n')
+    for (const { file, ignored, published } of mixed) {
+      console.error(`  ${file}`)
+      console.error(`    ignored:   ${ignored.join(', ')}`)
+      console.error(`    published: ${published.join(', ')}`)
+    }
+    console.error('\n`changeset version` rejects this outright, and it is not discovered until')
+    console.error('release day. Name the package that actually ships the change — for a dashboard')
+    console.error('change that is `@tapflowio/relay`, which builds it into its `public/`.')
+    process.exit(1)
   }
 
   if (added.length > 0) {


### PR DESCRIPTION
Three ways the changeset gates reported the wrong thing. All three were observed while releasing v0.18.0 (#462), which is also where the cost showed: one stopped the release, two sent me hand-verifying merges that were fine.

## What was wrong

**A changeset naming an ignored package alongside a published one passes CI and fails at release.** `changeset version` rejects the mix outright, but the PR gate only asks whether a changeset *exists* — it never opens one. Four such changesets, from four PRs that all went green, blocked v0.18.0. The gate now reads the frontmatter against `ignore` in `.changeset/config.json` and names the package to use instead (for a dashboard change, `@tapflowio/relay`, which builds it into its `public/`).

**The audit counted a back-merge as a merge of its own.** `Merge remote-tracking branch 'origin/main' into <feature>` is someone refreshing their branch. Diffed against its first parent it shows everything main did since the fork, all of which already had changesets — one such commit reported 32 files. `--first-parent` walks only what landed on main: 20 merges became 19, and the offender is exactly the one dropped.

**It also counted devDependency-only manifest edits and private packages.** Wiring a private test helper into three consumers read as shipped source, while the PR-time gate had correctly said otherwise about the same commit — one repository holding two answers. Publishing is now read from the manifest instead of a list of names; the list this replaces still held `docs` and `playground`, neither of which has been under `packages/` for some time, while `@tapflowio/test-utils` was absent from it and so counted as shipped.

## Two things I got wrong on the way, since they shaped the design

**I read the manifest from disk first, and it broke eight existing tests at once** — among them the one asserting a brand-new published package must be caught, which is the case the original comment was written to protect. The audit walks history; disk is today. It now reads at the revision under examination, and absent-or-unparseable still counts as publishing so a new package stays visible.

**The back-merge test proved nothing at first.** The branch forked after main had already moved, so the back-merge carried nothing and the case passed with or without the fix. It now forks before main advances, and has a release consume the changeset in between — the real shape, where the back-merge brings source without the note.

## Tests

Eight mutants, all killed — two only after the tests were fixed. The private check was covered as a pure function but not where it is wired into the audit, and the back-merge case is the one above. That gap is the same shape as the bugs themselves: the unit was right and the wiring was not.

`scripts/__tests__/` gains a unit file and three integration cases driving the real CLI against throwaway repositories, including one that must still fail — a new package with no manifest to judge it by.

Verified against this repository: `v0.17.0..HEAD` now reports "Every merge that changed published source carries a changeset," which is the answer I reached by hand during the release.

## Review

`.work/reviews/fix__changeset-gate-accuracy.md` — independent review skipped with the reason recorded: repository tooling, no published source (`changeset:check` agrees), and each defect was observed in production rather than hypothesised, with a failing test written before the fix.

Related: the `/release` skill's dist-tag step had hardcoded a one-time cleanup for a tag that no longer exists, while three stale tags it did not know about were live. Fixed in the same cycle — it now surveys every package's dist-tags instead of naming one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc4pFTHvZBsuDU1ibxT5eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Improved release checks to accurately identify shipped package changes, including historical, deleted, and dependency-related updates.
  * Added clearer handling for private, bundled, newly published, and mixed-package changes.
  * Enhanced release-branch detection and diagnostic messages.

* **Maintenance**
  * Generalized distribution-tag audits across publishable packages, with guidance for advancing or removing stale prerelease tags.

* **Tests**
  * Added coverage for release gating, back-merges, private-only changes, manifest issues, and newly published packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->