### PR TITLE
fix(relay): carry a reason on input:error, and stop blaming an agent for a session it never had

### DIFF
--- a/.changeset/relay-input-error-reason.md
+++ b/.changeset/relay-input-error-reason.md
@@ -10,9 +10,11 @@ own timeout, which its fallback would report as success. That reply carried no `
 relay the last producer of `input:error` without one, and the one whose answer was least in doubt: an
 agent infers a reason from its own state, while the relay is looking straight at the socket.
 
-It now sends `reason: 'channel-unavailable'`. Consumers that switch on the reason — the dashboard's
-per-reason notice, and `mcp-server`, which includes it in the error it raises — no longer have to fall
-back to the "unknown reason" rule for a message whose reason was never unclear.
+It now sends `reason: 'channel-unavailable'`. What visibly changes today is `mcp-server`, which puts the
+reason in the error it raises. The dashboard's output does not change — its unknown-reason rule already
+resolves to this same reason, and while the agent is away it suppresses the notice entirely — so the
+value here is that **absence of the field now means an agent older than it and nothing else**, which is
+what makes it possible to require the field later.
 
 The prose was also wrong for half the cases it covered. Two situations reach that reply: the session
 is held with a socket that is no longer open, or there is no such session — evicted after the reconnect
@@ -24,6 +26,11 @@ Both keep `channel-unavailable` rather than splitting into two wire reasons. The
 what a consumer must do differently, and a reconnect or a re-join answers both — the machine field was
 right for both cases while the prose was wrong for one, which is exactly why consumers should branch on
 `reason` and display `message`.
+
+One consequence of that collapse had to be followed through: the dashboard's copy for this reason told
+the reader to check the agent on the Mac, which is a wild goose chase for a session the relay simply no
+longer has. It now says to rejoin the session and leaves the specific cause to the message shown beside
+it.
 
 No protocol change: `reason` has been optional on this message since it was introduced, so this is
 additive. Absence of the field now means an agent older than it, and nothing else.

--- a/.changeset/relay-input-error-reason.md
+++ b/.changeset/relay-input-error-reason.md
@@ -10,11 +10,12 @@ own timeout, which its fallback would report as success. That reply carried no `
 relay the last producer of `input:error` without one, and the one whose answer was least in doubt: an
 agent infers a reason from its own state, while the relay is looking straight at the socket.
 
-It now sends `reason: 'channel-unavailable'`. What visibly changes today is `mcp-server`, which puts the
-reason in the error it raises. The dashboard's output does not change — its unknown-reason rule already
-resolves to this same reason, and while the agent is away it suppresses the notice entirely — so the
-value here is that **absence of the field now means an agent older than it and nothing else**, which is
-what makes it possible to require the field later.
+It now sends `reason: 'channel-unavailable'`. Two things change visibly: `mcp-server` puts the reason in
+the error it raises, and the dashboard's guidance for this reason is reworded (below). What does *not*
+change is the dashboard's branching — its unknown-reason rule already resolved to this same reason, and
+while the agent is away it suppresses the notice entirely. So the field itself buys something narrower
+and more durable: **absence now means an agent older than it and nothing else**, which is what makes it
+possible to require the field later.
 
 The prose was also wrong for half the cases it covered. Two situations reach that reply: the session
 is held with a socket that is no longer open, or there is no such session — evicted after the reconnect

--- a/.changeset/relay-input-error-reason.md
+++ b/.changeset/relay-input-error-reason.md
@@ -1,0 +1,29 @@
+---
+'@tapflowio/relay': patch
+---
+
+fix(relay): carry a reason on `input:error`, and stop blaming an agent for a session it never had
+
+The relay answers a terminal input it cannot dispatch — `input:touch:end`, `input:pinch:end`,
+`input:key`, `input:button` — so an MCP or browser caller fails immediately instead of waiting out its
+own timeout, which its fallback would report as success. That reply carried no `reason`, making the
+relay the last producer of `input:error` without one, and the one whose answer was least in doubt: an
+agent infers a reason from its own state, while the relay is looking straight at the socket.
+
+It now sends `reason: 'channel-unavailable'`. Consumers that switch on the reason — the dashboard's
+per-reason notice, and `mcp-server`, which includes it in the error it raises — no longer have to fall
+back to the "unknown reason" rule for a message whose reason was never unclear.
+
+The prose was also wrong for half the cases it covered. Two situations reach that reply: the session
+is held with a socket that is no longer open, or there is no such session — evicted after the reconnect
+grace expired, or never valid. Only the first is the agent's fault; in the second the agent can be
+perfectly healthy, and `agent offline` sent the reader after the wrong problem. It now says
+`Session not found` there, the same two strings `device:boot` already used for the same pair.
+
+Both keep `channel-unavailable` rather than splitting into two wire reasons. The set is derived from
+what a consumer must do differently, and a reconnect or a re-join answers both — the machine field was
+right for both cases while the prose was wrong for one, which is exactly why consumers should branch on
+`reason` and display `message`.
+
+No protocol change: `reason` has been optional on this message since it was introduced, so this is
+additive. Absence of the field now means an agent older than it, and nothing else.

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -86,9 +86,9 @@ diagnostic detail (`unknown key code: KeyFoo`) belongs. Absent or unrecognised r
 `channel-unavailable` — absence means *unknown*, never *fine*.
 
 Suppressed entirely while the agent is away. An absent agent cannot send this, so in that state the
-*relay* answers every terminal input itself with a reasonless `input:error`; a tapping tester would
-refresh the toast indefinitely, with advice contradicting the status card, which already says the relay
-is holding the session open and waiting.
+*relay* answers every terminal input itself (`agent offline`, `channel-unavailable` since #492); a
+tapping tester would refresh the toast indefinitely, with advice contradicting the status card, which
+already says the relay is holding the session open and waiting.
 
 A persistent indicator needs a protocol-level input-health signal, or acks that identify their channel
 and arrive in order. Two tests guard the decision (`DeviceViewer.inputError.test.tsx`): `input:done`

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -207,7 +207,7 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     if (msg.type === 'input:error') {
       // Suppressed while the agent is away, matching what `device:boot-error` does two branches down
       // and for a sharper reason: an absent agent cannot send this, so in that state the *relay*
-      // answers every terminal input itself (`RelayServer.ts`, reasonless `'agent offline'`). A
+      // answers every terminal input itself (`RelayServer.ts`, `channel-unavailable`). A
       // tapping tester would refresh this toast indefinitely, and its advice would contradict the
       // status card — which already says the relay is holding the session open and waiting.
       if (agentAway) return;

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -27,7 +27,11 @@ export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | nul
   // action names the agent rather than the device.
   'channel-unavailable': {
     title: 'Input is not reaching this device',
-    action: 'Reconnect, or check the agent on the Mac running it.',
+    // Names no cause. The reason covers two of them — an agent that is gone, and a session this relay
+    // no longer has — and the second says nothing about any agent's health, so an action that sent the
+    // reader to the Mac was wrong for it (#492). The specific cause arrives in `message` and is shown
+    // beside this.
+    action: 'Rejoin the session to continue.',
   },
   // Deliberately not folded into the line above: the protocol prescribes a *different* action for
   // this one ("boot the device"), and one sentence cannot give both.

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -82,9 +82,9 @@ export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | nul
  * the case being handled.
  *
  * Absence and unfamiliarity both resolve to `channel-unavailable`: absence means *unknown*, never
- * *fine* (an agent older than #490 omits the field, and the relay's own reasonless `input:error`
- * still does), and the protocol's rule for a reason a consumer does not recognise is the same
- * conservative reading. Resolving the *key* as well as the copy is what keeps two different unknown
+ * *fine* (an agent older than #490 omits the field), and the protocol's rule for a reason a consumer
+ * does not recognise is the same conservative reading. Every in-repo producer now sends one — the
+ * relay was the last that did not (#492) — so absence today means an older agent, nothing else. Resolving the *key* as well as the copy is what keeps two different unknown
  * reasons from stacking two identical toasts.
  *
  * `Object.hasOwn`, not `in` — `'toString' in INPUT_ERROR_NOTICE` is true, and a reason of `toString`

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -131,8 +131,9 @@ describe('DeviceViewer — input:error (#485)', () => {
     debug.mockRestore()
   })
 
-  // Absence means unknown, never fine: an agent older than #490 omits the field, and the relay's own
-  // `agent offline` reply still does.
+  // Absence means unknown, never fine: an agent older than #490 omits the field. Every in-repo
+  // producer sends one now — the relay was the last that did not (#492) — so the fixture below is an
+  // old agent rather than any current sender.
   it('treats an absent reason as channel-unavailable', () => {
     mounted()
     inputError(undefined, 'agent offline')
@@ -187,7 +188,7 @@ describe('DeviceViewer — input:error (#485)', () => {
     expect(toastError).not.toHaveBeenCalled()
   })
 
-  // While the agent is away the *relay* answers every terminal input itself, reasonlessly, so a
+  // While the agent is away the *relay* answers every terminal input itself, so a
   // tapping tester would keep this toast alive indefinitely — with advice that contradicts the status
   // card, which already says the relay is holding the session and waiting. `device:boot-error`
   // suppresses in the same state for the same kind of reason.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -72,8 +72,9 @@ required.
 
 There is deliberately **no shared message table**. One would be a runtime value, and this entry point
 must erase under `import type` (see HOW NOT) — so each agent owns its own wording. A static check in
-`scripts/__tests__/inputErrorReason.test.mjs` holds both producers to the one union, since neither
-agent's own test suite can see the other.
+`scripts/__tests__/inputErrorReason.test.mjs` holds both **agents** to the one union, since neither
+agent's own test suite can see the other. The relay is the third producer and needs no such check: it
+sends through `sendTo(socket, msg: RelayOutbound)`, so its literal is checked by the compiler.
 
 ## HOW NOT
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -64,6 +64,12 @@ therefore means *unknown*, never *fine*, and **a consumer meeting a reason it do
 treat it as `channel-unavailable`** — the conservative reading. Making the field required is the
 breaking step and has not been taken.
 
+Every in-repo producer now sends one. The relay was the last that did not (#492) — it answers a
+terminal input it cannot dispatch, and being the only producer that reads a socket rather than
+inferring from its own state, it was the one whose reason was least in doubt. So absence today means
+an agent older than this field and nothing else, which is what #491 needs before the field can become
+required.
+
 There is deliberately **no shared message table**. One would be a runtime value, and this entry point
 must erase under `import type` (see HOW NOT) — so each agent owns its own wording. A static check in
 `scripts/__tests__/inputErrorReason.test.mjs` holds both producers to the one union, since neither

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -38,6 +38,18 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 - Control message protocol: `input:touch:*`, `input:pinch:*`, `input:button`, `input:key`, `input:type`, `input:rotate`, `input:keyboard:toggle`, `device:boot`, `device:shutdown`, `session:start`, `session:end`, `clipboard:read`, `clipboard:write`.
 - **The message shapes live in [`@tapflowio/protocol`](../protocol/AGENTS.md), not here.** Every message the relay *originates* goes through `sendTo(socket, msg: RelayOutbound)`, so adding one means adding it to that union first — the compiler will not let you do it in the other order. Messages the relay only *forwards* keep their inbound type and are re-serialised unchanged.
 - **Clipboard bridge** (`clipboard:*`): browser→agent `clipboard:read` (`payload.press`: `'copy' | 'cut'` presses that chord on the device first) and `clipboard:write` (`payload.text`, `payload.pasteAfter`); agent→browser `clipboard:data` / `clipboard:write-done` / `clipboard:error`, correlated by `requestId`. Unlike the other agent→browser replies these are **bound to the session's own `agentSocket`** — their payload lands on the viewer's host OS clipboard, so a second agent must not be able to address someone else's session. An undeliverable request answers `clipboard:error` immediately rather than letting the caller's deadline expire. Agents advertise `capabilities: ['clipboard']` in `agent:register`; the relay echoes them on `session:joined` so a viewer can tell a capable agent from one that predates the feature instead of inferring it from silence.
+- **A terminal input the relay cannot dispatch is answered here, with a reason.** `input:touch:end` /
+  `input:pinch:end` / `input:key` / `input:button` (`TERMINAL_INPUT_TYPES`) get an `input:error` when
+  the session's agent socket is not open, so an MCP or browser caller fails now instead of waiting out
+  its own timeout — which its fallback would report as success. Non-terminal inputs get nothing:
+  no caller waits on a move, and answering one would widen the surface that set exists to bound.
+  Two situations reach that reply and only one is the agent's fault, so they carry **different prose
+  and the same reason**: a held session with a closed socket is `agent offline`, while no session at
+  all is `Session not found` — evicted after the reconnect grace, or never valid, and the agent may be
+  perfectly healthy. `device:boot` already told that pair apart with those two strings. The reason is
+  `channel-unavailable` for both because the set is derived from what a consumer must *do* differently
+  and both want a reconnect or a re-join; the machine field was right for both while the prose was
+  wrong for one, which is the concrete case for reading `reason` rather than `message` (#492).
 - JWTs are issued based on team invite links.
 - Serves the `public/` directory as HTTP static files (dashboard build output).
 - The relay does not buffer stream data — it forwards immediately on arrival.

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -41,8 +41,12 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 - **A terminal input the relay cannot dispatch is answered here, with a reason.** `input:touch:end` /
   `input:pinch:end` / `input:key` / `input:button` (`TERMINAL_INPUT_TYPES`) get an `input:error` when
   the session's agent socket is not open, so an MCP or browser caller fails now instead of waiting out
-  its own timeout — which its fallback would report as success. Non-terminal inputs get nothing:
-  no caller waits on a move, and answering one would widen the surface that set exists to bound.
+  its own timeout — which its fallback would report as success. Everything outside that set gets
+  nothing, and the set is not "the ones that matter": moves and starts have no waiter, but `input:type`
+  does (`input:type-done` / `input:type-error`, awaited in `mcp-server` and `flow-runner`) and receives
+  no answer here, so a type on an offline agent still burns its full deadline. Adding it to this set
+  would not fix that — those waiters key on the `input:type-*` pair and would ignore an `input:error`
+  — so the honest fix is a separate reply, which is why the set was left as it is rather than widened.
   Two situations reach that reply and only one is the agent's fault, so they carry **different prose
   and the same reason**: a held session with a closed socket is `agent offline`, while no session at
   all is `Session not found` — evicted after the reconnect grace, or never valid, and the agent may be

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -768,10 +768,25 @@ export class RelayServer {
         if (session?.agentSocket.readyState === WebSocket.OPEN) {
           session.agentSocket.send(JSON.stringify(msg))
         } else if (TERMINAL_INPUT_TYPES.has(msg.type) && ws.readyState === WebSocket.OPEN) {
-          // Agent offline or session evicted: a terminal input can't be dispatched.
-          // Reply to the sender (the MCP/browser socket) so it fails truthfully
-          // instead of falling through to its optimistic 2s timeout.
-          this.sendTo(ws, { type: 'input:error', sessionId: msg.sessionId!, message: 'agent offline' })
+          // A terminal input that cannot be dispatched. Reply to the sender (the MCP/browser socket)
+          // so it fails truthfully instead of falling through to its optimistic 2s timeout.
+          //
+          // Two situations reach here and only one of them is the agent's fault: the session may be
+          // held with a socket that is no longer open, or there may be no such session — evicted
+          // after the reconnect grace expired, or never valid. In the second the agent can be
+          // perfectly healthy, so `agent offline` is a wrong diagnosis, and it is the same pair
+          // `device:boot` already tells apart above for the same reason. Same two strings as there.
+          //
+          // The reason is `channel-unavailable` either way, and that is the point rather than an
+          // approximation: the set is derived from what a consumer must do differently, and both of
+          // these want a reconnect or a re-join. The machine field is right for both and the prose
+          // was wrong for one, which is why the prose is what changed.
+          this.sendTo(ws, {
+            type: 'input:error',
+            sessionId: msg.sessionId!,
+            message: session ? 'agent offline' : 'Session not found',
+            reason: 'channel-unavailable',
+          })
         }
         break
       }

--- a/packages/relay/src/__tests__/inputErrorReason.test.ts
+++ b/packages/relay/src/__tests__/inputErrorReason.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import type { RelayMessage } from '../types'
+import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+
+// #492. The relay answers a terminal input it cannot dispatch, and it was the last producer of
+// `input:error` sending no `reason` — while being the one that knows the answer with the most
+// certainty, since it is looking at the socket rather than inferring from its own state.
+//
+// Two situations reach that reply and only one is the agent's fault, so the prose split matters too:
+// a session held with a closed socket really is an absent agent, but no session at all can mean an
+// evicted id in front of a perfectly healthy agent.
+describe('input:error from the relay carries a reason (#492)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-input-reason-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  async function joinedSession() {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
+    }))
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
+    const sessionId = reply.registeredSessions![0].sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return { agent, browser, sessionId }
+  }
+
+  /** Leaves the session in the relay with a socket that is no longer open — the reconnect grace holds
+   *  the id, which is what makes this the branch where "the agent is gone" is the true statement. */
+  async function agentGone() {
+    const { agent, browser, sessionId } = await joinedSession()
+    const closed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await closed
+    return { browser, sessionId }
+  }
+
+  const terminals: Array<[string, Record<string, unknown>]> = [
+    ['input:touch:end', { x: 0.5, y: 0.5 }],
+    ['input:pinch:end', { f0: { x: 0.4, y: 0.4 }, f1: { x: 0.6, y: 0.6 } }],
+    ['input:key', { code: 'KeyA' }],
+    ['input:button', { name: 'home' }],
+  ]
+
+  for (const [type, payload] of terminals) {
+    it(`answers ${type} with reason channel-unavailable when the agent's socket is gone`, async () => {
+      const { browser, sessionId } = await agentGone()
+
+      browser.send(JSON.stringify({ type, sessionId, payload }))
+      // By type, not "the next message": losing the agent also produces a `session:terminated` and
+      // whichever lands first is not this test's subject.
+      const err = await waitForType(browser, 'input:error')
+      expect(err.sessionId).toBe(sessionId)
+      expect(err.reason).toBe('channel-unavailable')
+      expect(err.message).toBe('agent offline')
+
+      browser.close()
+    })
+  }
+
+  // The other branch. `agent offline` was a wrong diagnosis here — the relay has no session for this
+  // id, which says nothing about any agent's health — and `device:boot` already answered this pair
+  // with these two strings before this change.
+  it('says the session is not found, rather than blaming an agent, for an unknown session', async () => {
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId: 'no-such-session', payload: { x: 0.5, y: 0.5 },
+    }))
+    const err = await waitForType(browser, 'input:error')
+    expect(err.sessionId).toBe('no-such-session')
+    expect(err.reason).toBe('channel-unavailable')
+    expect(err.message).toBe('Session not found')
+    expect(err.message).not.toBe('agent offline')
+
+    browser.close()
+  })
+
+  // The reason is deliberately the same for both branches: the set is derived from what a consumer
+  // must do differently, and a reconnect or re-join answers both. Pinning the equality keeps a future
+  // change from splitting the wire vocabulary when only the wording needed to differ.
+  it('uses one reason for both branches while the wording differs', async () => {
+    const { browser, sessionId } = await agentGone()
+
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    const held = await waitForType(browser, 'input:error')
+
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: 'nope', payload: { x: 0.5, y: 0.5 } }))
+    const unknown = await waitForType(browser, 'input:error')
+
+    // Named, not merely equal: two absent reasons are also equal, and that is the state this whole
+    // change exists to end.
+    expect(held.reason).toBe('channel-unavailable')
+    expect(held.reason).toBe(unknown.reason)
+    expect(held.message).not.toBe(unknown.message)
+
+    browser.close()
+  })
+
+  // This change adds a field to an existing reply; it does not widen what gets answered. A move has
+  // no caller waiting on it, and inventing a reply for one would grow the surface the terminal-only
+  // set exists to bound.
+  it('still answers nothing for a non-terminal input', async () => {
+    const { browser, sessionId } = await agentGone()
+
+    browser.send(JSON.stringify({ type: 'input:touch:move', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    expect(await waitForTypeOrNull(browser, 'input:error', 100)).toBeNull()
+
+    browser.close()
+  })
+})

--- a/packages/relay/src/__tests__/inputErrorReason.test.ts
+++ b/packages/relay/src/__tests__/inputErrorReason.test.ts
@@ -79,8 +79,9 @@ describe('input:error from the relay carries a reason (#492)', () => {
       const { browser, sessionId } = await agentGone()
 
       browser.send(JSON.stringify({ type, sessionId, payload }))
-      // By type, not "the next message": losing the agent also produces a `session:terminated` and
-      // whichever lands first is not this test's subject.
+      // By type, not "the next message": losing the agent also produces a `session:agent-away`, and
+      // whichever lands first is not this test's subject. (Not `session:terminated` — that waits for
+      // the 15s grace to expire, long after this test is over.)
       const err = await waitForType(browser, 'input:error')
       expect(err.sessionId).toBe(sessionId)
       expect(err.reason).toBe('channel-unavailable')
@@ -130,15 +131,30 @@ describe('input:error from the relay carries a reason (#492)', () => {
     browser.close()
   })
 
-  // This change adds a field to an existing reply; it does not widen what gets answered. A move has
-  // no caller waiting on it, and inventing a reply for one would grow the surface the terminal-only
-  // set exists to bound.
-  it('still answers nothing for a non-terminal input', async () => {
-    const { browser, sessionId } = await agentGone()
+  // This change adds a field to an existing reply; it does not widen what gets answered. Every input
+  // type outside `TERMINAL_INPUT_TYPES` is listed, because the two ways of widening it are both
+  // harmful and neither is caught by testing one representative: adding `input:touch:start` would
+  // answer twice per tap, and adding `input:type` would answer a message whose waiters key on
+  // `input:type-done` / `input:type-error` (`mcp-server`, `flow-runner`) — they would ignore it and
+  // wait out the full deadline anyway, which is the failure this reply exists to prevent.
+  const nonTerminals: Array<[string, Record<string, unknown>]> = [
+    ['input:touch:start', { x: 0.5, y: 0.5 }],
+    ['input:touch:move', { x: 0.5, y: 0.5 }],
+    ['input:pinch:start', { f0: { x: 0.4, y: 0.4 }, f1: { x: 0.6, y: 0.6 } }],
+    ['input:pinch:move', { f0: { x: 0.4, y: 0.4 }, f1: { x: 0.6, y: 0.6 } }],
+    ['input:type', { text: 'hello' }],
+    ['input:rotate', { orientation: 'landscapeLeft' }],
+    ['input:keyboard:toggle', {}],
+  ]
 
-    browser.send(JSON.stringify({ type: 'input:touch:move', sessionId, payload: { x: 0.5, y: 0.5 } }))
-    expect(await waitForTypeOrNull(browser, 'input:error', 100)).toBeNull()
+  for (const [type, payload] of nonTerminals) {
+    it(`still answers nothing for ${type}`, async () => {
+      const { browser, sessionId } = await agentGone()
 
-    browser.close()
-  })
+      browser.send(JSON.stringify({ type, sessionId, payload }))
+      expect(await waitForTypeOrNull(browser, 'input:error', 100)).toBeNull()
+
+      browser.close()
+    })
+  }
 })


### PR DESCRIPTION
Closes #492.

The relay answers a terminal input it cannot dispatch — `input:touch:end`, `input:pinch:end`, `input:key`, `input:button` — so an MCP or browser caller fails immediately instead of waiting out its own timeout, which its fallback reports as success. That reply carried no `reason`, which made the relay the last producer of `input:error` without one, and the producer whose answer was least in doubt: an agent infers a reason from its own state, while the relay reads the socket directly.

## Two situations, one of them misdiagnosed

The `else if` covers a session held with a socket that is no longer open, and no such session at all — evicted after the reconnect grace, or never valid. Only the first is the agent's fault; in the second the agent can be perfectly healthy, and `agent offline` sent the reader after the wrong problem.

`device:boot` already told that pair apart, twelve lines earlier in the same file, with the two strings now used here and a comment giving the reason. So this is a missed application rather than a new judgement.

## Both branches keep `channel-unavailable`

Not split into two wire reasons. The set is derived from what a consumer must *do* differently and a reconnect or re-join answers both — the machine field was right for both cases while the prose was wrong for one, which is the concrete argument for branching on `reason` and displaying `message`.

That collapse had a consequence worth following through, and the review caught that I hadn't: the dashboard's copy for this reason told the reader to check the agent on the Mac, which is a wild goose chase for a session the relay simply no longer has — the exact misdirection this PR sets out to remove, reintroduced by the consumer. The action now names no cause and leaves it to the message shown beside it.

## What actually changes downstream

`mcp-server` is what visibly changes; it puts the reason in the error it raises. The dashboard's output does not — its unknown-reason rule already resolved to this same reason, and while the agent is away it suppresses the notice entirely. The real value is that **absence of the field now means an agent older than it and nothing else**, which is what #491 needs before the field can be required.

No protocol change: `reason` has been optional on this message since it was introduced.

## Review

`.work/reviews/fix__relay-input-error-reason.md` — one pre-PR channel against `96b8ce8`, handed my five mutations and asked what they missed. Five findings, all verified:

- **My commit claimed the docs were updated and three of four places were not**, including `DeviceViewer.tsx` — shipped source, and the comment that points a reader at the changed file. The paragraph I *did* edit is a near-copy of it, so I updated the mirror and left the original.
- **The non-terminal guard covered one of seven types.** Widening `TERMINAL_INPUT_TYPES` to include `input:touch:start` or `input:type` survived the whole suite, and both are harmful — the first answers twice per tap, the second answers a message whose waiters key on the `input:type-*` pair and would ignore it. All seven are now listed.
- **My `AGENTS.md` bullet over-generalised**: "no caller waits on a move" is true of moves and false of `input:type`, which is also excluded and *does* have a 15s waiter in two packages. The comment I replaced was correctly scoped.
- **The changeset overstated the benefit** (see above).
- A test comment named `session:terminated` where the awaited-past message is `session:agent-away`.

8 mutations, 2 of which survived initially. One lesson recorded: removing `reason` failed 5 tests, not 6 — the both-branches test compared two reasons for equality and `undefined === undefined` passes. It now names the value.

The plan carried a diagnostic test case — "the existing `clearState.test.ts` expectation of `agent offline` must keep passing; if it breaks, my branch judgement is wrong" — and it passed, because the reconnect grace holds the session. The reviewer confirmed that independently.

Two follow-ups recommended in the record: `input:type` burns its full deadline against an offline agent and needs an `input:type-error` from the relay rather than membership in this set; and a missing `sessionId` drops the required field from this reply, which predates this diff and affects `open-url` and `device:boot` equally.

Full suite 2187 passed + 1 skip (relay 570 → 583); typecheck, lint, build and a11y-lens clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal input errors now include a `channel-unavailable` reason.
  * Error messages distinguish between unavailable agents and missing sessions.
  * Dashboard guidance now recommends rejoining the session when the channel is unavailable.
* **Documentation**
  * Updated guidance to explain error reasons and compatibility with older agents.
* **Tests**
  * Added coverage for terminal input failures, missing sessions, unavailable agents, and non-terminal inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->