### PR TITLE
feat(scripts): audit pnpm.overrides for necessity, correctness and reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,38 @@ A dashboard change names **`@tapflowio/relay`**, never `@tapflowio/dashboard`. T
 
 `pnpm changeset:check` runs the same check locally, against committed work. A changeset written for an EARLIER PR must say so — `Backfills: #413` on its own line — or the audit keeps reporting that merge for the rest of the cycle. That gate cannot see anything already on main, so `/release` audits the merges too (`pnpm changeset:audit`) — four merged PRs once got as far as release preparation with no changelog entry between them, and only the audit would have caught it.
 
+### A security bump is `pnpm update` first, and an override only if that fails
+
+Reach for `pnpm.overrides` last. The usual situation is not that the declared range forbids the
+patch — it is that the **lockfile does not re-evaluate ranges**. The patch nearly always lands
+inside the same major, the declaring range is a caret, and `pnpm update <pkg>` takes it with no
+permanent entry to maintain. An override is a workaround for a stale lockfile, and it outlives the
+problem: measured on 2026-08-06, all fourteen entries in the block were inert — removing the whole
+thing and resolving cold produced a byte-identical tree.
+
+`pnpm overrides:audit` judges each entry: still needed, correct, and whether it reaches a published
+package's production tree. Run it before adding an entry, and when one is added, plan to remove it.
+
+**Derive an override key from the GHSA advisory, never from the Dependabot alert.** An alert reports
+only the affected range matching the version you happen to have installed. `fast-uri` patched three
+lines within fourteen minutes of each other; the alert showed one, and #471 shipped a key that left
+the current major line unguarded. The same mistake in #469 inherited a lower bound from an earlier
+advisory. Read the whole affected set:
+
+```bash
+gh api graphql -f query='{securityVulnerabilities(ecosystem:NPM, package:"NAME", first:100){
+  pageInfo{hasNextPage endCursor}
+  nodes{advisory{ghsaId severity} vulnerableVersionRange firstPatchedVersion{identifier}}}}'
+```
+
+Page it. `axios` has 73 advisories and `undici` 67, and a page that stops short reads exactly like
+"no such advisory" — the direction that hides a floor you needed. Repeat with `after:"<endCursor>"`
+until `hasNextPage` is false. `pnpm overrides:audit` does this for you.
+
+Scope the key to the major line its replacement targets — pnpm matches by range **intersection**,
+not containment, so a bare `<X` reaches every major below it and would force a cross-major jump on
+a consumer that declared one. Cap the replacement for the same reason.
+
 ---
 
 ## HOW NOT

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "changeset": "changeset",
     "changeset:check": "node scripts/check-changeset.mjs",
     "changeset:audit": "node scripts/check-changeset.mjs --audit",
+    "overrides:audit": "node scripts/audit-overrides.mjs",
     "version": "changeset version",
     "release": "pnpm build && changeset publish"
   },

--- a/scripts/__tests__/auditOverrides.test.mjs
+++ b/scripts/__tests__/auditOverrides.test.mjs
@@ -1,0 +1,326 @@
+// The audit's judgement, tested without running a resolve.
+//
+// Cases are the real defects it was written to find — #469's inherited lower bound, #471's
+// advisory with three patched lines, shell-quote's floor that a later advisory overtook — because
+// a checker whose tests are invented inputs only proves it is self-consistent.
+import { describe, it, expect } from 'vitest'
+import {
+  parseKey,
+  cmp,
+  major,
+  judgeKey,
+  floorsByPackage,
+  belowFloor,
+  resolvedVersions,
+  neededVerdict,
+  publishedReachers,
+  publishedWorkspaceNames,
+} from '../audit-overrides.mjs'
+
+const kinds = (r) => r.faults.map((f) => f.kind)
+const noteKinds = (r) => r.notes.map((n) => n.kind)
+
+describe('parseKey', () => {
+  it('splits on the LAST @, so scoped names survive', () => {
+    expect(parseKey('fast-uri@>=3.0.0 <3.1.5')).toEqual({ name: 'fast-uri', range: '>=3.0.0 <3.1.5' })
+    expect(parseKey('@hono/node-server@<2.0.5')).toEqual({ name: '@hono/node-server', range: '<2.0.5' })
+  })
+})
+
+describe('cmp / major', () => {
+  it('orders by numeric component, not lexically', () => {
+    expect(cmp('1.9.0', '1.8.4')).toBeGreaterThan(0)
+    expect(cmp('1.10.0', '1.9.0')).toBeGreaterThan(0) // '1.10.0' < '1.9.0' as strings
+    expect(cmp('3.1.5', '3.1.5')).toBe(0)
+  })
+  it('reads the major of a bare or partial version', () => {
+    expect(major('4.12.34')).toBe(4)
+    expect(major('0.28.1')).toBe(0)
+  })
+})
+
+describe('judgeKey — unbounded key lower bound', () => {
+  // pnpm matches by range INTERSECTION, so `<X` reaches every major below and the replacement
+  // would force a cross-major jump. Fixed for undici in #469, still present on four keys.
+  it('flags a bare upper-bound key', () => {
+    const r = judgeKey({ key: 'dompurify@<3.4.12', replacement: '>=3.4.12 <4' }, [])
+    expect(kinds(r)).toContain('unbounded-key-lower')
+  })
+
+  it('accepts a key scoped to its major', () => {
+    const r = judgeKey({ key: 'dompurify@>=3.0.0 <3.4.12', replacement: '>=3.4.12 <4' }, [])
+    expect(kinds(r)).not.toContain('unbounded-key-lower')
+  })
+})
+
+describe('judgeKey — unbounded replacement', () => {
+  it('flags a replacement with no cap', () => {
+    const r = judgeKey({ key: 'esbuild@>=0.27.3 <0.28.1', replacement: '>=0.28.1' }, [])
+    expect(kinds(r)).toContain('unbounded-replacement')
+  })
+
+  it('accepts an explicit cap, and accepts caret as its own cap', () => {
+    expect(kinds(judgeKey({ key: 'esbuild@>=0.27.3 <0.28.1', replacement: '>=0.28.1 <0.29.0' }, [])))
+      .not.toContain('unbounded-replacement')
+    expect(kinds(judgeKey({ key: 'hono@>=4.0.0 <4.12.34', replacement: '^4.12.34' }, [])))
+      .not.toContain('unbounded-replacement')
+  })
+})
+
+describe('judgeKey — stale replacement floor', () => {
+  // shell-quote's real history: the override targeted GHSA-w7jw (patched 1.8.4), then GHSA-395f
+  // landed ON 1.8.4 and the replacement floor was never raised.
+  const shellQuote = [
+    { ghsa: 'GHSA-w7jw-789q-3m8p', range: '>= 1.1.0, <= 1.8.3', patched: '1.8.4' },
+    { ghsa: 'GHSA-395f-4hp3-45gv', range: '<= 1.8.4', patched: '1.9.0' },
+  ]
+
+  it('flags a floor a later advisory overtook', () => {
+    const r = judgeKey({ key: 'shell-quote@>=1.0.0 <1.8.4', replacement: '^1.8.4' }, shellQuote)
+    expect(kinds(r)).toContain('stale-replacement-floor')
+    expect(r.faults.find((f) => f.kind === 'stale-replacement-floor').detail).toContain('1.9.0')
+  })
+
+  it('clears once the floor is raised', () => {
+    const r = judgeKey({ key: 'shell-quote@>=1.0.0 <1.9.0', replacement: '>=1.9.0 <2' }, shellQuote)
+    expect(kinds(r)).not.toContain('stale-replacement-floor')
+  })
+})
+
+describe('judgeKey — uncovered advisory line', () => {
+  // The #471 failure exactly: one advisory patched 4.1.2, 3.1.5 and 2.4.4 within fourteen minutes,
+  // and the key derived from the Dependabot alert covered only 3.x.
+  const fastUri = [
+    { ghsa: 'GHSA-7p8r-x3mc-p8w7', range: '>= 4.0.0, < 4.1.2', patched: '4.1.2' },
+    { ghsa: 'GHSA-7p8r-x3mc-p8w7', range: '>= 3.0.0, < 3.1.5', patched: '3.1.5' },
+    { ghsa: 'GHSA-7p8r-x3mc-p8w7', range: '< 2.4.4', patched: '2.4.4' },
+  ]
+
+  it('notices the current line left unguarded by a single key', () => {
+    const r = judgeKey({ key: 'fast-uri@>=3.0.0 <3.1.5', replacement: '>=3.1.5 <4' }, fastUri, '3')
+    expect(noteKinds(r)).toContain('uncovered-line')
+    expect(r.notes.map((n) => n.detail).join(' ')).toContain('4.x')
+  })
+
+  it('is silent once a sibling key covers that line', () => {
+    // Judged per package. Without this the three fast-uri keys each reported the other two.
+    const r = judgeKey({ key: 'fast-uri@>=3.0.0 <3.1.5', replacement: '>=3.1.5 <4' }, fastUri, '3', [
+      { key: 'fast-uri@>=2.0.0 <2.4.4', replacement: '>=2.4.4 <3' },
+      { key: 'fast-uri@>=4.0.0 <4.1.2', replacement: '>=4.1.2 <5' },
+    ])
+    expect(noteKinds(r)).not.toContain('uncovered-line')
+  })
+
+  it('is a note, never a fault — whether the line is worth a key is a human call', () => {
+    const r = judgeKey({ key: 'fast-uri@>=3.0.0 <3.1.5', replacement: '>=3.1.5 <4' }, fastUri, '3')
+    expect(kinds(r)).not.toContain('uncovered-line')
+  })
+
+  it('ignores lines below what the tree resolves', () => {
+    // Nothing can drift down into 2.x when 3.1.5 is installed.
+    const r = judgeKey({ key: 'fast-uri@>=3.0.0 <3.1.5', replacement: '>=3.1.5 <4' }, fastUri, '3')
+    expect(r.notes.map((n) => n.detail).join(' ')).not.toContain('2.x')
+  })
+
+  it('ignores a different advisory on an older major', () => {
+    // protobufjs produced seven of these — 5.x and 6.x advisories against a 7.x key.
+    const protobuf = [
+      { ghsa: 'GHSA-current', range: '>= 7.5.0, <= 7.6.4', patched: '7.6.5' },
+      { ghsa: 'GHSA-ancient', range: '>= 6.0.0, < 6.8.6', patched: '6.8.6' },
+    ]
+    const r = judgeKey({ key: 'protobufjs@>=7.5.0 <=7.6.4', replacement: '>=7.6.5 <8' }, protobuf, '7')
+    expect(noteKinds(r)).toEqual([])
+  })
+})
+
+describe('judgeKey — a line with no patch is reported, not blamed', () => {
+  it('separates unrescuable ranges from faults', () => {
+    // hono 3.x: last release 3.12.12 in 2024, only patch is 4.12.34. An override cannot fix that
+    // line — forcing a 3.x consumer to ^4 is a break, not a remedy.
+    const r = judgeKey({ key: 'hono@>=4.0.0 <4.12.34', replacement: '^4.12.34' }, [
+      { ghsa: 'GHSA-8j4g-w8fx-2239', range: '< 4.12.34', patched: '4.12.34' },
+      { ghsa: 'GHSA-old', range: '< 3.0.0', patched: null },
+    ])
+    expect(r.unrescuable).toEqual(['< 3.0.0'])
+    expect(kinds(r)).toEqual([])
+  })
+})
+
+describe('floorsByPackage / belowFloor', () => {
+  it('keeps the highest patch per compatibility line', () => {
+    const floors = floorsByPackage({
+      'fast-uri': [
+        { range: '>= 3.0.0, < 3.1.4', patched: '3.1.4' },
+        { range: '>= 3.0.0, < 3.1.5', patched: '3.1.5' },
+        { range: '>= 4.0.0, < 4.1.2', patched: '4.1.2' },
+      ],
+    })
+    expect(floors['fast-uri']).toEqual({ 3: '3.1.5', 4: '4.1.2' })
+  })
+
+  it('keeps 0.x minors apart, since each is its own compatibility line', () => {
+    const floors = floorsByPackage({
+      esbuild: [
+        { range: '>= 0.21.0, < 0.21.6', patched: '0.21.6' },
+        { range: '>= 0.28.0, < 0.28.1', patched: '0.28.1' },
+      ],
+    })
+    expect(floors.esbuild).toEqual({ '0.21': '0.21.6', '0.28': '0.28.1' })
+  })
+
+  it('judges each version against its OWN line', () => {
+    const floors = { 3: '3.1.5', 4: '4.1.2' }
+    // 4.1.0 is below the 4.x floor even though it is above the 3.x one.
+    expect(belowFloor(['3.1.5', '4.1.0'], floors)).toEqual(['4.1.0'])
+    expect(belowFloor(['3.1.5', '4.1.2'], floors)).toEqual([])
+  })
+
+  it('reports nothing when the package has no known advisories', () => {
+    expect(belowFloor(['1.0.0'], undefined)).toEqual([])
+  })
+})
+
+describe('resolvedVersions', () => {
+  const lock = [
+    'packages:',
+    '',
+    "  '@hono/node-server@2.0.12':",
+    '  fast-uri@3.1.5:',
+    '  fast-uri-other@9.9.9:',
+    '  hono@4.13.0:',
+  ].join('\n')
+
+  it('reads versions for a scoped and an unscoped name', () => {
+    expect(resolvedVersions(lock, 'fast-uri')).toEqual(['3.1.5'])
+    expect(resolvedVersions(lock, '@hono/node-server')).toEqual(['2.0.12'])
+  })
+
+  it('does not match a package whose name merely starts the same', () => {
+    // `fast-uri` must not pick up `fast-uri-other`.
+    expect(resolvedVersions(lock, 'fast-uri')).not.toContain('9.9.9')
+  })
+})
+
+// ── regressions the first round of tests could not have caught ────────────────
+
+describe('resolvedVersions — peer-suffixed and rangeless shapes', () => {
+  const lock = [
+    "  '@hono/node-server@2.0.12(hono@4.13.0)':",
+    '  axios@1.18.1(debug@4.4.3):',
+    '  esbuild@0.25.12(patch_hash=abc123):',
+    '  fast-uri@3.1.5:',
+  ].join('\n')
+
+  it('reads the package version, not the peer it is suffixed with', () => {
+    // The peer's `@` is the LAST one, so slicing there reported hono's version as node-server's.
+    expect(resolvedVersions(lock, '@hono/node-server')).toEqual(['2.0.12'])
+    expect(resolvedVersions(lock, 'axios')).toEqual(['1.18.1'])
+    expect(resolvedVersions(lock, 'esbuild')).toEqual(['0.25.12'])
+  })
+
+  it('returns nothing for an empty name instead of matching every scoped line', () => {
+    expect(resolvedVersions(lock, '')).toEqual([])
+  })
+})
+
+describe('parseKey / judgeKey — rangeless and exact-version keys', () => {
+  it('keeps the name intact when the key carries no range', () => {
+    // `"esbuild": ">=0.28.1"` is pnpm's documented default form.
+    expect(parseKey('esbuild')).toEqual({ name: 'esbuild', range: '' })
+    expect(parseKey('@hono/node-server')).toEqual({ name: '@hono/node-server', range: '' })
+  })
+
+  it('faults a rangeless key rather than mangling it', () => {
+    expect(kinds(judgeKey({ key: 'esbuild', replacement: '>=0.28.1' }, []))).toContain('rangeless-key')
+  })
+
+  it('does not call an exact version unbounded, in the key or the replacement', () => {
+    const r = judgeKey({ key: 'shell-quote@1.8.4', replacement: '1.9.0' }, [])
+    expect(kinds(r)).not.toContain('unbounded-key-lower')
+    expect(kinds(r)).not.toContain('unbounded-replacement')
+  })
+})
+
+describe('0.x lines are compatibility boundaries, not one bucket', () => {
+  const esbuild = [
+    { ghsa: 'GHSA-x', range: '>= 0.27.3, < 0.28.1', patched: '0.28.1' },
+    { ghsa: 'GHSA-x', range: '>= 0.29.0, < 0.29.4', patched: '0.29.4' },
+  ]
+
+  it('notices a second 0.x line the key does not cover', () => {
+    // Bucketing every 0.x into major 0 made `guarded` always contain the key's own line, so this
+    // note could never fire for a 0.x package — the one kind where each minor is breaking.
+    const r = judgeKey({ key: 'esbuild@>=0.27.3 <0.28.1', replacement: '>=0.28.1 <0.29.0' }, esbuild, '0.27')
+    expect(noteKinds(r)).toContain('uncovered-line')
+    expect(r.notes.map((n) => n.detail).join(' ')).toContain('0.29')
+  })
+
+  it('ignores a 0.x line below what the tree resolves', () => {
+    // The filter compared majors, which is `0 < 0` for every 0.x package — so it could not fire
+    // for exactly the packages `line()` exists for. With the tree on 0.29, an advisory patching
+    // an ancient 0.21 was still reported as an uncovered line nothing could reach.
+    const old = [
+      { ghsa: 'G1', range: '>= 0.29.0, < 0.29.4', patched: '0.29.4' },
+      { ghsa: 'G1', range: '>= 0.21.0, < 0.21.3', patched: '0.21.3' },
+    ]
+    const r = judgeKey({ key: 'esbuild@>=0.29.0 <0.29.4', replacement: '>=0.29.4 <0.30.0' }, old, '0.29')
+    expect(noteKinds(r)).toEqual([])
+  })
+
+  it('is silent once a sibling key covers the other 0.x line', () => {
+    const r = judgeKey(
+      { key: 'esbuild@>=0.27.3 <0.28.1', replacement: '>=0.28.1 <0.29.0' },
+      esbuild,
+      '0.27',
+      [{ key: 'esbuild@>=0.29.0 <0.29.4', replacement: '>=0.29.4 <0.30.0' }],
+    )
+    expect(noteKinds(r)).toEqual([])
+  })
+})
+
+describe('neededVerdict', () => {
+  // Keyed by compatibility line, which for a 0.x package is `0.<minor>`.
+  const floors = { '0.21': '0.21.6', '0.25': '0.25.13', '0.28': '0.28.1' }
+
+  it('RETIRE when removing it changes nothing — esbuild is below floor either way', () => {
+    const both = ['0.21.5', '0.25.12', '0.28.1']
+    expect(neededVerdict(both, both, floors).verdict).toBe('RETIRE')
+  })
+
+  it('KEEP only when removing it newly drops something below its floor', () => {
+    const r = neededVerdict(['0.28.1'], ['0.27.5'], { ...floors, '0.27': '0.27.6' })
+    expect(r.verdict).toBe('KEEP')
+    expect(r.newlyLow).toEqual(['0.27.5'])
+  })
+
+  it('does not judge one 0.x minor against another minor\'s floor', () => {
+    // Bucketing every 0.x under major `0` gave the whole line the newest patch anywhere in it, so
+    // 0.21.5 was measured against 0.28.1 and looked vulnerable to an advisory about a different
+    // compatibility line entirely.
+    expect(belowFloor(['0.21.6'], floors)).toEqual([])
+    expect(neededVerdict(['0.21.6'], ['0.21.6'], floors).verdict).toBe('RETIRE')
+  })
+
+  it('still catches a version below its OWN 0.x line floor', () => {
+    expect(belowFloor(['0.21.5'], floors)).toEqual(['0.21.5'])
+    expect(neededVerdict(['0.21.6'], ['0.21.5'], floors).verdict).toBe('KEEP')
+  })
+})
+
+describe('publishedReachers / publishedWorkspaceNames', () => {
+  const ls = JSON.stringify([
+    { name: '@tapflowio/relay', private: false },
+    { name: '@tapflowio/playground', private: true },
+    { name: 'tapflow', private: false },
+  ])
+  const why = ['@tapflowio/relay@0.18.0 /repo/packages/relay', '@tapflowio/playground@0.1.0 /repo/playground', 'dependencies:'].join('\n')
+
+  it('reads only the publishing workspace packages', () => {
+    expect(publishedWorkspaceNames(ls).sort()).toEqual(['@tapflowio/relay', 'tapflow'])
+  })
+
+  it('excludes a private package that pnpm why still lists', () => {
+    // Counting playground would report a dev-only override as reaching users.
+    expect(publishedReachers(why, publishedWorkspaceNames(ls))).toEqual(['@tapflowio/relay'])
+  })
+})

--- a/scripts/audit-overrides.mjs
+++ b/scripts/audit-overrides.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+// Judges every entry in root `pnpm.overrides`: is it still needed, is it correct, does it reach
+// production.
+//
+// Why: the block is hand-maintained, security-critical, and nothing validates it (#472). Measured
+// on 2026-08-06, all fourteen entries were inert — removing the whole block and resolving cold
+// produced a byte-identical tree — and six were also wrong. Nobody had asked, because there was no
+// way to ask.
+//
+// The keys go wrong for one repeatable reason. Both #469 and #471 derived a key from the Dependabot
+// ALERT, which reports only the range matching the version you happen to have installed. `fast-uri`
+// had three affected ranges patched within fourteen minutes of each other; the alert showed one,
+// and the key that came out of it left the current major line unguarded. So this reads the
+// advisory's full affected set instead, which is the whole point of the correctness check.
+//
+// Usage: pnpm overrides:audit [--json]
+//
+// This script REWRITES `package.json` and `pnpm-lock.yaml` while it works and restores them from
+// git. It refuses to start unless both are clean, so a crash can never lose uncommitted work and
+// recovery is `git checkout --` rather than a backup file it might fail to write.
+import { execFileSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import { pathToFileURL } from 'url'
+
+const MANAGED = ['package.json', 'pnpm-lock.yaml']
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim()
+
+const RECOVER = `git checkout -- ${MANAGED.join(' ')}`
+
+// ── pure helpers, exported for the tests ──────────────────────────────────────
+
+/**
+ * `"fast-uri@>=3.0.0 <3.1.5"` → `{ name: 'fast-uri', range: '>=3.0.0 <3.1.5' }`
+ *
+ * A key with no range at all — `"esbuild": ">=0.28.1"` — is pnpm's documented default form, and
+ * splitting on the last `@` turned it into `{ name: 'esbuil', range: 'esbuild' }`: a mangled name
+ * that then looked up an advisory, got no results, and reported as successfully checked.
+ */
+export function parseKey(key) {
+  const at = key.lastIndexOf('@')
+  if (at < 1) return { name: key, range: '' }
+  return { name: key.slice(0, at), range: key.slice(at + 1) }
+}
+
+// String() because a caller that passes a number — the shape this took before lines
+// replaced majors — would otherwise crash inside a comparison rather than compare wrongly.
+const parts = (v) => String(v).split('.').map((n) => Number.parseInt(n, 10) || 0)
+
+/** Semver compare, enough for `x.y.z` release versions. Prereleases are not used by this block. */
+export function cmp(a, b) {
+  const [pa, pb] = [parts(a), parts(b)]
+  for (let i = 0; i < 3; i++) if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0)
+  return 0
+}
+
+export const major = (v) => parts(v)[0]
+
+/**
+ * The compatibility line a version belongs to. For 0.x that is `0.<minor>`, not `0`.
+ *
+ * Under semver a 0.x minor is a breaking boundary, and the block already relies on that — the
+ * esbuild comment says so. Bucketing every 0.x into one line made `guarded` always contain the
+ * key's own line, so `uncovered-line` could not fire for a 0.x package at all, and made every 0.x
+ * advisory look like the one a key targeted.
+ */
+export const line = (v) => (major(v) === 0 ? `0.${parts(v)[1]}` : String(major(v)))
+
+/**
+ * Faults in one override entry, judged against the advisories that entry actually targets.
+ *
+ * `affected` is `[{ ghsa, range, patched }]` — one element per patched line, several lines per
+ * advisory. Which advisory an override was written for is not recorded anywhere, so it is inferred:
+ * the ones whose affected range shares a major with the key's own range.
+ *
+ * That inference is what keeps the check quiet. Judging against every advisory a package has ever
+ * had asks a key pinned to 7.x to also cover 5.x and 6.x lines that nothing in the tree could
+ * resolve — `protobufjs` alone produced seven such reports, all noise. The signal worth keeping is
+ * narrower: for the advisory this key targets, is another of ITS lines left unguarded?
+ */
+export function judgeKey({ key, replacement }, affected, resolvedLine, siblings = []) {
+  const { name, range } = parseKey(key)
+  const faults = []
+  const notes = []
+
+  const lower = range.match(/>=\s*([\d.]+)/)?.[1]
+  const upper = range.match(/<=?\s*([\d.]+)/)?.[1]
+  const replLower = replacement.match(/(?:>=|\^|~)\s*([\d.]+)/)?.[1]
+  const replUpper = replacement.match(/<\s*([\d.]+)/)?.[1]
+  const keyLine = line(lower ?? upper ?? '0')
+
+  // A key with no lower bound intersects every major below it — pnpm matches by range
+  // intersection, not containment — so the replacement would force a cross-major jump on a
+  // consumer that declared one. Fixed for undici in #469 and fast-uri/hono in #471.
+  // An exact version (`shell-quote@1.8.4`) intersects only itself; a key with no range at all
+  // matches every version there is, which is worse than a bare bound and gets its own fault.
+  const exactKey = /^\d/.test(range.trim())
+  if (!range) {
+    faults.push({ kind: 'rangeless-key', detail: `\`${key}\` has no range — it matches every version` })
+  } else if (!lower && !exactKey) {
+    faults.push({ kind: 'unbounded-key-lower', detail: `\`${key}\` reaches every major below` })
+  }
+
+  // Every replacement in this block caps except one. esbuild is 0.x, where each minor is breaking.
+  if (!replUpper && !/^\^|^~|^\d/.test(replacement.trim())) {
+    faults.push({ kind: 'unbounded-replacement', detail: `\`${replacement}\` has no upper bound` })
+  }
+
+  const patched = affected.filter((a) => a.patched)
+
+  // Which advisory an override targets is inferred from RANGE OVERLAP, not from the line the patch
+  // lands on. For a 0.x package those differ by construction — `esbuild@>=0.27.3 <0.28.1` is
+  // remediated by 0.28.1, a different line — so matching on the patch line found nothing at all.
+  const overlapsKey = (a) => {
+    const aLower = a.range.match(/>=\s*([\d.]+)/)?.[1]
+    const aUpper = a.range.match(/<=?\s*([\d.]+)/)?.[1]
+    if (aLower && upper && cmp(aLower, upper) > 0) return false
+    if (aUpper && lower && cmp(aUpper, lower) < 0) return false
+    return true
+  }
+  const targeted = new Set(patched.filter(overlapsKey).map((a) => a.ghsa))
+
+  // The failure that produced #471: one advisory patches several lines the same day — fast-uri
+  // shipped 4.1.2, 3.1.5 and 2.4.4 within fourteen minutes — and the key covers only the line the
+  // Dependabot alert happened to show, because an alert reports the installed version's range.
+  //
+  // A NOTE, not a fault, and the distinction is the difference between a tool people read and one
+  // they mute. Whether an uncovered line is worth a key depends on whether anything could ever
+  // declare that range, which this cannot know: nothing in the tree declares `undici@^8`, so
+  // demanding a key for the twelve advisories that also patch 8.x is noise. The faults below are
+  // the unambiguous ones. This is for a human to judge.
+  // Which lines this package already has cover for. Read from each entry's REPLACEMENT, not its
+  // key: a key guards the line its replacement moves you onto, and for 0.x those differ —
+  // `>=0.27.3 <0.28.1` is a key on line 0.27 that guards line 0.28.
+  //
+  // Judged per package, not per key: `fast-uri` carries three entries covering 2.x, 3.x and 4.x,
+  // and judging each alone had all three reporting the other two as unguarded.
+  const guarded = new Set(
+    [{ key, replacement }, ...siblings].map((e) => {
+      const fromRepl = e.replacement?.match(/(?:>=|\^|~)\s*([\d.]+)/)?.[1]
+      const r = parseKey(e.key).range
+      const fromKey = r.match(/>=\s*([\d.]+)/)?.[1] ?? r.match(/<=?\s*([\d.]+)/)?.[1]
+      return line(fromRepl ?? fromKey ?? '0')
+    }),
+  )
+
+  const uncovered = new Map()
+  // Compared as LINES, not majors. `major(a.patched) < major(floorV)` is `0 < 0` for every 0.x
+  // package, so this filter could not fire for exactly the packages `line()` was introduced for:
+  // with the tree on esbuild 0.29, an advisory patching 0.21 was still reported as uncovered.
+  const floorLine = resolvedLine ?? line(lower ?? upper ?? '0')
+  for (const a of patched) {
+    if (!targeted.has(a.ghsa)) continue
+    const l = line(a.patched)
+    if (guarded.has(l) || cmp(l, floorLine) < 0) continue
+    // One entry per line, highest patch wins — a dozen advisories on one line say one thing.
+    const prev = uncovered.get(l)
+    if (!prev || cmp(a.patched, prev.patched) > 0) uncovered.set(l, a)
+  }
+  for (const [l, a] of [...uncovered].sort((x, y) => cmp(x[1].patched, y[1].patched))) {
+    notes.push({
+      kind: 'uncovered-line',
+      detail: `${l}.x is affected too (${a.ghsa} patches it at ${a.patched}) and no key covers that line`,
+    })
+  }
+
+  // A later advisory landing on the same line leaves the replacement floor below the safe floor.
+  // shell-quote's `^1.8.4` permits 1.8.4, which a HIGH advisory later covered.
+  if (replLower) {
+    for (const a of patched) {
+      if (line(a.patched) !== line(replLower)) continue
+      if (cmp(replLower, a.patched) < 0) {
+        faults.push({
+          kind: 'stale-replacement-floor',
+          detail: `replacement floor ${replLower} is below ${a.patched} (${a.ghsa}, affected ${a.range})`,
+        })
+      }
+    }
+  }
+
+  const unrescuable = affected.filter((a) => !a.patched).map((a) => a.range)
+  return { name, key, replacement, faults, notes, unrescuable }
+}
+
+/**
+ * Highest advisory floor per compatibility LINE, per package.
+ *
+ * Keyed by `line()`, not `major()`. Keying by major collapsed 0.21.x, 0.27.x and 0.29.x into one
+ * bucket, so esbuild's whole 0.x history shared a single floor — the newest patch anywhere in 0.x
+ * was applied to every 0.x version present, and this feeds `belowFloor` and so the KEEP/RETIRE
+ * verdict.
+ */
+export function floorsByPackage(advisories) {
+  const out = {}
+  for (const [name, affected] of Object.entries(advisories)) {
+    for (const a of affected) {
+      if (!a.patched) continue
+      const l = line(a.patched)
+      out[name] ??= {}
+      if (!out[name][l] || cmp(a.patched, out[name][l]) > 0) out[name][l] = a.patched
+    }
+  }
+  return out
+}
+
+/** Versions in `resolved` that sit below the floor for their own compatibility line. */
+export function belowFloor(resolved, floorsForPackage) {
+  if (!floorsForPackage) return []
+  return resolved.filter((v) => {
+    const floor = floorsForPackage[line(v)]
+    return floor && cmp(v, floor) < 0
+  })
+}
+
+/**
+ * Every version pnpm resolved for `name`, from the lockfile's package list.
+ *
+ * Sliced by the name's own length, never by the last `@`: a peer-suffixed key such as
+ * `'@hono/node-server@2.0.12(hono@4.13.0)'` puts the PEER's `@` last, so that read reported hono's
+ * 4.13.0 as node-server's version — and the same for `axios@1.18.1(debug@4.4.3)`. Wrong versions
+ * here feed the KEEP/RETIRE verdict directly.
+ */
+export function resolvedVersions(lockfile, name) {
+  if (!name) return []
+  return [
+    ...new Set(
+      lockfile
+        .split('\n')
+        .map((l) => l.trimEnd().replace(/^ {2}'?/, ''))
+        .filter((l) => l.startsWith(`${name}@`))
+        .map((l) => l.slice(name.length + 1).match(/^[\d.]+/)?.[0])
+        .filter(Boolean),
+    ),
+  ]
+}
+
+/**
+ * Does this entry make the tree safer? Differential, not absolute.
+ *
+ * `esbuild` leaves 0.21.5 and 0.25.12 below their floor whether the entry is there or not — its
+ * key does not match them. Judging `without` against the floor alone called that KEEP. An entry
+ * earns KEEP only by preventing something the tree would otherwise resolve.
+ */
+export function neededVerdict(resolvedWith, resolvedWithout, floorsForPackage) {
+  const lowWith = belowFloor(resolvedWith, floorsForPackage)
+  const newlyLow = belowFloor(resolvedWithout, floorsForPackage).filter((v) => !lowWith.includes(v))
+  return { verdict: newlyLow.length ? 'KEEP' : 'RETIRE', newlyLow }
+}
+
+/**
+ * Workspace packages in `whyOutput` that actually publish.
+ *
+ * `pnpm why --prod` lists private packages too, and counting `@tapflowio/playground` would mark a
+ * dev-only override as reaching users.
+ */
+export function publishedReachers(whyOutput, publishedNames) {
+  const published = new Set(publishedNames)
+  return [
+    ...new Set(
+      whyOutput
+        .split('\n')
+        .filter((l) => /^(@tapflowio\/|tapflow@)/.test(l))
+        .map((l) => l.split('@').slice(0, l.startsWith('@') ? 2 : 1).join('@'))
+        .filter((n) => published.has(n)),
+    ),
+  ]
+}
+
+/** Workspace manifests that publish, from `pnpm ls -r --depth -1 --json`. */
+export function publishedWorkspaceNames(lsJson) {
+  return (
+    lsJson
+      .trim()
+      .split('\n')
+      .join('')
+      .replace(/\]\[/g, ',')
+      .match(/\{[^{}]*"name"[^{}]*\}/g)
+      ?.map((x) => JSON.parse(x))
+      .filter((x) => !x.private)
+      .map((x) => x.name) ?? []
+  )
+}
+
+// ── effectful parts ───────────────────────────────────────────────────────────
+
+function assertClean() {
+  const dirty = git('status', '--porcelain', '--', ...MANAGED)
+  if (dirty) {
+    console.error('Refusing to run: this script rewrites and restores these files from git.\n')
+    console.error(dirty)
+    // Deliberately not "commit or stash". If a previous run was interrupted these files are
+    // mid-rewrite with `pnpm.overrides` deleted, and committing that would land the deletion of
+    // the whole security block. Say how to undo before saying how to keep.
+    console.error(`\nIf a previous run was interrupted, undo it with:\n  ${RECOVER}`)
+    console.error('Otherwise commit or stash these changes first.')
+    process.exit(2)
+  }
+}
+
+const restore = () => git('checkout', '--', ...MANAGED)
+
+/** Restoring is not something to trust — check it, and be loud when it did not work. */
+function verifyRestored() {
+  const dirty = git('status', '--porcelain', '--', ...MANAGED)
+  if (!dirty) return true
+  console.error(`\nFATAL: the working tree was left rewritten:\n${dirty}`)
+  console.error(`Recover with:\n  ${RECOVER}`)
+  return false
+}
+
+// `finally` does not run for a signal, and the window it guards contains a `pnpm install` — the
+// command a user is most likely to interrupt when the registry stalls. Interrupted without this,
+// the repo is left with `pnpm.overrides` deleted and nothing says so.
+let mutating = false
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(sig, () => {
+    if (mutating) {
+      try { restore() } catch { /* verifyRestored reports it */ }
+      verifyRestored()
+    }
+    process.exit(130)
+  })
+}
+
+/** Resolve the workspace with `overrides` replaced, and hand back the resulting lockfile. */
+function resolveWith(overrides) {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8'))
+  if (overrides === null) delete pkg.pnpm.overrides
+  else pkg.pnpm.overrides = overrides
+  mutating = true
+  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+  // Cold on purpose. Against the existing lockfile pnpm keeps any resolution that still satisfies
+  // the range, so an override could look load-bearing purely because the lockfile is sticky —
+  // which is the very confusion this audit exists to remove.
+  // Bounded: without it a stalled registry leaves the tree rewritten for as long as the user waits.
+  execFileSync('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], {
+    stdio: 'pipe',
+    timeout: 10 * 60_000,
+  })
+  return readFileSync('pnpm-lock.yaml', 'utf8')
+}
+
+/** Full affected set per package, from the advisory database rather than from an alert. */
+function fetchAdvisories(names) {
+  const out = {}
+  for (const name of names) {
+    try {
+      const all = []
+      let after = null
+      // Paginated, because a single page silently truncates: axios has 73 advisories and undici
+      // 67, both past the 100-item ceiling this API allows in one request. A missed page reads as
+      // "no such advisory", which is the direction that hides a stale floor.
+      for (;;) {
+        const cursor = after ? `, after:"${after}"` : ''
+        const query = `{securityVulnerabilities(ecosystem:NPM, package:"${name}", first:100${cursor}){pageInfo{hasNextPage endCursor} nodes{advisory{ghsaId severity} vulnerableVersionRange firstPatchedVersion{identifier}}}}`
+        const raw = execFileSync('gh', ['api', 'graphql', '-f', `query=${query}`], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        const page = JSON.parse(raw).data.securityVulnerabilities
+        all.push(
+          ...page.nodes.map((n) => ({
+            ghsa: n.advisory.ghsaId,
+            severity: n.advisory.severity,
+            range: n.vulnerableVersionRange,
+            patched: n.firstPatchedVersion?.identifier ?? null,
+          })),
+        )
+        if (!page.pageInfo.hasNextPage) break
+        after = page.pageInfo.endCursor
+      }
+      out[name] = all
+    } catch {
+      out[name] = null // distinct from []: unknown, not "no advisories"
+    }
+  }
+  return out
+}
+
+/**
+ * Which of these packages is reachable from a **published** package's production tree.
+ *
+ * Private packages are excluded: `@tapflowio/playground` shows up in `pnpm why --prod` output and
+ * ships nothing, so counting it would mark a dev-only override as reaching users.
+ */
+function prodReachable(names) {
+  const publishedNames = publishedWorkspaceNames(
+    execFileSync('pnpm', ['ls', '-r', '--depth', '-1', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }),
+  )
+
+  const out = {}
+  for (const name of names) {
+    try {
+      const raw = execFileSync('pnpm', ['why', name, '-r', '--prod'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      out[name] = publishedReachers(raw, publishedNames)
+    } catch {
+      out[name] = []
+    }
+  }
+  return out
+}
+
+async function main() {
+  const asJson = process.argv.includes('--json')
+  // Every path here is relative and git pathspecs resolve against cwd, so a run from a package
+  // directory would inspect — and could rewrite — the wrong manifest.
+  process.chdir(git('rev-parse', '--show-toplevel'))
+  assertClean()
+
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8'))
+  const overrides = pkg.pnpm?.overrides ?? {}
+  const entries = Object.entries(overrides).map(([key, replacement]) => ({ key, replacement }))
+  if (!entries.length) {
+    console.log('No overrides to audit.')
+    return
+  }
+
+  const names = [...new Set(entries.map((e) => parseKey(e.key).name))]
+  const advisories = fetchAdvisories(names)
+  const reachable = prodReachable(names)
+
+  // Resolution as it stands, before anything is touched — the comparison baseline.
+  const withBlock = readFileSync('pnpm-lock.yaml', 'utf8')
+
+  let withoutBlock
+  try {
+    withoutBlock = resolveWith(null)
+  } finally {
+    restore()
+    mutating = false
+  }
+
+  const floors = floorsByPackage(
+    Object.fromEntries(Object.entries(advisories).filter(([, v]) => v !== null)),
+  )
+
+  const results = entries.map((e) => {
+    const { name } = parseKey(e.key)
+    const affected = advisories[name]
+    const resolved = resolvedVersions(withoutBlock, name)
+    // The line of the highest resolved version — `'4'`, or `'0.29'` for a 0.x package.
+    const resolvedLine = resolved.length
+      ? line(resolved.reduce((a, b) => (cmp(a, b) >= 0 ? a : b)))
+      : undefined
+    const siblings = entries.filter((o) => o !== e && parseKey(o.key).name === name)
+    const judged = affected
+      ? judgeKey(e, affected, resolvedLine, siblings)
+      : { ...e, name, faults: [], notes: [], unrescuable: [] }
+
+    const { verdict, newlyLow } = neededVerdict(
+      resolvedVersions(withBlock, name),
+      resolved,
+      floors[name],
+    )
+    return {
+      ...judged,
+      advisoriesKnown: affected !== null,
+      neededVerdict: verdict,
+      stillLow: newlyLow,
+      prodReachableFrom: reachable[name] ?? [],
+    }
+  })
+
+  if (!verifyRestored()) process.exit(3)
+
+  if (asJson) {
+    console.log(JSON.stringify(results, null, 2))
+  } else {
+    report(results)
+  }
+  process.exitCode = results.some((r) => r.faults.length) ? 1 : 0
+}
+
+function report(results) {
+  const retire = results.filter((r) => r.neededVerdict === 'RETIRE')
+  const faulty = results.filter((r) => r.faults.length)
+  const unknown = results.filter((r) => !r.advisoriesKnown)
+
+  console.log('\npnpm.overrides audit\n')
+  for (const r of results) {
+    const tags = [
+      r.neededVerdict,
+      r.prodReachableFrom.length ? 'PROD' : 'dev-only',
+      r.faults.length ? `${r.faults.length} fault(s)` : null,
+      r.notes.length ? `${r.notes.length} note(s)` : null,
+    ].filter(Boolean)
+    console.log(`  ${r.key}`)
+    console.log(`    ${tags.join('  ·  ')}`)
+    if (r.prodReachableFrom.length) console.log(`    reaches: ${r.prodReachableFrom.join(', ')}`)
+    if (r.neededVerdict === 'KEEP') console.log(`    without it: ${r.stillLow.join(', ')} below floor`)
+    for (const f of r.faults) console.log(`    ! ${f.kind}: ${f.detail}`)
+    for (const n of r.notes) console.log(`    - ${n.kind}: ${n.detail}`)
+    if (r.unrescuable.length) {
+      console.log(`    note: no patch exists for ${r.unrescuable.join(', ')} — an override cannot rescue that line`)
+    }
+    console.log()
+  }
+
+  if (unknown.length) {
+    // Never silent. Deriving keys from the advisory rather than from an alert is the reason this
+    // script exists, so a lookup that did not happen has to be visible.
+    console.log(`Advisory lookup unavailable for ${unknown.length} package(s) — correctness NOT checked:`)
+    console.log(`  ${[...new Set(unknown.map((r) => r.name))].join(', ')}`)
+    console.log('  (needs `gh` authenticated with network access)\n')
+  }
+  console.log(`${retire.length}/${results.length} entries change nothing and can be retired.`)
+  if (faulty.length) console.log(`${faulty.length} entr(ies) have faults — see above.`)
+  console.log(
+    '\nPrefer `pnpm update <pkg>` over adding an override: it leaves no permanent entry to maintain.',
+  )
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    // The original failure first: with `stdio: 'pipe'`, pnpm's reason lives in `err.stderr` and is
+    // otherwise never seen. Then restore, then say plainly whether that worked — a tree left
+    // rewritten has to be louder than a failed audit.
+    console.error(err.message)
+    if (err.stderr) console.error(String(err.stderr))
+    try { restore() } catch (e) { console.error(`restore failed: ${e.message}`) }
+    process.exit(verifyRestored() ? 1 : 3)
+  })
+}


### PR DESCRIPTION
Closes part of #472 — the audit itself. Wiring reachability into `check-changeset.mjs` is a follow-up, because that changes CI gate behaviour and this has to exist first to test it against a real case.

## Why

The `pnpm.overrides` block is hand-maintained, security-critical, and nothing validated it. Three questions get asked of it and nothing answered any of them.

**Is each entry still needed?** Measured: no. Removing the whole block and resolving **cold** — lockfile deleted — produces a tree that is exactly as safe. All fourteen entries are inert.

**Is each entry correct?** Six are not, and they go wrong for one repeatable reason: both #469 and #471 derived a key from the **Dependabot alert**, which reports only the affected range matching the version you happen to have installed. `fast-uri` patched three lines within fourteen minutes of each other; the alert showed one, and the key that came out of it left the current major line unguarded.

## What it reports

```
  shell-quote@<1.8.4
    RETIRE  ·  dev-only  ·  2 fault(s)
    ! unbounded-key-lower: `shell-quote@<1.8.4` reaches every major below
    ! stale-replacement-floor: replacement floor 1.8.4 is below 1.9.0 (GHSA-395f-4hp3-45gv)

  @hono/node-server@<2.0.5
    RETIRE  ·  PROD  ·  2 fault(s)
    reaches: @tapflowio/mcp-server
    ! stale-replacement-floor: replacement floor 2.0.5 is below 2.0.10 (GHSA-9mqv-5hh9-4cgg)

14/14 entries change nothing and can be retired.
5 entr(ies) have faults — see above.
```

It reproduces every defect listed by hand in #472, and finds all fourteen retirable.

## Design decisions worth review

**The necessity check is cold and differential.** Cold, because against the existing lockfile pnpm keeps any resolution that still satisfies the range — an override then looks load-bearing purely because the lockfile is sticky, which is the confusion this exists to remove. Differential, because `esbuild` leaves 0.21.5 and 0.25.12 below their floor whether the entry is there or not: its key does not match those versions. Judging "without" against the floor alone called that KEEP. An entry earns KEEP by preventing something, not by coexisting with it.

**Faults fail; notes do not.** An advisory line with no key is a note. Whether it deserves a key depends on whether anything could ever declare that range, which the script cannot know — nothing in the tree declares `undici@^8`, so failing on the twelve advisories that also patch 8.x would produce a tool people mute. Faults are the unambiguous defects: a rangeless or unbounded key, an uncapped replacement, a floor a later advisory overtook.

**0.x versions are keyed by `0.<minor>`.** There each minor is a compatibility boundary. Bucketing them all into major `0` made the uncovered-line note unable to fire for a 0.x package at all — the one kind where it matters most.

## Safety

It rewrites `package.json` and `pnpm-lock.yaml` as it works.

- Runs from the repo root, and **refuses to start unless both files are clean** — recovery is `git checkout --` rather than a backup file it might fail to write, and `git checkout` restores from the index, which is why detached HEAD, an in-progress rebase and linked worktrees all just work: nothing here ever reads HEAD.
- Restores on the exception path **and on SIGINT/SIGTERM/SIGHUP**. `finally` does not run for a signal, and the window it guards contains the `pnpm install` a user is most likely to interrupt when the registry stalls. That install now has a timeout for the same reason.
- **Verifies** the restore before reporting, on both paths, and exits 3 if the tree was left rewritten.
- The refusal message leads with how to *undo* an interrupted run. It used to say "commit or stash them first" — advice that, after an interrupted run, means committing the deletion of the entire security block.

## Verification

- Full suite green: **174 tests in `scripts/`**, 1996 overall
- Audit run against this repo leaves `git status` empty; running it against a dirty tree exits 2 and touches nothing
- `node scripts/check-changeset.mjs main` → no changeset required (no published source changed)

## Adversarial review

Two independent lenses — can it damage the repo, and are its judgements correct — recorded in `.work/reviews/feat__overrides-audit.md` against `9763418bd7d277995d29e177c0f3ec355c8d6932`. Both found real defects; seven of eight were fixed here.

The two worth naming: `resolvedVersions` was slicing on the last `@`, so a peer-suffixed lockfile key like `'@hono/node-server@2.0.12(hono@4.13.0)'` reported **hono's** version as node-server's, feeding the KEEP/RETIRE verdict wrong data — it had not produced a wrong verdict yet only because the phantom version happened to land on a major with no advisories. And both headline verdicts had **no test at all**: inverting the KEEP/RETIRE ternary, or flipping `!p.private`, left all 163 tests green. Both are now pure functions with tests.

**Deliberately not fixed:** there is no mutual-exclusion lock. Two concurrent runs are usually caught by the clean check, but if their start-up overlaps the second reads an already-rewritten lockfile as its baseline. The tree still ends clean; the audit is silently wrong, which for a tool whose output justifies deleting overrides is the worse failure. Worth a follow-up. Separately, pnpm 10 moves `overrides` into `pnpm-workspace.yaml`, so the managed-file list needs revisiting at that upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit command for reviewing dependency overrides and identifying unnecessary, outdated, malformed, or unresolved security-related entries.
  * Supports human-readable and JSON reports, including production reachability and vulnerable-version checks.
  * Restores managed project files after auditing and clearly reports failures.

* **Tests**
  * Added comprehensive coverage for version ranges, advisories, lockfiles, workspace dependencies, and override retirement decisions.

* **Documentation**
  * Added guidance for maintaining security dependency overrides and applying updates safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->