### PR TITLE
refactor(protocol): declare wire payload types once, and add a check that keeps them there

### DIFF
--- a/.changeset/wire-l2-payload-types.md
+++ b/.changeset/wire-l2-payload-types.md
@@ -1,0 +1,43 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/agent-core': patch
+'@tapflowio/flow-runner': patch
+'@tapflowio/mcp-server': patch
+'@tapflowio/relay': patch
+---
+
+refactor(protocol): wire payload types are declared once, and a check keeps them that way
+
+Every wire payload type was declared separately in three to five packages, and they had drifted **in
+both directions**: `@tapflowio/protocol` was missing the `payload` field on `clipboard:error` that both
+agents send and the viewer reads, while the dashboard's `session:chrome` declaration was missing three
+fields its own `DeviceViewer` reads. Nothing checked either side, which is the situation
+`@tapflowio/protocol` was created to end — it had been half done.
+
+Protocol now owns them and everyone else imports: `ChromeData`, `ChromeButton`, `ChromeRect`,
+`AndroidButton`, `AgentResources`, `SessionInfo`, `Point`, and `ClipboardErrorPayload` (which moves out
+of `agent-core`, since neither the dashboard nor `mcp-server` can reach that package). `agent-core`,
+`flow-runner` and the relay re-export the names they published, so no consumer of those packages
+changes — including third-party agents built on `AgentRegistry.register()`.
+
+Three shapes were also the same thing under different names, which is how the duplication survived:
+protocol's `DeviceSummary` was `AgentDevice` in the dashboard and `DeviceInfo` in `mcp-server` and
+`flow-runner`, and that last name collided with the relay's own `DeviceInfo`, which is a *different*
+shape. `DeviceSummary` is now the one name; `flow-runner` keeps exporting `DeviceInfo` as an alias
+because the CLI imports it.
+
+**The comments moved with the types, and that mattered more than the types.** `ChromeData`'s fields
+were described accurately only in `ios-agent`, which produces them: the viewer lays out against an
+*expanded* composite canvas (the device frame grown by the button margins), and protocol's copy said
+`compositeWidth` was "full PDF width including devicePadding" — a different quantity. Deleting the
+producer's declaration would have deleted the only correct description of the coordinate space three
+viewers compute against. Protocol's fields now carry it, with the two spaces named explicitly.
+
+A new check (`scripts/__tests__/protocolPayloadTypes.test.mjs`) fails if any package re-declares a
+protocol payload shape. It matches on **field sets, not names** — the inventory that planned this work
+grepped for names and missed two of the five copies of one shape for exactly the reason above, so a
+name-scoped check would have passed with all five standing and would be bypassed by a rename. It found
+two more copies during implementation: the relay's own `SessionInfo` and `agent-core`'s `Point`.
+
+No behaviour change: type declarations, imports and comments only. Every package's test count is
+unchanged.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -56,6 +56,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@tapflowio/protocol": "workspace:*",
     "ws": "^8.21.1"
   },
   "devDependencies": {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -1,3 +1,14 @@
+import type { AndroidButton, AgentResources, ClipboardErrorPayload, Point } from '@tapflowio/protocol'
+
+// These three are **wire** payload types, so `@tapflowio/protocol` owns them — it is the leaf both
+// consumers that read them can reach, and this package is not one of them (neither `dashboard` nor
+// `mcp-server` depends on `agent-core`). Re-exported under the same names so agent code and
+// third-party agents built on `AgentRegistry.register()` are unaffected.
+//
+// `export type`, not a bare `export { … } from`: the latter is a real runtime import of protocol's
+// `dist`, which would drag this package into the source-resolution rule in the root AGENTS.md.
+export type { AndroidButton, AgentResources, ClipboardErrorPayload, Point }
+
 export type Platform = string
 
 export type DeviceStatus = 'booted' | 'shutdown' | 'unknown'
@@ -11,26 +22,9 @@ export interface Device {
   osVersion?: string  // e.g. "iOS 18.3"
 }
 
-export interface Point {
-  x: number
-  y: number
-}
 
-export interface AgentResources {
-  cpuPercent: number
-  memUsedMB: number
-  memTotalMB: number
-  slotsAvailable: number
-  slotsTotal: number
-  reportedAt: number  // Date.now()
-}
 
 // Android physical button descriptor sent via session:chrome payload
-export interface AndroidButton {
-  name: string
-  accessibilityTitle: string
-  keyCode: number
-}
 
 // Closed role vocabulary shared by all platforms. Unmappable native roles
 // become 'other'; the platform-native string is preserved in rawRole.
@@ -75,21 +69,6 @@ export interface UIElement {
 // plain string list on the wire rather than a helper nobody on the reading side can call.
 export type AgentCapability = 'clipboard'
 
-/** Payload on every `clipboard:error` from a read. `sentinelParked` answers the one question the
- *  viewer needs to decide its fallback: is a marker still sitting on the device clipboard?
- *
- *  If it is, the agent's restore is about to overwrite whatever the device copies next, so
- *  pressing the plain chord as a fallback would hand the user a stale value — the exact bug the
- *  sentinel exists to prevent. If it is not, the chord is safe and is the only way the copy
- *  happens at all. Absent means "assume parked": an agent from before this field cannot tell us,
- *  and the silent-stale-paste failure is worse than a copy that did not happen.
- *
- *  `unsupported` is narrower — this backend has no clipboard channel whatsoever — and drives the
- *  paste fallback and the wording of the toast. */
-export interface ClipboardErrorPayload {
-  unsupported?: boolean
-  sentinelParked?: boolean
-}
 
 // ── Clipboard bridge shared contract ────────────────────────────────────────
 // Both agents implement the same protocol, so the limits and the sentinel vocabulary

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -24,5 +24,5 @@
     "dist",
     "node_modules"
   ],
-  "references": []
+  "references": [{ "path": "../protocol" }]
 }

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -7,7 +7,7 @@ import { usePerfMode } from '@/hooks/usePerfMode';
 import { IOSViewer } from './device/IOSViewer';
 import { AndroidViewer } from './device/AndroidViewer';
 import { SimulatorInfoCard } from './device/shared/SimulatorInfoCard';
-import type { AndroidButton, ChromeData, RelayMessage } from '@/lib/types';
+import type { AndroidChrome, ChromeData, RelayMessage } from '@/lib/types';
 import type { FrameTiming, PerfHook } from './perf/types';
 import { parseEnvelopeHeader, HEADER_SIZE, CODEC_H264, CODEC_AUDIO, type BinaryFrameHandler } from '@/lib/envelope';
 import { useAudioPlayback } from '@/hooks/useAudioPlayback';
@@ -29,8 +29,6 @@ interface Props {
    *  the parent decides where to go. */
   onSessionEnded?: (reason: SessionTerminatedReason) => void;
 }
-
-type AndroidChrome = { buttons: AndroidButton[]; streamType: 'h264'; screenWidth?: number; screenHeight?: number; cornerRadius?: number };
 
 export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecordingUploaded, onSessionEnded }: Props) {
   const sendRef = useRef<(msg: BrowserToRelay) => void>(() => {});

--- a/packages/dashboard/hooks/useAgentSession.ts
+++ b/packages/dashboard/hooks/useAgentSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRelay } from '@/hooks/useRelay'
-import type { AgentDevice, RelayMessage, SessionInfo } from '@/lib/types'
+import type { DeviceSummary, RelayMessage, SessionInfo } from '@/lib/types'
 
 export function useAgentSession(os: string) {
   const [sessions, setSessions] = useState<SessionInfo[]>([])
@@ -43,7 +43,7 @@ export function useAgentSession(os: string) {
 
   const agentGroups = sessions.filter((s) => s.devices.some((d) => d.platform === os))
 
-  const startDevice = useCallback((d: AgentDevice) => {
+  const startDevice = useCallback((d: DeviceSummary) => {
     setDeviceId(d.id)
     setBooting(true)
     setStatus('Booting…')

--- a/packages/dashboard/lib/coordinate-transform.ts
+++ b/packages/dashboard/lib/coordinate-transform.ts
@@ -1,5 +1,7 @@
-/** Normalized screen coordinate, each axis in [0, 1]. */
-export type NormPoint = { x: number; y: number }
+// The normalized 0-1 screen coordinate is the wire's own `Point` — the payload of
+// `input:touch:*`. Re-exported under this package's name, which says the units out loud.
+import type { Point } from '@tapflowio/protocol'
+export type { Point as NormPoint }
 
 /**
  * Convert a raw pointer position to a normalized screen coordinate for iOS.
@@ -13,13 +15,13 @@ export type NormPoint = { x: number; y: number }
  * (chrome JSON stores 2× values; the caller divides by 2 before passing here).
  */
 export function iosToNormScreen(
-  point: NormPoint,
+  point: Point,
   rect: { left: number; top: number; width: number; height: number },
   compositeW: number,
   compositeH: number,
   screenRect: { x: number; y: number; width: number; height: number },
   isLandscape: boolean,
-): NormPoint | null {
+): Point | null {
   const { x: sx, y: sy, width: sw, height: sh } = screenRect
   let cx: number, cy: number
   if (isLandscape) {
@@ -42,10 +44,10 @@ export function iosToNormScreen(
  *   portrait_x = yv,  portrait_y = 1 - xv
  */
 export function androidToNorm(
-  point: NormPoint,
+  point: Point,
   rect: { left: number; top: number; width: number; height: number },
   needsCSSRotation: boolean,
-): NormPoint | null {
+): Point | null {
   const xv = (point.x - rect.left) / rect.width
   const yv = (point.y - rect.top) / rect.height
   if (xv < 0 || xv > 1 || yv < 0 || yv > 1) return null
@@ -57,7 +59,7 @@ export function androidToNorm(
  * Given the second finger's normalized position, return both finger positions
  * for a pinch gesture. The first finger is the point-symmetric counterpart.
  */
-export function toPinchFingers(f1: NormPoint): { f0: NormPoint; f1: NormPoint } {
+export function toPinchFingers(f1: Point): { f0: Point; f1: Point } {
   return { f0: { x: 1 - f1.x, y: 1 - f1.y }, f1 }
 }
 

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -1,22 +1,16 @@
-import type { InputErrorReason, SessionTerminatedReason } from '@tapflowio/protocol'
+// Wire payload types come from `@tapflowio/protocol`, which owns them — this file used to declare
+// its own copies and they drifted (`session:chrome` here lacked three fields `DeviceViewer` reads).
+// `AgentDevice` and `DeviceInfo` were this package's names for shapes protocol calls `DeviceSummary`
+// and `DeviceDetails`; the old `DeviceInfo` also collided with the relay's own `DeviceInfo`, which is
+// the *other* shape. Re-exported so this module stays the one import site for view code.
+import type {
+  AgentResources, AndroidButton, ChromeButton, ChromeData, ChromeRect,
+  AndroidChrome, ChromePayload, ClipboardErrorPayload, DeviceDetails, DeviceSummary, InputErrorReason, SessionInfo, SessionTerminatedReason,
+} from '@tapflowio/protocol'
 
-export interface AgentResources {
-  cpuPercent: number
-  memUsedMB: number
-  memTotalMB: number
-  slotsAvailable: number
-  slotsTotal: number
-  reportedAt: number
-}
-
-export interface AgentDevice {
-  id: string
-  name: string
-  platform: string
-  status: string
-  osVersion?: string
-  sessionId: string
-  busy: boolean
+export type {
+  AgentResources, AndroidButton, ChromeButton, ChromeData, ChromeRect,
+  AndroidChrome, ChromePayload, DeviceDetails, DeviceSummary, SessionInfo,
 }
 
 export interface Comment {
@@ -32,61 +26,6 @@ export interface CommentAttachment {
   id: number
   file_path: string
   mime: string
-}
-
-export interface SessionInfo {
-  agentName?: string
-  platform?: string
-  resources?: AgentResources
-  devices: AgentDevice[]
-}
-
-export interface ChromeRect {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
-export interface ChromeButton {
-  name: string
-  accessibilityTitle: string
-  anchor: string
-  onTop: boolean                            // true = button is above device frame (e.g. home button)
-  normalOffset: { x: number; y: number }   // button center at retracted/default position in 2× composite px
-  rolloverOffset: { x: number; y: number } // button center at extended/hover position in 2× composite px
-  buttonW: number                           // button width in 2× composite px
-  buttonH: number                           // button height in 2× composite px
-  usagePage: number                         // HID usage page for SimulatorKit injection (0 = unknown)
-  usage: number                             // HID usage code (0 = unknown)
-  buttonPng?: string                        // base64 PNG of button at 2× (for CSS-animated overlay)
-  pressedPng?: string                       // base64 PNG of pressed state (imageDown asset)
-  pressedRect?: ChromeRect
-}
-
-export interface AndroidButton {
-  name: string
-  accessibilityTitle: string
-  keyCode: number
-}
-
-export interface ChromeData {
-  framePng: string         // full composite PDF at 2× — device frame visible, screen hole transparent
-  bezelWidth: number
-  bezelHeight: number
-  compositeWidth: number   // full PDF width including devicePadding, at 2× px
-  compositeHeight: number  // full PDF height including devicePadding, at 2× px
-  padding: { left: number; right: number; top: number; bottom: number }
-  screenRect: ChromeRect
-  screenCornerRadius: number  // screen corner radius in 2× px (0 if device has no rounded corners)
-  logicalWidth: number
-  logicalHeight: number
-  buttons: ChromeButton[]
-}
-
-export interface DeviceInfo {
-  deviceName: string
-  osVersion: string
 }
 
 export interface Recording {
@@ -148,8 +87,8 @@ export type RelayMessage =
   | { type: 'session:terminated'; sessionId: string; reason: SessionTerminatedReason }
   | { type: 'session:agent-away'; sessionId: string }
   | { type: 'session:rebound'; sessionId: string; capabilities: string[] }
-  | { type: 'session:chrome'; payload: ChromeData | { buttons: AndroidButton[]; streamType: 'h264' } }
-  | { type: 'session:deviceInfo'; payload: DeviceInfo }
+  | { type: 'session:chrome'; payload: ChromePayload }
+  | { type: 'session:deviceInfo'; payload: DeviceDetails }
   | { type: 'device:booting' }
   | { type: 'device:ready'; payload: { deviceId: string } }
   | { type: 'device:boot-error'; sessionId?: string; message: string }
@@ -166,5 +105,5 @@ export type RelayMessage =
   // agent → browser
   | { type: 'clipboard:data'; sessionId: string; requestId: string; payload: { text: string } }
   | { type: 'clipboard:write-done'; sessionId: string; requestId: string }
-  | { type: 'clipboard:error'; sessionId: string; requestId: string; message: string; payload?: { unsupported?: boolean; sentinelParked?: boolean } }
+  | { type: 'clipboard:error'; sessionId: string; requestId: string; message: string; payload?: ClipboardErrorPayload }
   | { type: 'error'; message: string }

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import type { AgentDevice, Build, RelayMessage, SessionInfo } from '@/lib/types'
+import type { DeviceSummary, Build, RelayMessage, SessionInfo } from '@/lib/types'
 
 vi.mock('@/lib/queries', () => ({
   getBuild: vi.fn(),
@@ -25,7 +25,7 @@ const makeSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
   ...overrides,
 })
 
-const makeDevice = (overrides: Partial<AgentDevice> = {}): AgentDevice => ({
+const makeDevice = (overrides: Partial<DeviceSummary> = {}): DeviceSummary => ({
   id: 'avd:Pixel_7',
   name: 'Pixel 7',
   platform: 'android',
@@ -197,7 +197,7 @@ describe('useAgentSession', () => {
 // ─── useDeviceSelector ─────────────────────────────────────────────────────────
 
 describe('useDeviceSelector', () => {
-  const devices: AgentDevice[] = [
+  const devices: DeviceSummary[] = [
     makeDevice({ id: 'd1', name: 'Pixel 7', osVersion: 'Android 14', platform: 'android' }),
     makeDevice({ id: 'd2', name: 'Pixel 6', osVersion: 'Android 13', platform: 'android' }),
     makeDevice({ id: 'd3', name: 'iPhone 15', osVersion: 'iOS 17', platform: 'ios' }),
@@ -221,7 +221,7 @@ describe('useDeviceSelector', () => {
   })
 
   it('returns osVersions sorted descending (newest first)', () => {
-    const mixedDevices: AgentDevice[] = [
+    const mixedDevices: DeviceSummary[] = [
       makeDevice({ osVersion: 'Android 13', platform: 'android' }),
       makeDevice({ osVersion: 'Android 15', platform: 'android' }),
       makeDevice({ osVersion: 'Android 14', platform: 'android' }),

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -27,7 +27,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SearchInput } from '@/components/ui/search-input';
-import type { AgentDevice, SessionInfo } from '@/lib/types';
+import type { DeviceSummary, SessionInfo } from '@/lib/types';
 import { getResourceHealth, type ResourceHealth } from '@/lib/resource-health';
 
 // Keyed by the reason so a new one cannot be added without deciding what the user is told. A
@@ -78,7 +78,7 @@ export function QASession() {
   //
   // Consumed on click, not on success — a failed boot does not re-arm it. Asking again means
   // turning it on again, which keeps an irreversible action tied to an explicit act.
-  const handleStartDevice = useCallback((d: AgentDevice) => {
+  const handleStartDevice = useCallback((d: DeviceSummary) => {
     consumeResetMode();
     startDevice(d);
   }, [consumeResetMode, startDevice]);
@@ -248,7 +248,7 @@ export function QASession() {
                 </p>
               ) : (
                 <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2">
-                  {versionedDevices.map((d: AgentDevice) => {
+                  {versionedDevices.map((d: DeviceSummary) => {
                     const isBooted = d.status === 'booted'
                     const isBusy = d.busy
                     const statusLabel = isBusy ? 'In use' : isBooted ? 'Booted' : 'Available'

--- a/packages/flow-runner/package.json
+++ b/packages/flow-runner/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@tapflowio/agent-core": "workspace:*",
+    "@tapflowio/protocol": "workspace:*",
     "ws": "^8.21.1",
     "yaml": "^2.6.0"
   },

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -1,3 +1,4 @@
+import type { DeviceSummary } from '@tapflowio/protocol'
 import { WebSocket } from 'ws'
 import type { UIElement } from '@tapflowio/agent-core'
 import { PlatformError } from '@tapflowio/agent-core'
@@ -16,20 +17,14 @@ class RelayHttpError extends PlatformError {
 // (agent/foreground-race 502, idle-timeout 504, 5xx, network 0) is retryable.
 const PERMANENT_QUERY_STATUSES = new Set([400, 401, 403, 404, 409])
 
-export interface DeviceInfo {
-  id: string
-  name: string
-  platform: string
-  status: string
-  osVersion?: string
-  sessionId: string
-  busy: boolean
-}
+// Protocol owns the wire shape. The name stays `DeviceInfo` because it is exported from this
+// package's public entry and `@tapflowio/cli` imports it — renaming would be a breaking change.
+export type { DeviceSummary as DeviceInfo } from '@tapflowio/protocol'
 
 export interface AgentSession {
   agentName?: string
   platform?: string
-  devices: DeviceInfo[]
+  devices: DeviceSummary[]
 }
 
 type RelayMsg = Record<string, unknown>

--- a/packages/flow-runner/tsconfig.json
+++ b/packages/flow-runner/tsconfig.json
@@ -24,7 +24,7 @@
     "dist",
     "node_modules"
   ],
-  "references": [
+  "references": [{ "path": "../protocol" },
     {
       "path": "../agent-core"
     }

--- a/packages/ios-agent/src/DeviceChromeLoader.ts
+++ b/packages/ios-agent/src/DeviceChromeLoader.ts
@@ -4,47 +4,17 @@ import { execFileSync } from 'child_process'
 import { existsSync, readFileSync, writeFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+// The chrome types are the wire payload of `session:chrome`, so `@tapflowio/protocol` owns them.
+// Their field descriptions — including the expanded-composite coordinate space this file computes —
+// moved there with them.
+import type { ChromeData, ChromeButton, ChromeRect } from '@tapflowio/protocol'
 
 const CHROME_MAP_PATH = '/Library/Developer/DeviceKit/chrome_map.plist'
 const CHROME_DIR = '/Library/Developer/DeviceKit/Chrome'
 const PROFILES_DIR = '/Library/Developer/CoreSimulator/Profiles/DeviceTypes'
 
-export interface ChromeRect {
-  x: number
-  y: number
-  width: number
-  height: number
-}
 
-export interface ChromeButton {
-  name: string
-  accessibilityTitle: string
-  anchor: string
-  onTop: boolean                            // true = button is above device frame (e.g. home button)
-  normalOffset: { x: number; y: number }   // button center in expanded composite 2× px (retracted/default)
-  rolloverOffset: { x: number; y: number } // button center at rollover (extended/hover) position
-  buttonW: number                           // button width in 2× composite px
-  buttonH: number                           // button height in 2× composite px
-  usagePage: number                         // HID usage page for SimulatorKit injection (0 = unknown)
-  usage: number                             // HID usage code (0 = unknown)
-  buttonPng?: string                        // base64 PNG of button at 2× (for CSS-animated overlay)
-  pressedPng?: string                       // base64 PNG of pressed state (imageDown asset)
-  pressedRect?: ChromeRect                  // position + size in expanded composite 2× px
-}
 
-export interface ChromeData {
-  framePng: string         // composite + buttons baked in at 2× — screen hole transparent
-  bezelWidth: number       // composite minus devicePadding, at 2× px
-  bezelHeight: number
-  compositeWidth: number   // expanded canvas width (composite + button margins), at 2× px
-  compositeHeight: number  // expanded canvas height, at 2× px
-  padding: { left: number; right: number; top: number; bottom: number }  // devicePadding at 2× px
-  screenRect: ChromeRect   // screen position in expanded composite coordinate space, at 2× px
-  screenCornerRadius: number  // screen corner radius in 2× px (0 if device has no rounded corners)
-  logicalWidth: number     // screen width in iOS logical pixels (pt)
-  logicalHeight: number    // screen height in iOS logical pixels (pt)
-  buttons: ChromeButton[]
-}
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -867,3 +837,5 @@ export class DeviceChromeLoader {
     }
   }
 }
+
+export type { ChromeData, ChromeButton, ChromeRect }

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,20 +1,15 @@
-import type { BrowserToRelay, InputErrorReason } from '@tapflowio/protocol'
-import { WebSocket } from 'ws'
+import type { BrowserToRelay, DeviceSummary, InputErrorReason } from '@tapflowio/protocol'
 
-export interface DeviceInfo {
-  id: string
-  name: string
-  platform: string
-  status: string
-  osVersion?: string
-  sessionId: string
-  busy: boolean
-}
+// Protocol owns the wire shape; this file used to declare an identical copy under a name the
+// relay uses for a *different* shape. Kept exported as `DeviceInfo` because that is this
+// package's public name for it.
+export type { DeviceSummary as DeviceInfo }
+import { WebSocket } from 'ws'
 
 export interface AgentSession {
   agentName?: string
   platform?: string
-  devices: DeviceInfo[]
+  devices: DeviceSummary[]
 }
 
 export interface BuildInfo {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -66,11 +66,13 @@ export interface ChromeButton {
   anchor: string
   /** true = button is above the device frame (e.g. home button) */
   onTop: boolean
-  /** button center at retracted/default position, in 2× composite px */
+  /** button center in the **expanded composite** space at 2× px (retracted/default) */
   normalOffset: { x: number; y: number }
-  /** button center at extended/hover position, in 2× composite px */
+  /** button center at the rollover (extended/hover) position, same space */
   rolloverOffset: { x: number; y: number }
+  /** button width in 2× composite px */
   buttonW: number
+  /** button height in 2× composite px */
   buttonH: number
   /** HID usage page for SimulatorKit injection (0 = unknown) */
   usagePage: number
@@ -80,6 +82,7 @@ export interface ChromeButton {
   buttonPng?: string
   /** base64 PNG of the pressed state (imageDown asset) */
   pressedPng?: string
+  /** position + size in the **expanded composite** space at 2× px */
   pressedRect?: ChromeRect
 }
 
@@ -89,20 +92,55 @@ export interface AndroidButton {
   keyCode: number
 }
 
-/** iOS device chrome — the bezel artwork and hit regions the viewer composites around the screen. */
+/** Payload on every `clipboard:error` from a read. `sentinelParked` answers the one question the
+ *  viewer needs to decide its fallback: is a marker still sitting on the device clipboard?
+ *
+ *  If it is, the agent's restore is about to overwrite whatever the device copies next, so
+ *  pressing the plain chord as a fallback would hand the user a stale value — the exact bug the
+ *  sentinel exists to prevent. If it is not, the chord is safe and is the only way the copy
+ *  happens at all. Absent means "assume parked": an agent from before this field cannot tell us,
+ *  and the silent-stale-paste failure is worse than a copy that did not happen.
+ *
+ *  `unsupported` is narrower — this backend has no clipboard channel whatsoever — and drives the
+ *  paste fallback and the wording of the toast. */
+export interface ClipboardErrorPayload {
+  unsupported?: boolean
+  sentinelParked?: boolean
+}
+
+/**
+ * iOS device chrome — the bezel artwork and hit regions the viewer composites around the screen.
+ *
+ * **Two coordinate spaces exist here and the field names do not distinguish them.** The composite
+ * PDF is the device frame; the *expanded* composite is that canvas grown by the button margins, and
+ * it is the space the viewer lays out against. `compositeWidth`/`Height`, `screenRect` and every
+ * `ChromeButton` offset are in the **expanded** space; `padding` is the device's own padding inside
+ * the un-expanded one. Getting this wrong puts buttons at an offset that looks almost right.
+ *
+ * These descriptions come from the producer (`ios-agent`'s `DeviceChromeLoader`, which computes
+ * `expandedW = pdfSize.width + buttonMargins`). They were previously accurate only in that file —
+ * this declaration said `compositeWidth` was "full PDF width including devicePadding", a different
+ * quantity — so they moved here with the type rather than being lost with it.
+ */
 export interface ChromeData {
-  /** full composite PDF at 2× — device frame visible, screen hole transparent */
+  /** composite with buttons baked in, at 2× — screen hole transparent */
   framePng: string
+  /** composite minus devicePadding, at 2× px */
   bezelWidth: number
   bezelHeight: number
-  /** full PDF width including devicePadding, at 2× px */
+  /** **expanded** canvas width — composite + button margins — at 2× px */
   compositeWidth: number
+  /** **expanded** canvas height, at 2× px */
   compositeHeight: number
+  /** devicePadding at 2× px, inside the un-expanded composite */
   padding: { left: number; right: number; top: number; bottom: number }
+  /** screen position in the **expanded** composite space, at 2× px */
   screenRect: ChromeRect
   /** screen corner radius in 2× px (0 if the device has no rounded corners) */
   screenCornerRadius: number
+  /** screen width in iOS logical pixels (pt) */
   logicalWidth: number
+  /** screen height in iOS logical pixels (pt) */
   logicalHeight: number
   buttons: ChromeButton[]
 }
@@ -229,7 +267,7 @@ export type RelayToBrowser =
   | { type: 'open-url:error'; sessionId: string; message: string }
   | { type: 'app:clear-state-error'; sessionId: string; message: string }
   | { type: 'input:error'; sessionId: string; message: string; reason?: InputErrorReason }
-  | { type: 'clipboard:error'; sessionId: string; requestId: string; message: string }
+  | { type: 'clipboard:error'; sessionId: string; requestId: string; message: string; payload?: ClipboardErrorPayload }
 
 /** Everything the relay originates. Messages it merely forwards keep their inbound type — they are
  *  not re-created, so they are not checked against this union. */

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -6,7 +6,7 @@ import path from 'path'
 import { randomUUID } from 'crypto'
 import { WebSocketServer, WebSocket } from 'ws'
 import { SessionManager } from './SessionManager.js'
-import type { RelayMessage, UIElement } from './types.js'
+import type { DeviceDetails, RelayMessage, UIElement } from './types.js'
 import type { ChromePayload, RelayOutbound } from '@tapflowio/protocol'
 import { Router, json } from './router.js'
 import { requireViewAuth, requireAuth, getAuth, verifyPat } from './middleware/auth.js'
@@ -629,7 +629,7 @@ export class RelayServer {
       case 'session:deviceInfo': {
         const session = this.sessions.get(msg.sessionId!)
         if (!session) break
-        this.sessions.setDeviceInfo(session.id, msg.payload as { deviceName: string; osVersion: string })
+        this.sessions.setDeviceInfo(session.id, msg.payload as DeviceDetails)
         if (session.browserSocket?.readyState === WebSocket.OPEN) {
           session.browserSocket.send(JSON.stringify(msg))
         }

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -3,7 +3,7 @@ import { WebSocket } from 'ws'
 import type { DeviceStatus } from '@tapflowio/agent-core'
 import { ValidationError } from '@tapflowio/agent-core'
 import type { AgentResources, SessionInfo } from './types.js'
-import type { ChromePayload, DeviceDetails } from '@tapflowio/protocol'
+import type { ChromePayload, DeviceDetails, DeviceReport } from '@tapflowio/protocol'
 
 export interface Session {
   id: string
@@ -30,8 +30,6 @@ export interface Session {
   deviceInfo?: DeviceDetails
   idleTimer: ReturnType<typeof setTimeout> | null
 }
-
-type RawDevice = { id: string; name: string; platform: string; status: string; osVersion?: string }
 
 /** What an `agent:register` says about the agent itself, as opposed to its devices. */
 export type AgentIdentity = {
@@ -65,7 +63,7 @@ export class SessionManager {
    */
   private static agentFields(
     agent: AgentIdentity,
-    device: RawDevice,
+    device: DeviceReport,
   ): Pick<Session, 'agentId' | 'agentName' | 'agentPlatform' | 'agentCapabilities' | 'deviceName' | 'devicePlatform' | 'deviceStatus' | 'deviceOsVersion'> {
     return {
       agentId: agent.agentId,
@@ -79,7 +77,7 @@ export class SessionManager {
     }
   }
 
-  create(agentSocket: WebSocket, devices: RawDevice[] = [], agentName?: string, agentPlatform?: string, agentId?: string, agentCapabilities?: string[]): string[] {
+  create(agentSocket: WebSocket, devices: DeviceReport[] = [], agentName?: string, agentPlatform?: string, agentId?: string, agentCapabilities?: string[]): string[] {
     const agentIds = this.agentSocketIndex.get(agentSocket) ?? new Set<string>()
     const agent: AgentIdentity = { agentId, agentName, agentPlatform, agentCapabilities }
     return devices.map((d) => {
@@ -189,7 +187,7 @@ export class SessionManager {
    * field refresh has to stay in step with `create()`. Written inline in `RelayServer`, the next
    * field added to `create()` would be missed on this path alone, and silently.
    */
-  rebind(sessionId: string, agentSocket: WebSocket, device: RawDevice, agent: AgentIdentity): void {
+  rebind(sessionId: string, agentSocket: WebSocket, device: DeviceReport, agent: AgentIdentity): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
     const old = session.agentSocket
@@ -277,7 +275,7 @@ export class SessionManager {
     if (session) session.chromeData = data
   }
 
-  setDeviceInfo(sessionId: string, info: { deviceName: string; osVersion: string }): void {
+  setDeviceInfo(sessionId: string, info: DeviceDetails): void {
     const session = this.sessions.get(sessionId)
     if (session) session.deviceInfo = info
   }

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -67,18 +67,14 @@ export type { AgentResources, UIElement }
 
 // The wire contract lives in @tapflowio/protocol so the relay, the dashboard and mcp-server cannot
 // drift apart. `DeviceInfo` is kept as an alias while call sites move over.
-import type { DeviceSummary, SessionTerminatedReason } from '@tapflowio/protocol'
-export type { DeviceReport, DeviceSummary, SessionTerminatedReason } from '@tapflowio/protocol'
+import type { DeviceSummary, SessionInfo, SessionTerminatedReason } from '@tapflowio/protocol'
+export type { DeviceDetails, DeviceReport, DeviceSummary, SessionInfo, SessionTerminatedReason } from '@tapflowio/protocol'
 
 export type DeviceInfo = DeviceSummary
 
-// agents:listed response groups devices by agent machine
-export interface SessionInfo {
-  agentName?: string
-  platform?: string
-  resources?: AgentResources
-  devices: DeviceInfo[]
-}
+// `agents:listed` groups devices by agent machine. Protocol owns the shape; this file used to
+// declare an identical copy. Its `devices` element is protocol's `DeviceSummary`, which the alias
+// below already points at.
 
 export interface RelayMessage {
   type: MessageType

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   packages/agent-core:
     dependencies:
+      '@tapflowio/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       ws:
         specifier: ^8.21.1
         version: 8.21.1
@@ -380,6 +383,9 @@ importers:
       '@tapflowio/agent-core':
         specifier: workspace:*
         version: link:../agent-core
+      '@tapflowio/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       ws:
         specifier: ^8.21.1
         version: 8.21.1

--- a/scripts/__tests__/protocolPayloadTypes.test.mjs
+++ b/scripts/__tests__/protocolPayloadTypes.test.mjs
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+
+// L2 of the wire-contract work (`.work/WIRE-CONTRACT-PLAN.md`). Wire payload types were declared in
+// three to five packages each and had drifted in both directions: protocol lacked
+// `clipboard:error`'s payload while the dashboard's `session:chrome` lacked three fields its own
+// viewer reads. `@tapflowio/protocol` owns them now.
+//
+// **Matched by field set, never by name.** The inventory that planned this work grepped for names and
+// missed two of five copies of one shape, because `mcp-server` and `flow-runner` called it
+// `DeviceInfo` while protocol calls it `DeviceSummary` and the dashboard called it `AgentDevice`. A
+// name-scoped check would have passed with all five standing, and would be bypassed by a rename.
+//
+// Source text, not an import: protocol's main entry must stay runtime-free so it erases under
+// `import type` (see its AGENTS.md HOW NOT), so this cannot load the types as values. Same technique
+// as `inputErrorReason.test.mjs`.
+
+const ROOT = new URL('../..', import.meta.url).pathname
+const PROTOCOL = join(ROOT, 'packages/protocol/src/index.ts')
+
+/**
+ * `interface X { … }` **and** `type X = { … }` → field names, with `?` kept so optionality is part of
+ * the identity.
+ *
+ * Both forms, and a body that fits on one line, because a pre-PR review planted five duplicates and an
+ * earlier version of this reported **one**: it required the `interface` keyword and a closing brace at
+ * the start of a line, so a `type` alias and a single-line interface both walked past. A check whose
+ * whole purpose is to be un-bypassable has to accept every form the duplicate can take.
+ */
+function interfaces(src) {
+  const out = new Map()
+  const re = /(?:export\s+)?(?:interface\s+(\w+)(?:\s+extends\s+([\w,\s]+?))?\s*|type\s+(\w+)\s*=\s*)\{([\s\S]*?)\}/g
+  for (const m of src.matchAll(re)) {
+    const [, iName, ext, tName, body] = m
+    const name = iName ?? tName
+    const fields = []
+    let depth = 0
+    for (const raw of body.split(/[\n;]/)) {
+      const line = raw.replace(/\/\/.*/, '').trim()
+      if (!line) continue
+      // Only top-level members count; an inline object literal's own keys are not fields of this type.
+      if (depth === 0) {
+        const f = line.match(/^(\w+\??)\s*:/)
+        if (f) fields.push(f[1])
+      }
+      depth += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
+    }
+    out.set(name, { fields, extends: ext ? ext.split(',').map((s) => s.trim()) : [] })
+  }
+  return out
+}
+
+/** Field set including inherited members, resolved within the same file. */
+function resolved(decls, name, seen = new Set()) {
+  if (seen.has(name)) return []
+  seen.add(name)
+  const d = decls.get(name)
+  if (!d) return []
+  return [...d.fields, ...d.extends.flatMap((e) => resolved(decls, e, seen))]
+}
+
+const key = (fields) => [...new Set(fields)].sort().join(',')
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (/\.tsx?$/.test(entry)) out.push(p)
+  }
+  return out
+}
+
+const protoDecls = interfaces(readFileSync(PROTOCOL, 'utf8'))
+/** Payload types worth guarding. Two fields is enough to be a real shape; one is a coincidence. */
+const guarded = new Map()
+for (const name of protoDecls.keys()) {
+  const fields = resolved(protoDecls, name)
+  if (fields.length >= 2) guarded.set(key(fields), name)
+}
+
+// A local declaration that legitimately shares a shape. Each entry needs a reason, because the
+// default answer is "import it from protocol instead".
+const ALLOWED = new Set([
+  // Same four fields as `ChromeRect`, different concept: the frame of an accessibility-tree element,
+  // which has nothing to do with device chrome. Shape matching cannot tell those apart, and merging
+  // them would couple the UI-tree schema to the bezel artwork. This is the known cost of matching by
+  // shape instead of by name — and the cost is worth paying, since name matching missed two of five
+  // copies of one shape when this work was planned.
+  'agent-core:UIElementFrame',
+  // `AgentSession` in mcp-server and flow-runner is `SessionInfo` minus `resources` — a narrower view
+  // for a client that does not read them, not a copy. Its field set differs so it never matches;
+  // listed so the next reader knows it was considered rather than missed.
+])
+
+describe('wire payload types are declared once, in @tapflowio/protocol', () => {
+  // A count floor is the wrong assertion: 13 shapes are guarded, so losing three still passed, and
+  // converting one protocol `interface` to a `type` alias used to drop it from the guard silently —
+  // taking every duplicate of that shape with it. Name the ones that must be there.
+  it('guards the payload shapes by name, so a shape cannot silently leave', () => {
+    const byName = new Set(guarded.values())
+    for (const name of [
+      'ChromeData', 'ChromeButton', 'ChromeRect', 'AndroidButton', 'AndroidChrome',
+      'AgentResources', 'SessionInfo', 'DeviceSummary', 'DeviceDetails', 'ClipboardErrorPayload',
+    ]) {
+      expect(byName, name).toContain(name)
+    }
+  })
+
+  it('no other package re-declares a protocol payload shape', () => {
+    const offenders = []
+    // Every workspace member, not just `packages/*`: `playground` is one and `playground/mock-agent.ts`
+    // builds an `AgentResources` of its own. A duplicate there drifts exactly like one in a package.
+    const roots = [
+      ...readdirSync(join(ROOT, 'packages')).map((p) => ['packages', p]),
+      ['.', 'playground'],
+    ]
+    for (const [parent, pkg] of roots) {
+      if (pkg === 'protocol') continue
+      const base = join(ROOT, parent, pkg)
+      let files
+      try { files = walk(base) } catch { continue }
+      for (const file of files) {
+        const src = readFileSync(file, 'utf8')
+        const decls = interfaces(src)
+        for (const name of decls.keys()) {
+          const k = key(resolved(decls, name))
+          const match = guarded.get(k)
+          if (match && !ALLOWED.has(`${pkg}:${name}`)) {
+            offenders.push(`${file.slice(ROOT.length)} declares ${name}, same shape as protocol's ${match}`)
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/scripts/__tests__/protocolPayloadTypes.test.mjs
+++ b/scripts/__tests__/protocolPayloadTypes.test.mjs
@@ -24,29 +24,43 @@ const PROTOCOL = join(ROOT, 'packages/protocol/src/index.ts')
  * the identity.
  *
  * Both forms, and a body that fits on one line, because a pre-PR review planted five duplicates and an
- * earlier version of this reported **one**: it required the `interface` keyword and a closing brace at
- * the start of a line, so a `type` alias and a single-line interface both walked past. A check whose
- * whole purpose is to be un-bypassable has to accept every form the duplicate can take.
+ * earlier version reported **one**: it required the `interface` keyword and a closing brace at the
+ * start of a line, so a `type` alias and a single-line interface both walked past.
+ *
+ * The body is found by **counting braces**, not by a lazy `[\s\S]*?` to the first `}`. That version
+ * truncated at the first nested object literal, so `ChromeData` was guarded as its first 6 fields
+ * instead of 11 and `ChromeButton` as 5 instead of 13 — a real duplicate of either would not have
+ * matched the truncated key at all. The by-name assertion below did not catch it, because a name being
+ * present says nothing about its field set being complete; that is why `FIELD_COUNTS` exists.
  */
 function interfaces(src) {
   const out = new Map()
-  const re = /(?:export\s+)?(?:interface\s+(\w+)(?:\s+extends\s+([\w,\s]+?))?\s*|type\s+(\w+)\s*=\s*)\{([\s\S]*?)\}/g
-  for (const m of src.matchAll(re)) {
-    const [, iName, ext, tName, body] = m
-    const name = iName ?? tName
-    const fields = []
+  const head = /(?:export\s+)?(?:interface\s+(\w+)(?:\s+extends\s+([\w,\s]+?))?\s*|type\s+(\w+)\s*=\s*)\{/g
+  for (const m of src.matchAll(head)) {
+    const name = m[1] ?? m[3]
+    const ext = m[2]
+    // Walk from the opening brace to its match.
     let depth = 0
+    let i = m.index + m[0].length - 1
+    const start = i + 1
+    for (; i < src.length; i++) {
+      if (src[i] === '{') depth++
+      else if (src[i] === '}' && --depth === 0) break
+    }
+    const body = src.slice(start, i)
+    const fields = []
+    let d = 0
     for (const raw of body.split(/[\n;]/)) {
       const line = raw.replace(/\/\/.*/, '').trim()
       if (!line) continue
-      // Only top-level members count; an inline object literal's own keys are not fields of this type.
-      if (depth === 0) {
+      // Only top-level members count; a nested literal's own keys are not fields of this type.
+      if (d === 0) {
         const f = line.match(/^(\w+\??)\s*:/)
         if (f) fields.push(f[1])
       }
-      depth += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
+      d += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
     }
-    out.set(name, { fields, extends: ext ? ext.split(',').map((s) => s.trim()) : [] })
+    out.set(name, { fields, extends: ext ? ext.split(',').map((x) => x.trim()) : [] })
   }
   return out
 }
@@ -61,6 +75,25 @@ function resolved(decls, name, seen = new Set()) {
 }
 
 const key = (fields) => [...new Set(fields)].sort().join(',')
+
+/**
+ * Workspace members, from `pnpm-workspace.yaml` rather than a hardcoded list — a new top-level member
+ * is then scanned without an edit here, which is what "every workspace member" has to mean to be true.
+ */
+function workspaceRoots() {
+  const yaml = readFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'utf8')
+  const globs = [...yaml.matchAll(/^\s*-\s*'([^']+)'/gm)].map((m) => m[1])
+  const roots = []
+  for (const g of globs) {
+    if (g.endsWith('/*')) {
+      const parent = g.slice(0, -2)
+      for (const entry of readdirSync(join(ROOT, parent))) roots.push([parent, entry])
+    } else {
+      roots.push(['.', g])
+    }
+  }
+  return roots
+}
 
 function walk(dir, out = []) {
   for (const entry of readdirSync(dir)) {
@@ -98,6 +131,17 @@ describe('wire payload types are declared once, in @tapflowio/protocol', () => {
   // A count floor is the wrong assertion: 13 shapes are guarded, so losing three still passed, and
   // converting one protocol `interface` to a `type` alias used to drop it from the guard silently —
   // taking every duplicate of that shape with it. Name the ones that must be there.
+  // A name being guarded says nothing about its field set being complete — which is exactly how the
+  // truncating body capture hid for a round. Pin the counts of the shapes with nested literals, since
+  // those are the ones a lazy match gets wrong.
+  it('guards complete field sets, not truncated ones', () => {
+    const count = (name) => new Set(resolved(protoDecls, name)).size
+    expect(count('ChromeData')).toBe(11)
+    expect(count('ChromeButton')).toBe(13)
+    expect(count('DeviceSummary')).toBe(7)
+    expect(count('SessionInfo')).toBe(4)
+  })
+
   it('guards the payload shapes by name, so a shape cannot silently leave', () => {
     const byName = new Set(guarded.values())
     for (const name of [
@@ -110,17 +154,21 @@ describe('wire payload types are declared once, in @tapflowio/protocol', () => {
 
   it('no other package re-declares a protocol payload shape', () => {
     const offenders = []
-    // Every workspace member, not just `packages/*`: `playground` is one and `playground/mock-agent.ts`
-    // builds an `AgentResources` of its own. A duplicate there drifts exactly like one in a package.
-    const roots = [
-      ...readdirSync(join(ROOT, 'packages')).map((p) => ['packages', p]),
-      ['.', 'playground'],
-    ]
-    for (const [parent, pkg] of roots) {
+    const scanned = []
+    for (const [parent, pkg] of workspaceRoots()) {
       if (pkg === 'protocol') continue
       const base = join(ROOT, parent, pkg)
       let files
-      try { files = walk(base) } catch { continue }
+      try {
+        files = walk(base)
+      } catch (e) {
+        // Only "not a directory" is tolerated. Swallowing everything let a permission error or a
+        // broken symlink skip a whole member while the test still reported green — a duplicate inside
+        // it would be invisible, which defeats the point of the check.
+        if (e.code === 'ENOTDIR' || e.code === 'ENOENT') continue
+        throw e
+      }
+      scanned.push(pkg)
       for (const file of files) {
         const src = readFileSync(file, 'utf8')
         const decls = interfaces(src)
@@ -133,6 +181,11 @@ describe('wire payload types are declared once, in @tapflowio/protocol', () => {
         }
       }
     }
+    // Coverage is asserted, not assumed: a member silently dropped from the walk is the other way this
+    // check goes quietly useless. `playground` is named because it is the one non-`packages/` member
+    // and it builds an `AgentResources` of its own.
+    expect(scanned).toContain('playground')
+    expect(scanned.length).toBeGreaterThanOrEqual(readdirSync(join(ROOT, 'packages')).length)
     expect(offenders).toEqual([])
   })
 })


### PR DESCRIPTION
First step of a multi-PR program to clean up the cross-package wire contract. The program plan lives at `.work/WIRE-CONTRACT-PLAN.md`; this is its **L2**.

## Why this program exists

Six "silent lie" bugs on the input path were fixed in one day (#482 → #500). Each fix was correct and each revealed the next gap, because the defect was in the **shape** of the contract rather than in any one message. Measured: 4 of the 6 were protocol-shaped, and the other 2 were harder to see because the wire could not express what the agent knew.

Six structural defects came out of that. This PR closes one of them.

## What was wrong

Every wire payload type was declared separately in three to five packages, and they had drifted **in both directions**:

- `@tapflowio/protocol` was missing the `payload` field on `clipboard:error` that both agents send and the viewer reads.
- The dashboard's `session:chrome` declaration was missing three fields its own `DeviceViewer` reads.

Nothing checked either side. This is the exact situation `@tapflowio/protocol` was created to end — it had been half done, and the other half drifted back apart.

Several shapes were also the same thing under different names, which is how the duplication survived a name-based search: `DeviceSummary` was `AgentDevice` in the dashboard and `DeviceInfo` in `mcp-server` and `flow-runner` — and that last name collided with the relay's own `DeviceInfo`, which is a *different* shape. `DeviceReport` was `RawDevice` in the relay. `Point` was `NormPoint` in the dashboard.

## What changed

Protocol owns them; everyone else imports. `agent-core`, `flow-runner`, the relay and the dashboard re-export the names they published, so no consumer of those packages changes — including third-party agents built on `AgentRegistry.register()`. `export type` rather than a bare re-export, so `agent-core` does not gain a runtime import of protocol's `dist`.

**The comments mattered more than the types.** `ChromeData` was described accurately only in `ios-agent`, which produces it: the viewer lays out against an *expanded* composite canvas — the device frame grown by the button margins — and protocol's copy said `compositeWidth` was "full PDF width including devicePadding", a different quantity. Deleting the producer's declaration would have deleted the only correct description of the coordinate space three viewers compute against. Protocol carries it now, with both spaces named explicitly.

## The check

`scripts/__tests__/protocolPayloadTypes.test.mjs` fails if any workspace member re-declares a protocol payload shape. It matches on **field sets, not names**: the inventory that planned this work grepped names and missed two of five copies of one shape, so a name-scoped check would have passed with all five standing and would be bypassed by a rename.

It earned itself repeatedly — five copies nobody had inventoried (the relay's `SessionInfo` and `RawDevice`, `agent-core`'s `Point`, the dashboard's `NormPoint`, plus two inline `{ deviceName, osVersion }` literals in the relay). One legitimate false positive, `UIElementFrame`, is allowlisted with its reason: same four fields as `ChromeRect`, but it is an accessibility-tree element's frame and merging them would couple the UI-tree schema to bezel artwork.

## Review

`.work/reviews/refactor__wire-l2-payload-types.md` — a design round (1 blocker: the clipboard requirement did not hold together, and my inventory was wrong) and a pre-PR round (2 majors), against `80a4063`.

The pre-PR round is worth summarising, because both findings were mine:

- **I deferred half of a fix that did not need deferring.** The design review correctly said typing the clipboard *bridge* needs types L3 creates. I deferred the whole thing, including the one-line field addition on protocol's own member that needs nothing — leaving the moved type referenced nowhere while the commit message named that drift as the motivation. Fixed, and the commit amended so the claim matches the code.
- **The check could be bypassed, and not hypothetically.** The first version required the `interface` keyword and a closing brace at line start. The reviewer planted five duplicates and it reported one: `type X = { … }` aliases, a single-line body, and the `playground` workspace member all walked past — and two inline literals in the relay were passing at that moment. A check whose whole value is being un-bypassable is worse than none when it is bypassable, because its presence reassures. All five forms now fail; verified by replanting them.

7 mutations, 4 of which survived the first version.

## Scope

No behaviour change: declarations, imports and comments. Every package's test count is unchanged — scripts 211 → 213 for the new check's two tests. typecheck, lint, build and a11y-lens clean.

Deliberately left for L3: removing `useClipboardBridge`'s casts, which needs `clipboard:data` / `clipboard:write-done` in protocol — those are agent→browser forwards, a category protocol does not model yet, and that is L3's subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared protocol types for device, session, Chrome, Android, coordinate, resource, and clipboard data.
  * Clipboard error messages can include additional status details.
* **Documentation**
  * Clarified Chrome coordinate-space and expanded-canvas behavior.
* **Bug Fixes**
  * Improved consistency of device and payload data across connected components.
* **Tests**
  * Added validation to detect duplicate payload type declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->