### PR TITLE
docs(contributing): state that issues are not assigned in advance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,12 @@ docs/             ← documentation site (VitePress)
 playground/       ← local integration test environment
 ```
 
+## Claiming an issue
+
+Issues are not assigned in advance. Open a draft PR or post your findings on the issue and it is yours — a comment reserving one does not hold it, so no issue sits blocked behind an intent that never lands.
+
+Check the labels before you start: `requires: macOS` means the change runs against a real simulator or emulator and cannot be verified without a Mac (Xcode / Android SDK). A `good first issue` without that label needs only Node.js and pnpm.
+
 ## Branches & releases
 
 - `main` is always deployable. Direct commits are not allowed. Start work on a `feature/{topic}` branch → PR → merge.


### PR DESCRIPTION
## Why

An outside contributor asked to be assigned #434. That issue needs a Mac with Xcode and a running simulator, and its first step is a measurement rather than a code change — so the answer was "no, and here is where to look instead". Nothing in the repo said how claiming works or which issues are gated on hardware, so both halves of that answer had to be written by hand.

The same traffic keeps arriving: tapflow is listed in good-first-issue directories, and the issues newcomers land on are not always the ones they can actually run.

## What

A `## Claiming an issue` section in `CONTRIBUTING.md`, placed before `Branches & releases` — a newcomer needs it earlier than the branch rules.

- **No advance assignment.** A draft PR or posted findings claims an issue; a reserving comment does not. Keeps issues from sitting blocked behind an intent that never lands.
- **Points at the new `requires: macOS` label**, so "can I even run this?" is answerable from the issue list.

## Repo settings changed alongside (not in this diff)

- New label `requires: macOS` — *Cannot be verified without a Mac (simulator/emulator required)*
- Applied to #378 and #434

#378 keeps `good first issue`. For someone with a Mac it genuinely is one — a single doctor check following the existing pattern, no interface change. What was missing was the hardware signal, so the fix is an added label rather than a removed one. Mac-free good first issues are now unambiguously #168 and #352.

## Follow-ups (not done here)

- More Mac-gated issues could take the label: #455 #447 #433 #432 #416 #334 #202 #151 #150 #44. Their titles already carry some signal, and labelling all of them is a separate sweep.
- #352 has a maintainer prerequisite (Docker Hub repo + `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`). It is recommended as Mac-free, but whoever picks it up will stop at the publish step until those exist.

## Review

Docs-only, so the adversarial review itself was skipped per AGENTS.md; the record with the skip reason and HEAD hash is in `.work/reviews/docs__contributing-issue-claiming.md`.

<!-- no-changeset: contributor-docs only, no published source changed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on claiming issues through draft pull requests or issue findings.
  * Clarified that comments do not reserve issues.
  * Documented labels indicating macOS requirements and Node.js/pnpm-only work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->