### PR TITLE
docs(contributing): a reviewer's cleared list expires when you fix the findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 - **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 - **A change spanning two or more packages, or both platforms, needs a second, earlier review — of the design, before the code.** One adversarial pass over the plan, in addition to the pre-PR one.
 
-**Read [contributing/adversarial-review.md](./contributing/adversarial-review.md) before launching a reviewer.** It covers how to design the channels, how to run the cross-cutting design pass, and how to keep the cost in minutes rather than hours — the same review can take 4 minutes or 106 depending only on what its prompt makes it execute.
+**Read [contributing/adversarial-review.md](./contributing/adversarial-review.md) before launching a reviewer.** It covers how to design the channels, how to run the cross-cutting design pass, why a reviewer's "checked and cleared" list expires as soon as you fix the findings, and how to keep the cost in minutes rather than hours — the same review can take 4 minutes or 106 depending only on what its prompt makes it execute.
 
 ### Design Principles (SOLID — priority subset)
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -75,4 +75,4 @@ Committed *why* behind non-obvious decisions. Read the relevant one **before** c
 | [android-video-streaming-diagnosis.md](./contributing/android-video-streaming-diagnosis.md) | diagnosis | Android emulator streaming issues traced to root cause, one section per issue |
 | [awdl-wifi-latency-diagnosis.md](./contributing/awdl-wifi-latency-diagnosis.md) | diagnosis | Periodic Wi-Fi stream hitch traced to AWDL via ICMP ping — method and evidence |
 | [workshop-lab-fork-observations.md](./contributing/workshop-lab-fork-observations.md) | reference | Third-party workshop-lab fork: independent iOS-sim capacity data (~4 seats/32GB) + where our extension seams stop |
-| [adversarial-review.md](./contributing/adversarial-review.md) | rules | How to run the pre-PR review and the cross-cutting design pass — channel design, prompt skeleton, why the same review costs 4 minutes or 106 |
+| [adversarial-review.md](./contributing/adversarial-review.md) | rules | How to run the pre-PR review and the cross-cutting design pass — channel design, prompt skeleton, why a cleared list ages with the diff, why the same review costs 4 minutes or 106 |

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -72,6 +72,33 @@ and waiting out sleeps.
   processes, with real waits. Budget for it and say so up front, rather than discovering it at 100
   minutes.
 
+## The cleared list ages with the diff
+
+A reviewer's "checked and cleared" list describes the code **as the reviewer read it**. Fixing the
+findings changes that code — so **after applying the fixes, re-check whether any fix invalidated a
+cleared item.** The list is evidence, not a warranty, and it expires the moment you edit.
+
+This is not a hypothetical. On #503 a reviewer cleared `setAgentCapabilities(msg.capabilities ?? [])`:
+type-dead now that `capabilities` is required, but live at runtime, and *"removing it would be caught
+by `sessionScope.test.tsx:35,74`"*. That was true when it was written. Both of those lines were
+`{ type: 'session:joined' } as BrowserInbound` — a fixture omitting the field — and a later finding in
+the same review was that those casts must go. Typing the fixtures correctly is right, and it silently
+removed the fallback's only coverage: the mutation went from caught to surviving all 297 tests, with
+nothing failing to say so.
+
+The failure mode is specific and worth naming: **a cleared item whose grounds are a test, where
+another finding changes that test.** So:
+
+- When a review yields several findings, treat the cleared list as **one of the things the fixes can
+  break**. Read it again at the end, not once at the start.
+- If a cleared item's grounds were "a test catches this", re-run that mutation after the fixes. Being
+  told a mutation is caught is not the same as it being caught now.
+- Record the reversal in the review file rather than quietly deleting it — strike the original and say
+  what overturned it. Someone later needs to know the clearance was real and then stopped being real.
+
+The same applies to your own mutation results: a mutation you ran before the fixes was run against
+code that no longer exists.
+
 ### A prompt skeleton that stays cheap
 
 What made the 4m30s pair cheap was structural, not stylistic. Each prompt carried:


### PR DESCRIPTION
<!-- no-changeset: docs-only — no published source changed -->

Follow-on from #503, where this cost real coverage.

## What happened

A reviewer's **"checked and cleared"** list describes the code as the reviewer read it. Applying the fixes changes that code — so a cleared item can stop being true, and nothing reports it.

On #503 a reviewer cleared `setAgentCapabilities(msg.capabilities ?? [])`: type-dead now that `capabilities` is required, live at runtime, and *"removing it would be caught by `sessionScope.test.tsx:35,74`"*. True when written.

Both of those lines were `{ type: 'session:joined' } as BrowserInbound` — a fixture omitting the field — and **another finding in the same review** was that those casts must go. Typing the fixtures correctly is right, and it took the fallback's only coverage with it: the mutation went from caught to surviving all 297 tests, with nothing failing to say so.

## The rule

The failure mode is specific: **a cleared item whose grounds are a test, where a different finding changes that test.** So the file now says to

- treat the cleared list as one of the things the fixes can break, and read it again at the end;
- re-run any mutation whose verdict was "a test catches this" **after** the fixes — being told it is caught is not the same as it being caught now;
- strike a reversal through in the record rather than deleting it, because someone later needs to know the clearance was real and then stopped being real.

Same applies to your own mutation results: one you ran before the fixes was run against code that no longer exists.

Placed as its own section rather than a bullet under "Verify the reviewer's grounds, not just its verdict" — that item is about validating a finding's evidence; this is the opposite direction, a *clearance* collapsing under your own edit. A bullet leaves no room for the worked example, and the example is what makes it recognisable.

## Also

`AGENTS.md` and `INDEX.md` summarise what this file covers, so both lines are updated to name the new section. `contributing/README.md`'s table carries only filename/type/topics, so it needs nothing.

## Review

Docs-only, so the review itself is skipped per the root `AGENTS.md`; the record with the skip reason is at `.work/reviews/docs__review-cleared-list-ages.md`. It also re-verifies the #503 sequence the example rests on — the mutation was measured at 0 of 297 failing after the cast fix, and failing again once the dedicated test landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated adversarial review guidance to require re-evaluating previously cleared findings after fixes, including changes to test evidence.
  * Added guidance for re-running affected mutation checks and recording any reversed conclusions.
  * Added the adversarial review guidance to the engineering documentation index with a description of its procedures and design recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->