### PR TITLE
docs: state that the agent needs Apple Silicon, and name the Intel failure

### DIFF
--- a/docs/guide/requirements.md
+++ b/docs/guide/requirements.md
@@ -10,8 +10,19 @@
 
 The agent runs on macOS. iOS and Android can run together on the same Mac.
 
-- macOS
+- macOS on **Apple Silicon** (M-series)
 - Node.js ≥ 22
+
+::: warning Intel Macs are not supported
+The agent ships native helper binaries built for arm64 only, so an Intel (x86_64) Mac cannot run them.
+Opening a build fails with a generic `spawn unknown error`.
+
+Apple Silicon is what tapflow has been developed and verified against. Intel support is possible and
+tracked in [#464](https://github.com/jo-duchan/tapflow/issues/464), but it is not scheduled — it needs
+a universal build plus verification on hardware the maintainers do not have.
+
+The relay has no such constraint. Only the machine running the **agent** needs Apple Silicon.
+:::
 
 ### iOS
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -8,6 +8,29 @@
 2. Check that the URL in the `--relay` option uses `ws://` — agents always connect over the local network.
 3. Run `tapflow doctor` to inspect your environment.
 
+## Opening a build fails with `spawn unknown error` {#spawn-unknown-error}
+
+Check the Mac's architecture:
+
+```bash
+uname -m        # arm64 = Apple Silicon, x86_64 = Intel
+```
+
+If it reports `x86_64`, this is an **Intel Mac and the agent does not support it**. The native helper
+binaries are built for arm64 only, so macOS refuses to exec them (`EBADARCH`), which Node surfaces as
+`Unknown system error -86` and the dashboard shows as `spawn unknown error`.
+
+There is no workaround on the agent side today. Run the agent on an Apple Silicon Mac — the relay and
+the dashboard have no such constraint, so only the machine driving the simulators has to change.
+
+Intel support is possible and tracked in
+[#464](https://github.com/jo-duchan/tapflow/issues/464); it needs a universal build and verification on
+hardware the maintainers do not have, so it is not scheduled. See
+[Requirements](/guide/requirements#agent).
+
+If `uname -m` says `arm64`, this is a different problem — a helper that is missing or not executable
+produces the same message. Check that the agent package installed completely.
+
 ## iOS Simulator service version mismatch {#ios-simulator-service-version-mismatch}
 
 After updating Xcode, you may see a macOS alert:

--- a/docs/ko/guide/requirements.md
+++ b/docs/ko/guide/requirements.md
@@ -10,8 +10,19 @@
 
 에이전트는 macOS에서 실행됩니다. iOS와 Android를 한 Mac에서 함께 실행할 수 있습니다.
 
-- macOS
+- **Apple Silicon**(M 시리즈) macOS
 - Node.js ≥ 22
+
+::: warning Intel Mac은 지원하지 않습니다
+에이전트가 함께 배포하는 네이티브 헬퍼 바이너리가 arm64 전용이라 Intel(x86_64) Mac에서는 실행되지
+않습니다. 빌드를 열면 `spawn unknown error`라는 모호한 오류가 납니다.
+
+tapflow가 개발과 검증에 사용해온 환경이 Apple Silicon입니다. Intel 지원은 가능하고
+[#464](https://github.com/jo-duchan/tapflow/issues/464)에서 다루고 있지만 아직 예정에 없습니다.
+유니버설 빌드가 필요하고, 메인테이너가 갖고 있지 않은 하드웨어에서 검증해야 합니다.
+
+릴레이에는 이 제약이 없습니다. **에이전트**를 실행하는 머신만 Apple Silicon이어야 합니다.
+:::
 
 ### iOS
 

--- a/docs/ko/guide/troubleshooting.md
+++ b/docs/ko/guide/troubleshooting.md
@@ -8,6 +8,28 @@
 2. `--relay` 옵션의 URL이 `ws://`인지 확인합니다. 에이전트는 항상 내부 네트워크로 연결합니다.
 3. `tapflow doctor`를 실행해 환경을 점검합니다.
 
+## 빌드를 열면 `spawn unknown error`가 납니다 {#spawn-unknown-error}
+
+먼저 Mac의 아키텍처를 확인하세요.
+
+```bash
+uname -m        # arm64면 Apple Silicon, x86_64면 Intel
+```
+
+`x86_64`가 나오면 **Intel Mac이고 에이전트가 지원하지 않는 환경**입니다. 네이티브 헬퍼 바이너리가
+arm64 전용이라 macOS가 실행을 거부하고(`EBADARCH`), Node가 그것을 `Unknown system error -86`으로
+올려보내면 대시보드에 `spawn unknown error`로 표시됩니다.
+
+현재 에이전트 쪽 우회 방법은 없습니다. 에이전트를 Apple Silicon Mac에서 실행하세요. 릴레이와
+대시보드에는 이 제약이 없으므로 시뮬레이터를 구동하는 머신만 바꾸면 됩니다.
+
+Intel 지원은 가능하고 [#464](https://github.com/jo-duchan/tapflow/issues/464)에서 다루고 있습니다.
+유니버설 빌드가 필요하고 메인테이너가 갖고 있지 않은 하드웨어에서 검증해야 해서 예정에는 없습니다.
+[시스템 요구사항](/ko/guide/requirements#에이전트)도 참고하세요.
+
+`uname -m`이 `arm64`를 출력하면 다른 문제입니다. 헬퍼 파일이 없거나 실행 권한이 없을 때도 같은
+메시지가 나오므로, 에이전트 패키지가 온전히 설치됐는지 확인하세요.
+
 ## iOS 시뮬레이터 서비스 버전 불일치 {#ios-simulator-service-version-mismatch}
 
 Xcode를 업데이트한 후 다음과 같은 macOS 알림이 표시될 수 있습니다:


### PR DESCRIPTION
Refs #464. Docs only.

## The defect is the reporting gap, not the missing support

tapflow has been developed and verified on Apple Silicon throughout, and we never claimed Intel support. But the constraint lived everywhere in the docs **except where someone looks before installing**:

- `requirements.md` listed "macOS" for the agent, with no architecture.
- The same page's Android section already requires a `google_apis/arm64-v8a` system image.
- `troubleshooting.md` already explains that "Apple Silicon Macs (M1/M2/M3) run Android Emulator in a native ARM64 environment".

So an Intel user gets a generic `spawn unknown error` — the helpers are arm64-only, macOS refuses to exec them with `EBADARCH`, Node reports `Unknown system error -86` — and has nothing to identify it with. That is what this fixes. #464 describes hardware we never supported; **not documenting it is the part that was ours.**

## What changed

**Requirements** now says Apple Silicon and explains what happens if you try, in both languages.

**Troubleshooting** gains an entry keyed on `spawn unknown error` — the string a stuck user actually searches — starting from `uname -m` so the answer is one command. It also says what to check when the architecture turns out to be fine, because a missing or non-executable helper produces the same message and sending an Apple Silicon user down the Intel path would be its own dead end.

Both note that only the machine running the **agent** is constrained. The relay and the dashboard are unaffected, which makes the fix "move the agent" rather than "replace the Mac".

## #464's labels

Being changed alongside this: `bug` to `enhancement`, `priority: high` to `priority: low`, `phase-4` to `phase-5-plus`. The documentation gap was the bug and this closes it; what remains is supporting hardware we had not targeted, which needs a universal build plus verification on machines the maintainers do not have — so it depends on the reporter's cooperation and is genuinely unscheduled.

No `priority: medium` label was created. The repo has `low` and `high`, and `low`'s own description — "address after higher-priority work" — is exactly this.

## Review

`.work/reviews/docs__apple-silicon-requirement.md`. Docs-only, so the adversarial review is skipped per the root AGENTS.md, with the skip reason and the direct verification recorded: the KO heading anchor is generated (checked in the built HTML, since a Korean slug was the one thing that could silently break), `ignoreDeadLinks` is unset so a dead internal link would fail the build, and `docs:build` passes.

## Recommended, deliberately not included

A `tapflow doctor` architecture check. Docs do not help a user who has already started installing, `packages/cli/src/commands/doctor.ts` exists, and `download-binary.ts` already reads `process.arch` — so it is cheap. But it is code rather than docs, and outside what was asked for here.