### PR TITLE
fix(mcp-server): stop reporting an unacknowledged input as success

### DIFF
--- a/.changeset/mcp-input-ack-truthfulness.md
+++ b/.changeset/mcp-input-ack-truthfulness.md
@@ -20,10 +20,20 @@ a drop invites a retry, and a retry of a landed input duplicates it. The error t
 input may have landed and to check device state rather than repeat it.
 
 **Whether silence is fatal is decided by what the session has already done.** A session that has
-answered an input before is judged strictly; one that never has keeps the optimistic path, because an
-agent that does not ack at all is exactly what the fallback was for. This degrades in the safe
-direction and needs nothing on the wire. A session's first input stays optimistic, which is the one
-case where silence genuinely does mean "an agent that does not ack".
+answered an input with `input:done` is judged strictly; one that never has keeps the optimistic path,
+because an agent that does not ack at all is exactly what the fallback was for. This degrades in the safe
+direction and needs nothing on the wire.
+
+`input:done` specifically, not any ack: the relay originates `input:error` to the client for a terminal
+input it cannot dispatch, so counting those would let one agent-offline blip mark a session as acking
+when its agent may never have answered anything — and then report every later input as unconfirmed on
+evidence the agent did not produce. A session that has never had an answer keeps the optimistic path
+indefinitely, so #457 is unchanged for an agent whose acks never arrive; what this buys is that once a
+session answers, silence after that is reported.
+
+One gap stays open and is documented rather than papered over: an ack carries no correlation id, so an
+ack arriving after its own input timed out is consumed by the next input's waiter. That needs a field on
+the wire (#499).
 
 **An `input:error` now carries advice, not just prose.** Each reason maps to what the caller should do
 — boot the device, reconnect, send the same input again in a moment, or never retry this one. The

--- a/.changeset/mcp-input-ack-truthfulness.md
+++ b/.changeset/mcp-input-ack-truthfulness.md
@@ -1,0 +1,37 @@
+---
+'@tapflowio/mcp-server': patch
+---
+
+fix(mcp-server): stop reporting an unacknowledged input as success
+
+`awaitInputAck` waited 2s for `input:done` / `input:error` and, on timeout, **returned successfully**.
+So `tap`, `swipe` and every other terminal gesture reported success when nothing had acked, and the
+model driving the session was told the tap landed and moved on.
+
+The fallback existed for agents predating the input-ack protocol and outlived them: both agents ack
+every terminal input unconditionally (#484, #488), and since #495 every producer also sends a
+machine-readable reason. When both ends are current, silence means something is actually wrong — which
+is exactly the case the fallback converted into a success.
+
+**Silence is now reported as "could not confirm", not as a drop.** That distinction is load-bearing:
+`ackInput` awaits a device verify on the first input after a boot or reconnect, on the same Mac the
+relay gates at 80% CPU, so an ack past the window can belong to an input that *did* land. Calling that
+a drop invites a retry, and a retry of a landed input duplicates it. The error tells the caller the
+input may have landed and to check device state rather than repeat it.
+
+**Whether silence is fatal is decided by what the session has already done.** A session that has
+answered an input before is judged strictly; one that never has keeps the optimistic path, because an
+agent that does not ack at all is exactly what the fallback was for. This degrades in the safe
+direction and needs nothing on the wire. A session's first input stays optimistic, which is the one
+case where silence genuinely does mean "an agent that does not ack".
+
+**An `input:error` now carries advice, not just prose.** Each reason maps to what the caller should do
+— boot the device, reconnect, send the same input again in a moment, or never retry this one. The
+`no-gesture` advice warns that part of the input may already have been applied, because that reason
+covers both "nothing landed" and "the opening frames landed and only the last was refused".
+
+Nothing is retried automatically. That was the first design and was discarded after review: the wire
+cannot distinguish those two `no-gesture` cases, so a client that retried would sometimes apply a drag
+twice with nobody able to see it had — and `TapflowClient` also drives `run_flow`, where a retry would
+make deterministic replay non-deterministic. Retrying is the caller's decision, which is why the reason
+now comes with advice instead of an action.

--- a/.changeset/mcp-input-ack-truthfulness.md
+++ b/.changeset/mcp-input-ack-truthfulness.md
@@ -19,6 +19,10 @@ relay gates at 80% CPU, so an ack past the window can belong to an input that *d
 a drop invites a retry, and a retry of a landed input duplicates it. The error tells the caller the
 input may have landed and to check device state rather than repeat it.
 
+A dropped relay connection is answered the same way. It used to be reported as "the input was not
+dispatched", which was wrong: every caller sends its input before awaiting the ack, so by the time the
+socket closes the input has left the process and the relay may already have forwarded it.
+
 **Whether silence is fatal is decided by what the session has already done.** A session that has
 answered an input with `input:done` is judged strictly; one that never has keeps the optimistic path,
 because an agent that does not ack at all is exactly what the fallback was for. This degrades in the safe

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -940,8 +940,14 @@ export class AndroidAgent implements DeviceAgent {
   }
 
   // Await a pointer-channel write and turn it into an outcome. scrcpy's methods are synchronous and
-  // return void, so `await` is a no-op there and `isReady()` is the whole signal; gRPC rejects (with
-  // a deadline, so an exceeded call is genuinely cancelled and answering failure is safe to retry).
+  // return void, so `await` is a no-op there and `isReady()` is the whole signal; gRPC rejects, with a
+  // deadline on input RPCs.
+  //
+  // The deadline is **not** a licence to retry, and this comment used to say it was. It cancels our
+  // call, not a request the emulator already applied — and since an unreachable emulator rejects on its
+  // own in 4ms, the case the deadline actually fires in is a connected-but-unresponsive emulator, where
+  // whether the input landed is unknowable and a retry can double it. AGENTS.md carries the full
+  // reasoning under "What the deadline does and does not buy".
   private async dispatchTo(pc: PointerControl, write: () => void | Promise<void>): Promise<InputOutcome> {
     if (!pc.isReady()) return 'channel-down'
     try {

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -45,13 +45,18 @@ landed to a model that then moved on (#457). Three things about the fix are easy
   invites a retry, and a retry of a landed input duplicates it. The thrown text says the input may have
   landed and to check device state rather than repeat.
 - **Whether silence is fatal is decided by what the session has already done**, not by a negotiated
-  flag: `ackedSessions` records any session that has answered an input, and only those are judged
-  strictly. An agent that never acks is never judged, which is the safe direction, and it needs nothing
-  on the wire. A capability flag was designed for this and discarded — it would have to be advertised by
+  flag: `ackedSessions` records any session that has answered an input with `input:done`, and only
+  those are judged strictly. **`input:done` and not `input:error`**, because the relay originates
+  `input:error` to this same socket for a terminal input it cannot dispatch — counting those would let
+  one agent-offline blip mark a session as acking when its agent may never have answered anything, and
+  then report every later input as unconfirmed on evidence the agent did not produce. Nothing in the
+  relay originates an `input:done`. An agent that never acks is never judged, which is the safe
+  direction, and it needs nothing on the wire. A capability flag was designed for this and discarded — it would have to be advertised by
   both agents, kept in step by a static check, and would then sit inert forever once every install had
   it, unremovable because consumers key on its absence. It would also have pre-decided the fork #491 is
-  open on. The residual gap is a session's **first** input, which stays optimistic; silence there
-  genuinely does mean an agent that does not ack.
+  open on. The residual gap is any session that has never had an answer — usually just its first input,
+  but **not bounded to one**: an agent whose acks never arrive keeps the optimistic path indefinitely.
+  What the gate buys is that once a session answers, silence after that is reported.
   The ledger is written in `dispatch`, not where the ack is awaited, so an ack that missed its own
   window still counts — that is the case worth learning from, and a ledger kept at the waiter would see
   nothing.
@@ -62,6 +67,12 @@ landed to a model that then moved on (#457). Three things about the fix are easy
   `run_flow`, so a retry here makes deterministic replay non-deterministic. Retrying is the caller's
   decision, and `REASON_ADVICE` is what it decides on — including the warning that `no-gesture` may
   already have applied part of the input.
+
+**A known gap this does not close**: an ack carries no correlation id, so the waiter matches any ack for
+the session. An ack that arrives after its own input timed out is consumed by the *next* input's waiter,
+which then reports the previous input's outcome — including reporting an unanswered input as landed. That
+needs a field on the wire and is tracked in #499; it is stated here rather than papered over, because it
+is the one way the gate above can still be defeated.
 
 ## HOW NOT
 

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -39,11 +39,15 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 predating the ack protocol and it outlived them, so a tap that never reached the device was reported as
 landed to a model that then moved on (#457). Three things about the fix are easy to undo.
 
-- **Silence is "could not confirm", not "dropped".** `ackInput` on both agents awaits a `simctl list` /
+- **Silence *and a dropped connection* are both "could not confirm", not "dropped".** `ackInput` on both agents awaits a `simctl list` /
   `adb` device verify on the first input after a boot or reconnect, on the same Mac the relay gates at
   80% CPU — so an ack past the window can belong to an input that **did** land. Calling that a drop
   invites a retry, and a retry of a landed input duplicates it. The thrown text says the input may have
   landed and to check device state rather than repeat.
+  The same holds when the socket closes mid-input, and that branch used to claim the opposite: every
+  caller sends its input **before** awaiting the ack, so by then the input has left this process and the
+  relay may have forwarded it. A close says nothing about whether the agent acks — only that we stopped
+  being able to hear it — so it is unconfirmed regardless of the ledger.
 - **Whether silence is fatal is decided by what the session has already done**, not by a negotiated
   flag: `ackedSessions` records any session that has answered an input with `input:done`, and only
   those are judged strictly. **`input:done` and not `input:error`**, because the relay originates

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -33,7 +33,39 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 
 `query_ui_tree` returns the unified element schema (`role`/`label`/`identifier`/`frame`/`enabled`/`rawRole`) via `GET /api/v1/sessions/:sessionId/ui-tree`. Frames are normalized 0-1, so a frame center multiplied by the screenshot pixel size feeds straight into `tap`.
 
+### Input acks: silence is answered "could not confirm", and never retried here
+
+`awaitInputAck` used to report **success** when no ack arrived within 2s. That fallback was for agents
+predating the ack protocol and it outlived them, so a tap that never reached the device was reported as
+landed to a model that then moved on (#457). Three things about the fix are easy to undo.
+
+- **Silence is "could not confirm", not "dropped".** `ackInput` on both agents awaits a `simctl list` /
+  `adb` device verify on the first input after a boot or reconnect, on the same Mac the relay gates at
+  80% CPU — so an ack past the window can belong to an input that **did** land. Calling that a drop
+  invites a retry, and a retry of a landed input duplicates it. The thrown text says the input may have
+  landed and to check device state rather than repeat.
+- **Whether silence is fatal is decided by what the session has already done**, not by a negotiated
+  flag: `ackedSessions` records any session that has answered an input, and only those are judged
+  strictly. An agent that never acks is never judged, which is the safe direction, and it needs nothing
+  on the wire. A capability flag was designed for this and discarded — it would have to be advertised by
+  both agents, kept in step by a static check, and would then sit inert forever once every install had
+  it, unremovable because consumers key on its absence. It would also have pre-decided the fork #491 is
+  open on. The residual gap is a session's **first** input, which stays optimistic; silence there
+  genuinely does mean an agent that does not ack.
+  The ledger is written in `dispatch`, not where the ack is awaited, so an ack that missed its own
+  window still counts — that is the case worth learning from, and a ledger kept at the waiter would see
+  nothing.
+- **Nothing is retried here.** A per-reason retry was designed and discarded: `no-gesture` means either
+  "nothing reached the device" or "the opening frames landed and only the last was refused", and the
+  wire cannot tell them apart, so a client that retried would sometimes apply a drag twice with nobody
+  able to see it had (tapflow#491 carries the vocabulary question). `TapflowClient` also drives
+  `run_flow`, so a retry here makes deterministic replay non-deterministic. Retrying is the caller's
+  decision, and `REASON_ADVICE` is what it decides on — including the warning that `no-gesture` may
+  already have applied part of the input.
+
 ## HOW NOT
 
 - Do not add relay-side logic to this package — it is a client only.
+- **Do not retry an input inside `TapflowClient`.** See above — the reason vocabulary cannot express
+  whether a refused gesture partially landed, so the client cannot know a retry is safe.
 - Do not introduce stateful session management beyond what `TapflowClient` already tracks.

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -240,13 +240,24 @@ describe('TapflowClient', () => {
       expect(err.message).toMatch(/do not repeat/i)
     })
 
-    // An error is an ack: it proves the agent answers. The reason path also skips the device verify, so
-    // it is the cheapest possible proof.
-    it('counts an input:error as evidence that the agent acks', async () => {
+    // Only `input:done` is the agent's word. The relay originates `input:error` to this same socket for
+    // a terminal input it cannot dispatch, so counting errors would let one agent-offline blip mark a
+    // session as acking when its agent may never have answered anything — and every later input would
+    // then be reported as unconfirmed on evidence the agent did not produce.
+    it('does not treat an input:error as evidence that the agent acks', async () => {
       relay.setInputAck('error')
       await expect(client.tap('sess-1', 1, 2)).rejects.toThrow('device not booted')
       relay.setInputAck('none')
-      await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
+      await expect(client.tap('sess-1', 3, 4)).resolves.toBeUndefined()
+    })
+
+    // The relay's own reply, verbatim: `agent offline` with `channel-unavailable`, which is what an
+    // older agent's session looks like from here. It must not arm the gate against that agent.
+    it('is not armed by the relay answering on an absent agent behalf', async () => {
+      relay.setInputAck('none')
+      relay.send({ type: 'input:error', sessionId: 'sess-1', message: 'agent offline', reason: 'channel-unavailable' })
+      await new Promise((r) => setTimeout(r, 20))
+      await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
     })
 
     // The ledger is written where messages arrive, not where an ack is awaited — so an ack that missed
@@ -258,7 +269,9 @@ describe('TapflowClient', () => {
       relay.send({ type: 'input:done', sessionId: 'sess-1' })           // the late ack, no waiter armed
       await new Promise((r) => setTimeout(r, 20))
       await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
-    })
+      // Two serial 2s windows plus a handshake; vitest's unconfigured default is 5s, which this would
+      // otherwise sit at 80% of and flake on a loaded runner.
+    }, 15_000)
 
     // A per-session ledger, not a per-client one: one session's agent acking says nothing about
     // another's. If it were global this would throw.
@@ -549,5 +562,24 @@ describe('REASON_ADVICE', () => {
   // "part of the gesture already landed", and a caller that repeats it may duplicate what did.
   it('warns that no-gesture may already have applied part of the input', () => {
     expect(REASON_ADVICE['no-gesture']).toMatch(/duplicate|already/i)
+  })
+
+  // Uniqueness alone lets two bodies be swapped, which is how a "retry this" could end up on a reason
+  // that must never be retried. These pin the *direction* of each one without freezing its wording —
+  // wording stays a judgement call, per the same rule the dashboard's notices follow.
+  it.each([
+    ['channel-starting', /again/i],          // the only reason whose action is to repeat the input
+    ['dispatch-failed', /do not repeat/i],   // stricter than the protocol table, on purpose
+    ['unsupported', /do not retry/i],
+    ['malformed', /bug/i],
+    ['not-booted', /boot_device/],
+    ['channel-unavailable', /reconnect/i],
+  ] as const)('points %s in the right direction', (reason, expected) => {
+    expect(REASON_ADVICE[reason]).toMatch(expected)
+  })
+
+  // And the two that must not be confusable: one says send it again, the other says never.
+  it('does not tell the caller to repeat an input that may have doubled', () => {
+    expect(REASON_ADVICE['dispatch-failed']).not.toMatch(/safe to send again|try it again/i)
   })
 })

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -206,11 +206,25 @@ describe('TapflowClient', () => {
       await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
     })
 
-    it('rejects (not optimistic) when the relay connection drops mid-input', async () => {
+    // The input is already on the wire by the time the ack is awaited — `tap` sends both frames first —
+    // so a close means "could not confirm", not "was not dispatched". It used to say the latter.
+    it('reports a drop mid-input as unconfirmed, not as undispatched', async () => {
       relay.setInputAck('none') // no ack will arrive
       const p = client.tap('sess-1', 1, 2)
       relay.lastClient().close() // drop the connection while awaiting the ack
-      await expect(p).rejects.toThrow(/closed/i)
+      const err = await p.catch((e: Error) => e)
+      expect(err.message).toMatch(/could not confirm/i)
+      expect(err.message).toMatch(/may have landed/i)
+      expect(err.message).toMatch(/do not repeat/i)
+    })
+
+    // And it does not depend on the ledger: a close is not evidence about whether the agent acks, so a
+    // session that has never answered one still gets the truth rather than an optimistic success.
+    it('reports a drop as unconfirmed even on a session that never acked', async () => {
+      relay.setInputAck('none')
+      const p = client.tap('sess-NEW', 1, 2)
+      relay.lastClient().close()
+      await expect(p).rejects.toThrow(/could not confirm/i)
     })
   })
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { WebSocketServer, WebSocket } from 'ws'
-import { TapflowClient } from '../client.js'
+import { TapflowClient, REASON_ADVICE, reasonAdvice } from '../client.js'
 
 // inputAck models the agent's terminal-input ack: 'done' = new agent (booted), 'error' = rejects with prose only, 'error-with-reason' = rejects with the machine-readable reason too, 'none' = older agent that never acks (degradation).
 function createMockRelay(): {
@@ -211,6 +211,77 @@ describe('TapflowClient', () => {
       const p = client.tap('sess-1', 1, 2)
       relay.lastClient().close() // drop the connection while awaiting the ack
       await expect(p).rejects.toThrow(/closed/i)
+    })
+  })
+
+  // #457. Silence used to be reported as success, so a tap that never reached the device was reported
+  // as landed to a model that then moved on. Two decisions carry the fix, and both are tested here:
+  // silence is answered with "could not confirm" rather than "dropped", and whether it is fatal at all
+  // is decided by what this session has already done rather than by a negotiated flag.
+  //
+  // The silent paths each cost the real 2s ack window. Fake timers are not an option — these drive a
+  // real WebSocket — so the count of them is kept deliberately small.
+  describe('input ack truthfulness (#457)', () => {
+    it('throws once a session has acked before and then goes silent', async () => {
+      await client.tap('sess-1', 1, 2)          // acks: this agent demonstrably answers input
+      relay.setInputAck('none')
+      await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
+    })
+
+    // "Dropped" would invite a retry, and `ackInput` awaits a device verify on the first input after a
+    // boot or reconnect — so an ack past the window can belong to an input that did land. Repeating it
+    // would duplicate it.
+    it('says the input may have landed, and does not call it dropped', async () => {
+      await client.tap('sess-1', 1, 2)
+      relay.setInputAck('none')
+      const err = await client.tap('sess-1', 3, 4).catch((e: Error) => e)
+      expect(err.message).toMatch(/may have landed/i)
+      expect(err.message).not.toMatch(/dropped/i)
+      expect(err.message).toMatch(/do not repeat/i)
+    })
+
+    // An error is an ack: it proves the agent answers. The reason path also skips the device verify, so
+    // it is the cheapest possible proof.
+    it('counts an input:error as evidence that the agent acks', async () => {
+      relay.setInputAck('error')
+      await expect(client.tap('sess-1', 1, 2)).rejects.toThrow('device not booted')
+      relay.setInputAck('none')
+      await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
+    })
+
+    // The ledger is written where messages arrive, not where an ack is awaited — so an ack that missed
+    // its own window still teaches us this agent acks. That case is the whole reason for the placement:
+    // a ledger kept at the waiter would learn nothing from it.
+    it('learns from an ack that arrives after its window expired', async () => {
+      relay.setInputAck('none')
+      await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined() // optimistic, nothing acked
+      relay.send({ type: 'input:done', sessionId: 'sess-1' })           // the late ack, no waiter armed
+      await new Promise((r) => setTimeout(r, 20))
+      await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
+    })
+
+    // A per-session ledger, not a per-client one: one session's agent acking says nothing about
+    // another's. If it were global this would throw.
+    it('does not let one session make another strict', async () => {
+      await client.tap('sess-1', 1, 2)
+      relay.setInputAck('none')
+      await expect(client.tap('sess-OTHER', 3, 4)).resolves.toBeUndefined()
+    })
+
+    // Regression guard for a discarded design. The first plan retried some reasons inside this client;
+    // the design review found that unsafe, because `no-gesture` can mean either "nothing landed" or
+    // "the opening frames landed and only the last was refused" and the wire cannot tell them apart.
+    // Retrying is the caller's decision, so the client must never re-send on its own.
+    it('never re-sends an input on any reason', async () => {
+      relay.setInputAck('error-with-reason')
+      await expect(client.tap('sess-1', 1, 2)).rejects.toThrow()
+      const ends = relay.sentMessages().filter((m) => m['type'] === 'input:touch:end')
+      expect(ends).toHaveLength(1)
+    })
+
+    it('carries the advice for the reason into the thrown message', async () => {
+      relay.setInputAck('error-with-reason') // channel-starting
+      await expect(client.tap('sess-1', 1, 2)).rejects.toThrow(REASON_ADVICE['channel-starting'])
     })
   })
 
@@ -445,5 +516,38 @@ describe('TapflowClient', () => {
       relay.lastClient().close()
       await expect(promise).rejects.toThrow('WebSocket closed')
     })
+  })
+})
+
+// The advice is what a language model acts on, so an entry that is missing, blank, or shared with a
+// reason whose required action differs would send it the wrong way. `tsc` enforces that every reason
+// has a key; none of the rest.
+describe('REASON_ADVICE', () => {
+  const reasons = Object.keys(REASON_ADVICE) as Array<keyof typeof REASON_ADVICE>
+
+  it('gives every reason non-blank advice', () => {
+    for (const r of reasons) expect(REASON_ADVICE[r].trim(), r).not.toBe('')
+  })
+
+  it('gives no two reasons the same advice', () => {
+    const values = reasons.map((r) => REASON_ADVICE[r])
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  // Absence means an agent older than the field, and an unfamiliar value means one newer than this
+  // build. Both resolve to `channel-unavailable` — the protocol's conservative reading — rather than to
+  // silence, which would be the dangerous direction.
+  it.each([undefined, 'some-future-reason', 'toString'])('resolves %s to the channel-unavailable advice', (r) => {
+    expect(reasonAdvice(r)).toBe(REASON_ADVICE['channel-unavailable'])
+  })
+
+  it('resolves a known reason to its own advice', () => {
+    expect(reasonAdvice('no-gesture')).toBe(REASON_ADVICE['no-gesture'])
+  })
+
+  // The one reason whose advice must warn about duplication: it covers both "nothing landed" and
+  // "part of the gesture already landed", and a caller that repeats it may duplicate what did.
+  it('warns that no-gesture may already have applied part of the input', () => {
+    expect(REASON_ADVICE['no-gesture']).toMatch(/duplicate|already/i)
   })
 })

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -270,13 +270,25 @@ export class TapflowClient {
         2_000,
       )
     } catch (e) {
-      // A WebSocket close (or any error that is not the timeout) means the input was not dispatched.
-      if (!(e instanceof Error) || e.message !== 'Request timed out') throw e
-      if (!strict) return
+      if (!(e instanceof Error)) throw e
+      const timedOut = e.message === 'Request timed out'
+      // A dropped connection is *also* unconfirmed, not undispatched. Every caller sends its input
+      // before awaiting the ack — `tap` sends both frames, `swipe` all ten — so by the time the socket
+      // closes the input has left this process and the relay may already have forwarded it. This branch
+      // used to claim the opposite, which is the same false certainty the rest of this method exists to
+      // remove. It is unconfirmed regardless of the ledger: a close says nothing about whether the agent
+      // acks, only that we stopped being able to hear it.
+      const disconnected = e.message === 'WebSocket closed'
+      // The one case the optimistic path is still for: silence from a session that has never answered
+      // an input at all is an agent that does not answer them.
+      if (timedOut && !strict) return
+      if (!timedOut && !disconnected) throw e
+      const cause = timedOut
+        ? 'this session has acknowledged input before, and this one went unanswered'
+        : 'the relay connection dropped before the acknowledgement arrived'
       throw new Error(
-        'Could not confirm the input reached the device: this session has acknowledged input before, ' +
-        'and this one went unanswered. Do not repeat the input — it may have landed. Check the device ' +
-        'state (screenshot or ui_tree) before deciding what to do next.',
+        `Could not confirm the input reached the device: ${cause}. Do not repeat the input — it may ` +
+        'have landed. Check the device state (screenshot or ui_tree) before deciding what to do next.',
       )
     }
     if (msg['type'] === 'input:error') {

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,4 +1,4 @@
-import type { BrowserToRelay } from '@tapflowio/protocol'
+import type { BrowserToRelay, InputErrorReason } from '@tapflowio/protocol'
 import { WebSocket } from 'ws'
 
 export interface DeviceInfo {
@@ -56,9 +56,42 @@ interface Waiter {
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
+/**
+ * What the caller should do about a refused input, keyed by the wire reason.
+ *
+ * The caller here is a language model, so this is advice rather than a machine action — and that is
+ * the decision, not a limitation. An automatic retry inside this client would hide a duplicate-input
+ * hazard from the only party able to judge it: `no-gesture` in particular can mean either "nothing
+ * reached the device" or "the opening frames already landed and only the last was refused", and the
+ * wire cannot tell them apart (see the note on tapflow#491). A client that retried would sometimes
+ * apply a drag twice with nobody able to see that it had. `TapflowClient` also drives `run_flow`, so
+ * a retry here would make deterministic replay non-deterministic.
+ */
+export const REASON_ADVICE: Record<InputErrorReason, string> = {
+  'not-booted': 'The device is not running. Call boot_device for this session before sending input.',
+  'channel-unavailable': 'The input channel is gone. Reconnect the session before sending more input; repeating this input will not help.',
+  'channel-starting': 'The input channel is still coming up. The same input is safe to send again in a moment.',
+  'dispatch-failed': 'The device rejected the input, and whether it landed is not knowable. Do not repeat it.',
+  unsupported: 'This input is not supported on the active connection to the device. Do not retry it.',
+  malformed: 'The message did not carry what the input needs. This is a bug in tapflow rather than something to retry.',
+  'no-gesture': 'The gesture this input was completing is gone. Part of it may already have been applied to the device, so repeating it may duplicate what landed.',
+}
+
+export function reasonAdvice(reason: string | undefined): string {
+  // Absent or unrecognised resolves to `channel-unavailable`, per the protocol's conservative rule.
+  // `Object.hasOwn`, not `in`: a reason of `toString` would otherwise return a function.
+  const key: InputErrorReason =
+    reason !== undefined && Object.hasOwn(REASON_ADVICE, reason)
+      ? (reason as InputErrorReason)
+      : 'channel-unavailable'
+  return REASON_ADVICE[key]
+}
+
 export class TapflowClient {
   private ws: WebSocket | null = null
   private waiters: Waiter[] = []
+  /** Sessions that have answered at least one input. See `awaitInputAck`. */
+  private ackedSessions = new Set<string>()
 
   constructor(
     private readonly relayUrl: string,
@@ -97,6 +130,14 @@ export class TapflowClient {
   }
 
   private dispatch(msg: RelayMsg): void {
+    // Recorded here rather than where the ack is awaited, because the ack that teaches us the most is
+    // the one that arrives *late*: it missed its window, was reported optimistically, and still proves
+    // this agent acks — so the next input can be judged strictly. A ledger kept at the waiter would
+    // never see it.
+    if (msg['type'] === 'input:done' || msg['type'] === 'input:error') {
+      const sid = msg['sessionId']
+      if (typeof sid === 'string') this.ackedSessions.add(sid)
+    }
     for (let i = 0; i < this.waiters.length; i++) {
       if (this.waiters[i].predicate(msg)) {
         const [w] = this.waiters.splice(i, 1)
@@ -170,34 +211,54 @@ export class TapflowClient {
     )
   }
 
-  // Awaits the agent's terminal-input ack (sent on the gesture's last message).
-  // input:error → the device wasn't booted / no input channel, so the gesture was
-  // dropped: surface it as a failure. A timeout means an older agent/relay that
-  // doesn't ack input — fall back to optimistic success so tap/swipe keep working
-  // (additive protocol, graceful degradation).
+  /**
+   * Awaits the agent's terminal-input ack, sent on the gesture's last message.
+   *
+   * Silence used to be reported as **success**: the fallback existed for agents predating the ack
+   * protocol, and it outlived them, so a tap that never reached the device was reported as landed to a
+   * model that then moved on (#457).
+   *
+   * Two things make the fix honest.
+   *
+   * **Silence is answered with "could not confirm", never with "dropped".** `ackInput` awaits a
+   * `simctl list` / `adb` device verify on the first input after a boot or reconnect, on the same Mac
+   * the relay gates at 80% CPU — so an ack past the window can belong to an input that *did* land.
+   * Calling that a drop invites a retry, and a retry of a landed input duplicates it.
+   *
+   * **Whether silence is fatal is decided by what this session has already done**, not by a
+   * negotiated flag. If it has answered an input before, the agent demonstrably acks and later silence
+   * is a real anomaly. If it never has, this is an agent that does not ack at all and the optimistic
+   * path is correct for it. That degrades in the safe direction and needs nothing on the wire — where
+   * a capability flag would have to be advertised, kept in step across both agents, and then live
+   * forever as an inert field once every install has it.
+   *
+   * The residual gap is the **first** input of a session, which stays optimistic. Bounded to one input,
+   * and silence there genuinely does mean "an agent that does not ack".
+   */
   private async awaitInputAck(sessionId: string): Promise<void> {
+    const strict = this.ackedSessions.has(sessionId)
     let msg: RelayMsg
     try {
       msg = await this.waitFor(
         (m) =>
           (m['type'] === 'input:done' || m['type'] === 'input:error') &&
           m['sessionId'] === sessionId,
-        // Short window: acks are near-instant (the reconnect-verify adds one sub-second simctl/adb call); a lapse means an older agent/relay that never acks → optimistic (see catch below).
         2_000,
       )
     } catch (e) {
-      // Only a timeout means an older agent/relay that never acks → assume dispatched.
-      // A WebSocket close (or any other error) means the input was NOT dispatched — surface it.
-      if (e instanceof Error && e.message === 'Request timed out') return
-      throw e
+      // A WebSocket close (or any error that is not the timeout) means the input was not dispatched.
+      if (!(e instanceof Error) || e.message !== 'Request timed out') throw e
+      if (!strict) return
+      throw new Error(
+        'Could not confirm the input reached the device: this session has acknowledged input before, ' +
+        'and this one went unanswered. Do not repeat the input — it may have landed. Check the device ' +
+        'state (screenshot or ui_tree) before deciding what to do next.',
+      )
     }
     if (msg['type'] === 'input:error') {
-      // Surface the machine-readable reason alongside the prose. Acting on it — retrying a
-      // `channel-starting` instead of failing, and dropping the optimistic timeout fallback above
-      // for reasons that say "never retry" — is #457, not this change.
       const reason = msg['reason'] as string | undefined
       const prose = (msg['message'] as string) ?? 'Input failed'
-      throw new Error(reason ? `${prose} (${reason})` : prose)
+      throw new Error(`${prose}${reason ? ` (${reason})` : ''} — ${reasonAdvice(reason)}`)
     }
   }
 

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -71,6 +71,14 @@ export const REASON_ADVICE: Record<InputErrorReason, string> = {
   'not-booted': 'The device is not running. Call boot_device for this session before sending input.',
   'channel-unavailable': 'The input channel is gone. Reconnect the session before sending more input; repeating this input will not help.',
   'channel-starting': 'The input channel is still coming up. The same input is safe to send again in a moment.',
+  // Deliberately stricter than the protocol table, which says "may retry once". The only producer is
+  // Android's pointer dispatch, and `android-agent/AGENTS.md` records what the call deadline does and
+  // does not buy: it cancels our call, not a request the emulator already applied, so the case it
+  // actually fires in is a connected-but-unresponsive emulator where "did it land" is unknowable and
+  // "a caller that retries on the error can double it". That analysis postdates and corrects the
+  // source comment on `dispatchTo`, which still reads "safe to retry". Which of the two the protocol
+  // table should follow is open (tapflow#491); until it is settled the advice a model acts on takes
+  // the side that cannot double an input.
   'dispatch-failed': 'The device rejected the input, and whether it landed is not knowable. Do not repeat it.',
   unsupported: 'This input is not supported on the active connection to the device. Do not retry it.',
   malformed: 'The message did not carry what the input needs. This is a bug in tapflow rather than something to retry.',
@@ -130,11 +138,19 @@ export class TapflowClient {
   }
 
   private dispatch(msg: RelayMsg): void {
+    // `input:done` only, and that is load-bearing: the **relay** originates `input:error` to this very
+    // socket for a terminal input it cannot dispatch (`RelayServer.ts`, `'agent offline'` /
+    // `'Session not found'`, both `channel-unavailable`). Counting those would let one agent-offline
+    // blip — or an input for a session this client never joined — mark a session as acking when its
+    // agent may never have answered anything, and every later input would then be reported as
+    // unconfirmed on the strength of evidence the agent did not produce. Nothing in the relay
+    // originates an `input:done`, so that one is the agent's word and no one else's.
+    //
     // Recorded here rather than where the ack is awaited, because the ack that teaches us the most is
     // the one that arrives *late*: it missed its window, was reported optimistically, and still proves
     // this agent acks — so the next input can be judged strictly. A ledger kept at the waiter would
     // never see it.
-    if (msg['type'] === 'input:done' || msg['type'] === 'input:error') {
+    if (msg['type'] === 'input:done') {
       const sid = msg['sessionId']
       if (typeof sid === 'string') this.ackedSessions.add(sid)
     }
@@ -232,8 +248,16 @@ export class TapflowClient {
    * a capability flag would have to be advertised, kept in step across both agents, and then live
    * forever as an inert field once every install has it.
    *
-   * The residual gap is the **first** input of a session, which stays optimistic. Bounded to one input,
-   * and silence there genuinely does mean "an agent that does not ack".
+   * The residual gap is any session that has never had an answer — usually just its first input, but
+   * **not bounded to one**: an agent whose acks never arrive at all keeps the optimistic path
+   * indefinitely, and #457 is unchanged for it. What the gate buys is that the moment a session answers
+   * once, silence after that is reported. Closing the rest needs something that distinguishes "does not
+   * ack" from "did not ack this time", which per-input acks cannot express on their own.
+   *
+   * One thing this does **not** fix: an ack carries no correlation id, so the predicate below matches
+   * any ack for the session. An ack that arrives after its own input timed out is consumed by the next
+   * input's waiter, which then reports the previous input's outcome. Recorded as a known gap rather than
+   * papered over — see the issue linked from `AGENTS.md`.
    */
   private async awaitInputAck(sessionId: string): Promise<void> {
     const strict = this.ackedSessions.has(sessionId)


### PR DESCRIPTION
Closes #457.

`awaitInputAck` waited 2s for `input:done` / `input:error` and, on timeout, **returned successfully**. So `tap`, `swipe` and every other terminal gesture reported success when nothing had acked, and the model driving the session was told the tap landed and moved on. The fallback existed for agents predating the ack protocol and outlived them — both agents ack every terminal input (#484, #488), and since #495 every producer sends a reason too, so with both ends current silence means something is actually wrong.

## Three decisions, all of which the review changed

**Silence is "could not confirm", not "dropped".** `ackInput` awaits a device verify on the first input after a boot or reconnect, on the same Mac the relay gates at 80% CPU — so an ack past the window can belong to an input that *did* land. Calling that a drop invites a retry, and a retry of a landed input duplicates it. The error says the input may have landed and to check device state instead of repeating.

**Whether silence is fatal is decided by what the session has already done**, not by a negotiated flag. `ackedSessions` records any session that has answered with `input:done`; only those are judged strictly. An agent that never acks is never judged, which needs nothing on the wire. The ledger is written in `dispatch` rather than at the waiter, so an ack that missed its own window still counts — that is the case worth learning from.

**Nothing is retried here.** Each reason carries advice for the caller instead, including a warning that `no-gesture` may already have applied part of the input.

## What the reviews took out

**The design review discarded both halves of the first plan and cut it from four packages to one.**

A per-reason auto-retry was unsafe on both platforms. `no-gesture` means either "nothing reached the device" or "the opening frames landed and only the last was refused" — `TouchHelper`'s ownership record is deliberately conditional on delivery, so both are real — and the wire reason is identical, so a client that retried would sometimes apply a 300ms drag twice with nobody able to see it had. On Android the same reason can follow a `touchDown` that reached the guest, with the retry then going out over a different backend. `TapflowClient` also drives `run_flow`, where a retry makes deterministic replay non-deterministic.

A capability flag (`'input-ack'`) was the wrong mechanism. My sticky-capabilities argument was contradicted by the protocol's own comment — *"a restarted agent may advertise a different set (an upgrade is the usual reason to restart one)"* — and a **rollback** restart would have made the client report every input as dropped to an agent that cannot ack, inviting exactly the double-input the retry cell was rejected for. It was also a version stamp wearing capability clothing: both agents would have had to advertise it, a static check would police the pairing, and one release cycle later it would be permanently inert and unremovable because consumers key on its absence. And it would have pre-decided the fork #491 is explicitly open on, while listing this work as its prerequisite.

**The pre-PR review then found a blocker, and it was mine from earlier the same day.** The ledger counted `input:error` as evidence too — but the relay originates `input:error` to this very socket for a terminal input it cannot dispatch, which is the reply #495 had just given a reason to. One agent-offline blip, or a single input for a session this client never joined, marked a session as acking when its agent may never have answered anything; every later input then threw "this session has acknowledged input before", which was false, at the exact population the optimistic path protects. Counting only `input:done` fixes it and is simpler: nothing in the relay originates one.

It also caught that "bounded to one input" was false (the gap is any session that never gets an answer), that the advice suite pinned uniqueness but not direction so two bodies could be swapped, and that one test sat at 80% of vitest's unconfigured 5s default.

One finding I did not accept as stated: the reviewer read the `dispatch-failed` advice as inverting the protocol, citing `dispatchTo`'s comment that the deadline made a retry safe. That comment had itself been refuted by the analysis in `android-agent/AGENTS.md` written during the PR that reviewed it (#488) — the deadline cancels our call, not a request the emulator applied. So the advice stands and **the stale comment is corrected here**, since it is what misleads a reader. Which side the protocol table should take is #491's.

## Review

`.work/reviews/fix__mcp-input-ack-truthfulness.md` — design round (2 channels, discarded the design) and a pre-PR round against `2dd32ee`. 10 mutations, 2 of them regression guards for what the reviews removed.

## Follow-up filed

**#499** — an input ack carries no correlation id, so an ack arriving after its own input timed out is consumed by the next input's waiter and reports the previous input's outcome. It predates this change and this change makes it consequential; it needs a field on the wire, and `clipboard:*` already sets the precedent with `requestId`. Documented next to the gate rather than papered over, because it is the one way that gate can still be defeated.

Full suite 2200 passed + 1 skip (mcp-server 41 → 63); typecheck, lint, build and a11y-lens clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input errors now include actionable guidance, including when to retry, reconnect, reboot, or investigate.
  * Input acknowledgement status is tracked independently for each session.
  * Previously acknowledged sessions report unanswered or disconnected inputs as unconfirmed.

* **Bug Fixes**
  * Prevented automatic retries when input delivery is uncertain.
  * Improved handling of input errors, late acknowledgements, and acknowledgement timeouts.

* **Documentation**
  * Clarified timeout behavior and safe retry guidance for input dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->