### PR TITLE
fix(ios-agent): recover from a dead touch-helper instead of dropping input silently

### DIFF
--- a/.changeset/touch-helper-death-recovery.md
+++ b/.changeset/touch-helper-death-recovery.md
@@ -1,0 +1,35 @@
+---
+'@tapflowio/ios-agent': patch
+---
+
+fix(ios-agent): recover from a dead touch-helper instead of dropping every input silently
+
+When the `touch-helper` process died on its own, `TouchHelper` kept pointing at the corpse and
+every write returned early at a `stdin.writable` guard. The session accepted no further input for
+the rest of its life while the stream kept running, so the viewer tapped a screen that updated
+normally and nothing happened — and nothing was reported to the browser or to an MCP caller.
+
+- The helper is now replaced as soon as it dies, not on the next input, so the first tap after a
+  death does not wait for the replacement to start up.
+- Replacing is bounded to 3 spawns in any 30-second window, which self-clears, so a helper that
+  cannot run does not churn processes and a transient failure is not permanent.
+- A helper that never announces readiness at all is replaced after a deadline. Otherwise
+  running-but-never-ready has no exit: nothing asks for a replacement because it is running, and
+  every input is refused because it is not ready.
+- A gesture is only ever continued by the process that *received its opening frame*. A touch end or pinch end injects
+  coordinates the *previous* process had latched, so delivering one to a replacement would release
+  the touch at (0,0) and report success; a move with no preceding down is not the gesture the
+  tester made either. Both are refused, even when a healthy replacement is available.
+- A freshly spawned helper is not usable for its first ~200ms, and a frame written before it starts
+  reading stdin lands nothing at all — the frames buffer and then drain in one go, which collapses a
+  swipe into microseconds. The helper already announced when it was ready; that announcement is now
+  what gates a write, so those frames report failure instead of reporting success and vanishing.
+  This was reachable without any helper death: an MCP caller tapping as soon as `boot_device`
+  returns is inside that window.
+- Terminal inputs now ack on whether the write reached a helper that is ready to inject rather than
+  on whether the helper object exists. `input:touch:end`, `input:pinch:end`, `input:key`, `input:button`,
+  `input:type` and `clipboard:write` with `pasteAfter` answer an error instead of success when the
+  input was dropped. Two `input:button` branches deliberately write nothing — a home press-down and
+  a button with no HID mapping on this device's chrome — and those answer from the channel's health
+  instead, so a healthy channel is not reported as a failure and a dead one is not reported as a
+  success.

--- a/.changeset/touch-helper-death-recovery.md
+++ b/.changeset/touch-helper-death-recovery.md
@@ -9,8 +9,9 @@ every write returned early at a `stdin.writable` guard. The session accepted no 
 the rest of its life while the stream kept running, so the viewer tapped a screen that updated
 normally and nothing happened — and nothing was reported to the browser or to an MCP caller.
 
-- The helper is now replaced as soon as it dies, not on the next input, so the first tap after a
-  death does not wait for the replacement to start up.
+- The helper is now replaced when it dies rather than on the next input — as soon as the spawn
+  budget below allows it — so the first tap after a death does not wait for the replacement to
+  start up.
 - Replacing is bounded to 3 spawns in any 30-second window, which self-clears, so a helper that
   cannot run does not churn processes and a transient failure is not permanent.
 - A helper that never announces readiness at all is replaced after a deadline. Otherwise

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -78,9 +78,10 @@ When changing the Swift source, **always update both locations simultaneously**:
 
 `touch-helper` can die on its own, and when it did the session accepted no further input for the
 rest of its life while the stream kept flowing — the viewer tapped a screen that updated normally
-and nothing happened (#482). `TouchHelper` now replaces the process **as soon as it dies** rather
-than on the next input, so the first tap after a death does not pay the helper's start-up cost
-(`xcode-select -p`, two `dlopen`s, a `SimServiceContext` device lookup).
+and nothing happened (#482). `TouchHelper` now replaces the process **when it dies** rather than on
+the next input — immediately, when the spawn budget below allows it — so the first tap after a death
+does not pay the helper's start-up cost (`xcode-select -p`, two `dlopen`s, a `SimServiceContext`
+device lookup).
 
 Five things about it are easy to undo by accident:
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -39,25 +39,112 @@ touch-helper <udid|booted>
 
 Injects HID events directly into the iOS Simulator via `SimDeviceLegacyHIDClient` + IndigoHID.
 
-stdin protocol (variable-length frames):
-- types 1–5, 9 : 9 bytes — `[type:u8][a:u8/f32BE][b:f32BE]`
-- types 6–8    : 17 bytes — `[type:u8][x1:f32BE][y1:f32BE][x2:f32BE][y2:f32BE]`
+stdin protocol (variable-length frames). Note the payload is **not** one layout: two of the four
+rows carry integers and two carry floats, so reading the whole table as "two floats" is how a frame
+ends up carrying garbage:
 
-| type | action |
-|------|--------|
-| 1 | touch start (x, y normalized 0–1) |
-| 2 | touch move (x, y) |
-| 3 | touch end |
-| 4 | HID button (a=usagePage, b=usage) |
-| 5 | legacy button (a=code) |
-| 6 | pinch start (x1,y1 = finger0, x2,y2 = finger1) |
-| 7 | pinch move |
-| 8 | pinch end |
-| 9 | key press ([0]=modifierBitmap, [4–7]=hidUsage u32BE) |
+| types | size | payload |
+|-------|------|---------|
+| 1–3 | 9 bytes | `[type:u8][x:f32BE][y:f32BE]` |
+| 4, 5, 10, 11 | 9 bytes | `[type:u8][a:u32BE][b:u32BE]` |
+| 9 | 9 bytes | `[type:u8][modifiers:u8][pad:u8 ×3][usage:u32BE]` |
+| 6–8 | 17 bytes | `[type:u8][x1:f32BE][y1:f32BE][x2:f32BE][y2:f32BE]` |
+
+The **gesture role** column decides how a frame is treated when the helper process has been
+replaced — see "Helper death and recovery" below. A frame that *continues* a gesture is delivered
+only to the process that received the frame that opened it, and never revives a dead helper.
+
+| type | action | gesture role |
+|------|--------|--------------|
+| 1 | touch start (x, y normalized 0–1) | opens |
+| 2 | touch move (x, y) | continues — a move with no preceding down is not the gesture the tester made, and on the digitizer path the injected message is identical to a touch start's (`mask`/`contact` derive only from `isUp`), so a lone move lands as a fresh tap |
+| 3 | touch end | continues — **injects `lastX/lastY`, ignoring the coordinates in the frame** |
+| 4 | HID button (a=usagePage, b=usage) | self-contained — down→50ms→up completes inside the helper |
+| 5 | legacy button (a=code) | self-contained — same |
+| 6 | pinch start (x1,y1 = finger0, x2,y2 = finger1) | opens |
+| 7 | pinch move | continues — as with type 2, a move with no preceding down is not the gesture the tester made, and that is the whole reason. Unlike type 2 the injected message *does* differ from a down (`injectTwoFinger` passes `direction` separately as well as deriving `eventType`), so the "reads as a fresh tap" argument does not apply here |
+| 8 | pinch end | continues — **injects `pinchLast*`; `TouchHelper.pinchEnd()` sends all-zero coordinates precisely because the helper does not read them** |
+| 9 | key press | self-contained — modifier down/up completes inside the frame |
+| 10 | button down (a=usagePage, b=usage) | self-contained |
+| 11 | button up (a=usagePage, b=usage) | self-contained — the helper keeps no record of which buttons are down, so a paired down is not a precondition |
 
 When changing the Swift source, **always update both locations simultaneously**:
 1. `src/touch-helper.swift` — stdin protocol changes
-2. `src/TouchHelper.ts` — byte layout in the `write()` method
+2. `src/TouchHelper.ts` — byte layout in the frame builders (`coordFrame` / `buttonFrame` / `twoFingerFrame`) and in `sendKey`, which builds its own
+
+---
+
+### Helper death and recovery
+
+`touch-helper` can die on its own, and when it did the session accepted no further input for the
+rest of its life while the stream kept flowing — the viewer tapped a screen that updated normally
+and nothing happened (#482). `TouchHelper` now replaces the process **as soon as it dies** rather
+than on the next input, so the first tap after a death does not pay the helper's start-up cost
+(`xcode-select -p`, two `dlopen`s, a `SimServiceContext` device lookup).
+
+Five things about it are easy to undo by accident:
+
+- **Running is not usable, and the helper says which it is.** It announces itself on stderr once it
+  holds its HID client and is about to read stdin (`touch-helper.swift:281`). Measured on a real
+  simulator: **186–247ms** after spawn (n=5), and a gesture written before that announcement lands
+  **nothing** — the frames sit in the pipe and are drained in one go when it finally starts reading,
+  collapsing a swipe into microseconds. So `isReady()` requires the announcement and `isRunning()`
+  does not, and they answer different questions: writes are gated on the first, replacement
+  decisions on the second. Gating replacement on readiness would spawn a second helper while the
+  first was still starting.
+  This window is not only reached after a death. `sendChromeData` starts the helper and
+  `device:ready` follows a local socket connect later — tens of ms — so **an MCP caller that taps
+  as soon as `boot_device` returns lands inside it**, which is how it was found.
+  A helper that never announces itself is replaced after `READY_DEADLINE_MS`. Without that,
+  running-but-never-ready has no exit at all: nothing asks for a replacement because it is running,
+  and every input is refused because it is not ready, so a wedge in the CoreSimulator device lookup
+  would strand the session until the device was rebooted. The replacement goes through the same
+  death path, so the rolling window bounds it.
+- **A pid is what says the exec succeeded.** When the binary is missing, non-executable, or the
+  wrong architecture (#464), libuv still returns an open stdin pipe and reports the failure a tick
+  later. Measured: `stdin.writable` is `true` on a process that does not exist, and
+  `stdin.write()` returning `false` is indistinguishable from ordinary backpressure. `spawnHelper`
+  checks `proc.pid` and is the only gate — a process without one never becomes the active helper,
+  and recovery from an exec failure is therefore lazy — the next self-contained frame retries.
+  Not because node stays silent (it does emit `'error'`, which is why that branch attaches its own
+  logger) but because the branch returns before wiring `handleDeath`, so nothing eagerly replaces
+  a process that never lived.
+- **A gesture belongs to the process that *received* its opening frame.** Because replacement is
+  eager, a mid-gesture death normally leaves a healthy process standing by — so checking liveness
+  is not enough. `TouchHelper` records the process that took the opening frame and refuses the rest
+  of the gesture if it is no longer the current one. Writing a touch end to a fresh process would
+  release the touch at (0,0), because that process's latches are zero, **and report it as
+  delivered**.
+  The ownership is recorded **only when the opening frame was actually delivered**, and that
+  condition is load-bearing rather than defensive. Recording it unconditionally looks equivalent —
+  "if the open failed there is nothing live to record" — and stops being equivalent the moment
+  readiness exists: during the start-up window the open is refused while the process is alive and
+  about to become ready, so identity would then pass and the continuation would reach a process
+  that never saw the down. This was removed once as untestable and put back after a review found
+  the case; see `.work/reviews/fix__touch-helper-death-recovery.md`.
+- **Replacing is bounded by a rolling window** — at most 3 spawns in any 30s. Deliberately not a
+  count of consecutive fast failures: the helper's start-up is expensive, so "died too fast" cannot
+  be separated from "died slowly" without guessing how long start-up takes, and a helper that
+  reliably dies just past that guess would reset such a counter every time and churn a process
+  every few seconds for the life of the agent, with no input and no user involved. The window
+  bounds it whatever the lifetime, and it self-clears, so a session that briefly could not start a
+  helper is not left without input until the device is rebooted.
+- **A helper must never outlive the reference to it.** `sendChromeData` stops the outgoing helper,
+  and `cleanupDeviceState` bumps `bootSeq` so a boot still awaiting simctl cannot install one onto
+  a state that reconnect has already dropped. Both used to leak a single child process; a
+  self-reviving one would respawn for the life of the agent with nothing left to stop it.
+
+Every write reports whether it reached a helper that is ready to inject — not whether the device
+acted on it, which HID is fire-and-forget about — and `IOSAgent.ackInput` answers on that rather
+than on `state.touchHelper !== null`. The wrapper object outlives its process, which is what made
+the original failure silent.
+
+Verified on a real simulator (iPhone 17 Pro, iOS 26.5), with an idle screenshot pair byte-identical
+as the control: killing the helper while idle and swiping again opens Spotlight, so input recovers
+without a reconnect; a gesture attempted inside the start-up window reports failure on every frame
+and indeed changes nothing; and killing it mid-gesture leaves `isReady()` true — the replacement is
+genuinely up — while the terminal frame is still refused, after which a fresh gesture works, so no
+touch is left held.
 
 Compile (output to `bin/`):
 ```bash

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -353,6 +353,12 @@ export class IOSAgent implements DeviceAgent {
   }
 
   private cleanupDeviceState(state: DeviceState): void {
+    // Invalidate any boot still in flight against this state. `_scheduleReconnect` drops the map,
+    // but a `handleDeviceBoot` awaiting simctl holds its own reference and its seq still matched,
+    // so it would go on to build a TouchHelper on a state nobody owns. That used to leak one
+    // child process; a self-reviving helper would respawn for the life of the agent with no
+    // reference left to stop it.
+    state.bootSeq++
     void state.streamReader?.cancel()
     state.streamReader = null
     state.captureStreamer = null // reader.cancel() kills the helper proc; drop the ref so a stale requestKeyframe() no-ops
@@ -370,6 +376,10 @@ export class IOSAgent implements DeviceAgent {
 
   private sendChromeData(state: DeviceState, device: Device): void {
     if (!this.ws) return
+    // Stop the outgoing helper before dropping the reference. This used to leak a child process;
+    // now that a helper revives itself on death, an orphan would also keep respawning with
+    // nobody left holding a reference to stop it.
+    state.touchHelper?.stop()
     state.touchHelper = new TouchHelper(device.id)
     state.touchHelper.start()
     this.ws.send(JSON.stringify({
@@ -556,6 +566,11 @@ export class IOSAgent implements DeviceAgent {
       if (seq !== state.bootSeq) return
 
       const refreshed = await this.simctl.listDevices()
+      // Another await, and `sendChromeData` below starts a helper process. A shutdown or a newer
+      // boot arriving in this gap would otherwise get a helper installed for the device it is
+      // taking down — and one that revives itself, so the stale reference outlives the boot that
+      // returns just below.
+      if (seq !== state.bootSeq) return
       const refreshedDevice = refreshed.find((d) => d.id === deviceId) ?? target
       this.sendChromeData(state, {
         ...refreshedDevice,
@@ -752,8 +767,10 @@ export class IOSAgent implements DeviceAgent {
       case 'input:touch:end': {
         const state = this.deviceStates.get(msg.sessionId!)
         if (!state) break
-        state.touchHelper?.touchEnd()
-        void this.ackInput(state, state.touchHelper !== null) // terminal of a tap/swipe → ack the gesture
+        // The helper's answer, not its existence: a helper whose process has died reports every
+        // write as dropped, and that is what the caller needs to hear (#482).
+        const dispatched = state.touchHelper?.touchEnd() ?? false
+        void this.ackInput(state, dispatched) // terminal of a tap/swipe → ack the gesture
         break
       }
       case 'input:pinch:start': {
@@ -774,8 +791,7 @@ export class IOSAgent implements DeviceAgent {
       case 'input:pinch:end': {
         const state = this.deviceStates.get(msg.sessionId!)
         if (!state) break
-        state.touchHelper?.pinchEnd()
-        void this.ackInput(state, state.touchHelper !== null)
+        void this.ackInput(state, state.touchHelper?.pinchEnd() ?? false)
         break
       }
       case 'input:rotate': {
@@ -832,7 +848,13 @@ export class IOSAgent implements DeviceAgent {
             state.softKeyboardVisible = false
             await this.simctl.hideSoftwareKeyboard(state.deviceId).catch(() => {})
           }
-          state.touchHelper?.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])
+          // Throwing routes into the input:type-error below. Without it a dropped chord still
+          // answers input:type-done: the text sits on the device pasteboard, nothing was pasted
+          // into the app, and the caller moves on. Unlike the copy path in clipboard:read there
+          // is no pasteboard deadline here to fail loudly in its place.
+          if (!state.touchHelper?.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])) {
+            throw new PlatformError('Cannot paste the text — no input channel to the device')
+          }
         }
         // Ack on completion so a following input step (e.g. pressKey Enter) is
         // only sent after the paste has actually landed.
@@ -861,16 +883,16 @@ export class IOSAgent implements DeviceAgent {
           // Hide the SW keyboard first so iOS re-initialises the HW keyboard
           // context. Skipping this causes input-source desync (qks / ㅂㅏㄴ symptoms).
           state.softKeyboardVisible = false
-          this.simctl.hideSoftwareKeyboard(state.deviceId)
-            .then(() => state.touchHelper?.sendKey(usage, modifiers ?? 0))
-            .catch((e: unknown) => {
-              logger.error('hideSoftwareKeyboard (on key) failed:', e)
-              state.touchHelper?.sendKey(usage, modifiers ?? 0)
-            })
+          // The ack belongs after the deferred chord, not beside it. Acking out here ran before
+          // the key was ever written, so the answer could only be a guess — and the guess was
+          // "delivered". The hide failing is not fatal (the key still goes out), so the catch
+          // resolves and the send happens exactly once either way.
+          void this.simctl.hideSoftwareKeyboard(state.deviceId)
+            .catch((e: unknown) => { logger.error('hideSoftwareKeyboard (on key) failed:', e) })
+            .then(() => this.ackInput(state, state.touchHelper?.sendKey(usage, modifiers ?? 0) ?? false))
         } else {
-          state.touchHelper?.sendKey(usage, modifiers ?? 0)
+          void this.ackInput(state, state.touchHelper?.sendKey(usage, modifiers ?? 0) ?? false)
         }
-        void this.ackInput(state, state.touchHelper !== null)
         break
       }
       case 'input:button': {
@@ -882,19 +904,24 @@ export class IOSAgent implements DeviceAgent {
         // device's actual chrome button names. Dashboard already sends the raw
         // chrome names (e.g. "volume-up"), which pass through unchanged.
         const chromeName = IOS_BUTTON_ALIASES[name] ?? name
+        // Two branches below deliberately write nothing — a home press-down, and a button this
+        // device's chrome has no HID mapping for. Neither is a dropped input, so they answer
+        // with the channel's health instead of a write result; reporting an error there would
+        // trade this issue's false success for a false failure.
+        let dispatched = state.touchHelper?.isReady() ?? false
         if (chromeName === 'home') {
           // Home has no HID down/up split — always a single legacy press. Send once on release
           // (or on a phase-less legacy message) so a down+up pair doesn't fire it twice.
-          if (phase !== 'down') state.touchHelper?.pressLegacyButton(0)
+          if (phase !== 'down') dispatched = state.touchHelper?.pressLegacyButton(0) ?? false
         } else {
           const btn = state.loadedChrome?.buttons.find((b) => b.name === chromeName)
           if (btn && btn.usagePage > 0 && btn.usage > 0) {
-            if (phase === 'down') state.touchHelper?.pressButtonDown(btn.usagePage, btn.usage)
-            else if (phase === 'up') state.touchHelper?.pressButtonUp(btn.usagePage, btn.usage)
-            else state.touchHelper?.pressButton(btn.usagePage, btn.usage)
+            if (phase === 'down') dispatched = state.touchHelper?.pressButtonDown(btn.usagePage, btn.usage) ?? false
+            else if (phase === 'up') dispatched = state.touchHelper?.pressButtonUp(btn.usagePage, btn.usage) ?? false
+            else dispatched = state.touchHelper?.pressButton(btn.usagePage, btn.usage) ?? false
           }
         }
-        void this.ackInput(state, state.touchHelper !== null)
+        void this.ackInput(state, dispatched)
         break
       }
       case 'open-url': {
@@ -1123,7 +1150,12 @@ export class IOSAgent implements DeviceAgent {
             state.softKeyboardVisible = false
             await this.simctl.hideSoftwareKeyboard(state.deviceId).catch(() => {})
           }
-          state.touchHelper.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])
+          // Same reason as input:type: the deadline above proves the pasteboard took the text,
+          // not that the chord reached the device, so a dead channel here would answer
+          // clipboard:write-done having pasted nothing.
+          if (!state.touchHelper.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])) {
+            throw new PlatformError('Cannot press paste — no input channel to the device')
+          }
         }
         // Ack only once the write (and the paste, when asked for) actually landed.
         this.clipboardQueue(state.deviceId, write)

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -1153,7 +1153,7 @@ export class IOSAgent implements DeviceAgent {
           // Same reason as input:type: the deadline above proves the pasteboard took the text,
           // not that the chord reached the device, so a dead channel here would answer
           // clipboard:write-done having pasted nothing.
-          if (!state.touchHelper.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])) {
+          if (!state.touchHelper?.sendKey(KEY_CODE_MAP['KeyV'], MODIFIER_BITS['MetaLeft'])) {
             throw new PlatformError('Cannot press paste — no input channel to the device')
           }
         }

--- a/packages/ios-agent/src/TouchHelper.ts
+++ b/packages/ios-agent/src/TouchHelper.ts
@@ -7,106 +7,127 @@ const logger = createLogger('ios-agent:touch-helper')
 
 const BINARY = join(import.meta.dirname, '..', 'bin', 'touch-helper')
 
+// At most this many spawns in any window of this length. A rolling window rather than a count
+// of consecutive failures: the helper's start-up is expensive (a subprocess, two dlopens, a
+// device lookup), so "it failed quickly" cannot be told apart from "it failed slowly" without
+// guessing how long start-up takes — and a helper that reliably dies just after that guess would
+// reset a consecutive counter forever and churn processes for the life of the agent. A window
+// bounds it whatever the lifetime, and it self-clears, so a session that briefly could not start
+// a helper is not stuck without input until the device is rebooted.
+const RESPAWN_LIMIT = 3
+const RESPAWN_WINDOW_MS = 30_000
+
+// The helper announces itself on stderr once it holds its HID client and is about to start
+// reading stdin (`touch-helper.swift:281`). Measured against a real simulator: 186–247ms after
+// spawn (n=5), and a gesture written before it lands *nothing* — the frames are buffered by the
+// pipe and then drained in one go, which collapses a swipe into microseconds and iOS reads it as
+// no gesture at all. So "the pipe is open" is not the same as "the device will act on this", and
+// reporting the first as success is the same lie as #482 in a narrower window.
+const READY_MARKER = 'touch-helper ready'
+// A helper that wedges *before* announcing would otherwise never be replaced: it is running, so
+// nothing asks for a new one, and it is not ready, so every input is refused — honestly, but
+// forever. The announcement comes after a device lookup through CoreSimulator, which is where a
+// wedge would sit. Measured start-up is 186–247ms, so this is roughly twenty times the worst case
+// observed rather than a tight bound.
+const READY_DEADLINE_MS = 5_000
+
 export class TouchHelper {
   private proc: ChildProcess | null = null
+  // The process that received the current gesture's opening frame. Mid-gesture frames are only
+  // meaningful to that one, so they are checked against it rather than against liveness alone.
+  private gestureProc: ChildProcess | null = null
   private lastX = 0
   private lastY = 0
+  private stopped = false
+  private ready = false
+  private readyTimer: ReturnType<typeof setTimeout> | null = null
+  private spawns: number[] = []
 
   constructor(private readonly udid: string) {}
 
   start(): void {
-    const bin = BINARY
-    this.proc = spawn(bin, [this.udid], { stdio: ['pipe', 'ignore', 'pipe'] })
-    this.proc.stderr?.on('data', (d: Buffer) => {
-      const msg = d.toString().trim()
-      // print all lines, even debug: lines, until we're confident it's working
-      logger.error(msg)
-    })
-    this.proc.on('exit', (code) => {
-      logger.error(`exited with code ${code ?? 'null'}`)
-    })
-    this.proc.on('error', (e) => {
-      logger.error(`spawn error: ${e.message}`)
-    })
+    this.stopped = false
+    this.spawnHelper()
   }
 
   stop(): void {
+    this.stopped = true
+    this.clearReadyDeadline()
     killWithSigkillFallback(this.proc)
     this.proc = null
+    this.gestureProc = null
   }
 
-  touchStart(x: number, y: number): void {
+  // Whether an input written right now actually reaches the device. Two conditions, and they are
+  // deliberately not the same question as `isRunning()`: a helper that is still starting up is
+  // very much alive and must not be replaced, but a frame written to it is dropped on the floor.
+  isReady(): boolean {
+    return this.isRunning() && this.ready
+  }
+
+  // Whether the helper process exists with an open pipe — the question a *replacement* decision
+  // asks. `this.proc` only ever holds a process that execed (`spawnHelper` is the gate), so from
+  // here on stdin closing is what death looks like.
+  private isRunning(): boolean {
+    return this.proc?.stdin?.writable === true
+  }
+
+  touchStart(x: number, y: number): boolean {
     this.lastX = x
     this.lastY = y
-    this.write(1, x, y)
+    return this.openGesture(this.coordFrame(1, x, y))
   }
 
-  touchMove(x: number, y: number): void {
+  touchMove(x: number, y: number): boolean {
     this.lastX = x
     this.lastY = y
-    this.write(2, x, y)
+    return this.continueGesture(this.coordFrame(2, x, y))
   }
 
-  touchEnd(): void {
-    this.write(3, this.lastX, this.lastY)
+  touchEnd(): boolean {
+    return this.continueGesture(this.coordFrame(3, this.lastX, this.lastY))
   }
 
-  pressButton(usagePage: number, usage: number): void {
-    if (!this.proc?.stdin?.writable) return
-    const buf = Buffer.allocUnsafe(9)
-    buf.writeUInt8(4, 0)
-    buf.writeUInt32BE(usagePage, 1)
-    buf.writeUInt32BE(usage, 5)
-    this.proc.stdin.write(buf)
+  pressButton(usagePage: number, usage: number): boolean {
+    return this.sendSelfContained(this.buttonFrame(4, usagePage, usage))
   }
 
   // Real-time button hold: down + up sent as separate frames so the hold lasts as long as
   // the user holds the button in the dashboard (e.g. Action button long-press). type 4 above
   // remains the fixed short-press path.
-  private writeButtonOp(type: number, usagePage: number, usage: number): void {
-    if (!this.proc?.stdin?.writable) return
-    const buf = Buffer.allocUnsafe(9)
-    buf.writeUInt8(type, 0)
-    buf.writeUInt32BE(usagePage, 1)
-    buf.writeUInt32BE(usage, 5)
-    this.proc.stdin.write(buf)
+  pressButtonDown(usagePage: number, usage: number): boolean {
+    return this.sendSelfContained(this.buttonFrame(10, usagePage, usage))
   }
 
-  pressButtonDown(usagePage: number, usage: number): void {
-    this.writeButtonOp(10, usagePage, usage)
-  }
-
-  pressButtonUp(usagePage: number, usage: number): void {
-    this.writeButtonOp(11, usagePage, usage)
+  // Self-contained despite being the tail of a pair: the helper keeps no record of which
+  // buttons are down (`touch-helper.swift` sends one op per frame), so a fresh process serves
+  // this exactly as the old one would have. Refusing it would be worse — a `down` that reached
+  // a live helper could then never be released.
+  pressButtonUp(usagePage: number, usage: number): boolean {
+    return this.sendSelfContained(this.buttonFrame(11, usagePage, usage))
   }
 
   // Legacy path for home (code=0) and lock (code=1) buttons
-  pressLegacyButton(code: number): void {
-    if (!this.proc?.stdin?.writable) return
-    const buf = Buffer.allocUnsafe(9)
-    buf.writeUInt8(5, 0)
-    buf.writeUInt32BE(code, 1)
-    buf.writeUInt32BE(0, 5)
-    this.proc.stdin.write(buf)
+  pressLegacyButton(code: number): boolean {
+    return this.sendSelfContained(this.buttonFrame(5, code, 0))
   }
 
-  pinchStart(x1: number, y1: number, x2: number, y2: number): void {
-    this.writeTwoFinger(6, x1, y1, x2, y2)
+  pinchStart(x1: number, y1: number, x2: number, y2: number): boolean {
+    return this.openGesture(this.twoFingerFrame(6, x1, y1, x2, y2))
   }
 
-  pinchMove(x1: number, y1: number, x2: number, y2: number): void {
-    this.writeTwoFinger(7, x1, y1, x2, y2)
+  pinchMove(x1: number, y1: number, x2: number, y2: number): boolean {
+    return this.continueGesture(this.twoFingerFrame(7, x1, y1, x2, y2))
   }
 
-  pinchEnd(): void {
-    this.writeTwoFinger(8, 0, 0, 0, 0)
+  pinchEnd(): boolean {
+    return this.continueGesture(this.twoFingerFrame(8, 0, 0, 0, 0))
   }
 
   // HID keyboard — type 9 frame: [9][modifiers][pad x3][usage:u32BE]
   // modifiers: USB HID modifier bitmap (0x01=LeftCtrl, 0x02=LeftShift, 0x04=LeftAlt, 0x08=LeftMeta, …)
   // usage: keyboard usage code from HID Keyboard/Keypad page (0x07)
-  sendKey(usage: number, modifiers = 0): void {
-    if (!this.proc?.stdin?.writable) return
+  sendKey(usage: number, modifiers = 0): boolean {
     const buf = Buffer.allocUnsafe(9)
     buf.writeUInt8(9, 0)
     buf.writeUInt8(modifiers, 1)
@@ -114,26 +135,162 @@ export class TouchHelper {
     buf.writeUInt8(0, 3)
     buf.writeUInt8(0, 4)
     buf.writeUInt32BE(usage, 5)
-    this.proc.stdin.write(buf)
+    return this.sendSelfContained(buf)
   }
 
-  private writeTwoFinger(type: number, x1: number, y1: number, x2: number, y2: number): void {
-    if (!this.proc?.stdin?.writable) return
+  private coordFrame(type: number, x: number, y: number): Buffer {
+    const buf = Buffer.allocUnsafe(9)
+    buf.writeUInt8(type, 0)
+    buf.writeFloatBE(x, 1)
+    buf.writeFloatBE(y, 5)
+    return buf
+  }
+
+  private buttonFrame(type: number, a: number, b: number): Buffer {
+    const buf = Buffer.allocUnsafe(9)
+    buf.writeUInt8(type, 0)
+    buf.writeUInt32BE(a, 1)
+    buf.writeUInt32BE(b, 5)
+    return buf
+  }
+
+  private twoFingerFrame(type: number, x1: number, y1: number, x2: number, y2: number): Buffer {
     const buf = Buffer.allocUnsafe(17)
     buf.writeUInt8(type, 0)
     buf.writeFloatBE(x1, 1)
     buf.writeFloatBE(y1, 5)
     buf.writeFloatBE(x2, 9)
     buf.writeFloatBE(y2, 13)
-    this.proc.stdin.write(buf)
+    return buf
   }
 
-  private write(type: number, x: number, y: number): void {
-    if (!this.proc?.stdin?.writable) return
-    const buf = Buffer.allocUnsafe(9)
-    buf.writeUInt8(type, 0)
-    buf.writeFloatBE(x, 1)
-    buf.writeFloatBE(y, 5)
-    this.proc.stdin.write(buf)
+  // Frames that carry their whole payload: a dead helper is replaced before the frame goes out,
+  // so input recovers rather than staying dead for the rest of the session (#482).
+  private sendSelfContained(buf: Buffer): boolean {
+    // `isRunning`, not `isReady`: replacing a helper that is merely still starting up would spawn
+    // a second one, burn the window budget, and make the wait longer rather than shorter.
+    if (!this.isRunning()) this.respawn()
+    return this.send(buf)
+  }
+
+  // A gesture's opening frame. Self-contained, and it records which process is serving the
+  // gesture so the frames that follow can be held to it.
+  private openGesture(buf: Buffer): boolean {
+    const sent = this.sendSelfContained(buf)
+    // Only a *delivered* open owns the gesture. Recording unconditionally looks equivalent and is
+    // not: during the start-up window the open is refused while `this.proc` is a healthy process
+    // that becomes ready ~200ms later, so identity would then pass and the rest of the gesture
+    // would reach a process that never received the down — a release at (0,0) reported as
+    // delivered, which is the exact defect this guard exists to prevent.
+    this.gestureProc = sent ? this.proc : null
+    return sent
+  }
+
+  // Everything after the opening frame. These are meaningless to any other process: types 3 and
+  // 8 inject coordinate latches the helper accumulated (`lastX/lastY`, `pinchLast*`) — a pinch
+  // end's own coordinates are all zero for exactly that reason — and a type 2 or 7 move with no
+  // preceding down is not the gesture the tester made.
+  //
+  // Checking liveness is not enough. Replacement is eager, so by the time a terminal frame
+  // arrives after a mid-gesture death there is usually a healthy process to write to, and a
+  // fresh one has those latches at zero: the tap would be released at (0,0) and reported as
+  // delivered. Identity is what the guard has to be about.
+  private continueGesture(buf: Buffer): boolean {
+    if (this.proc === null || this.proc !== this.gestureProc) return false
+    return this.send(buf)
+  }
+
+  private send(buf: Buffer): boolean {
+    if (!this.isReady()) return false
+    // A `false` from write() is backpressure: node buffers the frame and flushes it when the
+    // pipe drains, so it does not mean the input was dropped.
+    this.proc?.stdin?.write(buf)
+    return true
+  }
+
+  private armReadyDeadline(proc: ChildProcess): void {
+    this.clearReadyDeadline()
+    const timer = setTimeout(() => {
+      if (this.proc !== proc || this.ready) return
+      logger.error(`no readiness announcement within ${READY_DEADLINE_MS}ms — replacing the helper`)
+      killWithSigkillFallback(proc)
+      // Through the same path as a real death, so the replacement is subject to the same window.
+      this.handleDeath(proc)
+    }, READY_DEADLINE_MS)
+    timer.unref?.()
+    this.readyTimer = timer
+  }
+
+  private clearReadyDeadline(): void {
+    if (this.readyTimer) { clearTimeout(this.readyTimer); this.readyTimer = null }
+  }
+
+  private respawn(): void {
+    if (this.stopped) return
+    const now = Date.now()
+    this.spawns = this.spawns.filter((t) => now - t < RESPAWN_WINDOW_MS)
+    if (this.spawns.length >= RESPAWN_LIMIT) return
+    this.spawnHelper()
+  }
+
+  private spawnHelper(): void {
+    const proc = spawn(BINARY, [this.udid], { stdio: ['pipe', 'ignore', 'pipe'] })
+    this.spawns.push(Date.now())
+    this.ready = false
+
+    // The one place that decides whether a spawn counts as a helper, and it has to decide
+    // synchronously: the frame that triggered this spawn is written immediately after.
+    //
+    // A pid is the only signal available that early. When the exec fails — binary missing, no
+    // execute bit, wrong architecture (#464) — libuv still hands back an open stdin pipe and
+    // reports the failure on a LATER tick. Measured against a real spawn of a nonexistent path,
+    // `stdin.writable` is `true` on a process that does not exist, and `stdin.write()` returning
+    // `false` is indistinguishable from ordinary backpressure on a healthy helper. A pid is
+    // assigned only once the exec succeeded.
+    if (proc.pid === undefined) {
+      proc.on('error', (e) => logger.error(`spawn error: ${e.message}`))
+      this.proc = null
+      return
+    }
+
+    this.proc = proc
+    this.armReadyDeadline(proc)
+    // Cap what is retained: the marker is short, and a helper that never announces itself can
+    // still emit warnings indefinitely.
+    let tail = ''
+    proc.stderr?.on('data', (d: Buffer) => {
+      const msg = d.toString()
+      // Guarded on identity so a superseded process's late announcement cannot mark a newer one
+      // ready.
+      if (!this.ready && this.proc === proc) {
+        const seen = tail + msg
+        if (seen.includes(READY_MARKER)) {
+          this.ready = true
+          tail = ''
+          this.clearReadyDeadline()
+        // Retain only enough to rejoin a marker split across two chunks.
+        } else tail = seen.slice(-READY_MARKER.length)
+      }
+      // print all lines, even debug: lines, until we're confident it's working
+      logger.error(msg.trim())
+    })
+    proc.on('exit', (code) => {
+      logger.error(`exited with code ${code ?? 'null'}`)
+      this.handleDeath(proc)
+    })
+    proc.on('error', (e) => {
+      logger.error(`spawn error: ${e.message}`)
+      this.handleDeath(proc)
+    })
+  }
+
+  // Replace the helper as soon as it dies rather than on the next input. Waiting would make
+  // the first tap after a death pay the whole start-up cost (xcode-select, two dlopens, a
+  // device lookup), and that tap is the one the tester is watching.
+  private handleDeath(proc: ChildProcess): void {
+    if (this.proc !== proc) return // superseded by a newer spawn, or stop() already cleared it
+    this.clearReadyDeadline()
+    this.proc = null
+    this.respawn()
   }
 }

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -83,7 +83,7 @@ import { AudioCaptureStreamer } from '../AudioCaptureStreamer'
 import { launchAudioHelper } from '@tapflowio/audiotap-helper'
 import { SimctlWrapper } from '../SimctlWrapper'
 import { TouchHelper } from '../TouchHelper'
-import { waitForOpen, waitForType } from '@tapflowio/test-utils'
+import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 const MockTouchHelper = vi.mocked(TouchHelper)
 const MockAudioStreamer = vi.mocked(AudioCaptureStreamer)
 const mockLaunchAudioHelper = vi.mocked(launchAudioHelper)
@@ -626,11 +626,16 @@ describe('IOSAgent', () => {
       browser.close()
     })
 
-    it('does not install a helper onto a state that teardown has already dropped', async () => {
-      // `cleanupDeviceState` bumps bootSeq for this: a boot awaiting simctl holds its own
-      // reference to the state, and `deviceStates.clear()` does not reach it. Without the bump it
-      // runs on to build a TouchHelper nobody owns — and a self-reviving one would respawn for
-      // the life of the agent with nothing left to stop it.
+    it('does not install a helper onto a state that a reconnect has already dropped', async () => {
+      // What `cleanupDeviceState`'s bootSeq bump is actually for. A boot awaiting simctl holds its
+      // own reference to the state, and `_scheduleReconnect`'s `deviceStates.clear()` does not
+      // reach it. `sendChromeData`'s `!this.ws` guard covers the window only until the reconnect
+      // completes — after that the socket is live again and the abandoned boot goes on to build a
+      // TouchHelper nobody owns, which a self-reviving helper would keep respawning for the life
+      // of the agent with nothing left to stop it.
+      //
+      // Driving the reconnect is the whole point: an `agent.disconnect()` version of this test
+      // passes with the bump deleted, because ws stays null forever and the guard above catches it.
       const simctl = mockSimctl(false)
       let releaseBoot = (): void => {}
       ;(simctl.boot as ReturnType<typeof vi.fn>).mockImplementation(
@@ -638,7 +643,7 @@ describe('IOSAgent', () => {
       )
       const browser = new WebSocket(`ws://localhost:${port}`)
       await waitForOpen(browser)
-      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      const agent = new IOSAgent({ intervalMs: 50, reconnectDelays: [20] }, simctl)
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
@@ -649,13 +654,35 @@ describe('IOSAgent', () => {
       await vi.waitFor(() => expect(simctl.boot).toHaveBeenCalled(), { timeout: 500 })
       expect(MockTouchHelper.mock.results).toHaveLength(0)
 
-      agent.disconnect() // tears the state down while the boot is still awaiting simctl
-      releaseBoot()
-      await new Promise((r) => setTimeout(r, 150)) // let the abandoned boot run as far as it will
+      // Drop the relay and bring it back on the same port so the agent's own reconnect runs.
+      browser.close()
+      await relay.stop()
+      relay = new RelayServer({ port })
+      await relay.start()
+      const rejoined = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(rejoined)
+      // A join only succeeds once the agent has re-registered, so this is the barrier that says
+      // the socket is live again — and therefore that `!this.ws` no longer guards anything.
+      let joined = null
+      for (let i = 0; i < 20 && joined === null; i++) {
+        rejoined.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+        joined = await waitForTypeOrNull(rejoined, 'session:joined', 150)
+      }
+      expect(joined).not.toBeNull()
 
+      // The abandoned boot returns at the seq check *before* its second `listDevices`, so that
+      // call not happening is the assertion — no sleep, and it fails if the bump is removed
+      // (the boot then runs on to `listDevices` and builds the helper). `setImmediate` drains the
+      // microtask queue, which is all the guarded path needs to reach its early return.
+      const listCallsBeforeRelease = (simctl.listDevices as ReturnType<typeof vi.fn>).mock.calls.length
+      releaseBoot()
+      await new Promise((r) => setImmediate(r))
+
+      expect(simctl.listDevices).toHaveBeenCalledTimes(listCallsBeforeRelease)
       expect(MockTouchHelper.mock.results).toHaveLength(0)
 
-      browser.close()
+      agent.disconnect()
+      rejoined.close()
     })
 
     it('answers input:type-error when the paste chord is dropped', async () => {

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -6,23 +6,35 @@ import { spawnSync } from 'child_process'
 import { ValidationError, PlatformError, MAX_CLIPBOARD_BYTES } from '@tapflowio/agent-core'
 import { ClipboardTooLargeError } from '../SimctlWrapper.js'
 
+// A live helper. Since #482 every write reports whether it reached the helper process and the
+// agent acks on that answer, so the mock has to state it — returning undefined would model a
+// helper that silently drops everything. `killHelper()` below flips one over to that state.
 vi.mock('../TouchHelper', () => ({
   TouchHelper: vi.fn(function () { return ({
     start: vi.fn(),
     stop: vi.fn(),
-    touchStart: vi.fn(),
-    touchMove: vi.fn(),
-    touchEnd: vi.fn(),
-    pressButton: vi.fn(),
-    pressButtonDown: vi.fn(),
-    pressButtonUp: vi.fn(),
-    pressLegacyButton: vi.fn(),
-    pinchStart: vi.fn(),
-    pinchMove: vi.fn(),
-    pinchEnd: vi.fn(),
-    sendKey: vi.fn(),
+    isReady: vi.fn(() => true),
+    touchStart: vi.fn(() => true),
+    touchMove: vi.fn(() => true),
+    touchEnd: vi.fn(() => true),
+    pressButton: vi.fn(() => true),
+    pressButtonDown: vi.fn(() => true),
+    pressButtonUp: vi.fn(() => true),
+    pressLegacyButton: vi.fn(() => true),
+    pinchStart: vi.fn(() => true),
+    pinchMove: vi.fn(() => true),
+    pinchEnd: vi.fn(() => true),
+    sendKey: vi.fn(() => true),
   }) }),
 }))
+
+// The #482 state: the helper object is still there and the stream is still running, but its
+// child process is gone, so every write is dropped.
+function killHelper(th: Record<string, ReturnType<typeof vi.fn>>): void {
+  for (const [name, fn] of Object.entries(th)) {
+    if (name !== 'start' && name !== 'stop') fn.mockReturnValue(false)
+  }
+}
 
 // Mock the capture streamer so codec-negotiation tests can read the codec arg the
 // agent picked, without spawning the real helper binary. start() returns a stream
@@ -422,6 +434,239 @@ describe('IOSAgent', () => {
       const e = await errored
       expect(e.sessionId).toBe(agent.sessionId)
       expect(e.message).toBe('device not booted')
+
+      agent.disconnect()
+      browser.close()
+    })
+  })
+
+  // #482: the helper process dies, the session keeps streaming, and every input is dropped.
+  // The agent used to ack on `state.touchHelper !== null` — the wrapper object, which is still
+  // there — so the caller was told each dropped input had been delivered.
+  describe('input acks when the helper process has died (#482)', () => {
+    beforeEach(() => { MockTouchHelper.mockClear() })
+
+    async function bootedSession(simctl = mockSimctl(true)) {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:ready')
+      // device:ready is not a sync point for the helper — wait on the mock itself.
+      await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterThan(0), { timeout: 500 })
+      return { browser, agent, simctl, th: MockTouchHelper.mock.results[0].value }
+    }
+
+    it('answers input:error for a tap the dead helper dropped', async () => {
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+
+      // The device is still booted — this is the input channel failing, not the device.
+      expect((await errored).message).toBe('input channel not ready')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('answers input:error for a pinch the dead helper dropped', async () => {
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:error')
+      const f0 = { x: 0.2, y: 0.2 }, f1 = { x: 0.8, y: 0.8 }
+      browser.send(JSON.stringify({ type: 'input:pinch:start', sessionId: agent.sessionId, payload: { f0, f1 } }))
+      browser.send(JSON.stringify({ type: 'input:pinch:end', sessionId: agent.sessionId, payload: { f0, f1 } }))
+      expect((await errored).message).toBe('input channel not ready')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('answers input:done again once the helper has recovered, without a reconnect', async () => {
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      await errored
+
+      // TouchHelper respawns itself, so the session heals in place — the same object starts
+      // reporting delivery again. Nothing re-issues the session.
+      th.touchEnd.mockReturnValue(true)
+      th.isReady.mockReturnValue(true)
+
+      const done = waitForType(browser, 'input:done')
+      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      expect((await done).sessionId).toBe(agent.sessionId)
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('answers input:error for a button the dead helper dropped', async () => {
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload: { name: 'home' } }))
+      expect((await errored).message).toBe('input channel not ready')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    // The two branches that deliberately write nothing answer with the channel's health. Both
+    // directions need pinning: a seed of `false` invents a failure on a healthy channel, and a
+    // seed of `true` is the silent success this whole issue is about.
+    const noWriteBranches: Array<[string, Record<string, unknown>]> = [
+      ['a home press-down', { name: 'home', phase: 'down' }],
+      // `mockSimctl` reports no typeId, so DeviceChromeLoader finds nothing and `loadedChrome`
+      // stays null for this whole suite — this pair covers the "no chrome button matched" branch.
+      // The narrower `usagePage > 0 && usage > 0` sub-guard inside it is unreached here and
+      // untested; it predates this change.
+      ['a button with no chrome entry', { name: 'volume-up' }],
+    ]
+
+    for (const [label, payload] of noWriteBranches) {
+      it(`does not invent a failure for ${label} on a healthy channel`, async () => {
+        const { browser, agent, th } = await bootedSession()
+
+        const done = waitForType(browser, 'input:done')
+        browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload }))
+        expect((await done).sessionId).toBe(agent.sessionId)
+        expect(th.pressLegacyButton).not.toHaveBeenCalled()
+        expect(th.pressButtonDown).not.toHaveBeenCalled()
+
+        agent.disconnect()
+        browser.close()
+      })
+
+      it(`does not claim success for ${label} on a dead channel`, async () => {
+        const { browser, agent, th } = await bootedSession()
+        killHelper(th)
+
+        const errored = waitForType(browser, 'input:error')
+        browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload }))
+        expect((await errored).message).toBe('input channel not ready')
+
+        agent.disconnect()
+        browser.close()
+      })
+    }
+
+    it('answers input:error for a key the dead helper dropped', async () => {
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      expect((await errored).message).toBe('input channel not ready')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('answers input:error for a key deferred behind hiding the software keyboard', async () => {
+      // The branch the ack used to race: the chord is sent inside the hide's continuation, so
+      // acking beside it answered before the key had been written at all.
+      const { browser, agent, simctl, th } = await bootedSession()
+      browser.send(JSON.stringify({ type: 'input:keyboard:toggle', sessionId: agent.sessionId }))
+      await waitForType(browser, 'keyboard:toggled')
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:error')
+      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      expect((await errored).message).toBe('input channel not ready')
+      expect(simctl.hideSoftwareKeyboard).toHaveBeenCalledWith('dev-1')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('stops a helper that input created while a boot was still in flight', async () => {
+      // handleDeviceBoot clears the helper up front and then awaits simctl. An input arriving
+      // inside that window builds a fresh one through ensureTouchHelper, and sendChromeData
+      // later replaces it. That used to leak one child process; now the orphan revives itself
+      // for the life of the agent with nothing left holding a reference to stop it.
+      const simctl = mockSimctl(false)
+      let releaseBoot = (): void => {}
+      ;(simctl.boot as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise<void>((resolve) => { releaseBoot = () => resolve() }),
+      )
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      const booting = waitForType(browser, 'device:booting')
+      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await booting
+      await vi.waitFor(() => expect(simctl.boot).toHaveBeenCalled(), { timeout: 500 })
+
+      browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
+      const orphan = MockTouchHelper.mock.results[0].value
+
+      const ready = waitForType(browser, 'device:ready')
+      releaseBoot()
+      await ready
+      await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(2), { timeout: 1000 })
+
+      expect(orphan.stop).toHaveBeenCalled()
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('does not install a helper onto a state that teardown has already dropped', async () => {
+      // `cleanupDeviceState` bumps bootSeq for this: a boot awaiting simctl holds its own
+      // reference to the state, and `deviceStates.clear()` does not reach it. Without the bump it
+      // runs on to build a TouchHelper nobody owns — and a self-reviving one would respawn for
+      // the life of the agent with nothing left to stop it.
+      const simctl = mockSimctl(false)
+      let releaseBoot = (): void => {}
+      ;(simctl.boot as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise<void>((resolve) => { releaseBoot = () => resolve() }),
+      )
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      const booting = waitForType(browser, 'device:booting')
+      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await booting
+      await vi.waitFor(() => expect(simctl.boot).toHaveBeenCalled(), { timeout: 500 })
+      expect(MockTouchHelper.mock.results).toHaveLength(0)
+
+      agent.disconnect() // tears the state down while the boot is still awaiting simctl
+      releaseBoot()
+      await new Promise((r) => setTimeout(r, 150)) // let the abandoned boot run as far as it will
+
+      expect(MockTouchHelper.mock.results).toHaveLength(0)
+
+      browser.close()
+    })
+
+    it('answers input:type-error when the paste chord is dropped', async () => {
+      // No pasteboard deadline guards this path, unlike the copy in clipboard:read — the text
+      // lands on the device clipboard and nothing reaches the app under test.
+      const { browser, agent, th } = await bootedSession()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'input:type-error')
+      browser.send(JSON.stringify({ type: 'input:type', sessionId: agent.sessionId, payload: { text: 'hello' } }))
+      expect((await errored).message).toContain('no input channel')
 
       agent.disconnect()
       browser.close()
@@ -1952,6 +2197,26 @@ describe('IOSAgent', () => {
       await done
       expect(th.sendKey).toHaveBeenCalledWith(0x19, 0x08)   // KeyV + MetaLeft
       expect(simctl.setPasteboard).toHaveBeenCalledWith('dev-1', 'x')
+
+      agent.disconnect(); browser.close()
+    })
+
+    it('answers clipboard:error when the paste chord is dropped (#482)', async () => {
+      // The pasteboard deadline above proves the device took the text, not that the chord
+      // reached it — so a dead input channel here used to answer clipboard:write-done having
+      // pasted nothing into the app.
+      const simctl = mockSimctl(true)
+      const { agent, browser } = await bootWith(simctl)
+      await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterThan(0), { timeout: 500 })
+      const th = MockTouchHelper.mock.results[MockTouchHelper.mock.results.length - 1].value
+      th.sendKey.mockClear()
+      killHelper(th)
+
+      const errored = waitForType(browser, 'clipboard:error')
+      browser.send(JSON.stringify({
+        type: 'clipboard:write', sessionId: agent.sessionId, requestId: 'r6b', payload: { text: 'x', pasteAfter: true },
+      }))
+      expect((await errored).message).toContain('no input channel')
 
       agent.disconnect(); browser.close()
     })

--- a/packages/ios-agent/src/__tests__/TouchHelper.snapshot.test.ts
+++ b/packages/ios-agent/src/__tests__/TouchHelper.snapshot.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
 
 vi.mock('child_process', () => {
   const mockStdin = {
@@ -6,8 +7,15 @@ vi.mock('child_process', () => {
     write: vi.fn(),
   }
   const mockProc = {
+    // A pid is what tells TouchHelper the exec succeeded — libuv leaves it undefined when the
+    // binary never ran, while still handing back a writable stdin pipe.
+    pid: 1234,
     stdin: mockStdin,
-    stderr: { on: vi.fn() },
+    // A real emitter: the helper's readiness announcement arrives here, and nothing is written
+    // to the device before it. The process object is shared across every test in this file, so
+    // each TouchHelper adds another listener to it — uncapped, or node warns about a leak partway
+    // through the file. The stale listeners are harmless: `ready` is per-instance.
+    stderr: new EventEmitter().setMaxListeners(0),
     on: vi.fn(),
     kill: vi.fn(),
   }
@@ -27,6 +35,13 @@ function capturedHex(): string {
   return buf.toString('hex').replace(/(.{2})/g, '$1 ').trimEnd()
 }
 
+// Mid-gesture frames are only delivered to the process that received the gesture's opening
+// frame (#482), so a snapshot of one has to open the gesture first and then look past it.
+function openThenClear(open: () => void): void {
+  open()
+  ;(vi.mocked(spawn) as ReturnType<typeof vi.fn>).mock.results[0]!.value.stdin.write.mockClear()
+}
+
 describe('TouchHelper stdin byte protocol snapshots', () => {
   let helper: TouchHelper
 
@@ -34,6 +49,8 @@ describe('TouchHelper stdin byte protocol snapshots', () => {
     vi.clearAllMocks()
     helper = new TouchHelper('dev-1')
     helper.start()
+    const proc = vi.mocked(spawn).mock.results[0]!.value as { stderr: EventEmitter }
+    proc.stderr.emit('data', Buffer.from('info: touch-helper ready (udid=dev-1) digitizer=true\n'))
   })
 
   afterEach(() => vi.restoreAllMocks())
@@ -46,14 +63,14 @@ describe('TouchHelper stdin byte protocol snapshots', () => {
 
   // ── type 2: touchMove ────────────────────────────────────────────────────
   it('type 2 — touchMove(0.25, 0.75) → 9 bytes', () => {
+    openThenClear(() => helper.touchStart(0, 0))
     helper.touchMove(0.25, 0.75)
     expect(capturedHex()).toMatchInlineSnapshot(`"02 3e 80 00 00 3f 40 00 00"`)
   })
 
   // ── type 3: touchEnd ─────────────────────────────────────────────────────
   it('type 3 — touchEnd() carries lastX/lastY set by touchStart', () => {
-    helper.touchStart(0.1, 0.2)
-    vi.mocked(spawn).mock.results[0]!.value.stdin.write.mockClear()
+    openThenClear(() => helper.touchStart(0.1, 0.2))
     helper.touchEnd()
     expect(capturedHex()).toMatchInlineSnapshot(`"03 3d cc cc cd 3e 4c cc cd"`)
   })
@@ -80,6 +97,7 @@ describe('TouchHelper stdin byte protocol snapshots', () => {
 
   // ── type 7: pinchMove ────────────────────────────────────────────────────
   it('type 7 — pinchMove(0.3, 0.4, 0.6, 0.7) → 17 bytes', () => {
+    openThenClear(() => helper.pinchStart(0, 0, 0, 0))
     helper.pinchMove(0.3, 0.4, 0.6, 0.7)
     expect(capturedHex()).toMatchInlineSnapshot(
       `"07 3e 99 99 9a 3e cc cc cd 3f 19 99 9a 3f 33 33 33"`,
@@ -88,6 +106,7 @@ describe('TouchHelper stdin byte protocol snapshots', () => {
 
   // ── type 8: pinchEnd ─────────────────────────────────────────────────────
   it('type 8 — pinchEnd() → 17 bytes all zero coords', () => {
+    openThenClear(() => helper.pinchStart(0, 0, 0, 0))
     helper.pinchEnd()
     expect(capturedHex()).toMatchInlineSnapshot(
       `"08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"`,

--- a/packages/ios-agent/src/__tests__/TouchHelper.test.ts
+++ b/packages/ios-agent/src/__tests__/TouchHelper.test.ts
@@ -1,28 +1,81 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
+import type { TouchHelper as TouchHelperType } from '../TouchHelper.js'
 
 vi.mock('child_process', () => ({ spawn: vi.fn() }))
 
-function makeFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdin: EventEmitter & { writable: boolean; write: ReturnType<typeof vi.fn> }
-    stderr: EventEmitter
-    kill: ReturnType<typeof vi.fn>
-  }
-  proc.stdin = Object.assign(new EventEmitter(), { writable: true, write: vi.fn() }) as never
+type FakeProc = EventEmitter & {
+  pid: number | undefined
+  stdin: EventEmitter & { writable: boolean; write: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+}
+
+let nextPid = 4242
+
+// A running helper: libuv assigned a pid and stdin is an open pipe. Running is not the same as
+// usable — see announceReady.
+function makeFakeProc(): FakeProc {
+  const proc = new EventEmitter() as FakeProc
+  proc.pid = nextPid++
+  proc.stdin = Object.assign(new EventEmitter(), { writable: true, write: vi.fn(() => true) }) as never
   proc.stderr = new EventEmitter()
   proc.kill = vi.fn(() => true) // matches ChildProcess.kill() on a live process
   return proc
 }
 
-async function setupHelper() {
-  const { spawn } = await import('child_process')
+// A helper that never execed — a missing binary, a missing execute bit, or an arm64-only binary
+// on an Intel Mac (#464 EBADARCH). Measured against a real `spawn` of a nonexistent path: libuv
+// leaves `pid` undefined and reports the failure on a LATER tick, while stdin is already an open
+// pipe whose `writable` reads `true`. `write()` returns false, but that is indistinguishable from
+// ordinary backpressure on a healthy helper, so it is not a signal either. `pid` is the only
+// thing that tells the truth synchronously.
+function makeFailedProc(): FakeProc {
   const proc = makeFakeProc()
-  vi.mocked(spawn).mockReturnValue(proc as never)
+  proc.pid = undefined
+  proc.stdin.write = vi.fn(() => false)
+  return proc
+}
+
+// The helper announces itself on stderr once it holds its HID client and is about to start
+// reading stdin (`touch-helper.swift:281`). Measured on a real simulator: 186–247ms after spawn
+// (n=5), and a gesture written before it lands nothing at all — the frames sit in the pipe and
+// are drained in one go, collapsing a swipe into microseconds. So tests have to say when a helper
+// reached that point, and the window before it is a real state worth covering.
+function announceReady(proc: FakeProc): void {
+  proc.stderr.emit('data', Buffer.from(`info: touch-helper ready (udid=dev-1) digitizer=true\n`))
+}
+
+// Node closes stdin when the child goes away, and `kill()` stops being deliverable once the
+// process is reaped. Modelling both keeps a mutation from passing because the fake stayed
+// writable on a corpse.
+function die(proc: FakeProc, code: number | null = 1): void {
+  proc.stdin.writable = false
+  proc.kill = vi.fn(() => false)
+  proc.emit('exit', code)
+}
+
+async function loadHelper(procs: FakeProc[]) {
+  const { spawn } = await import('child_process')
+  const mock = vi.mocked(spawn)
+  mock.mockReset()
+  let i = 0
+  mock.mockImplementation((() => procs[Math.min(i++, procs.length - 1)]) as never)
   const { TouchHelper } = await import('../TouchHelper.js')
-  const helper = new TouchHelper('dev-1')
+  return { helper: new TouchHelper('dev-1'), spawn: mock }
+}
+
+async function startedHelper(procs: FakeProc[]) {
+  const { helper, spawn } = await loadHelper(procs)
   helper.start()
-  return { helper, proc }
+  announceReady(procs[0])
+  return { helper, spawn }
+}
+
+async function setupHelper() {
+  const proc = makeFakeProc()
+  const { helper, spawn } = await startedHelper([proc])
+  return { helper, proc, spawn }
 }
 
 // Timer-precision cases (SIGKILL suppressed/fired) are covered by childProcessKill.test.ts —
@@ -51,4 +104,444 @@ describe('TouchHelper.stop()', () => {
     expect(proc.kill).toHaveBeenCalledTimes(1)
     expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
   })
+})
+
+// A running helper is not a usable one. Measured: ~200ms between the two, and a frame written in
+// between is silently ineffective — which is #482's failure in a narrower window, so it must not
+// be reported as delivered.
+describe('TouchHelper — a helper that is running but not yet ready', () => {
+  it('reports failure for a frame written before the helper announces itself', async () => {
+    const proc = makeFakeProc()
+    const { helper } = await loadHelper([proc])
+    helper.start()
+
+    expect(helper.isReady()).toBe(false)
+    expect(helper.touchStart(0.5, 0.5)).toBe(false)
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('reports success once it does', async () => {
+    const proc = makeFakeProc()
+    const { helper } = await loadHelper([proc])
+    helper.start()
+    announceReady(proc)
+
+    expect(helper.isReady()).toBe(true)
+    expect(helper.touchStart(0.5, 0.5)).toBe(true)
+    expect(proc.stdin.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not replace a helper that is merely still starting up', async () => {
+    // Replacing it would spawn a second process, spend the window budget, and make the wait
+    // longer rather than shorter.
+    const { helper, spawn } = await loadHelper([makeFakeProc(), makeFakeProc()])
+    helper.start()
+
+    for (let i = 0; i < 10; i++) expect(helper.touchStart(0.5, 0.5)).toBe(false)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it('tolerates the announcement arriving split across stderr chunks', async () => {
+    const proc = makeFakeProc()
+    const { helper } = await loadHelper([proc])
+    helper.start()
+
+    proc.stderr.emit('data', Buffer.from('info: touch-hel'))
+    proc.stderr.emit('data', Buffer.from('per ready (udid=dev-1)\n'))
+
+    expect(helper.isReady()).toBe(true)
+  })
+
+  it('does not hand the rest of a gesture to a helper the opening frame never reached', async () => {
+    // The trap in `openGesture`: recording the owner unconditionally reads as equivalent, and is
+    // not. Here the open is refused because the helper is still starting, yet `this.proc` is a
+    // healthy process that becomes ready a moment later — so identity would pass and the terminal
+    // frame would inject a release at (0,0) on a process that never saw the down, reported as
+    // delivered.
+    const proc = makeFakeProc()
+    const { helper } = await loadHelper([proc])
+    helper.start()
+
+    expect(helper.touchStart(0.4, 0.6)).toBe(false)
+    announceReady(proc)
+    expect(helper.isReady()).toBe(true)
+
+    expect(helper.touchEnd()).toBe(false)
+    expect(helper.touchMove(0.5, 0.7)).toBe(false)
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('replaces a helper that never announces itself, so the session is not dead for good', async () => {
+    // Running-but-never-ready has no other exit: nothing asks for a replacement (it is running)
+    // and every input is refused (it is not ready). A wedge in the device lookup would otherwise
+    // strand the session until the device was rebooted.
+    vi.useFakeTimers()
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper, spawn } = await loadHelper([first, second])
+    helper.start()
+
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(spawn).toHaveBeenCalledTimes(1) // still within its budget to start
+    expect(first.kill).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(spawn).toHaveBeenCalledTimes(2)
+
+    announceReady(second)
+    expect(helper.isReady()).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('does not replace a helper that announced itself in time', async () => {
+    vi.useFakeTimers()
+    const { helper, proc, spawn } = await setupHelper()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(proc.kill).not.toHaveBeenCalled()
+    expect(helper.isReady()).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('does not let a superseded process mark its replacement ready', async () => {
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper } = await startedHelper([first, second])
+    die(first)
+
+    announceReady(first) // the corpse's last words arrive after the replacement is up
+
+    expect(helper.isReady()).toBe(false)
+    announceReady(second)
+    expect(helper.isReady()).toBe(true)
+  })
+})
+
+// #482: a helper that dies on its own left `this.proc` pointing at the corpse. Every write
+// then returned early at a `stdin.writable` guard and the session accepted no further input,
+// while the stream kept running and nothing was reported.
+describe('TouchHelper — recovery from a helper that died on its own', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('respawns on exit without waiting for the next input', async () => {
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper, spawn } = await startedHelper([first, second])
+    expect(spawn).toHaveBeenCalledTimes(1)
+
+    die(first)
+
+    // Eager, not lazy: the replacement is already starting up before anyone taps, which is what
+    // buys the ~200ms it needs. Verified on a real simulator — a kill while idle, then the next
+    // swipe lands.
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(helper.isReady()).toBe(false)
+    announceReady(second)
+    expect(helper.isReady()).toBe(true)
+  })
+
+  it('respawns when a running helper errors rather than exiting', async () => {
+    // Not the same as an exec failure: that one has no pid, takes the early return in
+    // spawnHelper, and recovers lazily. This is a process that did start and then errored, which
+    // goes through the same death path as an exit.
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper, spawn } = await startedHelper([first, second])
+
+    first.stdin.writable = false
+    first.emit('error', new Error('boom'))
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    announceReady(second)
+    expect(helper.isReady()).toBe(true)
+  })
+
+  it('recovers lazily when the exec failed, since that death path never fires', async () => {
+    const replacement = makeFakeProc()
+    const { helper, spawn } = await loadHelper([makeFailedProc(), replacement])
+    helper.start()
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(helper.isReady()).toBe(false)
+
+    // The frame that triggers the respawn cannot itself land — the replacement is not ready yet,
+    // and saying otherwise is the lie this whole change is about.
+    expect(helper.touchStart(0.5, 0.5)).toBe(false)
+    expect(spawn).toHaveBeenCalledTimes(2)
+
+    announceReady(replacement)
+    expect(helper.touchStart(0.5, 0.5)).toBe(true)
+  })
+
+  it('reports failure when the helper closes stdin without exiting', async () => {
+    // #482 in its purest form: the process reference is still there and no death event has
+    // fired, but the pipe is gone.
+    const { helper, proc } = await setupHelper()
+
+    proc.stdin.writable = false
+
+    expect(helper.isReady()).toBe(false)
+    expect(helper.touchEnd()).toBe(false)
+  })
+
+  it('sends the next gesture to the replacement process', async () => {
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper } = await startedHelper([first, second])
+    die(first)
+    announceReady(second)
+
+    expect(helper.touchStart(0.5, 0.5)).toBe(true)
+    expect(second.stdin.write).toHaveBeenCalledTimes(1)
+    expect(first.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('does not respawn while the helper is alive', async () => {
+    const { helper, proc, spawn } = await setupHelper()
+
+    for (let i = 0; i < 20; i++) helper.touchStart(0.1, 0.1)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(proc.stdin.write).toHaveBeenCalledTimes(20)
+  })
+
+  it('does not respawn after an intentional stop, not even for an input', async () => {
+    // A healthy replacement is queued up deliberately: if stop() did not latch, the input below
+    // would spawn it and the agent would be serving a helper it asked to be gone.
+    const first = makeFakeProc()
+    const { helper, spawn } = await startedHelper([first, makeFakeProc()])
+    vi.useFakeTimers() // swallow stop()'s pending SIGKILL timer
+
+    helper.stop()
+    die(first, null) // SIGTERM landing, arriving after stop() cleared the reference
+    expect(spawn).toHaveBeenCalledTimes(1)
+
+    expect(helper.touchStart(0.5, 0.5)).toBe(false)
+    expect(helper.isReady()).toBe(false)
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it('never makes a process that failed to exec the active helper', async () => {
+    const first = makeFakeProc()
+    const failed = makeFailedProc()
+    const { helper } = await startedHelper([first, failed])
+
+    die(first)
+
+    expect(helper.touchStart(0.5, 0.5)).toBe(false)
+    // The load-bearing assertion: a pid-less process must not have become `this.proc`, and the
+    // only way to tell from out here is that its announcement cannot make the helper ready.
+    // Asserting `isReady() === false` alone would pass for any fresh process.
+    announceReady(failed)
+    expect(helper.isReady()).toBe(false)
+    expect(helper.touchStart(0.5, 0.5)).toBe(false)
+  })
+})
+
+describe('TouchHelper — respawn budget', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('stops spawning at the ceiling, and keeps reporting failure after it', async () => {
+    const { helper, spawn } = await loadHelper([makeFailedProc()])
+    helper.start() // attempt 1 — fails
+
+    // Each self-contained frame retries, so a permanently broken install (#464) would spawn a
+    // doomed process per tap without this ceiling.
+    for (let i = 0; i < 50; i++) expect(helper.touchStart(0.5, 0.5)).toBe(false)
+
+    expect(spawn).toHaveBeenCalledTimes(3)
+  })
+
+  it('bounds churn from a helper that keeps dying, with no input at all', async () => {
+    const procs = Array.from({ length: 8 }, () => makeFakeProc())
+    const { helper } = await startedHelper(procs)
+
+    for (const p of procs) die(p)
+
+    expect(vi.mocked((await import('child_process')).spawn)).toHaveBeenCalledTimes(3)
+    expect(helper.isReady()).toBe(false)
+  })
+
+  it('bounds it whatever the helper\'s lifetime — the ceiling is not a guess about start-up', async () => {
+    // The failure mode a consecutive-failure counter has. A helper that reliably outlives the
+    // "it died too fast" threshold and then dies resets such a counter every time, so it churns a
+    // process every few seconds for the life of the agent — no input, no user, no ceiling. The
+    // helper's own start-up is expensive enough (measured 186–247ms) to make any fixed threshold
+    // a guess, and this is the direction a wrong guess fails in.
+    vi.useFakeTimers()
+    const procs = Array.from({ length: 8 }, () => makeFakeProc())
+    const { helper: _h, spawn } = await startedHelper(procs)
+
+    for (const p of procs) {
+      await vi.advanceTimersByTimeAsync(3_000)
+      die(p)
+    }
+
+    expect(spawn).toHaveBeenCalledTimes(3)
+  })
+
+  it('lets go of the corpse when it stops spawning, so a later stop() signals nothing', async () => {
+    // #479's SIGKILL fallback arms a timer against whatever stop() was handed. Keeping a
+    // reference to a reaped process past the ceiling would aim that timer at a pid the OS is free
+    // to have reassigned by then.
+    const procs = Array.from({ length: 4 }, () => makeFakeProc())
+    const { helper } = await startedHelper(procs)
+    // Three deaths reach the ceiling. procs[3] was never handed out, so its death is a no-op.
+    for (const p of procs) die(p)
+
+    helper.stop()
+
+    for (const [i, p] of procs.entries()) expect(p.kill, `procs[${i}]`).not.toHaveBeenCalled()
+  })
+
+  it('serves a helper that crashes rarely without ever reaching the ceiling', async () => {
+    vi.useFakeTimers()
+    const procs = [makeFakeProc(), makeFakeProc(), makeFakeProc(), makeFakeProc()]
+    const { helper, spawn } = await startedHelper(procs)
+
+    // One crash per minute is well inside the window, so each one is replaced. Each replacement
+    // has to announce itself, or the readiness deadline replaces it first — which is the
+    // behaviour a different test pins.
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(60_000)
+      die(procs[i])
+      announceReady(procs[i + 1])
+    }
+
+    expect(spawn).toHaveBeenCalledTimes(4)
+    expect(helper.isReady()).toBe(true)
+  })
+
+  it('recovers on its own once the window slides, so a transient failure is not permanent', async () => {
+    vi.useFakeTimers()
+    const last = makeFakeProc()
+    const { helper, spawn } = await loadHelper([makeFailedProc(), makeFailedProc(), makeFailedProc(), last])
+    helper.start()
+    for (let i = 0; i < 5; i++) helper.touchStart(0.5, 0.5)
+    expect(spawn).toHaveBeenCalledTimes(3)
+
+    // Without this the ceiling is absorbing: no spawn can happen, so none can succeed, and only
+    // a reboot would revive input on the session.
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(helper.touchStart(0.5, 0.5)).toBe(false) // spawned, not ready yet
+    expect(spawn).toHaveBeenCalledTimes(4)
+    announceReady(last)
+    expect(helper.touchStart(0.5, 0.5)).toBe(true)
+  })
+})
+
+// The case the frame-type split alone does not cover. Replacement is eager, so after a
+// mid-gesture death there is normally a healthy process standing by — and writing the rest of
+// the gesture to it is worse than dropping it, because the new process has the coordinate
+// latches at zero and would release the touch at (0,0) while reporting success. Confirmed on a
+// real simulator: the guard holds, and the next fresh gesture works, so nothing stays held.
+describe('TouchHelper — a gesture belongs to the process that opened it', () => {
+  const continuations: Array<[string, (h: TouchHelperType) => boolean]> = [
+    ['touchEnd', (h) => h.touchEnd()],
+    ['touchMove', (h) => h.touchMove(0.5, 0.7)],
+    ['pinchMove', (h) => h.pinchMove(0.1, 0.1, 0.2, 0.2)],
+    ['pinchEnd', (h) => h.pinchEnd()],
+  ]
+
+  for (const [name, call] of continuations) {
+    it(`refuses ${name} after the opening process died, even though a live one is standing by`, async () => {
+      const first = makeFakeProc()
+      const second = makeFakeProc()
+      const { helper } = await startedHelper([first, second])
+      expect(helper.touchStart(0.4, 0.6)).toBe(true)
+      expect(helper.pinchStart(0.1, 0.1, 0.9, 0.9)).toBe(true)
+      first.stdin.write.mockClear()
+
+      die(first)
+      announceReady(second)
+
+      // The replacement is healthy and usable — that is the point. Liveness is not the question.
+      expect(helper.isReady()).toBe(true)
+      expect(call(helper)).toBe(false)
+      expect(second.stdin.write).not.toHaveBeenCalled()
+    })
+  }
+
+  it('serves the next gesture normally once it opens on the replacement', async () => {
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper } = await startedHelper([first, second])
+    helper.touchStart(0.4, 0.6)
+    die(first)
+    announceReady(second)
+
+    expect(helper.touchStart(0.1, 0.2)).toBe(true)
+    expect(helper.touchEnd()).toBe(true)
+    expect(second.stdin.write).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not carry a gesture across an intentional restart either', async () => {
+    const first = makeFakeProc()
+    const second = makeFakeProc()
+    const { helper } = await startedHelper([first, second])
+    helper.touchStart(0.4, 0.6)
+    vi.useFakeTimers() // swallow stop()'s pending SIGKILL timer
+    helper.stop()
+    helper.start()
+    announceReady(second)
+
+    expect(helper.isReady()).toBe(true)
+    expect(helper.touchEnd()).toBe(false)
+    vi.useRealTimers()
+  })
+})
+
+describe('TouchHelper — which frames may resurrect the helper', () => {
+  // Leaves the helper dead with budget to spare: the process died, and the eager respawn that
+  // followed produced one that never execed. What the next frame does now is the whole question.
+  async function deadWithBudget() {
+    const first = makeFakeProc()
+    const { helper, spawn } = await startedHelper([first, makeFailedProc(), makeFakeProc()])
+    die(first)
+    expect(helper.isReady()).toBe(false)
+    spawn.mockClear()
+    return { helper, spawn }
+  }
+
+  const continuations: Array<[number, string, (h: TouchHelperType) => boolean]> = [
+    [2, 'touchMove', (h) => h.touchMove(0.5, 0.7)],
+    [3, 'touchEnd', (h) => h.touchEnd()],
+    [7, 'pinchMove', (h) => h.pinchMove(0.1, 0.1, 0.2, 0.2)],
+    [8, 'pinchEnd', (h) => h.pinchEnd()],
+  ]
+
+  for (const [type, name, call] of continuations) {
+    it(`type ${type} (${name}) reports failure rather than respawning`, async () => {
+      const { helper, spawn } = await deadWithBudget()
+
+      expect(call(helper)).toBe(false)
+      expect(spawn).not.toHaveBeenCalled()
+    })
+  }
+
+  // 1, 4, 5, 6, 9, 10, 11 — each carries its whole payload, so a fresh process serves it exactly
+  // as the old one would have. The frame that triggers the respawn still reports failure, because
+  // the replacement needs ~200ms before anything written to it reaches the device.
+  const selfContained: Array<[number, string, (h: TouchHelperType) => boolean]> = [
+    [1, 'touchStart', (h) => h.touchStart(0.5, 0.5)],
+    [4, 'pressButton', (h) => h.pressButton(0x0c, 0xe9)],
+    [5, 'pressLegacyButton', (h) => h.pressLegacyButton(0)],
+    [6, 'pinchStart', (h) => h.pinchStart(0.1, 0.1, 0.2, 0.2)],
+    [9, 'sendKey', (h) => h.sendKey(0x04, 0)],
+    [10, 'pressButtonDown', (h) => h.pressButtonDown(0x0c, 0xe9)],
+    [11, 'pressButtonUp', (h) => h.pressButtonUp(0x0c, 0xe9)],
+  ]
+
+  for (const [type, name, call] of selfContained) {
+    it(`type ${type} (${name}) resurrects the helper`, async () => {
+      const { helper, spawn } = await deadWithBudget()
+
+      expect(call(helper)).toBe(false) // spawned, not usable yet — and it says so
+      expect(spawn).toHaveBeenCalledTimes(1)
+    })
+  }
 })

--- a/packages/ios-agent/src/__tests__/TouchHelper.test.ts
+++ b/packages/ios-agent/src/__tests__/TouchHelper.test.ts
@@ -110,6 +110,7 @@ describe('TouchHelper.stop()', () => {
 // between is silently ineffective — which is #482's failure in a narrower window, so it must not
 // be reported as delivered.
 describe('TouchHelper — a helper that is running but not yet ready', () => {
+  afterEach(() => vi.useRealTimers())
   it('reports failure for a frame written before the helper announces itself', async () => {
     const proc = makeFakeProc()
     const { helper } = await loadHelper([proc])
@@ -192,7 +193,6 @@ describe('TouchHelper — a helper that is running but not yet ready', () => {
 
     announceReady(second)
     expect(helper.isReady()).toBe(true)
-    vi.useRealTimers()
   })
 
   it('does not replace a helper that announced itself in time', async () => {
@@ -204,7 +204,6 @@ describe('TouchHelper — a helper that is running but not yet ready', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
     expect(proc.kill).not.toHaveBeenCalled()
     expect(helper.isReady()).toBe(true)
-    vi.useRealTimers()
   })
 
   it('does not let a superseded process mark its replacement ready', async () => {
@@ -440,6 +439,7 @@ describe('TouchHelper — respawn budget', () => {
 // latches at zero and would release the touch at (0,0) while reporting success. Confirmed on a
 // real simulator: the guard holds, and the next fresh gesture works, so nothing stays held.
 describe('TouchHelper — a gesture belongs to the process that opened it', () => {
+  afterEach(() => vi.useRealTimers())
   const continuations: Array<[string, (h: TouchHelperType) => boolean]> = [
     ['touchEnd', (h) => h.touchEnd()],
     ['touchMove', (h) => h.touchMove(0.5, 0.7)],
@@ -491,7 +491,6 @@ describe('TouchHelper — a gesture belongs to the process that opened it', () =
 
     expect(helper.isReady()).toBe(true)
     expect(helper.touchEnd()).toBe(false)
-    vi.useRealTimers()
   })
 })
 


### PR DESCRIPTION
Closes #482.

`TouchHelper` kept pointing at the `touch-helper` process after it died, so every write returned early at a `stdin.writable` guard. The session accepted no further input for the rest of its life while the stream kept running — the viewer tapped a screen that updated normally and nothing happened, and nothing was reported to the browser or to an MCP caller. Follow-on from #479, which fixed the symptom (a SIGKILL timer armed against an already-exited process) and left the cause as scoped out.

## What changed

**Replacement is eager.** The helper is replaced when it dies, not on the next input, so the replacement is already starting up before anyone taps.

**Bounded by a rolling window** — at most 3 spawns in any 30s. Deliberately not a count of consecutive fast failures: start-up is expensive enough that "died too fast" cannot be separated from "died slowly" without guessing how long it takes, and a helper that reliably dies just past such a guess would reset a counter every time and churn a process every few seconds for the life of the agent. The window bounds it whatever the lifetime, and it self-clears.

**Running is not usable.** The helper announces itself on stderr once it holds its HID client and is about to read stdin — measured at 186–247ms after spawn (n=5). A gesture written before that lands *nothing*: the frames sit in the pipe and drain in one go, collapsing a swipe into microseconds. `isReady()` requires the announcement and gates writes; `isRunning()` does not and gates replacement, since replacing a helper that is merely starting would spawn a second one. A helper that never announces is replaced after a deadline, because running-but-never-ready otherwise has no exit at all.

That window is reachable **without any helper death**: `sendChromeData` starts the helper and `device:ready` follows a local socket connect later, so an MCP caller tapping as soon as `boot_device` returns lands inside it. That is how it was found.

**A gesture belongs to the process that received its opening frame.** Frame type alone is not a sufficient guard — because replacement is eager, a mid-gesture death normally leaves a *ready* process standing by, and a touch end delivered to it releases the touch at (0,0) (that process's latches are zero) while reporting success. A pinch end is worse, carrying no coordinates at all by design.

**The acks answer on the write result**, not on `state.touchHelper !== null` — the wrapper object outlives its process, which is what made the original failure silent. Covers `input:touch:end`, `input:pinch:end`, `input:key` (including the branch deferred behind hiding the software keyboard, where the ack used to run before the key was ever written), `input:button`, `input:type` and `clipboard:write` with `pasteAfter`. The two `input:button` branches that deliberately write nothing answer from the channel's health instead, so a healthy channel is not reported as a failure and a dead one is not reported as a success.

Also closes two ways a helper could outlive the reference to it — each used to leak one child process, and would now leak a self-reviving one: `sendChromeData` stops the outgoing helper, and `cleanupDeviceState` bumps `bootSeq` so a boot still awaiting simctl cannot install one onto a state that teardown has dropped.

## Verified on a real simulator

iPhone 17 Pro / iOS 26.5, with a byte-identical pair of idle screenshots as the control so any change is a real one:

| check | result |
|---|---|
| kill while idle, then swipe | replacement up within 335ms; Spotlight opens, no reconnect |
| kill mid-gesture | `isReady()` is **true** — the replacement is genuinely up — and the terminal frame is still refused; a fresh gesture then works, so no touch is left held |
| gesture inside the start-up window | every frame reports failure, and indeed nothing changes on screen |
| gesture opened after readiness | all frames delivered, 739KB of visual change |

## Review

Three adversarial rounds, six independent channels: a design pass over the plan (not required for a single-package change — taken because the mechanism turned out to be wrong), a pre-PR pass, and a delta pass over the fixes. Recorded in `.work/reviews/fix__touch-helper-death-recovery.md`.

The rounds changed the work substantively rather than polishing it:

- The design pass replaced the mechanism (lazy respawn cannot report honestly with the signal the plan proposed).
- The pre-PR pass found that eager replacement defeats a frame-type guard, and that a 2s "died too fast" rule makes the ceiling unreachable for a helper that dies slowly.
- The delta pass — both channels independently — found that recording gesture ownership unconditionally is only equivalent until readiness exists, which the same PR introduced. That was a mutation I had judged untestable and removed; the record says so.

26 mutations across three rounds, 24 caught; the two survivors are recorded as equivalent with the reasoning, and one is deliberately kept as a guard whose failure mode is killing a working helper.

## Out of scope

- **The dashboard does not consume `input:error`** — it declares both ack types in `lib/types.ts` and has no handler, so only `mcp-server` hears them. Filed separately. Recovery reaches the tester without it (the next tap works); the notification only matters when recovery permanently fails.
- **#457** (mcp-server treating an ack timeout as success) — four packages, separate change.
- `KeyboardHelperDaemon`'s unbounded respawn: same shape, but command-driven and each failure rejects a promise the caller sees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS touch, pinch, keyboard, button, and paste reliability when input handling is interrupted.
  - Automatically restores input handling after unexpected service failures without requiring a device reconnect.
  - Prevents inputs from being reported as successful when they were not delivered.
  - Added clearer failures for text and clipboard actions when input cannot be dispatched.
  - Preserved active gesture behavior during recovery and improved shutdown and reconnect cleanup.
  - Added controlled recovery limits to prevent repeated restart attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->