### PR TITLE
docs(agents): require pnpm for test runs, never npx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Covering every consumer uniformly means covering the ones that cannot read TypeS
 per tool is the point, not the cost.
 
 ### Test Hygiene
-Tests run through `pnpm --filter <pkg> test`, never `npx vitest` — not even from inside the package directory, and not for a single file. npm rewrites the root `package.json` on its way through and collapses `pnpm.overrides` to `pnpm: {}`, leaving `pnpm-lock.yaml` rewritten beside it, and it reports none of that. Reviewing #474 cost exactly this: one `npx vitest` on one test file, and the entire override block was gone with only `git status` to say so. `git checkout HEAD -- package.json pnpm-lock.yaml` puts both back.
+Tests run through `pnpm --filter <pkg> test`, never `npx vitest` — not even from inside the package directory, and not for a single file. npm rewrites the root `package.json` on its way through and collapses `pnpm.overrides` to `pnpm: {}`, leaving `pnpm-lock.yaml` rewritten beside it, and it reports none of that. Reviewing #474 cost exactly this: one `npx vitest` on one test file, and the entire override block was gone with only `git status` to say so. `git checkout HEAD -- package.json pnpm-lock.yaml` puts both back — check `git diff` on them first if you were editing either on purpose, since that discards everything uncommitted in both.
 
 After running tests (especially repeated or looped runs), always check for zombie vitest processes and kill them:
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ Covering every consumer uniformly means covering the ones that cannot read TypeS
 per tool is the point, not the cost.
 
 ### Test Hygiene
+Tests run through `pnpm --filter <pkg> test`, never `npx vitest` — not even from inside the package directory, and not for a single file. npm rewrites the root `package.json` on its way through and collapses `pnpm.overrides` to `pnpm: {}`, leaving `pnpm-lock.yaml` rewritten beside it, and it reports none of that. Reviewing #474 cost exactly this: one `npx vitest` on one test file, and the entire override block was gone with only `git status` to say so. `git checkout HEAD -- package.json pnpm-lock.yaml` puts both back.
+
 After running tests (especially repeated or looped runs), always check for zombie vitest processes and kill them:
 ```bash
 ps aux | grep vitest | grep -v grep


### PR DESCRIPTION
## Summary

Adds one paragraph to the Test Hygiene section of `AGENTS.md`: tests go through `pnpm --filter <pkg> test`, never `npx vitest`.

`npx` rewrites the root `package.json` on its way through and collapses the whole `pnpm.overrides` block to `pnpm: {}`, rewriting `pnpm-lock.yaml` beside it. It prints nothing while doing so — the only trace is `git status`.

This is not hypothetical. It happened during the review of #474: one `npx vitest run` on a single test file inside `packages/android-agent`, and the entire override block was gone. Recovered with `git checkout HEAD -- package.json pnpm-lock.yaml`, and every run after that went through `pnpm`.

The wording deliberately stops short of claiming security patches get disabled. #477/#478 measured every entry in that block as inert — removing it and resolving cold produces a byte-identical tree — so the damage is a silently dirtied manifest and lockfile, not a changed dependency tree. Overstating it would have put this paragraph at odds with the overrides section added in those PRs.

## Checklist

- [x] Docs-only — no code, config or workflow changes
- [x] `pnpm changeset:check` → "No published source changed — no changeset required."
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

Review record: `.work/reviews/docs__agents-test-hygiene-pnpm.md` against HEAD `817cacac5590d63eb1b1f1277e20dc41cb053e6e`. Docs-only, so the independent-context review itself is skipped per AGENTS.md; the record instead documents the evidence behind the claim the paragraph makes, and what was deliberately left out of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added test hygiene guidance for running package tests.
  * Documented how to avoid and restore unintended package metadata or lockfile changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->