### PR TITLE
chore(github): add a feature request template and close the blank-issue path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,6 +68,18 @@ body:
       label: macOS version (iOS agent only)
       placeholder: "e.g. macOS 15.4 — leave blank if not applicable"
 
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Mac architecture (the machine running the agent)
+      description: "Run `uname -m`. Apple Silicon reports `arm64`, Intel reports `x86_64`."
+      options:
+        - arm64 (Apple Silicon)
+        - x86_64 (Intel)
+        - Not applicable (no agent involved)
+    validations:
+      required: true
+
   - type: input
     id: xcode
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting guide
+    url: https://tapflow.dev/guide/troubleshooting
+    about: Common setup and runtime failures with their fixes — worth a look before filing.
+  - name: Documentation
+    url: https://tapflow.dev
+    about: Guides and reference for installing, self-hosting, and running tapflow.
+  - name: Report a security vulnerability
+    url: https://github.com/jo-duchan/tapflow/security/advisories/new
+    about: Report it privately here. Do not open a public issue for a security problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please search existing issues first — and note tapflow's scope: it is self-hosted, and it does not send app data or streams to external services. A proposal that requires an outside service will not be accepted.
+        Please search existing issues first — and note tapflow's scope: it is self-hosted, and app data and streams never leave your network. A proposal that routes them through an outside service will not be accepted.
 
         Reporting something broken instead? Use the [Bug Report](https://github.com/jo-duchan/tapflow/issues/new?template=bug_report.yml) template.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Propose a new capability or an improvement to an existing one
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first — and note tapflow's scope: it is self-hosted, and it does not send app data or streams to external services. A proposal that requires an outside service will not be accepted.
+
+        Reporting something broken instead? Use the [Bug Report](https://github.com/jo-duchan/tapflow/issues/new?template=bug_report.yml) template.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation you hit, not the solution you have in mind. What were you trying to do, and where did tapflow get in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like tapflow to do?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part does this touch?
+      options:
+        - iOS (simulator)
+        - Android (emulator)
+        - Both platforms
+        - Relay / dashboard / CLI
+        - MCP server (AI-agent path)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Including anything you tried as a workaround, and why it was not enough.
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to work on this


### PR DESCRIPTION
## Why

`bug_report.yml` was the only issue template, and it applies the `bug` label itself. Everything else fell through to a blank issue — no template, no label, no guidance.

#464 arrived that way. An external reporter filed a packaging defect with `[Feature Request]` typed into the title by hand and nothing labelled, so triage had to reconstruct both the type and the priority from the body. A label audit of all 37 open issues traced two more unlabelled issues to the same path.

## What

- **`feature_request.yml`** — `labels: ["enhancement"]`. Asks for the problem before the proposal, and states tapflow's scope up front (self-hosted, no external services) so out-of-scope proposals self-filter.
- **`config.yml`** — `blank_issues_enabled: false`, plus contact links for troubleshooting, docs, and private security reporting. The advisory link is live: private vulnerability reporting is enabled on this repo.
- **`bug_report.yml`** — one new required field: the agent host's architecture (`uname -m`). No manifest declares a `cpu` field, so arm64-vs-x86_64 is invisible unless asked. In #464 the reporter had to run `lipo -info` themselves to explain their own failure.

All three parse clean against the issue-form schema shape (`yaml@2.9.0`, no duplicate ids, no unknown field types).

## Trade-off worth a second look

`blank_issues_enabled: false` removes an escape hatch — a reporter who fits neither template now has only the contact links. I took that as the right call because the blank path's measured output is #464, and the `area` dropdown carries a `Not sure` option to absorb the "where does this belong" case. One line to revert if a real report turns up that fits neither form.

## Repo settings changed alongside (not in this diff)

The label audit behind this PR also applied:

- Type/phase gaps filled: #351 #422 (`test`+`phase-4`), #421 (`bug`), #284 #293 #168 (`enhancement`), #457 (`phase-5`) — no open issue is now missing either, except #464 by intent
- `requires: macOS` swept across 18 issues, which leaves 16 that a contributor without a Mac can filter to
- New label `priority: high`

#464 itself ended at `enhancement` · `requires: macOS`, with no phase — Intel support is under consideration pending the reporter's willingness to test, not scheduled.

## Review

Config-only, no runtime path, so the adversarial review was skipped; the record with the skip reason, the schema validation output, and both trade-offs is in `.work/reviews/chore__issue-templates.md`.

CodeRabbit raised one finding, accepted: the scope note rejected any proposal that "requires an outside service", which contradicts the Cloudflare and Vercel DNS provider integrations already shipped for LAN HTTPS certificate issuance. The line now draws the same boundary AGENTS.md does — app data and streams, not outside services in general.

<!-- no-changeset: GitHub issue templates only, no published source changed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured issue templates for bug reports and feature requests.
  * Bug reports now capture the agent machine architecture.
  * Feature requests include fields for the problem, proposed solution, affected platform or component, alternatives, and contribution interest.
  * Added links to troubleshooting resources, documentation, and private security reporting.
  * Disabled blank issue submissions to help direct reports through the appropriate channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
