### PR TITLE
fix(dashboard): tell the tester when an input never reached the device

### DIFF
--- a/.changeset/dashboard-input-error.md
+++ b/.changeset/dashboard-input-error.md
@@ -27,11 +27,15 @@ and `no-gesture` (the gesture is gone; a fresh one works). Reporting an error fo
 fixed by the time it is read is noise.
 
 There is **no session-level "input unavailable" state**, which was the first design and was discarded
-after review. Per-input acks cannot support one: nothing on the wire announces that a replaced helper
-is healthy again, the acks are not ordered (a success awaits a child process while a refusal is sent
-synchronously), and an ack does not say which channel answered — so on Android a working Home button
-would have erased a warning about a dead touch channel. The toast's own lifetime carries it instead:
+after review. Per-input acks cannot support one: no message carries evidence that input is working
+again — a replaced helper announces nothing, and an agent restart is not the same as a healthy channel —
+the acks are not ordered (a dispatch is awaited before its ack while a refusal is not), and an ack does
+not say which channel answered, so on Android, where buttons always take the adb path, a working Home
+button would have erased a warning about a dead touch channel. The toast's own lifetime carries it instead:
 repeats reuse one id, so it stays up while inputs keep failing and fades when they stop.
+
+Nothing is shown while the agent is away, either: the relay answers every terminal input itself in that
+state, and the viewer already says the session is being held open and waiting.
 
 Dashboard-only change, released as part of `@tapflowio/relay` because that is the package the built
 dashboard ships inside.

--- a/.changeset/dashboard-input-error.md
+++ b/.changeset/dashboard-input-error.md
@@ -1,0 +1,37 @@
+---
+'@tapflowio/relay': patch
+---
+
+fix(dashboard): tell the tester when an input never reached the device
+
+The relay forwarded `input:done` / `input:error` to the browser and the dashboard dropped both. They
+were declared in `lib/types.ts` and had no handler anywhere, so the only consumer of a failed input
+was `mcp-server` — the experimental path. Manual testing, which is tapflow's primary use, heard
+nothing.
+
+That mattered more after #484/#488/#490. Before those, an agent reported a dropped input as success;
+now it reports the truth with a machine-readable `reason`, and the truth was being discarded before it
+reached a human. Concretely, a session whose input channel has permanently failed (a helper binary
+that is missing or built for the wrong architecture) showed a stream that kept updating, taps that did
+nothing, and no indication anywhere.
+
+A failed input now raises a toast whose copy is chosen by `reason`, so the tester is told what to do
+rather than just that something failed — reconnect, start the device, report a bug, or that the input
+has no equivalent on this device. `not-booted` gets its own wording because the protocol prescribes a
+different action for it than for `channel-unavailable`. The wire `message` rides along as the
+description, which is where its detail (`unknown key code: KeyFoo`) is useful; it is not used as the
+headline, because it is free prose each agent owns and cannot be localised.
+
+Two reasons are deliberately shown nowhere: `channel-starting` (the input channel is up ~200ms later)
+and `no-gesture` (the gesture is gone; a fresh one works). Reporting an error for something already
+fixed by the time it is read is noise.
+
+There is **no session-level "input unavailable" state**, which was the first design and was discarded
+after review. Per-input acks cannot support one: nothing on the wire announces that a replaced helper
+is healthy again, the acks are not ordered (a success awaits a child process while a refusal is sent
+synchronously), and an ack does not say which channel answered — so on Android a working Home button
+would have erased a warning about a dead touch channel. The toast's own lifetime carries it instead:
+repeats reuse one id, so it stays up while inputs keep failing and fades when they stop.
+
+Dashboard-only change, released as part of `@tapflowio/relay` because that is the package the built
+dashboard ships inside.

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -56,16 +56,25 @@ A latched "input unavailable" line on the status card was designed and discarded
 like the obvious improvement to whoever reads this next. It cannot be made honest on the current
 protocol, for three independent reasons:
 
-- **Nothing announces recovery.** iOS replaces a dead helper eagerly and is injecting again ~200ms
-  later, with no message to the browser. And `channel-unavailable`'s own advice is *do not blindly
-  retry*, so the only edge that could clear a latch requires the tester to do what the UI just told
-  them not to.
-- **The acks are unordered.** `ackInput` awaits a `simctl` / `adb` child on the success path and sends
-  refusals synchronously, so an earlier input's `input:done` can arrive after a later input's
-  `input:error` and clear a latch that is still true.
-- **An ack does not say which channel answered.** On Android a button always takes the adb path while
-  touch takes the pointer channel, so pressing Home to check whether input works at all succeeds — and
-  under the latch that success erased the warning about the dead touch channel.
+- **Nothing announces that input is working again.** iOS replaces a dead helper eagerly and is
+  injecting ~200ms later with no message to the browser, so no edge carries *evidence of input health*.
+  Lifecycle messages do arrive — `session:rebound` on an agent restart, `session:joined` on a socket
+  reconnect, both already handled above — but neither is that evidence: with a helper binary still
+  missing (#464) a rebound would clear the latch and the next tap would raise it again. The only
+  signal that would mean anything is a successful input, and `channel-unavailable`'s own advice is *do
+  not blindly retry*, so a latch's clear edge needs the tester to do what the UI just told them not
+  to.
+- **The acks are unordered.** A success is awaited and a refusal is not, so an earlier input's
+  `input:done` can arrive after a later input's `input:error` and clear a latch that is still true. Not
+  via `ackInput`'s boot verify, which looks like the culprit and is cached on `device:ready` — the
+  paths that reorder on every input are Android awaiting the dispatch itself before acking
+  (`pressButton` → `adb shell input`, measured 26–29ms steady state) and iOS acking a key only after
+  awaiting `hideSoftwareKeyboard`, while a `malformed` or `channel-down` refusal reaches `ws.send`
+  within microtasks.
+- **An ack does not say which channel answered.** On Android a button always takes the adb path, while
+  touch takes the pointer channel whenever a video backend is up — which is every streaming session,
+  the only kind a tester has. So pressing Home to check whether input works at all succeeds on a
+  session whose touch channel is dead, and under the latch that success erased the warning.
 
 Instead the toast's own lifetime carries the state: repeats reuse `id`, which sonner refreshes rather
 than stacks, so it stays up while inputs keep failing and fades on its own when they stop. **Being
@@ -75,6 +84,11 @@ Copy lives here rather than in the agents because `message` on the wire is free 
 and cannot be localised; `reason` is the contract. `message` rides along as the description, where its
 diagnostic detail (`unknown key code: KeyFoo`) belongs. Absent or unrecognised reasons resolve to
 `channel-unavailable` — absence means *unknown*, never *fine*.
+
+Suppressed entirely while the agent is away. An absent agent cannot send this, so in that state the
+*relay* answers every terminal input itself with a reasonless `input:error`; a tapping tester would
+refresh the toast indefinitely, with advice contradicting the status card, which already says the relay
+is holding the session open and waiting.
 
 A persistent indicator needs a protocol-level input-health signal, or acks that identify their channel
 and arrive in order. Two tests guard the decision (`DeviceViewer.inputError.test.tsx`): `input:done`

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -47,6 +47,39 @@ The audience is the whole team (PO, PM, designers, backend, QA) — not just QA.
 - Components that combine multiple `useEffect` + `react-hook-form` `Controller` + `useWatch` (e.g. `DefaultSettings`) can hang in jsdom under full render. `vitest.config.ts` has `testTimeout: 10000` as a safety net — a timeout failure means the test setup needs fixing, not more retries.
 - When mocking `fetch` in a component that fires multiple concurrent `useEffect` fetches (e.g. `GET /api/v1/settings` + `GET /api/v1/apps`), use URL-based dispatch (`mockImplementation((url) => {...})`) instead of `mockResolvedValueOnce` chains — call order is non-deterministic.
 
+### `input:error` is shown per input, and there is no session-level input state
+
+A failed input surfaces as a toast keyed on the wire `reason` (`lib/inputErrorNotice.ts`), or is shown
+nowhere for the two reasons that fix themselves. `input:done` is **not handled at all**.
+
+A latched "input unavailable" line on the status card was designed and discarded, and it will look
+like the obvious improvement to whoever reads this next. It cannot be made honest on the current
+protocol, for three independent reasons:
+
+- **Nothing announces recovery.** iOS replaces a dead helper eagerly and is injecting again ~200ms
+  later, with no message to the browser. And `channel-unavailable`'s own advice is *do not blindly
+  retry*, so the only edge that could clear a latch requires the tester to do what the UI just told
+  them not to.
+- **The acks are unordered.** `ackInput` awaits a `simctl` / `adb` child on the success path and sends
+  refusals synchronously, so an earlier input's `input:done` can arrive after a later input's
+  `input:error` and clear a latch that is still true.
+- **An ack does not say which channel answered.** On Android a button always takes the adb path while
+  touch takes the pointer channel, so pressing Home to check whether input works at all succeeds — and
+  under the latch that success erased the warning about the dead touch channel.
+
+Instead the toast's own lifetime carries the state: repeats reuse `id`, which sonner refreshes rather
+than stacks, so it stays up while inputs keep failing and fades on its own when they stop. **Being
+observed rather than stored is the point** — there is no clear edge to get wrong.
+
+Copy lives here rather than in the agents because `message` on the wire is free prose each agent owns
+and cannot be localised; `reason` is the contract. `message` rides along as the description, where its
+diagnostic detail (`unknown key code: KeyFoo`) belongs. Absent or unrecognised reasons resolve to
+`channel-unavailable` — absence means *unknown*, never *fine*.
+
+A persistent indicator needs a protocol-level input-health signal, or acks that identify their channel
+and arrive in order. Two tests guard the decision (`DeviceViewer.inputError.test.tsx`): `input:done`
+must do nothing, and a success between two failures must change nothing.
+
 ## HOW NOT
 
 - Do not reintroduce the `next` package.

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -13,6 +13,7 @@ import { parseEnvelopeHeader, HEADER_SIZE, CODEC_H264, CODEC_AUDIO, type BinaryF
 import { useAudioPlayback } from '@/hooks/useAudioPlayback';
 import type { ClipboardBridgeMessage, ClipboardMessageHandler } from '@/hooks/useClipboardBridge';
 import { canDecodeH264 } from '@/lib/decoders/pickDecoder';
+import { resolveInputError } from '@/lib/inputErrorNotice';
 import { StatsOverlay } from './perf/StatsOverlay';
 import { MetricsPanel } from './perf/MetricsPanel';
 import { toast } from 'sonner';
@@ -195,6 +196,25 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       rebindRef.current = { pending: 0, appInstalled: false };
       setBootError(msg.message);
     }
+    // An input the device never got. Deliberately no session-level state behind this: the acks are
+    // per-input, unordered (a success awaits a `simctl`/`adb` child while a refusal is sent
+    // synchronously) and do not say which channel answered — on Android buttons always take the adb
+    // path while touch takes the pointer channel. A latch built on them cleared itself on an
+    // unrelated success, and nothing on the wire announces that a replaced helper is healthy again,
+    // so it had no honest clear edge either. The toast's own lifetime is the state: repeats reuse
+    // `id`, which sonner refreshes rather than stacks, so it stays up while inputs keep failing and
+    // fades on its own when they stop. See `.work/2026-08-08-dashboard-input-error-plan.md`.
+    if (msg.type === 'input:error') {
+      const { key, notice } = resolveInputError(msg.reason);
+      if (notice) {
+        toast.error(notice.title, { id: `input:${key}`, description: `${notice.action} (${msg.message})`, duration: 6000 });
+      } else {
+        console.debug(`[tapflow] input refused, shown nowhere: ${key} — ${msg.message}`);
+      }
+    }
+    // `input:done` is deliberately not handled. It was only ever needed to release the latch above,
+    // and there is no latch.
+
     if (msg.type === 'device:booting') {
       setDeviceReady(false);
       setInstalling(false);

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -197,17 +197,32 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       setBootError(msg.message);
     }
     // An input the device never got. Deliberately no session-level state behind this: the acks are
-    // per-input, unordered (a success awaits a `simctl`/`adb` child while a refusal is sent
-    // synchronously) and do not say which channel answered — on Android buttons always take the adb
-    // path while touch takes the pointer channel. A latch built on them cleared itself on an
-    // unrelated success, and nothing on the wire announces that a replaced helper is healthy again,
-    // so it had no honest clear edge either. The toast's own lifetime is the state: repeats reuse
+    // per-input, unordered (a dispatch is awaited before its ack while a refusal is not) and do not
+    // say which channel answered — on Android buttons always take the adb path while touch takes the
+    // pointer channel on any streaming session. A latch built on them cleared itself on an unrelated
+    // success, and no message carries evidence that input is working again, so it had no honest clear
+    // edge either. The toast's own lifetime is the state: repeats reuse
     // `id`, which sonner refreshes rather than stacks, so it stays up while inputs keep failing and
     // fades on its own when they stop. See `.work/2026-08-08-dashboard-input-error-plan.md`.
     if (msg.type === 'input:error') {
+      // Suppressed while the agent is away, matching what `device:boot-error` does two branches down
+      // and for a sharper reason: an absent agent cannot send this, so in that state the *relay*
+      // answers every terminal input itself (`RelayServer.ts`, reasonless `'agent offline'`). A
+      // tapping tester would refresh this toast indefinitely, and its advice would contradict the
+      // status card — which already says the relay is holding the session open and waiting.
+      if (agentAway) return;
       const { key, notice } = resolveInputError(msg.reason);
       if (notice) {
-        toast.error(notice.title, { id: `input:${key}`, description: `${notice.action} (${msg.message})`, duration: 6000 });
+        // `sessionId` in the id so a toast still on screen from the session just left cannot be
+        // refreshed by a failure in the next one.
+        toast.error(notice.title, {
+          id: `input:${sessionId}:${key}`,
+          description: `${notice.action} (${msg.message})`,
+          // The only "state" this design has. A finite lifetime is what makes the toast disappear
+          // when inputs stop failing, with no clear signal — set explicitly and above sonner's
+          // 4000ms default, which is short enough to lapse between two unhurried taps.
+          duration: 6000,
+        });
       } else {
         console.debug(`[tapflow] input refused, shown nowhere: ${key} — ${msg.message}`);
       }

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -212,6 +212,14 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       // status card — which already says the relay is holding the session open and waiting.
       if (agentAway) return;
       const { key, notice } = resolveInputError(msg.reason);
+      // A reason this build does not know about is normalised away, and without this line it would
+      // vanish with it: the tester correctly sees the conservative copy, but nobody can tell the
+      // dashboard is behind its agents. That is the situation the growth of this union guarantees, so
+      // it needs a trace. Absence is *not* logged — a pre-#490 agent omits the field on every input,
+      // and that case is documented rather than surprising.
+      if (msg.reason !== undefined && msg.reason !== key) {
+        console.debug(`[tapflow] unrecognised input:error reason "${msg.reason}", treated as ${key}`);
+      }
       if (notice) {
         // `sessionId` in the id so a toast still on screen from the session just left cannot be
         // refreshed by a failure in the next one.

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -35,9 +35,15 @@ export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | nul
     title: 'The device is not running',
     action: 'Start it again to continue testing.',
   },
-  // Reached on a channel that looked healthy — most often a connected-but-unresponsive Android
-  // emulator, where the gRPC call is refused while the socket still reports itself writable. One
-  // retry is worth it; a repeat means the guest is not answering.
+  // Reached on a channel that looked healthy. The measured producer is an Android emulator that is
+  // gone: on the default backend `isReady()` only means "we have not closed it", so the dispatch is
+  // attempted and the RPC rejects (4ms, `ECONNREFUSED`) — see `android-agent/AGENTS.md`. The protocol
+  // allows one retry, and for that case a retry is free because nothing was applied. It is *not* free
+  // for the narrower case of an emulator still connected but not answering, where the call times out
+  // without saying whether the input landed; `android-agent` records that a retry there can double
+  // the input, and that the eventual answer is a distinct "unknown, do not retry" reason rather than a
+  // shorter deadline. Until that reason exists this cell cannot separate the two, so the copy stops at
+  // one retry rather than inviting repeats.
   'dispatch-failed': {
     title: 'The device rejected that input',
     action: 'Try once more. If it keeps failing, restart the device.',

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -1,0 +1,95 @@
+import type { InputErrorReason } from '@tapflowio/protocol'
+
+/**
+ * What a tester is told when an input fails, keyed by the reason.
+ *
+ * Keyed exhaustively so a new reason cannot be added without deciding what the user is told — the
+ * same rule `SESSION_ENDED_NOTICE` states in `src/pages/QASession.tsx`, and the reason a closed
+ * literal union exists. `null` means the reason is shown nowhere, which is a decision per entry
+ * rather than a default.
+ *
+ * The copy lives here and not in the agents on purpose. `message` on the wire is free prose each
+ * agent owns; `reason` is the contract. Rendering `message` would make an agent's English the UI's
+ * copy — unlocalisable, and written by the layer furthest from the reader. `message` is carried as
+ * the description instead, where its diagnostic detail (`unknown key code: KeyFoo`) belongs.
+ */
+export interface InputErrorNotice {
+  /** What happened, in the reader's terms — not the wire's. */
+  title: string
+  /** What to do about it. The protocol's per-reason advice is written for a program ("rebind"); this
+   *  is the same advice for a person. */
+  action: string
+}
+
+export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | null> = {
+  // The channel is gone and will not come back on its own. #464 (a helper binary that is missing or
+  // built for the wrong architecture) lands here and is not fixed by restarting the device, so the
+  // action names the agent rather than the device.
+  'channel-unavailable': {
+    title: 'Input is not reaching this device',
+    action: 'Reconnect, or check the agent on the Mac running it.',
+  },
+  // Deliberately not folded into the line above: the protocol prescribes a *different* action for
+  // this one ("boot the device"), and one sentence cannot give both.
+  'not-booted': {
+    title: 'The device is not running',
+    action: 'Start it again to continue testing.',
+  },
+  // Reached on a channel that looked healthy — most often a connected-but-unresponsive Android
+  // emulator, where the gRPC call is refused while the socket still reports itself writable. One
+  // retry is worth it; a repeat means the guest is not answering.
+  'dispatch-failed': {
+    title: 'The device rejected that input',
+    action: 'Try once more. If it keeps failing, restart the device.',
+  },
+  // About the input, not the channel: this build of the agent cannot express it on the connection in
+  // use. Retrying is guaranteed to fail, so the action says so rather than suggesting a retry.
+  unsupported: {
+    title: 'That input is not supported on this device',
+    action: 'Everything else still works — this one has no equivalent here.',
+  },
+  // The dashboard sent something incomplete. That is our bug, and a tester reporting it is the only
+  // way it gets found, so it is never silent.
+  malformed: {
+    title: 'tapflow sent a malformed input',
+    action: 'This is a bug in tapflow — please report it with what you were doing.',
+  },
+  // Silent: the channel is coming up and the measured window is 186–247ms. Only standalone inputs (a
+  // key, a button) are ever refused for this — a continuation frame is judged on gesture ownership
+  // first — and pressing again is the instinct anyway. An error here would be noise for something
+  // already fixed by the time it was read.
+  'channel-starting': null,
+  // Silent: the gesture this frame belonged to is gone, which happens on the first gesture after any
+  // helper death because the replacement is eager. A fresh gesture normally works. The guarantee is
+  // not "the next one lands" — a helper that keeps dying before it is ready refuses every terminal
+  // frame — but that case exhausts the respawn budget and surfaces as `channel-unavailable`, so it
+  // is bounded and ends up visible.
+  'no-gesture': null,
+}
+
+/**
+ * Resolve a wire `reason` to the copy to show and the key to dedupe on.
+ *
+ * Takes `string | undefined` rather than `InputErrorReason | undefined` on purpose. The parameter's
+ * whole job is to absorb values this build does not know about — a newer agent against an older
+ * dashboard — and typing it as the union would describe that case as impossible while it is exactly
+ * the case being handled.
+ *
+ * Absence and unfamiliarity both resolve to `channel-unavailable`: absence means *unknown*, never
+ * *fine* (an agent older than #490 omits the field, and the relay's own reasonless `input:error`
+ * still does), and the protocol's rule for a reason a consumer does not recognise is the same
+ * conservative reading. Resolving the *key* as well as the copy is what keeps two different unknown
+ * reasons from stacking two identical toasts.
+ *
+ * `Object.hasOwn`, not `in` — `'toString' in INPUT_ERROR_NOTICE` is true, and a reason of `toString`
+ * would otherwise return a function as the notice.
+ */
+export function resolveInputError(
+  reason: string | undefined,
+): { key: InputErrorReason; notice: InputErrorNotice | null } {
+  const key: InputErrorReason =
+    reason !== undefined && Object.hasOwn(INPUT_ERROR_NOTICE, reason)
+      ? (reason as InputErrorReason)
+      : 'channel-unavailable'
+  return { key, notice: INPUT_ERROR_NOTICE[key] }
+}

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -1,4 +1,4 @@
-import type { SessionTerminatedReason } from '@tapflowio/protocol'
+import type { InputErrorReason, SessionTerminatedReason } from '@tapflowio/protocol'
 
 export interface AgentResources {
   cpuPercent: number
@@ -162,7 +162,7 @@ export type RelayMessage =
   | { type: 'open-url:done'; sessionId: string }
   | { type: 'open-url:error'; sessionId: string; message: string }
   | { type: 'input:done'; sessionId: string }
-  | { type: 'input:error'; sessionId: string; message: string }
+  | { type: 'input:error'; sessionId: string; message: string; reason?: InputErrorReason }
   // agent → browser
   | { type: 'clipboard:data'; sessionId: string; requestId: string; payload: { text: string } }
   | { type: 'clipboard:write-done'; sessionId: string; requestId: string }

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import type { InputErrorReason } from '@tapflowio/protocol'
+import type { RelayMessage } from '@/lib/types'
+import { INPUT_ERROR_NOTICE } from '@/lib/inputErrorNotice'
+
+// #485. The relay forwards `input:done` / `input:error` to the browser and the dashboard used to drop
+// both. After #482/#484/#488 the agents tell the truth about a dropped input, and the truth was being
+// thrown away before it reached a human.
+//
+// There is no session-level state behind this on purpose — a latch was designed, reviewed and
+// discarded (see the plan). Two of the tests below are regression guards for that decision rather
+// than for the feature.
+let deliver: ((msg: RelayMessage) => void) | null = null
+
+vi.mock('@/hooks/useRelay', () => ({
+  useRelay: (onMessage: (msg: RelayMessage) => void) => {
+    deliver = onMessage
+    return { send: vi.fn(), connected: true }
+  },
+}))
+vi.mock('@/hooks/usePerfMode', () => ({ usePerfMode: () => ({ perfMode: false, visible: false }) }))
+vi.mock('@/hooks/useAudioPlayback', () => ({ useAudioPlayback: () => ({ pushFrame: vi.fn() }) }))
+vi.mock('@/lib/decoders/pickDecoder', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/decoders/pickDecoder')>()),
+  canDecodeH264: () => false,
+}))
+const toastError = vi.fn()
+const toastDismiss = vi.fn()
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: toastError, info: vi.fn(), dismiss: toastDismiss },
+}))
+
+const { DeviceViewer } = await import('@/components/DeviceViewer')
+
+function mounted() {
+  render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+  act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+}
+
+/** An `input:error` as the agents send it. `reason` is typed loosely so a test can post a value this
+ *  build does not know about — the case the unknown-reason rule exists for. */
+function inputError(reason?: string, message = 'input channel not ready') {
+  act(() => {
+    deliver!({ type: 'input:error', sessionId: 's1', message, reason } as unknown as RelayMessage)
+  })
+}
+
+const opts = () => toastError.mock.calls.map(([, o]) => o as { id: string; description: string; duration: number })
+
+describe('DeviceViewer — input:error (#485)', () => {
+  beforeEach(() => { toastError.mockClear(); toastDismiss.mockClear(); deliver = null })
+
+  it('tells the tester when input is not reaching the device', () => {
+    mounted()
+    inputError('channel-unavailable')
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
+    expect(opts()[0]!.id).toBe('input:channel-unavailable')
+  })
+
+  // A dead channel produces one error per tap, at whatever rate the tester taps. Nothing dedupes
+  // them here — every call carries the same `id`, and sonner refreshes that toast rather than
+  // stacking a new one, which is also what keeps it on screen while the taps continue.
+  it('reuses one toast id across a burst so repeats refresh rather than stack', () => {
+    mounted()
+    for (let i = 0; i < 5; i++) inputError('channel-unavailable')
+    expect(toastError).toHaveBeenCalledTimes(5)
+    expect(new Set(opts().map((o) => o.id)).size).toBe(1)
+  })
+
+  // The protocol prescribes a different action for this than for `channel-unavailable` — boot the
+  // device, rather than reconnect — so one shared line would be wrong for one of them.
+  it('gives not-booted its own copy', () => {
+    mounted()
+    inputError('not-booted')
+    inputError('channel-unavailable')
+    const [notBooted, unavailable] = toastError.mock.calls.map(([t]) => t as string)
+    expect(notBooted).not.toBe(unavailable)
+    expect(notBooted).toBe(INPUT_ERROR_NOTICE['not-booted']!.title)
+  })
+
+  it('carries the wire message as diagnostic detail, not as the headline', () => {
+    mounted()
+    inputError('unsupported', 'unknown key code: KeyFoo')
+    expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE.unsupported!.title)
+    expect(opts()[0]!.description).toContain('unknown key code: KeyFoo')
+  })
+
+  // Android's default emulator backend answers a dead emulator with this, not with
+  // `channel-unavailable`: the gRPC call is refused while the socket still reports itself writable.
+  it('surfaces dispatch-failed', () => {
+    mounted()
+    inputError('dispatch-failed', 'the device rejected the input')
+    expect(toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces malformed — a dashboard bug is never silent', () => {
+    mounted()
+    inputError('malformed', 'this input does not fit what the device is doing')
+    expect(toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['channel-starting', 'no-gesture'])('shows nothing for %s — it fixes itself', (reason) => {
+    mounted()
+    inputError(reason)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  // Absence means unknown, never fine: an agent older than #490 omits the field, and the relay's own
+  // `agent offline` reply still does.
+  it('treats an absent reason as channel-unavailable', () => {
+    mounted()
+    inputError(undefined, 'agent offline')
+    expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
+    expect(opts()[0]!.id).toBe('input:channel-unavailable')
+  })
+
+  // A newer agent against this build. Silence would be the dangerous direction — the reason exists
+  // because something went wrong, and a build that cannot name it still must not imply "fine".
+  it('treats a reason it does not know as channel-unavailable, under one id', () => {
+    mounted()
+    inputError('some-future-reason')
+    inputError('another-future-reason')
+    expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
+    expect(new Set(opts().map((o) => o.id)).size).toBe(1)
+  })
+
+  it('does not read a prototype key as a notice', () => {
+    mounted()
+    inputError('toString')
+    expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
+  })
+
+  it('ignores an input:error for another session', () => {
+    mounted()
+    act(() => {
+      deliver!({ type: 'input:error', sessionId: 'other', message: 'x', reason: 'channel-unavailable' })
+    })
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  // --- regression guards for the discarded latch design ---
+
+  // `input:done` was only ever needed to release a latch. Handling it would mean the latch is back,
+  // and the review found three independent sequences in which that latch lies.
+  it('does nothing on input:done', () => {
+    mounted()
+    inputError('channel-unavailable')
+    act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
+    expect(toastDismiss).not.toHaveBeenCalled()
+    expect(toastError).toHaveBeenCalledTimes(1)
+  })
+
+  // The sequence both review channels found independently: on Android a button always takes the adb
+  // path while touch takes the pointer channel, so a tester checking "is input dead at all?" with
+  // Home gets a success — which under the latch design erased the warning about the dead touch
+  // channel. Here the success changes nothing and the next failure speaks for itself.
+  it('lets a success between two failures change nothing', () => {
+    mounted()
+    inputError('channel-unavailable')
+    act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
+    inputError('channel-unavailable')
+    expect(toastError).toHaveBeenCalledTimes(2)
+    expect(toastDismiss).not.toHaveBeenCalled()
+  })
+})
+
+describe('INPUT_ERROR_NOTICE', () => {
+  // The Record is what forces a decision per reason; this only pins that no entry was left as an
+  // empty string, which the type cannot express. A new reason fails at `tsc`, not here.
+  it('gives every non-silent reason both a title and an action', () => {
+    for (const [reason, notice] of Object.entries(INPUT_ERROR_NOTICE) as Array<[InputErrorReason, typeof INPUT_ERROR_NOTICE[InputErrorReason]]>) {
+      if (notice === null) continue
+      expect(notice.title.length, reason).toBeGreaterThan(0)
+      expect(notice.action.length, reason).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -150,6 +150,29 @@ describe('DeviceViewer — input:error (#485)', () => {
     expect(new Set(opts().map((o) => o.id)).size).toBe(1)
   })
 
+  // Normalising an unknown reason is right for the tester and lossy for everyone else: without a
+  // trace, a dashboard running behind its agents looks identical to one seeing a genuinely dead
+  // channel. The name it did not recognise is the only clue that the union has moved on.
+  it('leaves a trace of a reason it did not recognise', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    mounted()
+    inputError('some-future-reason')
+    expect(debug).toHaveBeenCalledTimes(1)
+    expect(String(debug.mock.calls[0]![0])).toContain('some-future-reason')
+    debug.mockRestore()
+  })
+
+  // An agent older than #490 omits the field on every single input. Logging that would be noise about
+  // a state the protocol documents as normal.
+  it('does not log for an absent reason', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    mounted()
+    inputError(undefined, 'agent offline')
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(debug).not.toHaveBeenCalled()
+    debug.mockRestore()
+  })
+
   it('does not read a prototype key as a notice', () => {
     mounted()
     inputError('toString')

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -5,7 +5,7 @@ import type { RelayMessage } from '@/lib/types'
 import { INPUT_ERROR_NOTICE } from '@/lib/inputErrorNotice'
 
 // #485. The relay forwards `input:done` / `input:error` to the browser and the dashboard used to drop
-// both. After #482/#484/#488 the agents tell the truth about a dropped input, and the truth was being
+// both. After #484/#488/#490 the agents tell the truth about a dropped input, and the truth was being
 // thrown away before it reached a human.
 //
 // There is no session-level state behind this on purpose — a latch was designed, reviewed and
@@ -27,9 +27,14 @@ vi.mock('@/lib/decoders/pickDecoder', async (importOriginal) => ({
 }))
 const toastError = vi.fn()
 const toastDismiss = vi.fn()
+const toastInfo = vi.fn()
+const toastSuccess = vi.fn()
 vi.mock('sonner', () => ({
-  toast: { success: vi.fn(), error: toastError, info: vi.fn(), dismiss: toastDismiss },
+  toast: { success: toastSuccess, error: toastError, info: toastInfo, dismiss: toastDismiss },
 }))
+/** Every surface a latch could be rebuilt on. A guard that watched only `dismiss` would pass a latch
+ *  implemented as a second toast. */
+const quiet = () => [toastDismiss, toastInfo, toastSuccess].forEach((f) => expect(f).not.toHaveBeenCalled())
 
 const { DeviceViewer } = await import('@/components/DeviceViewer')
 
@@ -49,14 +54,19 @@ function inputError(reason?: string, message = 'input channel not ready') {
 const opts = () => toastError.mock.calls.map(([, o]) => o as { id: string; description: string; duration: number })
 
 describe('DeviceViewer — input:error (#485)', () => {
-  beforeEach(() => { toastError.mockClear(); toastDismiss.mockClear(); deliver = null })
+  beforeEach(() => { [toastError, toastDismiss, toastInfo, toastSuccess].forEach((f) => f.mockClear()); deliver = null })
 
   it('tells the tester when input is not reaching the device', () => {
     mounted()
     inputError('channel-unavailable')
     expect(toastError).toHaveBeenCalledTimes(1)
     expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
-    expect(opts()[0]!.id).toBe('input:channel-unavailable')
+    expect(opts()[0]!.id).toBe('input:s1:channel-unavailable')
+    // The lifetime IS the state here — it is what makes the notice disappear once inputs stop
+    // failing, with nothing on the wire to clear it. `Infinity` would make the toast permanent, which
+    // is the opposite of the design, so this is pinned rather than left to a default.
+    expect(opts()[0]!.duration).toBe(6000)
+    expect(opts()[0]!.duration).toBeGreaterThan(4000) // sonner's default, short enough to lapse between two unhurried taps
   })
 
   // A dead channel produces one error per tap, at whatever rate the tester taps. Nothing dedupes
@@ -78,6 +88,10 @@ describe('DeviceViewer — input:error (#485)', () => {
     const [notBooted, unavailable] = toastError.mock.calls.map(([t]) => t as string)
     expect(notBooted).not.toBe(unavailable)
     expect(notBooted).toBe(INPUT_ERROR_NOTICE['not-booted']!.title)
+    // Both halves, not just the headline: sharing the *action* would still give one of the two the
+    // wrong instruction, which is the entire reason this reason is not folded into the other.
+    expect(opts()[0]!.description).toContain(INPUT_ERROR_NOTICE['not-booted']!.action)
+    expect(opts()[1]!.description).toContain(INPUT_ERROR_NOTICE['channel-unavailable']!.action)
   })
 
   it('carries the wire message as diagnostic detail, not as the headline', () => {
@@ -85,10 +99,13 @@ describe('DeviceViewer — input:error (#485)', () => {
     inputError('unsupported', 'unknown key code: KeyFoo')
     expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE.unsupported!.title)
     expect(opts()[0]!.description).toContain('unknown key code: KeyFoo')
+    // What to do about it has to survive the trip too — the wire message alone is a symptom.
+    expect(opts()[0]!.description).toContain(INPUT_ERROR_NOTICE.unsupported!.action)
   })
 
-  // Android's default emulator backend answers a dead emulator with this, not with
-  // `channel-unavailable`: the gRPC call is refused while the socket still reports itself writable.
+  // Android's default emulator backend answers an unreachable emulator with this, not with
+  // `channel-unavailable`: the RPC rejects (measured 4ms, `ECONNREFUSED`) while `isReady()` still
+  // reports true, because on that backend it only means "we have not closed it".
   it('surfaces dispatch-failed', () => {
     mounted()
     inputError('dispatch-failed', 'the device rejected the input')
@@ -102,9 +119,16 @@ describe('DeviceViewer — input:error (#485)', () => {
   })
 
   it.each(['channel-starting', 'no-gesture'])('shows nothing for %s — it fixes itself', (reason) => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
     mounted()
-    inputError(reason)
+    inputError(reason, 'no gesture is in progress to complete — start a new one')
     expect(toastError).not.toHaveBeenCalled()
+    quiet()
+    // Shown nowhere is not the same as dropped: the reason still has to be findable, or a silent cell
+    // becomes indistinguishable from a handler that forgot the case.
+    expect(debug).toHaveBeenCalledTimes(1)
+    expect(String(debug.mock.calls[0]![0])).toContain(reason)
+    debug.mockRestore()
   })
 
   // Absence means unknown, never fine: an agent older than #490 omits the field, and the relay's own
@@ -113,7 +137,7 @@ describe('DeviceViewer — input:error (#485)', () => {
     mounted()
     inputError(undefined, 'agent offline')
     expect(toastError.mock.calls[0]![0]).toBe(INPUT_ERROR_NOTICE['channel-unavailable']!.title)
-    expect(opts()[0]!.id).toBe('input:channel-unavailable')
+    expect(opts()[0]!.id).toBe('input:s1:channel-unavailable')
   })
 
   // A newer agent against this build. Silence would be the dangerous direction — the reason exists
@@ -140,6 +164,18 @@ describe('DeviceViewer — input:error (#485)', () => {
     expect(toastError).not.toHaveBeenCalled()
   })
 
+  // While the agent is away the *relay* answers every terminal input itself, reasonlessly, so a
+  // tapping tester would keep this toast alive indefinitely — with advice that contradicts the status
+  // card, which already says the relay is holding the session and waiting. `device:boot-error`
+  // suppresses in the same state for the same kind of reason.
+  it('stays quiet while the agent is away', () => {
+    mounted()
+    act(() => { deliver!({ type: 'session:agent-away', sessionId: 's1' }) })
+    inputError(undefined, 'agent offline')
+    inputError('channel-unavailable')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
   // --- regression guards for the discarded latch design ---
 
   // `input:done` was only ever needed to release a latch. Handling it would mean the latch is back,
@@ -148,7 +184,7 @@ describe('DeviceViewer — input:error (#485)', () => {
     mounted()
     inputError('channel-unavailable')
     act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
-    expect(toastDismiss).not.toHaveBeenCalled()
+    quiet()
     expect(toastError).toHaveBeenCalledTimes(1)
   })
 
@@ -162,18 +198,30 @@ describe('DeviceViewer — input:error (#485)', () => {
     act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
     inputError('channel-unavailable')
     expect(toastError).toHaveBeenCalledTimes(2)
-    expect(toastDismiss).not.toHaveBeenCalled()
+    quiet()
   })
 })
 
 describe('INPUT_ERROR_NOTICE', () => {
   // The Record is what forces a decision per reason; this only pins that no entry was left as an
   // empty string, which the type cannot express. A new reason fails at `tsc`, not here.
+  const shown = (Object.entries(INPUT_ERROR_NOTICE) as Array<[InputErrorReason, typeof INPUT_ERROR_NOTICE[InputErrorReason]]>)
+    .filter((e): e is [InputErrorReason, NonNullable<typeof e[1]>] => e[1] !== null)
+
   it('gives every non-silent reason both a title and an action', () => {
-    for (const [reason, notice] of Object.entries(INPUT_ERROR_NOTICE) as Array<[InputErrorReason, typeof INPUT_ERROR_NOTICE[InputErrorReason]]>) {
-      if (notice === null) continue
-      expect(notice.title.length, reason).toBeGreaterThan(0)
-      expect(notice.action.length, reason).toBeGreaterThan(0)
+    for (const [reason, notice] of shown) {
+      expect(notice.title.trim(), reason).not.toBe('') // `.length > 0` would accept a single space
+      expect(notice.action.trim(), reason).not.toBe('')
+    }
+  })
+
+  // The reason a reason exists is that a consumer must do something different. Two of them sharing
+  // wording means one is being given the other's instruction — the defect `not-booted` was split out
+  // to avoid — and `tsc` cannot see it, because a `Record` only checks that every key is present.
+  it('gives no two shown reasons the same wording', () => {
+    for (const field of ['title', 'action'] as const) {
+      const values = shown.map(([, n]) => n[field])
+      expect(new Set(values).size, field).toBe(values.length)
     }
   })
 })


### PR DESCRIPTION
Closes #485.

`input:done` / `input:error` were declared in `packages/dashboard/lib/types.ts` and handled nowhere, so the relay forwarded them and the browser dropped them. The only consumer of a failed input was `mcp-server` — the experimental path — leaving manual testing, which AGENTS.md names as the default perspective, hearing nothing.

That mattered more after #484/#488/#490. Before those, an agent reported a dropped input as success; now it reports the truth with a machine-readable `reason`, and the truth was being discarded before a human saw it. A session whose input channel has permanently failed (a helper binary missing or built for the wrong architecture, #464) showed a stream that kept updating, taps that did nothing, and no indication anywhere.

## What a tester sees now

A failed input raises a toast whose copy is chosen by `reason`, so they are told **what to do** rather than only that something failed. `not-booted` gets its own wording because the protocol prescribes a different action for it (boot the device) than for `channel-unavailable` (reconnect). The wire `message` rides along as the description, where its detail (`unknown key code: KeyFoo`) is useful — it is not the headline, because it is free prose each agent owns and cannot be localised.

`channel-starting` and `no-gesture` are shown nowhere: both are fixed by the time the message could be read. Nothing is shown while the agent is away either — the relay answers every terminal input itself in that state, and the viewer already says the session is being held open.

## There is no session-level "input unavailable" state, and that is the interesting part

That was the first design — a latched line on the status card, cleared by `input:done` and the boot lifecycle. A two-channel design review discarded it, and each channel produced a blocker independently. Per-input acks cannot support a latch:

- **No message carries evidence that input is working again.** iOS replaces a dead helper eagerly and is injecting ~200ms later silently. Lifecycle messages do arrive (`session:rebound`, `session:joined`) but neither is evidence of input *health* — with the binary still missing, a latch would clear and re-raise on the next tap. The only signal that means anything is a successful input, and `channel-unavailable`'s own advice is *do not blindly retry*.
- **The acks are unordered.** A dispatch is awaited before its ack while a refusal is not, so an earlier input's `input:done` can land after a later input's `input:error`.
- **An ack does not say which channel answered.** On Android buttons always take the adb path while touch takes the pointer channel, so a tester pressing Home to check whether input works at all succeeds — and that success erased the warning about the dead touch channel. Both review channels found this sequence independently.

The toast's own lifetime carries it instead: repeats reuse one `id`, which sonner refreshes rather than stacks, so it stays up while inputs keep failing and fades on its own when they stop. **Observed rather than stored**, so there is no clear edge to get wrong. Two tests guard the decision, and `AGENTS.md` records why, because a latch will look like the obvious improvement to whoever reads this next.

## Review

`.work/reviews/fix__dashboard-input-error-unhandled.md` — design round (2 channels, discarded the design) plus a pre-PR round (2 channels) against `d74b49d`.

The pre-PR round is worth summarising because of what it found. The first channel was handed the ten mutations I had already run and asked what they *missed* — **four survived**, and all four were things documented but not guarded:

- `duration: 6000` was read by no test, and it is the only state this design has. `Infinity` made the toast permanent — the opposite of the documented behaviour — with nothing failing.
- The two tests said to guard the discarded latch watched only `toast.dismiss`, so a latch rebuilt as `toast.info('Input is working again')` passed both.
- `notice.action` was never checked through the render path, so dropping it passed, as did `not-booted` sharing `channel-unavailable`'s action.
- The `agentAway` interaction was reachable and pinned in neither direction. Now decided and tested.

The second channel checked whether the prose is true and found **five false claims**, including one that named the wrong backend (`socket.writable` is scrcpy's signal, not gRPC's) and one overstatement in the very paragraph written to stop the latch being rebuilt. All corrected; details and evidence in the record.

16 mutations total, 6 of which survived initially. None of my own ten touched those six — they had followed what I implemented rather than what I claimed.

## Scope

Dashboard only. `SimulatorInfoCard`, `IOSViewer` and `AndroidViewer` are untouched. The changeset names `@tapflowio/relay`, since that is the package the built dashboard ships inside.

Two follow-ups recommended in the record: a persistent session-level indicator needs a protocol-level input-health signal (or acks that name their channel and arrive in order), and the dashboard's inbound `RelayMessage` union is the remaining half of the drift `@tapflowio/protocol` was created to remove.

Full suite 2175 passed + 1 skip (dashboard 275 → 292); typecheck, lint, build and a11y-lens clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, reason-specific notifications when dashboard input actions fail.
  * Included relay-provided error details in notifications for easier troubleshooting.
  * Reused notifications for repeated failures to reduce duplicate alerts.

* **Bug Fixes**
  * Suppressed transient errors and notifications when the agent is away.
  * Improved handling of unknown or missing error reasons with a fallback notice.
  * Prevented completion events from incorrectly clearing active error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->