### PR TITLE
fix(test): resolve cross-package imports to source, not the last build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,31 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 - Comments only when the WHY is non-obvious. Write new comments in English; leave existing Korean comments unless you're already editing that line.
 - When changing an interface, update `agent-core` first, then align implementations.
 
+### A package whose tests import a sibling extends `vitest.shared.ts`
+
+Cross-package imports resolve through `exports` to `dist/`, so without it a test in one package
+exercises whatever was last *built* of another. #459 shipped a regression behind a green 1889-test
+run for exactly that reason: `ios-agent` stands up a real `RelayServer`, and the relay it stood up
+was the previous one. It surfaced only when the pre-commit `tsc -b` refreshed the build.
+
+`ssr.resolve`, not `resolve` — vitest runs in node and takes the SSR resolution path. Measured:
+`resolve.conditions`, `NODE_OPTIONS=--conditions=source` and `server.deps.inline` all still loaded
+`dist`. And `source` is **prepended** to vite's defaults rather than replacing them; a replacement
+list applies to every dependency, and dropping `node` from it sent jsdom to the wrong entry of
+`decimal.js`.
+
+Adding a package that imports a sibling in its tests means adding the config too.
+`scripts/__tests__/testsReadSource.test.mjs` finds those packages by inspection and fails if one is
+missing it — and separately plants a marker in a built artifact to prove the resolution actually
+lands on source, because a config can be present and not work.
+
+**Not** solved by pointing the manifests at source with `publishConfig`, which needs no per-tool
+config at all and was tried first. `pnpm deploy` does not apply `publishConfig`
+([pnpm#6693](https://github.com/pnpm/pnpm/issues/6693), open), so the Docker image would ship
+`node_modules` full of `.ts` and die on boot — and `packages/cli/bin/tapflow.js` is plain node too.
+Covering every consumer uniformly means covering the ones that cannot read TypeScript. Opting in
+per tool is the point, not the cost.
+
 ### Test Hygiene
 After running tests (especially repeated or looped runs), always check for zombie vitest processes and kill them:
 ```bash

--- a/packages/android-agent/vitest.config.ts
+++ b/packages/android-agent/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, defineConfig } from 'vitest/config'
+import { sourceFirst } from '../../vitest.shared'
+
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({}))

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, defineConfig } from 'vitest/config'
+import { sourceFirst } from '../../vitest.shared'
+
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({}))

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vitest/config'
+import { mergeConfig, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { sourceFirst } from '../../vitest.shared'
 
-export default defineConfig({
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({
   plugins: [react()],
   resolve: {
     alias: { '@': path.resolve(__dirname, '.') },
@@ -13,4 +16,4 @@ export default defineConfig({
     setupFiles: ['./src/__tests__/setup.ts'],
     testTimeout: 10000,
   },
-})
+}))

--- a/packages/flow-runner/vitest.config.ts
+++ b/packages/flow-runner/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, defineConfig } from 'vitest/config'
+import { sourceFirst } from '../../vitest.shared'
+
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({}))

--- a/packages/ios-agent/vitest.config.ts
+++ b/packages/ios-agent/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, defineConfig } from 'vitest/config'
+import { sourceFirst } from '../../vitest.shared'
+
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({}))

--- a/packages/relay/vitest.config.ts
+++ b/packages/relay/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, defineConfig } from 'vitest/config'
+import { sourceFirst } from '../../vitest.shared'
+
+// `sourceFirst`: this package's tests import a sibling, and must see its source rather than the
+// last thing built of it. See vitest.shared.ts.
+export default mergeConfig(sourceFirst, defineConfig({}))

--- a/scripts/__tests__/testsReadSource.test.mjs
+++ b/scripts/__tests__/testsReadSource.test.mjs
@@ -1,0 +1,102 @@
+// A test in one package must exercise its sibling's SOURCE, not whatever was last built of it.
+//
+// #459 shipped a regression behind a green 1889-test run because that was not true: `ios-agent`
+// stands up a real `RelayServer`, the import resolved through `exports` to `dist/`, and `dist` was
+// stale. It surfaced only when the pre-commit `tsc -b` refreshed the build.
+//
+// The guard is `ssr.resolve.conditions` in `vitest.shared.ts`, which each affected package extends.
+// Two ways that silently stops working — a package drops the config, or a NEW package starts
+// importing a sibling and never adds it — so this checks both, and checks the resolution itself
+// rather than trusting the config to mean what it says.
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'child_process'
+import { readFileSync, readdirSync, existsSync, writeFileSync, appendFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const PKGS = join(ROOT, 'packages')
+
+const packageDirs = () =>
+  readdirSync(PKGS).filter((d) => existsSync(join(PKGS, d, 'package.json')))
+
+/** Does this package's own test files import a sibling workspace package? */
+function testsImportASibling(dir) {
+  const tests = join(PKGS, dir, 'src', '__tests__')
+  if (!existsSync(tests)) return false
+  try {
+    execFileSync('grep', ['-rlq', '@tapflowio/', tests], { stdio: 'ignore' })
+    return true
+  } catch { return false }
+}
+
+const extendsShared = (dir) => {
+  const cfg = join(PKGS, dir, 'vitest.config.ts')
+  return existsSync(cfg) && readFileSync(cfg, 'utf8').includes('sourceFirst')
+}
+
+describe('every package whose tests import a sibling reads its source', () => {
+  // Derived, not listed. A hardcoded list is exactly how vitest came to be the tool nobody had
+  // switched on: it described the day it was written.
+  const affected = packageDirs().filter(testsImportASibling)
+
+  it('finds the packages by inspection, not from a list', () => {
+    expect(affected.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it.each(affected)('%s extends the shared config', (dir) => {
+    expect(extendsShared(dir), `packages/${dir} imports a sibling in its tests but does not extend sourceFirst`).toBe(true)
+  })
+})
+
+describe("the copied condition list still matches vite's", () => {
+  // `vitest.shared.ts` cannot import `vite` — most packages that load it do not depend on it — so
+  // it copies `defaultServerConditions`. Copies go stale silently, and the way this one goes stale
+  // is ugly: dropping `node` from the list sent jsdom to the wrong entry of `decimal.js` and killed
+  // ten dashboard tests with `Decimal is not a constructor`.
+  it('has not drifted', () => {
+    const actual = JSON.parse(execFileSync('node', ['--input-type=module', '-e',
+      `import('vite').then(v => console.log(JSON.stringify(v.defaultServerConditions)))`],
+      { cwd: join(PKGS, 'dashboard'), encoding: 'utf8' }))
+    const copied = readFileSync(join(ROOT, 'vitest.shared.ts'), 'utf8')
+      .match(/conditions:\s*\[([^\]]*)\]/)[1]
+      .split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
+
+    expect(copied[0], 'source must come first, or the build wins').toBe('source')
+    expect(copied.slice(1)).toEqual(actual)
+  }, 30_000)
+})
+
+describe('and the resolution really lands on source', () => {
+  // The config could be present and not work — a vitest upgrade moving the setting, a merge that
+  // drops it. So this plants a marker in a built artifact and asserts a cross-package import
+  // cannot see it. It is the only assertion here that would survive the config being a no-op.
+  const RELAY_DIST = join(PKGS, 'relay', 'dist', 'index.js')
+  const MARKER = '__LOADED_FROM_DIST__'
+
+  it('a cross-package import does not see a symbol that exists only in dist', () => {
+    if (!existsSync(RELAY_DIST)) {
+      throw new Error('packages/relay/dist/index.js is missing — run `pnpm build` first; this test needs a build to plant a marker in')
+    }
+    const before = readFileSync(RELAY_DIST, 'utf8')
+    appendFileSync(RELAY_DIST, `\nexport const ${MARKER} = true;\n`)
+    try {
+      const probe = join(PKGS, 'ios-agent', 'src', '__tests__', 'zz-source-resolution.probe.test.ts')
+      writeFileSync(probe, [
+        `import { it, expect } from 'vitest'`,
+        `import * as relay from '@tapflowio/relay'`,
+        `it('resolves to source', () => { expect('${MARKER}' in relay).toBe(false) })`,
+        '',
+      ].join('\n'))
+      try {
+        execFileSync('npx', ['vitest', 'run', '--root', join(PKGS, 'ios-agent'),
+          'src/__tests__/zz-source-resolution.probe.test.ts'],
+          { cwd: ROOT, stdio: 'pipe', encoding: 'utf8' })
+      } finally {
+        execFileSync('rm', ['-f', probe])
+      }
+    } finally {
+      writeFileSync(RELAY_DIST, before)
+    }
+  }, 120_000)
+})

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Shared by every package whose tests import a sibling workspace package.
+ *
+ * Without it those imports resolve through `exports` to `dist/`, so a test in one package
+ * exercises whatever was last *built* of another. #459 shipped a regression behind a green
+ * 1889-test run for exactly that reason: `ios-agent` stands up a real `RelayServer`, and the relay
+ * it stood up was the previous one. It surfaced only when the pre-commit `tsc -b` refreshed `dist`.
+ *
+ * `ssr.resolve`, not `resolve`: vitest runs in node, so it takes the SSR resolution path. Measured
+ * — `resolve.conditions`, `NODE_OPTIONS=--conditions=source` and `server.deps.inline` all still
+ * loaded `dist`; only this one switched.
+ *
+ * Why not point the manifests at source instead, which would need no config at all: `pnpm deploy`
+ * does not apply `publishConfig`, so the Docker image would ship `node_modules` full of `.ts` and
+ * die on boot with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING — and `packages/cli/bin/tapflow.js`
+ * is plain node too. Covering every consumer uniformly means covering the ones that cannot read
+ * TypeScript. Opting in per tool is the point, not the cost.
+ */
+export const sourceFirst = defineConfig({
+  // `source` PREPENDED to vite's own defaults, never replacing them. Replacing looks equivalent and
+  // is not: the list applies to every dependency, not just workspace ones, and dropping `node` sent
+  // jsdom to the wrong entry of `decimal.js` — ten dashboard tests died on
+  // `TypeError: Decimal is not a constructor`, nowhere near anything this change is about.
+  //
+  // The defaults are copied rather than imported because `vite` is not a dependency of most of the
+  // packages that load this file. `scripts/__tests__/testsReadSource.test.mjs` compares this list
+  // against vite's real `defaultServerConditions`, so a version that changes them fails by name
+  // instead of by whatever breaks next.
+  ssr: { resolve: { conditions: ['source', 'module', 'node', 'development|production'] } },
+})
+
+export default sourceFirst


### PR DESCRIPTION
A test in one package imported its sibling through `exports`, which resolves to `dist/`. So the suite could pass against code that no longer existed — which is how #459 shipped a regression behind a green 1889-test run: `ios-agent` stands up a real `RelayServer`, and the relay it stood up was the previous one. It surfaced only when the pre-commit `tsc -b` refreshed the build.

Six packages — the ones whose tests import a sibling — now extend `vitest.shared.ts`, which prepends the `source` condition to vite's SSR resolution.

## The check that matters

Reinstate the #459 gate in relay's source and run ios-agent **without building**:

| | result |
|---|---|
| with the config | **12 tests fail** |
| without it | 288 pass — the state that hid the regression |

Full suite 1957 pass, typecheck and lint clean.

## What this rejected, and why it is worth knowing

The first attempt pointed the manifests at source and let `publishConfig` restore `dist/` at publish time — **no per-tool config at all**, and pnpm documents that as the purpose of the feature. It looked more fundamental and I recommended it.

Review found it ships a broken container. **`pnpm deploy` does not apply `publishConfig`** ([pnpm#6693](https://github.com/pnpm/pnpm/issues/6693), open since 2023, PR #7647 unmerged). The Dockerfile is `pnpm deploy` → `CMD node dist/server.js`, so the deployed `node_modules` would keep `.ts` entry points and node refuses to strip types there — `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, dead on boot. `docker-publish.yml` builds the image and never runs it, so CI could not have caught it. Reproduced by running the exact deploy and the exact CMD.

A documented workaround exists — a post-deploy script re-applying `publishConfig` — and it works; I built it and the relay booted. It was still the wrong trade:

- its failure mode is a shipped artifact that crashes on boot, invisible to CI, so adopting it also means adding image-run coverage
- `packages/cli/bin/tapflow.js` is plain node too, and it is the file npm users execute, so it cannot become TypeScript-aware

The design reason underneath: `publishConfig` declares *"this package is its source, the build is for outsiders."* tapflow ships an npm package, **a Docker image, and a plain-node CLI bin** — two of three consume the build through node. Covering every consumer uniformly means covering the ones that cannot read TypeScript. Opting in per tool is the point, not the cost. If tapflow stopped shipping a container, the other answer becomes correct.

## Two things I got wrong on the way

Both were caught by running things, not by reading them.

**Writing the condition list by hand replaced vite's defaults instead of extending them.** It applies to every dependency, not just workspace ones, and losing `node` sent jsdom to the wrong entry of `decimal.js` — ten dashboard tests died on `Decimal is not a constructor`, nowhere near anything this change touches. The defaults are copied now, and since `vite` is not a dependency of most packages that load the shared config, a test compares the copy against vite's real `defaultServerConditions` so drift fails by name.

**I nearly discarded the right answer.** An absolute `--config` path double-joined with `--root`, the config failed to *load*, and I read that as `ssr.resolve` not working. Config not loaded and config ineffective are different failures.

## Tests

`scripts/__tests__/testsReadSource.test.mjs` finds affected packages **by inspection rather than from a list** — a hardcoded list is precisely how vitest came to be the tool nobody had switched on — and plants a marker in a built artifact to prove resolution really lands on source, because a config can be present and not work.

Six mutants kill it: a package dropping the config, a new package never adding it, a gutted setting, a misspelled condition, the default list drifting, and `source` losing first place. The previous design's test survived five equivalent mutations; that is why this one asserts the property instead of the configuration.

## Review

`.work/reviews/fix__tests-read-source-vitest.md` — the pre-PR review was run against the rejected design and is what produced this one; its findings and the design argument are recorded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc4pFTHvZBsuDU1ibxT5eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by ensuring cross-package tests resolve current source code before built artifacts.
  * Added safeguards to detect configuration drift and verify source resolution across packages.

* **Tests**
  * Expanded automated coverage for cross-package imports and source-first test behavior.

* **Documentation**
  * Added guidance for configuring packages whose tests import sibling packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->