### PR TITLE
refactor(protocol): give every wire message a name

### DIFF
--- a/.changeset/named-message-interfaces.md
+++ b/.changeset/named-message-interfaces.md
@@ -1,0 +1,47 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/relay': patch
+---
+
+refactor(protocol): give every wire message a name
+
+58 messages were anonymous members of a union, which meant two things could not be done. A single
+message could not be referred to — consumers reached for `Extract<Union, { type: 'x' }>`, one of them
+needing `extends { payload: infer P }` to get at a payload. And shared structure had nowhere to live:
+eight session-scoped failures carry the same `{ sessionId, message }` contract with no place to say so,
+and the comment explaining it floated above a union line.
+
+Each message is now an `export interface`, and the unions are unions of those names.
+
+- **`SessionError`** — the eight session-scoped failures extend it. Not for DRY (two fields) but so
+  that "this is a failure addressed to a session" is something a reader and a check can see, and the
+  contract note has a home. `error` does not inherit: it has no `sessionId`, which is the whole point
+  of that member.
+- **Direction suffixes where a literal means two things.** `app:install` and `app:launch` travel in
+  both directions with *different* shapes — the browser sends `buildId`, the relay resolves it and
+  sends `payload: { filePath, bundleId }`. Naming forced the split: `AppInstallToRelay` /
+  `AppInstallToAgent`. `device:shutdown` is identical in both directions, so it is one interface both
+  unions reference, which now says out loud that the relay forwards it untouched.
+- `GenericError`, because `Error` would shadow the global.
+
+**Names were derived from the `type` literals mechanically, not typed by hand.** The conversion's real
+hazard is a copy-paste that leaves two interfaces holding each other's literal, and `AgentToBrowser`
+has seven members whose shape is identical apart from the literal. A type-level equivalence check
+cannot see it — a union is a set, so which name owns which literal is not part of the comparison, and
+the routing check compares membership, so the literal set is unchanged. Measured: the swap produced
+zero errors from the nine equivalence assertions.
+
+So `typeAssertions.ts` carries one binding per message (`_InputDone: InputDone['type'] = 'input:done'`),
+and `scripts/__tests__/protocolMessageNames.test.mjs` asserts every message has one — plus that the
+eight failures declare `extends SessionError`, which no type can state about itself because every
+object with `{ sessionId, message }` is assignable to it.
+
+The conversion itself was proven with `Equals<Union, UnionOld>` against verbatim snapshots and then
+deleted along with them; that net was for the conversion window, not for keeping.
+
+**Two properties were given up, neither visible to that proof.** A named `interface` has no implicit
+index signature, so a message is no longer assignable to `Record<string, unknown>` — nothing breaks
+today because the three such sinks in this repo only ever receive fresh object literals, and the fix
+when one needs a typed value is to type the sink rather than widen the message. And an `interface` can
+be reopened by a consumer via `declare module`, which an anonymous union member could not. Both are
+recorded in `packages/protocol/AGENTS.md`.

--- a/packages/dashboard/hooks/useClipboardBridge.ts
+++ b/packages/dashboard/hooks/useClipboardBridge.ts
@@ -1,17 +1,16 @@
-import type { BrowserInbound, BrowserToRelay, ClipboardRequest } from '@tapflowio/protocol'
+import type {
+  BrowserToRelay, ClipboardData, ClipboardError, ClipboardRequest, ClipboardWriteDone,
+} from '@tapflowio/protocol'
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
 
-/** The three replies a clipboard request can get, derived from the wire union rather than described
- *  again here. The hand-written shape this replaces was `{ type: string; payload?: unknown }`, wide
- *  enough to accept any message at all — so every read of a field went through a cast that asserted
- *  what the wire already said, and `DeviceViewer` needed an `as unknown as` to route into it. */
-export type ClipboardBridgeMessage = Extract<
-  BrowserInbound,
-  { type: 'clipboard:data' | 'clipboard:write-done' | 'clipboard:error' }
->
-
-type ClipboardErrorReply = Extract<ClipboardBridgeMessage, { type: 'clipboard:error' }>
+/** The three replies a clipboard request can get. Named members of the wire union rather than an
+ *  `Extract<>` over it — L1 gave every message a name, so this says what it means.
+ *
+ *  The hand-written shape this replaces was `{ type: string; payload?: unknown }`, wide enough to
+ *  accept any message at all — so every read of a field went through a cast that asserted what the
+ *  wire already said, and `DeviceViewer` needed an `as unknown as` to route into it. */
+export type ClipboardBridgeMessage = ClipboardData | ClipboardWriteDone | ClipboardError
 
 export type ClipboardMessageHandler = (msg: ClipboardBridgeMessage) => void
 
@@ -108,14 +107,14 @@ const byteLength = (s: string): number => new TextEncoder().encode(s).length
 /** True when the agent said this backend has no clipboard channel at all. It can therefore
  *  never have a sentinel parked on the device, which makes pressing the plain chord safe —
  *  the one error where falling back is provably harmless rather than a gamble. */
-const isUnsupportedBackend = (msg: ClipboardErrorReply): boolean => !!msg.payload?.unsupported
+const isUnsupportedBackend = (msg: ClipboardError): boolean => !!msg.payload?.unsupported
 
 /** May the viewer press the plain chord after a failed bridged copy? Only when the agent says
  *  no sentinel is on the device. If one is, the agent's restore lands right after and overwrites
  *  whatever the chord copies, so the user pastes a stale value. Absent means assume parked —
  *  an agent that predates the field cannot tell us, and a silent stale paste is the worse half
  *  of the trade. See ClipboardErrorPayload in agent-core. */
-const noSentinelParked = (msg: ClipboardErrorReply): boolean =>
+const noSentinelParked = (msg: ClipboardError): boolean =>
   // `unsupported` implies it: a backend with no clipboard channel cannot park anything. Accepting
   // it keeps `{ unsupported: true }` alone — the natural encoding, and what a third-party agent
   // would most likely send — from silently costing the user their fallback copy.

--- a/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, act, fireEvent } from '@testing-library/react'
-import type { BrowserToRelay } from '@tapflowio/protocol'
+import type { DeviceBoot, BrowserToRelay } from '@tapflowio/protocol'
 import type { BrowserInbound } from '@/lib/types'
 
 // #426 stage 2. When an agent restarts, the relay re-points the session at the new socket and sends
@@ -39,7 +39,7 @@ const CHROME = {
 const boots = () =>
   send.mock.calls
     .map(([m]) => m)
-    .filter((m): m is Extract<BrowserToRelay, { type: 'device:boot' }> => m.type === 'device:boot')
+    .filter((m): m is DeviceBoot => m.type === 'device:boot')
 
 const installs = () => send.mock.calls.filter(([m]) => m.type === 'app:install')
 

--- a/packages/dashboard/src/__tests__/DeviceViewer.reset.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.reset.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 import { act } from 'react'
-import type { BrowserToRelay } from '@tapflowio/protocol'
+import type { DeviceBoot, BrowserToRelay } from '@tapflowio/protocol'
 import type { BrowserInbound } from '@/lib/types'
 
 // The viewer is only exercised through its message handler here — the decoders, the audio path and
@@ -30,7 +30,7 @@ const { DeviceViewer } = await import('@/components/DeviceViewer')
 function bootModes(): Array<string | undefined> {
   return send.mock.calls
     .map(([msg]) => msg)
-    .filter((msg): msg is Extract<BrowserToRelay, { type: 'device:boot' }> => msg.type === 'device:boot')
+    .filter((msg): msg is DeviceBoot => msg.type === 'device:boot')
     .map((msg) => msg.payload.resetMode)
 }
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -39,6 +39,48 @@ The cost of a broad name is ambiguity about what belongs — answered by the two
 - **The binary frame envelope (TFFE).** That is a separate wire format with its own header layout — see [`contributing/frame-envelope.md`](../../contributing/frame-envelope.md). It is currently implemented separately in the relay and the dashboard, which is the same kind of drift risk, but unifying it is not this package's job today.
 - **Domain types that are not on the wire.** `Build`, `ReleaseGroup`, UI view models — those stay in their own packages.
 
+## Every message is a named `interface`, and naming cost two things
+
+A message is `export interface AppInstallDone { type: 'app:install-done'; … }`, and the unions are
+unions of those names. That is what lets a consumer refer to one message, and what gives shared
+structure (`SessionError`) and per-message documentation somewhere to live.
+
+**`interface`, not `type X = { … }`** — the alias form cannot be `extends`ed, and the intersection
+workaround (`type X = SessionError & { … }`) stops `Extract<Union, { type: 'x' }>` resolving to a single
+member, which `useClipboardBridge` depends on to read a reply without a cast.
+
+Two properties were given up for that, neither visible to the type-equivalence check that proved the
+conversion, so they are written down here instead:
+
+- **An `interface` has no implicit index signature.** An anonymous `type X = { … }` is assignable to
+  `Record<string, unknown>`; a named interface is not. Nothing broke, because the three
+  `Record<string, unknown>` sinks in this repo (`flow-runner/src/RelayClient.ts`,
+  `mcp-server/src/client.ts`, `test-utils/src/socket.ts`) are only ever handed fresh object literals.
+  **The fix when one of them needs a typed value is to type the sink**, not to widen the message —
+  replacing `type RelayMsg = Record<string, unknown>` with `BrowserToRelay` is the point of that work,
+  not a casualty of it.
+- **An `interface` can be reopened by a consumer.** `declare module '@tapflowio/protocol'` can add a
+  field to any message, which an anonymous union member could not. Measured: a consumer can give
+  `GenericError` a `sessionId` and defeat the assertion in `typeAssertions.ts` that says it has none.
+  It takes deliberate augmentation, so the risk is low — but the HOW NOT rule below ("do not widen a
+  message") is now bypassable without editing this package.
+
+### The name must be derivable from the literal
+
+`InputDone` ↔ `input:done`: PascalCase over the literal's `:` and `-` segments. Five names deliberately
+break the rule and are listed in `scripts/__tests__/protocolMessageNames.test.mjs` — `GenericError`
+(`Error` would shadow the global), and `AppInstall`/`AppLaunch` × `ToAgent`/`ToRelay`, because those two
+literals travel in both directions carrying **different shapes**: the browser sends `buildId`, the relay
+resolves it into `payload: { filePath, bundleId }`. Naming forced that split into the open.
+
+`device:shutdown` is the opposite case — identical in both directions, so it is **one** interface that
+`RelayToAgent` and `BrowserToRelay` both reference, which states that the relay forwards it untouched.
+
+The derivation is checked in source, and it is the only guard here that a regeneration cannot satisfy.
+The per-message bindings in `typeAssertions.ts` (`_InputDone: InputDone['type'] = 'input:done'`) compare
+two copies of one fact, so they catch an author who edits one of them; measured, editing both left every
+assertion green.
+
 ## Browser-inbound messages are split by producer, and one union is shared
 
 A browser receives 28 message types. They come from two producers, and the difference matters to the

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -161,23 +161,56 @@ export type ChromePayload = ChromeData | AndroidChrome
 
 // ── relay → agent ────────────────────────────────────────────────────────────
 
-export type RelayToAgent =
-  | { type: 'agent:registered'; registeredSessions: Array<{ deviceId: string; sessionId: string }> }
-  | { type: 'stream:request-idr'; sessionId: string }
-  | { type: 'device:shutdown'; sessionId: string; payload: { deviceId: string } }
-  | { type: 'app:install'; sessionId: string; payload: { filePath: string; bundleId: string | null } }
-  | { type: 'app:launch'; sessionId: string; payload: { bundleId: string } }
-  | { type: 'screenshot:request'; sessionId: string; requestId: string; format: 'png' | 'jpeg' }
-  | { type: 'ui:tree:request'; sessionId: string; requestId: string }
+export interface AgentRegistered {
+  type: 'agent:registered'
+  registeredSessions: Array<{ deviceId: string; sessionId: string }>
+}
 
-/**
- * Why a session stopped existing, server-side. A literal union rather than a string so that adding
- * a case is a compile-time event for every consumer that switches on it.
- *
- * Named `session:terminated`, not `session:ended`: `session:end` is already a message the *browser*
- * sends to ask for shutdown, and the two would sit one letter apart in the same switch. This one
- * travels the other way and is not an acknowledgement of that request.
- */
+export interface StreamRequestIdr {
+  type: 'stream:request-idr'
+  sessionId: string
+}
+
+export interface DeviceShutdown {
+  type: 'device:shutdown'
+  sessionId: string
+  payload: { deviceId: string }
+}
+
+export interface AppInstallToAgent {
+  type: 'app:install'
+  sessionId: string
+  payload: { filePath: string; bundleId: string | null }
+}
+
+export interface AppLaunchToAgent {
+  type: 'app:launch'
+  sessionId: string
+  payload: { bundleId: string }
+}
+
+export interface ScreenshotRequest {
+  type: 'screenshot:request'
+  sessionId: string
+  requestId: string
+  format: 'png' | 'jpeg'
+}
+
+export interface UiTreeRequest {
+  type: 'ui:tree:request'
+  sessionId: string
+  requestId: string
+}
+
+export type RelayToAgent =
+  | AgentRegistered
+  | StreamRequestIdr
+  | DeviceShutdown
+  | AppInstallToAgent
+  | AppLaunchToAgent
+  | ScreenshotRequest
+  | UiTreeRequest
+
 export type SessionTerminatedReason = 'agent-disconnected'
 
 /**
@@ -240,74 +273,229 @@ export type InputErrorReason =
  *  Declared once here and referenced by both directions rather than written into each, because two
  *  copies of one message drift. That is not hypothetical: the dashboard kept a hand-copy of this
  *  whole surface and four members had diverged from it, with nothing reporting the difference. */
+// `sessionId` is optional on these three and required on the errors below, because here the two
+// producers genuinely disagree. Both agents stamp it on every one of these
+// (`IOSAgent.ts:401,411,606`, `AndroidAgent.ts:461,867,878`) and the forward gate resolves the
+// session before forwarding, so a *forwarded* copy always carries it — but the relay's own replay
+// to a re-joining viewer does not (`RelayServer.ts:1079,1082,1089`), and it is the same declaration.
+// Optional is what one declaration can honestly say about two producers that differ. Bringing the
+// replay up to the agents' shape, and tightening this to required, belongs with L4 — the layer that
+// types the relay's own sends.
+export interface SessionChrome {
+  type: 'session:chrome'
+  sessionId?: string
+  payload: ChromePayload
+}
+
+export interface SessionDeviceInfo {
+  type: 'session:deviceInfo'
+  sessionId?: string
+  payload: DeviceDetails
+}
+
+export interface DeviceReady {
+  type: 'device:ready'
+  sessionId?: string
+  payload: { deviceId: string }
+}
+
+/**
+ * `sessionId` is what makes a failure findable. A dashboard viewer holds one session per socket,
+ * so an uncorrelated error still lands somewhere sensible — but an MCP caller waits for the reply
+ * that carries its own sessionId, and without one it waits out the deadline instead (#445).
+ *
+ * Required here is a **specification the relay does not yet meet**, not a description of the wire.
+ * Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
+ * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
+ * through `msg.sessionId!` — `JSON.stringify` then drops the key. Seven sites do this
+ * (`RelayServer.ts:719,743,752,786,803,1109,1138`). No in-repo client omits a sessionId, so the
+ * gap is reachable only from a third-party one.
+ *
+ * Optional would describe that wire accurately and still be the wrong contract: an MCP caller that
+ * receives an uncorrelatable `input:error` has nothing it can do with it — it waits out the
+ * deadline either way. The producer is what has to change, and the only correct thing for it to
+ * send with no sessionId is `{ type: 'error' }` below, which exists for exactly that. So this
+ * required field is what makes #444 "send `error` instead" rather than "delete the `!`".
+ */
+export interface SessionError {
+  sessionId: string
+  message: string
+}
+
+export interface AppInstallError extends SessionError {
+  type: 'app:install-error'
+}
+
+export interface AppLaunchError extends SessionError {
+  type: 'app:launch-error'
+}
+
+export interface DeviceBootError extends SessionError {
+  type: 'device:boot-error'
+}
+
+export interface OpenUrlError extends SessionError {
+  type: 'open-url:error'
+}
+
+export interface AppClearStateError extends SessionError {
+  type: 'app:clear-state-error'
+}
+
+export interface InputError extends SessionError {
+  type: 'input:error'
+  reason?: InputErrorReason
+}
+
+// `requestId` is required on the same terms, and with a narrower guarantee behind it: the forward
+// gate resolves `sessionId` only, and both agents read the id as optional
+// (`IOSAgent.ts:1078`, `AndroidAgent.ts:1262`) and pass it straight through. What holds today is
+// that `ClipboardRequest.requestId` is required and the only requester — the dashboard's bridge —
+// is typed with it; `mcp-server` and `flow-runner` send no clipboard message at all. When one of
+// them gains a clipboard tool, this required field is what turns a missing id into a compile error
+// instead of a reply the bridge drops on `if (!msg.requestId) return`. Holding the untyped senders
+// to it is L4.
+export interface ClipboardError extends SessionError {
+  type: 'clipboard:error'
+  requestId: string
+  payload?: ClipboardErrorPayload
+}
+
 export type RelayOrAgentToBrowser =
-  // `sessionId` is optional on these three and required on the errors below, because here the two
-  // producers genuinely disagree. Both agents stamp it on every one of these
-  // (`IOSAgent.ts:401,411,606`, `AndroidAgent.ts:461,867,878`) and the forward gate resolves the
-  // session before forwarding, so a *forwarded* copy always carries it — but the relay's own replay
-  // to a re-joining viewer does not (`RelayServer.ts:1079,1082,1089`), and it is the same declaration.
-  // Optional is what one declaration can honestly say about two producers that differ. Bringing the
-  // replay up to the agents' shape, and tightening this to required, belongs with L4 — the layer that
-  // types the relay's own sends.
-  | { type: 'session:chrome'; sessionId?: string; payload: ChromePayload }
-  | { type: 'session:deviceInfo'; sessionId?: string; payload: DeviceDetails }
-  | { type: 'device:ready'; sessionId?: string; payload: { deviceId: string } }
-  // `sessionId` is what makes a failure findable. A dashboard viewer holds one session per socket,
-  // so an uncorrelated error still lands somewhere sensible — but an MCP caller waits for the reply
-  // that carries its own sessionId, and without one it waits out the deadline instead (#445).
-  //
-  // Required here is a **specification the relay does not yet meet**, not a description of the wire.
-  // Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
-  // sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
-  // through `msg.sessionId!` — `JSON.stringify` then drops the key. Seven sites do this
-  // (`RelayServer.ts:719,743,752,786,803,1109,1138`). No in-repo client omits a sessionId, so the
-  // gap is reachable only from a third-party one.
-  //
-  // Optional would describe that wire accurately and still be the wrong contract: an MCP caller that
-  // receives an uncorrelatable `input:error` has nothing it can do with it — it waits out the
-  // deadline either way. The producer is what has to change, and the only correct thing for it to
-  // send with no sessionId is `{ type: 'error' }` below, which exists for exactly that. So this
-  // required field is what makes #444 "send `error` instead" rather than "delete the `!`".
-  | { type: 'app:install-error'; sessionId: string; message: string }
-  | { type: 'app:launch-error'; sessionId: string; message: string }
-  | { type: 'device:boot-error'; sessionId: string; message: string }
-  | { type: 'open-url:error'; sessionId: string; message: string }
-  | { type: 'app:clear-state-error'; sessionId: string; message: string }
-  | { type: 'input:error'; sessionId: string; message: string; reason?: InputErrorReason }
-  // `requestId` is required on the same terms, and with a narrower guarantee behind it: the forward
-  // gate resolves `sessionId` only, and both agents read the id as optional
-  // (`IOSAgent.ts:1078`, `AndroidAgent.ts:1262`) and pass it straight through. What holds today is
-  // that `ClipboardRequest.requestId` is required and the only requester — the dashboard's bridge —
-  // is typed with it; `mcp-server` and `flow-runner` send no clipboard message at all. When one of
-  // them gains a clipboard tool, this required field is what turns a missing id into a compile error
-  // instead of a reply the bridge drops on `if (!msg.requestId) return`. Holding the untyped senders
-  // to it is L4.
-  | { type: 'clipboard:error'; sessionId: string; requestId: string; message: string; payload?: ClipboardErrorPayload }
+  | SessionChrome
+  | SessionDeviceInfo
+  | DeviceReady
+  | AppInstallError
+  | AppLaunchError
+  | DeviceBootError
+  | OpenUrlError
+  | AppClearStateError
+  | InputError
+  | ClipboardError
+
+export interface AgentsListed {
+  type: 'agents:listed'
+  sessions: SessionInfo[]
+}
+
+export interface SessionJoined {
+  type: 'session:joined'
+  sessionId: string
+  capabilities: string[]
+}
+
+export interface SessionTerminated {
+  type: 'session:terminated'
+  sessionId: string
+  reason: SessionTerminatedReason
+}
+
+// The socket carrying this session's agent went away and the relay is holding the session open
+// in case the agent comes back. Nothing is streaming. Sent so the viewer can say what is going on
+// instead of showing a frame that stopped updating — the symptom #426 opened with.
+//
+// While the same browser socket stays attached, at most one of `session:rebound` (it came back)
+// or `session:terminated` (it did not) follows. Both are addressed to `browserSocket`, so a
+// viewer that disconnects in between gets neither, and re-joining re-sends this one.
+export interface SessionAgentAway {
+  type: 'session:agent-away'
+  sessionId: string
+}
+
+// The agent behind this session restarted and the relay re-pointed the session at its new socket
+// — same sessionId, nothing streaming. The viewer has to ask for the device again, because the
+// codec negotiation and tier live in its own `device:boot` payload and nowhere the relay can see.
+// `capabilities` rides along because `session:joined` is sent once and a restarted agent may
+// advertise a different set (an upgrade is the usual reason to restart one).
+export interface SessionRebound {
+  type: 'session:rebound'
+  sessionId: string
+  capabilities: string[]
+}
+
+// The escape hatch for a failure the relay cannot correlate to a session. Every typed member above
+// carries a sessionId; when there is genuinely none to carry, this is the message to send — not a
+// typed error with the key dropped by `JSON.stringify`.
+export interface GenericError {
+  type: 'error'
+  message: string
+}
 
 /** Messages the relay originates and no agent sends. */
 export type RelayToBrowser =
   | RelayOrAgentToBrowser
-  | { type: 'agents:listed'; sessions: SessionInfo[] }
-  | { type: 'session:joined'; sessionId: string; capabilities: string[] }
-  | { type: 'session:terminated'; sessionId: string; reason: SessionTerminatedReason }
-  // The socket carrying this session's agent went away and the relay is holding the session open
-  // in case the agent comes back. Nothing is streaming. Sent so the viewer can say what is going on
-  // instead of showing a frame that stopped updating — the symptom #426 opened with.
-  //
-  // While the same browser socket stays attached, at most one of `session:rebound` (it came back)
-  // or `session:terminated` (it did not) follows. Both are addressed to `browserSocket`, so a
-  // viewer that disconnects in between gets neither, and re-joining re-sends this one.
-  | { type: 'session:agent-away'; sessionId: string }
-  // The agent behind this session restarted and the relay re-pointed the session at its new socket
-  // — same sessionId, nothing streaming. The viewer has to ask for the device again, because the
-  // codec negotiation and tier live in its own `device:boot` payload and nowhere the relay can see.
-  // `capabilities` rides along because `session:joined` is sent once and a restarted agent may
-  // advertise a different set (an upgrade is the usual reason to restart one).
-  | { type: 'session:rebound'; sessionId: string; capabilities: string[] }
-  // The escape hatch for a failure the relay cannot correlate to a session. Every typed member above
-  // carries a sessionId; when there is genuinely none to carry, this is the message to send — not a
-  // typed error with the key dropped by `JSON.stringify`.
-  | { type: 'error'; message: string }
+  | AgentsListed
+  | SessionJoined
+  | SessionTerminated
+  | SessionAgentAway
+  | SessionRebound
+  | GenericError
+
+export interface DeviceBooting {
+  type: 'device:booting'
+  sessionId: string
+}
+
+export interface DeviceShutdownDone {
+  type: 'device:shutdown-done'
+  sessionId: string
+  payload: { deviceId: string }
+}
+
+export interface AppInstallDone {
+  type: 'app:install-done'
+  sessionId: string
+}
+
+export interface AppLaunchDone {
+  type: 'app:launch-done'
+  sessionId: string
+}
+
+export interface AppClearStateDone {
+  type: 'app:clear-state-done'
+  sessionId: string
+}
+
+export interface OpenUrlDone {
+  type: 'open-url:done'
+  sessionId: string
+}
+
+export interface InputDone {
+  type: 'input:done'
+  sessionId: string
+}
+
+export interface InputTypeDone {
+  type: 'input:type-done'
+  sessionId: string
+}
+
+export interface InputTypeError extends SessionError {
+  type: 'input:type-error'
+}
+
+// iOS only — Android's `input:keyboard:toggle` is a client-side forwarding flag with no device
+// side effect, so it has nothing to report back.
+export interface KeyboardToggled {
+  type: 'keyboard:toggled'
+  sessionId: string
+  payload: { visible: boolean }
+}
+
+export interface ClipboardData {
+  type: 'clipboard:data'
+  sessionId: string
+  requestId: string
+  payload: { text: string }
+}
+
+export interface ClipboardWriteDone {
+  type: 'clipboard:write-done'
+  sessionId: string
+  requestId: string
+}
 
 /** Messages an agent produces. The relay forwards them byte-for-byte (`JSON.stringify(msg)`) rather
  *  than re-creating them, so it never constructs one — which is exactly why they were missing from
@@ -335,20 +523,18 @@ export type RelayToBrowser =
  *  brought up to the agents' shape in the same change. Tracked there rather than left implicit. */
 export type AgentToBrowser =
   | RelayOrAgentToBrowser
-  | { type: 'device:booting'; sessionId: string }
-  | { type: 'device:shutdown-done'; sessionId: string; payload: { deviceId: string } }
-  | { type: 'app:install-done'; sessionId: string }
-  | { type: 'app:launch-done'; sessionId: string }
-  | { type: 'app:clear-state-done'; sessionId: string }
-  | { type: 'open-url:done'; sessionId: string }
-  | { type: 'input:done'; sessionId: string }
-  | { type: 'input:type-done'; sessionId: string }
-  | { type: 'input:type-error'; sessionId: string; message: string }
-  // iOS only — Android's `input:keyboard:toggle` is a client-side forwarding flag with no device
-  // side effect, so it has nothing to report back.
-  | { type: 'keyboard:toggled'; sessionId: string; payload: { visible: boolean } }
-  | { type: 'clipboard:data'; sessionId: string; requestId: string; payload: { text: string } }
-  | { type: 'clipboard:write-done'; sessionId: string; requestId: string }
+  | DeviceBooting
+  | DeviceShutdownDone
+  | AppInstallDone
+  | AppLaunchDone
+  | AppClearStateDone
+  | OpenUrlDone
+  | InputDone
+  | InputTypeDone
+  | InputTypeError
+  | KeyboardToggled
+  | ClipboardData
+  | ClipboardWriteDone
 
 /** Everything a browser socket can receive, whoever produced it. This is what a viewer's message
  *  handler should be typed with — the two unions above answer "who sends this", which matters to
@@ -357,7 +543,12 @@ export type BrowserInbound = RelayToBrowser | AgentToBrowser
 
 /** The agent's *stream* socket, not a browser. Its own direction because it has its own audience:
  *  the consumer is `agent-core`'s stream registration, and nothing in a browser reads it. */
-export type RelayToStream = { type: 'stream:registered' }
+export interface StreamRegistered {
+  type: 'stream:registered'
+}
+
+export type RelayToStream =
+  | StreamRegistered
 
 /** Everything the relay originates. Messages it merely forwards keep their inbound type — they are
  *  not re-created, so they are not checked against this union. */
@@ -386,37 +577,159 @@ export interface Point {
 
 /** The two clipboard requests a viewer can make. Kept as its own union because the bridge sends
  *  them through one call that takes the type as an argument. */
+export interface ClipboardRead {
+  type: 'clipboard:read'
+  sessionId: string
+  requestId: string
+  payload?: { press?: 'copy' | 'cut' }
+}
+
+export interface ClipboardWrite {
+  type: 'clipboard:write'
+  sessionId: string
+  requestId: string
+  payload: { text: string; pasteAfter?: boolean }
+}
+
 export type ClipboardRequest =
-  | { type: 'clipboard:read'; sessionId: string; requestId: string; payload?: { press?: 'copy' | 'cut' } }
-  | { type: 'clipboard:write'; sessionId: string; requestId: string; payload: { text: string; pasteAfter?: boolean } }
+  | ClipboardRead
+  | ClipboardWrite
+
+
+export interface AgentsList {
+  type: 'agents:list'
+}
+
+export interface SessionStart {
+  type: 'session:start'
+  sessionId: string
+}
+
+// The relay handles `session:end`, but nothing in this repo sends it — the dashboard and
+// mcp-server both use `session:leave`. Kept because the relay's handler is the contract for any
+// client that does send it; remove it here only together with that handler.
+export interface SessionEnd {
+  type: 'session:end'
+  sessionId: string
+}
+
+export interface SessionLeave {
+  type: 'session:leave'
+  sessionId: string
+}
+
+// `external` is added by the relay on the way through — the browser never sets it.
+export interface DeviceBoot {
+  type: 'device:boot'
+  sessionId: string
+  payload: { deviceId: string; resetMode?: 'app-only' | 'full-erase'; acceptH264?: boolean; secureContext?: boolean }
+}
+
+export interface AppInstallToRelay {
+  type: 'app:install'
+  sessionId: string
+  buildId: number
+}
+
+export interface AppLaunchToRelay {
+  type: 'app:launch'
+  sessionId: string
+  buildId: number
+}
+
+export interface AppClearState {
+  type: 'app:clear-state'
+  sessionId: string
+  payload?: { bundleId?: string }
+}
+
+export interface OpenUrl {
+  type: 'open-url'
+  sessionId: string
+  payload: { url: string }
+}
+
+export interface InputTouchStart {
+  type: 'input:touch:start'
+  sessionId: string
+  payload: Point
+}
+
+export interface InputTouchMove {
+  type: 'input:touch:move'
+  sessionId: string
+  payload: Point
+}
+
+// `payload` is accepted but ignored: the agents call `touchEnd()` without reading it. The
+// dashboard omits it, mcp-server sends the last point. Optional here because that is what the
+// wire actually carries — not because the coordinate means anything on this message.
+export interface InputTouchEnd {
+  type: 'input:touch:end'
+  sessionId: string
+  payload?: Point
+}
+
+export interface InputPinchStart {
+  type: 'input:pinch:start'
+  sessionId: string
+  payload: { f0: Point; f1: Point }
+}
+
+export interface InputPinchMove {
+  type: 'input:pinch:move'
+  sessionId: string
+  payload: { f0: Point; f1: Point }
+}
+
+export interface InputPinchEnd {
+  type: 'input:pinch:end'
+  sessionId: string
+}
+
+export interface InputType {
+  type: 'input:type'
+  sessionId: string
+  payload: { text: string }
+}
+
+export interface InputButton {
+  type: 'input:button'
+  sessionId: string
+  payload: { name: string; phase?: 'down' | 'up' }
+}
+
+export interface InputRotate {
+  type: 'input:rotate'
+  sessionId: string
+}
+
+export interface InputKeyboardToggle {
+  type: 'input:keyboard:toggle'
+  sessionId: string
+}
 
 export type BrowserToRelay =
-  | { type: 'agents:list' }
-  | { type: 'session:start'; sessionId: string }
-  // The relay handles `session:end`, but nothing in this repo sends it — the dashboard and
-  // mcp-server both use `session:leave`. Kept because the relay's handler is the contract for any
-  // client that does send it; remove it here only together with that handler.
-  | { type: 'session:end'; sessionId: string }
-  | { type: 'session:leave'; sessionId: string }
-  // `external` is added by the relay on the way through — the browser never sets it.
-  | { type: 'device:boot'; sessionId: string; payload: { deviceId: string; resetMode?: 'app-only' | 'full-erase'; acceptH264?: boolean; secureContext?: boolean } }
-  | { type: 'device:shutdown'; sessionId: string; payload: { deviceId: string } }
-  | { type: 'app:install'; sessionId: string; buildId: number }
-  | { type: 'app:launch'; sessionId: string; buildId: number }
-  | { type: 'app:clear-state'; sessionId: string; payload?: { bundleId?: string } }
-  | { type: 'open-url'; sessionId: string; payload: { url: string } }
-  | { type: 'input:touch:start'; sessionId: string; payload: Point }
-  | { type: 'input:touch:move'; sessionId: string; payload: Point }
-  // `payload` is accepted but ignored: the agents call `touchEnd()` without reading it. The
-  // dashboard omits it, mcp-server sends the last point. Optional here because that is what the
-  // wire actually carries — not because the coordinate means anything on this message.
-  | { type: 'input:touch:end'; sessionId: string; payload?: Point }
-  | { type: 'input:pinch:start'; sessionId: string; payload: { f0: Point; f1: Point } }
-  | { type: 'input:pinch:move'; sessionId: string; payload: { f0: Point; f1: Point } }
-  | { type: 'input:pinch:end'; sessionId: string }
+  | AgentsList
+  | SessionStart
+  | SessionEnd
+  | SessionLeave
+  | DeviceBoot
+  | DeviceShutdown
+  | AppInstallToRelay
+  | AppLaunchToRelay
+  | AppClearState
+  | OpenUrl
+  | InputTouchStart
+  | InputTouchMove
+  | InputTouchEnd
+  | InputPinchStart
+  | InputPinchMove
+  | InputPinchEnd
   | InputKey
-  | { type: 'input:type'; sessionId: string; payload: { text: string } }
-  | { type: 'input:button'; sessionId: string; payload: { name: string; phase?: 'down' | 'up' } }
-  | { type: 'input:rotate'; sessionId: string }
-  | { type: 'input:keyboard:toggle'; sessionId: string }
+  | InputType
+  | InputButton
+  | InputRotate
+  | InputKeyboardToggle
   | ClipboardRequest
+

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -6,7 +6,18 @@
 // `@ts-expect-error` is itself a compile error. So the guard cannot rot silently, which is exactly
 // the failure mode this whole package was built to remove.
 
-import type { AgentToBrowser, BrowserInbound, BrowserToRelay, RelayOutbound } from './index.js'
+import type {
+  AgentRegistered, AgentToBrowser, AgentsList, AgentsListed, AppClearState, AppClearStateDone,
+  AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent, AppInstallToRelay, AppLaunchDone,
+  AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound, BrowserToRelay, ClipboardData,
+  ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone, DeviceBoot, DeviceBootError,
+  DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone, GenericError, InputButton, InputDone,
+  InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove, InputPinchStart, InputRotate,
+  InputTouchEnd, InputTouchMove, InputTouchStart, InputType, InputTypeDone, InputTypeError, KeyboardToggled,
+  OpenUrl, OpenUrlDone, OpenUrlError, RelayOutbound, ScreenshotRequest, SessionAgentAway, SessionChrome,
+  SessionDeviceInfo, SessionEnd, SessionJoined, SessionLeave, SessionRebound, SessionStart,
+  SessionTerminated, StreamRegistered, StreamRequestIdr, UiTreeRequest,
+} from './index.js'
 
 // ── must NOT compile ─────────────────────────────────────────────────────────
 
@@ -79,3 +90,73 @@ export const errorWithReason: RelayOutbound = { type: 'input:error', sessionId: 
 
 // @ts-expect-error - the reason set is closed; a free string would let each agent invent its own
 export const errorWithFreeReason: RelayOutbound = { type: 'input:error', sessionId: 's', message: 'x', reason: 'something-else' }
+
+// ── name ↔ literal bindings ────────────────────────────────────────────────────────────────────────
+//
+// One line per message, and the only thing here that survived L1's conversion window. The `Equals<>`
+// net that proved the conversion compared union *contents*, and a union is a set — so which interface
+// got which `type` literal was not part of the comparison at all. `AgentToBrowser` has seven members
+// whose shape is identical apart from the literal, so a copy-paste that swaps two of them passed
+// `Equals`, passed the routing check (which compares membership) and passed the payload check.
+// Measured: the swap produced two errors here and zero from the nine `Equals` assertions.
+//
+// `scripts/__tests__/protocolMessageNames.test.mjs` asserts every message interface has a line here —
+// a guard you can forget one entry of is a guard with 57-of-58 coverage, and the gap is invisible.
+export const _AgentRegistered: AgentRegistered['type'] = 'agent:registered'
+export const _AgentsList: AgentsList['type'] = 'agents:list'
+export const _AgentsListed: AgentsListed['type'] = 'agents:listed'
+export const _AppClearState: AppClearState['type'] = 'app:clear-state'
+export const _AppClearStateDone: AppClearStateDone['type'] = 'app:clear-state-done'
+export const _AppClearStateError: AppClearStateError['type'] = 'app:clear-state-error'
+export const _AppInstallDone: AppInstallDone['type'] = 'app:install-done'
+export const _AppInstallError: AppInstallError['type'] = 'app:install-error'
+export const _AppInstallToAgent: AppInstallToAgent['type'] = 'app:install'
+export const _AppInstallToRelay: AppInstallToRelay['type'] = 'app:install'
+export const _AppLaunchDone: AppLaunchDone['type'] = 'app:launch-done'
+export const _AppLaunchError: AppLaunchError['type'] = 'app:launch-error'
+export const _AppLaunchToAgent: AppLaunchToAgent['type'] = 'app:launch'
+export const _AppLaunchToRelay: AppLaunchToRelay['type'] = 'app:launch'
+export const _ClipboardData: ClipboardData['type'] = 'clipboard:data'
+export const _ClipboardError: ClipboardError['type'] = 'clipboard:error'
+export const _ClipboardRead: ClipboardRead['type'] = 'clipboard:read'
+export const _ClipboardWrite: ClipboardWrite['type'] = 'clipboard:write'
+export const _ClipboardWriteDone: ClipboardWriteDone['type'] = 'clipboard:write-done'
+export const _DeviceBoot: DeviceBoot['type'] = 'device:boot'
+export const _DeviceBootError: DeviceBootError['type'] = 'device:boot-error'
+export const _DeviceBooting: DeviceBooting['type'] = 'device:booting'
+export const _DeviceReady: DeviceReady['type'] = 'device:ready'
+export const _DeviceShutdown: DeviceShutdown['type'] = 'device:shutdown'
+export const _DeviceShutdownDone: DeviceShutdownDone['type'] = 'device:shutdown-done'
+export const _GenericError: GenericError['type'] = 'error'
+export const _InputButton: InputButton['type'] = 'input:button'
+export const _InputDone: InputDone['type'] = 'input:done'
+export const _InputError: InputError['type'] = 'input:error'
+export const _InputKey: InputKey['type'] = 'input:key'
+export const _InputKeyboardToggle: InputKeyboardToggle['type'] = 'input:keyboard:toggle'
+export const _InputPinchEnd: InputPinchEnd['type'] = 'input:pinch:end'
+export const _InputPinchMove: InputPinchMove['type'] = 'input:pinch:move'
+export const _InputPinchStart: InputPinchStart['type'] = 'input:pinch:start'
+export const _InputRotate: InputRotate['type'] = 'input:rotate'
+export const _InputTouchEnd: InputTouchEnd['type'] = 'input:touch:end'
+export const _InputTouchMove: InputTouchMove['type'] = 'input:touch:move'
+export const _InputTouchStart: InputTouchStart['type'] = 'input:touch:start'
+export const _InputType: InputType['type'] = 'input:type'
+export const _InputTypeDone: InputTypeDone['type'] = 'input:type-done'
+export const _InputTypeError: InputTypeError['type'] = 'input:type-error'
+export const _KeyboardToggled: KeyboardToggled['type'] = 'keyboard:toggled'
+export const _OpenUrl: OpenUrl['type'] = 'open-url'
+export const _OpenUrlDone: OpenUrlDone['type'] = 'open-url:done'
+export const _OpenUrlError: OpenUrlError['type'] = 'open-url:error'
+export const _ScreenshotRequest: ScreenshotRequest['type'] = 'screenshot:request'
+export const _SessionAgentAway: SessionAgentAway['type'] = 'session:agent-away'
+export const _SessionChrome: SessionChrome['type'] = 'session:chrome'
+export const _SessionDeviceInfo: SessionDeviceInfo['type'] = 'session:deviceInfo'
+export const _SessionEnd: SessionEnd['type'] = 'session:end'
+export const _SessionJoined: SessionJoined['type'] = 'session:joined'
+export const _SessionLeave: SessionLeave['type'] = 'session:leave'
+export const _SessionRebound: SessionRebound['type'] = 'session:rebound'
+export const _SessionStart: SessionStart['type'] = 'session:start'
+export const _SessionTerminated: SessionTerminated['type'] = 'session:terminated'
+export const _StreamRegistered: StreamRegistered['type'] = 'stream:registered'
+export const _StreamRequestIdr: StreamRequestIdr['type'] = 'stream:request-idr'
+export const _UiTreeRequest: UiTreeRequest['type'] = 'ui:tree:request'

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -62,57 +62,81 @@ function forwardedToBrowser(src) {
   return found
 }
 
-/** One member's field names, each suffixed `?` when optional. The names are the cheap half of this
- *  file and they are not the substance: the twelve new declarations exist for their *fields*, and a
- *  name-only check stays green if every one of them loses `sessionId` or turns it optional. */
-function memberSignature(src, name, type) {
-  const body = unionBody(src, name)
-  const at = body.indexOf(`{ type: '${type}'`)
-  if (at === -1) return null
-  let depth = 0
-  let end = at
-  for (; end < body.length; end++) {
-    if (body[end] === '{') depth++
-    else if (body[end] === '}' && --depth === 0) break
+/** `export interface Name { … }` bodies, by name. L1 moved every message out of its union and into one
+ *  of these, so a parser that reads only union bodies now finds nothing — it did, and this file's
+ *  `stream:registered` assertion is what said so. */
+function interfaceBodies(src) {
+  const out = new Map()
+  for (const m of src.matchAll(/export interface (\w+)(?: extends (\w+))? \{\n((?:  [^\n]*\n)+)\}/g)) {
+    out.set(m[1], { body: m[3].replace(/^\s*\/\/.*$/gm, ''), extends: m[2] ?? null })
   }
-  const inner = body.slice(at + 1, end)
-  // Top-level fields only — a nested `payload: { deviceId: string }` must not contribute `deviceId`.
-  const fields = []
+  return out
+}
+
+const IFACES = interfaceBodies(protocolSrc)
+
+/** The `type` literal an interface declares. A base like `SessionError` carries none. */
+function literalOf(name) {
+  const m = IFACES.get(name)?.body.match(/^ {2}type: '([^']+)';?$/m)
+  return m ? m[1] : null
+}
+
+/** Fields of an interface with `extends` resolved, each suffixed `?` when optional, **sorted**.
+ *  Declaration order carries no meaning, and `extends SessionError` puts the inherited pair first —
+ *  which reordered three signatures that had not otherwise changed. Sorting keeps the check aimed at
+ *  what a consumer can observe: which fields exist and which are optional. */
+function fieldsOf(name) {
+  const decl = IFACES.get(name)
+  if (!decl) return null
+  const own = []
   let nest = 0
-  for (const part of inner.split(';')) {
+  for (const line of decl.body.split('\n')) {
     const before = nest
-    nest += (part.match(/\{/g) ?? []).length - (part.match(/\}/g) ?? []).length
+    nest += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
     if (before !== 0) continue
-    const m = part.match(/^\s*(\w+)(\??):/)
-    if (m && m[1] !== 'type') fields.push(m[1] + m[2])
+    // Top-level fields only — a nested `payload: { deviceId: string }` must not contribute `deviceId`.
+    const m = line.match(/^ {2}(\w+)(\??):/)
+    if (m && m[1] !== 'type') own.push(m[1] + m[2])
   }
-  return fields.join(' ')
+  const inherited = decl.extends ? (fieldsOf(decl.extends) ?? '').split(' ').filter(Boolean) : []
+  return [...inherited, ...own].sort().join(' ')
 }
 
 function unionBody(src, name) {
   const start = src.indexOf(`export type ${name} =`)
+  expect(start, `${name} not found in protocol`).toBeGreaterThan(-1)
   const rest = src.slice(start)
   const end = rest.search(/\n\s*\n/)
   return rest.slice(0, end === -1 ? undefined : end).replace(/^\s*\/\/.*$/gm, '')
 }
 
-/** Members of a union type, following one level of referenced unions (`| OtherUnion`). */
-function unionMembers(src, name) {
-  const start = src.indexOf(`export type ${name} =`)
-  expect(start, `${name} not found in protocol`).toBeGreaterThan(-1)
-  const rest = src.slice(start)
-  const end = rest.search(/\n\s*\n/)
-  // Comments out, or a member is whatever the prose mentions: the note on `RelayOrAgentToBrowser`
-  // points at `{ type: 'error' }` to explain why that one is NOT shared, and the parser read it as
-  // an eleventh member — a false positive that reads exactly like a real declaration.
-  const body = rest.slice(0, end === -1 ? undefined : end).replace(/^\s*\/\/.*$/gm, '')
+/** Interface names a union denotes, following one level of referenced unions (`| OtherUnion`). */
+function unionRefs(src, name) {
+  const out = []
+  for (const m of unionBody(src, name).matchAll(/^\s*\|\s*(\w+)\s*$/gm)) {
+    if (IFACES.has(m[1])) out.push(m[1])
+    else out.push(...unionRefs(src, m[1]))
+  }
+  return out
+}
 
+/** Message `type` literals a union denotes. */
+function unionMembers(src, name) {
   const types = new Set()
-  for (const m of body.matchAll(/\{\s*type: '([^']+)'/g)) types.add(m[1])
-  for (const m of body.matchAll(/^\s*\|\s*([A-Z]\w+)\s*$/gm)) {
-    for (const t of unionMembers(src, m[1])) types.add(t)
+  for (const ref of unionRefs(src, name)) {
+    const lit = literalOf(ref)
+    expect(lit, `${ref} declares no type literal`).not.toBeNull()
+    types.add(lit)
   }
   return types
+}
+
+/** The pinned signature lookup: find the interface in this union that owns `type`, return its fields. */
+function memberSignature(src, name, type) {
+  for (const ref of unionRefs(src, name)) {
+    if (literalOf(ref) === type) return fieldsOf(ref)
+  }
+  return null
 }
 
 describe('browser-inbound routing matches the protocol union', () => {
@@ -153,39 +177,83 @@ describe('browser-inbound routing matches the protocol union', () => {
   //
   // `sessionId` is required on all twelve forwarded messages and on the seven shared errors; it is
   // optional on exactly the three the relay also replays without one (see the note in the union).
+  //
+  // All five message unions are here, not just the browser-inbound three. The bindings in
+  // `typeAssertions.ts` pin 58 literals and read like per-message coverage, but a literal is all they
+  // pin — measured, `ScreenshotRequest.requestId`, `DeviceBoot.sessionId` and `DeviceBoot.payload.deviceId`
+  // could all be made optional with every assertion green, and `sessionId?` is the widening
+  // `packages/protocol/AGENTS.md` calls near-irreversible.
+  //
+  // `payload` is one token here, so a change *inside* a nested literal is still invisible. The named
+  // payload types have their field counts pinned in `protocolPayloadTypes`; inline ones like
+  // `device:boot`'s do not, and closing that is a separate job.
   const SIGNATURES = {
     AgentToBrowser: {
       'device:booting': 'sessionId',
-      'device:shutdown-done': 'sessionId payload',
+      'device:shutdown-done': 'payload sessionId',
       'app:install-done': 'sessionId',
       'app:launch-done': 'sessionId',
       'app:clear-state-done': 'sessionId',
       'open-url:done': 'sessionId',
       'input:done': 'sessionId',
       'input:type-done': 'sessionId',
-      'input:type-error': 'sessionId message',
-      'keyboard:toggled': 'sessionId payload',
-      'clipboard:data': 'sessionId requestId payload',
-      'clipboard:write-done': 'sessionId requestId',
+      'input:type-error': 'message sessionId',
+      'keyboard:toggled': 'payload sessionId',
+      'clipboard:data': 'payload requestId sessionId',
+      'clipboard:write-done': 'requestId sessionId',
     },
     RelayOrAgentToBrowser: {
-      'session:chrome': 'sessionId? payload',
-      'session:deviceInfo': 'sessionId? payload',
-      'device:ready': 'sessionId? payload',
-      'app:install-error': 'sessionId message',
-      'app:launch-error': 'sessionId message',
-      'device:boot-error': 'sessionId message',
-      'open-url:error': 'sessionId message',
-      'app:clear-state-error': 'sessionId message',
-      'input:error': 'sessionId message reason?',
-      'clipboard:error': 'sessionId requestId message payload?',
+      'session:chrome': 'payload sessionId?',
+      'session:deviceInfo': 'payload sessionId?',
+      'device:ready': 'payload sessionId?',
+      'app:install-error': 'message sessionId',
+      'app:launch-error': 'message sessionId',
+      'device:boot-error': 'message sessionId',
+      'open-url:error': 'message sessionId',
+      'app:clear-state-error': 'message sessionId',
+      'input:error': 'message reason? sessionId',
+      'clipboard:error': 'message payload? requestId sessionId',
+    },
+    BrowserToRelay: {
+      'agents:list': '',
+      'session:start': 'sessionId',
+      'session:end': 'sessionId',
+      'session:leave': 'sessionId',
+      'device:boot': 'payload sessionId',
+      'device:shutdown': 'payload sessionId',
+      'app:install': 'buildId sessionId',
+      'app:launch': 'buildId sessionId',
+      'app:clear-state': 'payload? sessionId',
+      'open-url': 'payload sessionId',
+      'input:touch:start': 'payload sessionId',
+      'input:touch:move': 'payload sessionId',
+      'input:touch:end': 'payload? sessionId',
+      'input:pinch:start': 'payload sessionId',
+      'input:pinch:move': 'payload sessionId',
+      'input:pinch:end': 'sessionId',
+      'input:key': 'payload sessionId',
+      'input:type': 'payload sessionId',
+      'input:button': 'payload sessionId',
+      'input:rotate': 'sessionId',
+      'input:keyboard:toggle': 'sessionId',
+      'clipboard:read': 'payload? requestId sessionId',
+      'clipboard:write': 'payload requestId sessionId',
+    },
+    RelayToAgent: {
+      'agent:registered': 'registeredSessions',
+      'stream:request-idr': 'sessionId',
+      'device:shutdown': 'payload sessionId',
+      'app:install': 'payload sessionId',
+      'app:launch': 'payload sessionId',
+      'screenshot:request': 'format requestId sessionId',
+      'ui:tree:request': 'requestId sessionId',
     },
     RelayToBrowser: {
       'agents:listed': 'sessions',
-      'session:joined': 'sessionId capabilities',
-      'session:terminated': 'sessionId reason',
+      'session:joined': 'capabilities sessionId',
+      'session:terminated': 'reason sessionId',
       'session:agent-away': 'sessionId',
-      'session:rebound': 'sessionId capabilities',
+      'session:rebound': 'capabilities sessionId',
       error: 'message',
     },
   }
@@ -241,9 +309,15 @@ describe('browser-inbound routing matches the protocol union', () => {
     const bridge = readFileSync(join(root, 'packages/dashboard/hooks/useClipboardBridge.ts'), 'utf8')
     const viewer = readFileSync(join(root, 'packages/dashboard/components/DeviceViewer.tsx'), 'utf8')
 
-    const declared = bridge.match(/export type ClipboardBridgeMessage = Extract<[\s\S]*?>\n/)
-    expect(declared, 'ClipboardBridgeMessage is no longer an Extract<> of the wire union').not.toBeNull()
-    const wanted = [...declared[0].matchAll(/'([^']+)'/g)].map((m) => m[1]).sort()
+    // L1 replaced the `Extract<>` with named members, so the expected set comes from resolving those
+    // names to their literals — still derived from the bridge's own declaration, not restated here.
+    const declared = bridge.match(/export type ClipboardBridgeMessage = ([\w |]+)\n/)
+    expect(declared, 'ClipboardBridgeMessage is no longer a union of named wire messages').not.toBeNull()
+    const wanted = declared[1].split('|').map((n) => n.trim()).filter(Boolean).map((n) => {
+      const lit = literalOf(n)
+      expect(lit, `${n} is not a protocol message interface`).not.toBeNull()
+      return lit
+    }).sort()
 
     const at = viewer.indexOf('clipboardHandlerRef.current?.(msg)')
     expect(at, 'DeviceViewer no longer routes into the clipboard bridge').toBeGreaterThan(-1)

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -311,7 +311,11 @@ describe('browser-inbound routing matches the protocol union', () => {
 
     // L1 replaced the `Extract<>` with named members, so the expected set comes from resolving those
     // names to their literals — still derived from the bridge's own declaration, not restated here.
-    const declared = bridge.match(/export type ClipboardBridgeMessage = ([\w |]+)\n/)
+    // Up to the next blank line, not the next newline. A one-line capture truncates the moment the
+    // declaration wraps, and it truncates *silently*: `wanted` loses the trailing members, and if the
+    // author also forgot to route them then `routed` is short by the same ones and the sets match. The
+    // count pin below does not help — the truncation lands on exactly the old count.
+    const declared = bridge.match(/export type ClipboardBridgeMessage =([\s\S]*?)\n\s*\n/)
     expect(declared, 'ClipboardBridgeMessage is no longer a union of named wire messages').not.toBeNull()
     const wanted = declared[1].split('|').map((n) => n.trim()).filter(Boolean).map((n) => {
       const lit = literalOf(n)

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Two facts about `packages/protocol/src/index.ts` that no type can state about itself.
+//
+// **1. Which interface owns which `type` literal.** `Equals<Union, UnionOld>` — the net L1 used to
+// prove the conversion preserved every union — compares union *contents*, and a union is a set. Which
+// name got which literal is not part of the comparison. `AgentToBrowser` has seven members whose shape
+// is identical apart from the literal (`{ type: <literal>; sessionId: string }`), so swapping two of
+// them passes `Equals`, passes `browserInboundRouting` (which compares membership, so the literal set
+// is unchanged) and passes `protocolPayloadTypes`. Measured: the swap produced zero errors from the
+// nine `Equals` assertions and two from the bindings.
+//
+// The bindings in `typeAssertions.ts` (`export const _InputDone: InputDone['type'] = 'input:done'`)
+// are what catch it, and this file asserts every message interface has one — a guard you can forget an
+// entry of is a guard with 56-of-57 coverage, and the missing one is invisible.
+//
+// **2. That a session-scoped failure declares `extends SessionError`.** This cannot be asserted with a
+// type: every object with `{ sessionId, message }` is assignable to `SessionError`, so the assignment
+// succeeds whether or not the interface declares the inheritance. And `extends` is transparent to
+// `Equals` — inherited members arrive in the resolved member set, so an error written inline instead
+// passes every type-level check. The inheritance exists for the family relation, which is source text,
+// so the check reads source text.
+
+const root = join(import.meta.dirname, '../..')
+const src = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
+const assertionsRaw = readFileSync(join(root, 'packages/protocol/src/typeAssertions.ts'), 'utf8')
+// Comments out before anything looks for declarations. The bindings' own note explains what `Equals<>`
+// did and did not catch, and the "net is gone" assertion below read that prose as the net still being
+// there. Same shape as the bug in `browserInboundRouting`, where a comment mentioning `{ type: 'error' }`
+// was counted as an eleventh union member.
+const assertions = assertionsRaw.replace(/^\s*\/\/.*$/gm, '')
+
+/** Every `export interface` that declares a `type: '<literal>'` — i.e. every wire message.
+ *
+ *  Bodies are found by counting braces, not by matching a run of two-space lines. The regex version
+ *  skipped any interface with a blank line in its body — and `expect(messages.size).toBe(58)` was then
+ *  satisfied *because* of the skip, so a new message with no binding passed all seventeen assertions.
+ *  A count is only coverage if the parser cannot lose a declaration. */
+function messageInterfaces(text) {
+  const out = new Map()
+  for (const m of text.matchAll(/export interface (\w+)(?: extends (\w+))? \{/g)) {
+    let depth = 0
+    let end = m.index + m[0].length - 1
+    for (; end < text.length; end++) {
+      if (text[end] === '{') depth++
+      else if (text[end] === '}' && --depth === 0) break
+    }
+    const body = text.slice(m.index + m[0].length, end)
+    const lit = body.match(/^ {2}type: '([^']+)';?$/m)
+    if (lit) out.set(m[1], { literal: lit[1], extends: m[2] ?? null, body })
+  }
+  return out
+}
+
+/** The interface name a `type` literal implies: PascalCase over its `:`/`-` segments.
+ *
+ *  This is the only assertion here that a regeneration cannot satisfy. The bindings in
+ *  `typeAssertions.ts` compare two copies of one fact — the interface's literal and the binding's — so
+ *  they catch an author who edits one. They do not catch an author who edits both, and since the names
+ *  were *derived* mechanically, "regenerate the table" is the natural response to a rename in progress:
+ *  it re-derives from the declarations it is meant to check. Measured — swapping two literals in
+ *  `index.ts` *and* their two binding lines left all 228 script assertions green.
+ *
+ *  A derivation rule is independent of both copies. */
+function derivedName(literal) {
+  return literal.split(/[:-]/).map((p) => p[0].toUpperCase() + p.slice(1)).join('')
+}
+
+// Names that deliberately do not follow the derivation, each because the literal alone cannot name the
+// interface. Two literals travel in both directions with different shapes, so each needs two names; and
+// `Error` would shadow the global.
+const NAME_EXCEPTIONS = new Map([
+  ['GenericError', 'error'],
+  ['AppInstallToAgent', 'app:install'],
+  ['AppInstallToRelay', 'app:install'],
+  ['AppLaunchToAgent', 'app:launch'],
+  ['AppLaunchToRelay', 'app:launch'],
+])
+
+const messages = messageInterfaces(src)
+
+describe('protocol message interfaces', () => {
+  it('found every message interface — the parser is not quietly empty', () => {
+    // Without this the two assertions below pass on an empty map. The count is pinned rather than
+    // derived so that a parser that stops matching says so, instead of reporting full coverage of
+    // nothing. L2 shipped that exact failure in the other direction. 57 came from L1's conversion plus
+    // `InputKey`, which was already named and is a message like any other.
+    expect(messages.size).toBe(58)
+    // `InputKey` predates L1 and has always been named; it must be in here too.
+    expect(messages.has('InputKey')).toBe(true)
+  })
+
+  it('every message interface has a name↔literal binding', () => {
+    const missing = []
+    const wrong = []
+    for (const [name, { literal }] of messages) {
+      const line = assertions.match(new RegExp(`^export const _${name}: ${name}\\['type'\\] = '([^']+)'$`, 'm'))
+      if (!line) missing.push(name)
+      // The compiler already rejects a binding whose value disagrees with the interface. This catches
+      // the other direction — a binding whose literal drifted along *with* the interface, which
+      // compiles and asserts nothing about what the wire carries.
+      else if (line[1] !== literal) wrong.push(`_${name} says '${line[1]}', interface says '${literal}'`)
+    }
+    expect(missing).toEqual([])
+    expect(wrong).toEqual([])
+  })
+
+  it('every message name is derivable from its literal', () => {
+    const offenders = []
+    for (const [name, { literal }] of messages) {
+      const expected = NAME_EXCEPTIONS.get(name)
+      if (expected !== undefined) {
+        // An exception still has to name the right message.
+        if (literal !== expected) offenders.push(`${name} is listed for '${expected}' but declares '${literal}'`)
+        continue
+      }
+      if (name !== derivedName(literal)) offenders.push(`${name} declares '${literal}', which derives ${derivedName(literal)}`)
+    }
+    expect(offenders).toEqual([])
+    // Pinned so an exception cannot be added quietly to make a rename compile.
+    expect(NAME_EXCEPTIONS.size).toBe(5)
+  })
+
+  it('a session-scoped failure declares extends SessionError', () => {
+    const offenders = []
+    for (const [name, { literal, extends: base, body }] of messages) {
+      const isFailure = /error$/.test(literal)
+      const hasSession = /^ {2}sessionId[?]?:/m.test(body) || base === 'SessionError'
+      // `error` is the escape hatch for a failure that cannot be attributed to a session, so it has no
+      // `sessionId` and cannot be a `SessionError`. That is the member's nature, not an exception.
+      if (!isFailure || !hasSession) continue
+      if (base !== 'SessionError') offenders.push(`${name} ('${literal}')`)
+    }
+    expect(offenders).toEqual([])
+    expect([...messages].filter(([, m]) => m.extends === 'SessionError')).toHaveLength(8)
+    // The one failure that deliberately does not inherit.
+    expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: null })
+    // What the base carries, pinned. `browserInboundRouting`'s signatures resolve `extends` and sort,
+    // so they cannot tell an inherited field from an own-declared one: moving `sessionId` out of the
+    // base and into all eight subclasses leaves every signature identical and every check green.
+    // Measured. This line is what makes the inheritance mean something.
+    const base = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
+      .match(/export interface SessionError \{([^}]*)\}/)
+    expect(base, 'SessionError is gone').not.toBeNull()
+    expect([...base[1].matchAll(/^ {2}(\w+)(\??):/gm)].map((m) => m[1] + m[2]).sort()).toEqual(['message', 'sessionId'])
+  })
+
+  it('the L1 conversion net is gone', () => {
+    // `Equals` and the `…Old` snapshots were the conversion-window net and were deleted with it. If
+    // they come back, they are being mistaken for lasting protection — they compare unions that no
+    // longer have an "old" to compare against, so a fresh snapshot would be taken from the same
+    // declarations it is meant to check.
+    expect(assertions).not.toMatch(/type \w+Old =/)
+    expect(assertions).not.toMatch(/Equals</)
+  })
+})

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -14,7 +14,7 @@ import { join } from 'node:path'
 //
 // The bindings in `typeAssertions.ts` (`export const _InputDone: InputDone['type'] = 'input:done'`)
 // are what catch it, and this file asserts every message interface has one — a guard you can forget an
-// entry of is a guard with 56-of-57 coverage, and the missing one is invisible.
+// entry of is a guard with 57-of-58 coverage, and the missing one is invisible.
 //
 // **2. That a session-scoped failure declares `extends SessionError`.** This cannot be asserted with a
 // type: every object with `{ sessionId, message }` is assignable to `SessionError`, so the assignment
@@ -85,7 +85,7 @@ describe('protocol message interfaces', () => {
   it('found every message interface — the parser is not quietly empty', () => {
     // Without this the two assertions below pass on an empty map. The count is pinned rather than
     // derived so that a parser that stops matching says so, instead of reporting full coverage of
-    // nothing. L2 shipped that exact failure in the other direction. 57 came from L1's conversion plus
+    // nothing. L2 shipped that exact failure in the other direction. 58 is 57 from L1's conversion plus
     // `InputKey`, which was already named and is a message like any other.
     expect(messages.size).toBe(58)
     // `InputKey` predates L1 and has always been named; it must be in here too.

--- a/scripts/__tests__/protocolPayloadTypes.test.mjs
+++ b/scripts/__tests__/protocolPayloadTypes.test.mjs
@@ -105,11 +105,40 @@ function walk(dir, out = []) {
   return out
 }
 
-const protoDecls = interfaces(readFileSync(PROTOCOL, 'utf8'))
+const protoSrc = readFileSync(PROTOCOL, 'utf8')
+const protoDecls = interfaces(protoSrc)
 /** Payload types worth guarding. Two fields is enough to be a real shape; one is a coincidence. */
+// Payload shapes only. A **message** is identified by its `type` literal, not by its field set (D14 in
+// the wire-contract program), and L1 turned 58 messages into interfaces — many sharing a low-arity set
+// like `{type, sessionId}`. Keying those by field set would make this check report the next package
+// that happens to declare `interface Foo { type: string; sessionId: string }` as re-declaring a
+// protocol payload, which it is not. Measured at the time: zero such collisions existed, so this is
+// removing a tripwire L1 planted rather than fixing a live failure.
+// Payload shapes only, which means excluding two kinds of declaration.
+//
+// **Messages.** A message is identified by its `type` literal, not by its field set (D14 in the
+// wire-contract program), and L1 turned 58 of them into interfaces — many sharing a low-arity set like
+// `{type, sessionId}`.
+//
+// **Bases that messages inherit.** `SessionError` carries no `type`, so the first rule keeps it, and
+// its shape `{sessionId, message}` is the most common local error DTO in this repo. Measured: a plain
+// `interface RelayFailure { sessionId: string; message: string }` in `mcp-server` was reported as
+// re-declaring a protocol payload — and the advice this check gives ("import it from protocol instead")
+// is wrong for that case. A message base is a structural fragment of the message family, not a shape a
+// consumer should import.
+//
+// Scoped to bases of *messages*, not every base. `DeviceReport` is also extended — by `DeviceSummary`,
+// which is a payload — and excluding it would drop a real shape from the guarded set. The heir having a
+// `type` field is what makes its base part of the message family.
+const bases = new Set(
+  [...protoSrc.matchAll(/export interface (\w+) extends (\w+) \{([^}]*)\}/g)]
+    .filter((m) => /^ {2}type: '/m.test(m[3]))
+    .map((m) => m[2]),
+)
 const guarded = new Map()
 for (const name of protoDecls.keys()) {
   const fields = resolved(protoDecls, name)
+  if (fields.includes('type') || bases.has(name)) continue
   if (fields.length >= 2) guarded.set(key(fields), name)
 }
 


### PR DESCRIPTION
Layer 1 of the wire-contract program (`.work/WIRE-CONTRACT-PLAN.md`). Follows #503 (L3).

## What was wrong

58 messages were anonymous members of a union, and that blocked two things.

**A single message could not be referred to.** Consumers reached for `Extract<Union, { type: 'x' }>` — one of them needing `extends { payload: infer P }` just to get at a payload.

**Shared structure had nowhere to live.** Eight session-scoped failures carry the same `{ sessionId, message }` contract with no place to say so, and the note explaining that contract floated above a union line.

## What this does

Each message is an `export interface`; the unions are unions of those names. `interface` rather than a `type` alias, because the alias cannot be `extends`ed and the intersection workaround stops `Extract<Union, { type: 'x' }>` resolving to one member — which `useClipboardBridge` relies on to read a reply without a cast.

`SessionError` is the base for the eight session-scoped failures. Not for DRY at two fields, but so the family relation is something a reader and a check can see. `error` does not inherit — it has no `sessionId`, which is that member's whole purpose.

**Naming forced a split anonymity had hidden.** `app:install` and `app:launch` travel in both directions with *different* shapes: the browser sends `buildId`, the relay resolves it into `payload: { filePath, bundleId }`. They become `AppInstallToRelay` / `AppInstallToAgent`. `device:shutdown` is identical both ways, so it is **one** interface both unions reference — which now states that the relay forwards it untouched.

## The names were generated, not typed

The conversion's real hazard is a copy-paste that leaves two interfaces holding each other's literal, and `AgentToBrowser` has seven members whose shape is identical apart from the literal. **No type-level check sees that** — a union is a set, so which name owns which literal is not part of the comparison. Measured: the swap produced zero errors from the nine equivalence assertions.

So names were derived from the literals mechanically, and the relation is asserted two ways because the cheap one is the same fact twice:

- a per-message binding in `typeAssertions.ts` — catches an author who edits one copy;
- a source check that the name is **derivable** from the literal — catches one who edits both, or who regenerates the binding table from the declarations it is meant to check. Measured: that regeneration left all 228 assertions green.

## Guards, all mutation-verified

`protocolMessageNames.test.mjs` (new) — bindings exist and agree, names derive, the eight failures declare their base, and `SessionError` still carries both fields. That last one matters: the signature table resolves `extends` and sorts, so moving `sessionId` out of the base into all eight subclasses is otherwise invisible.

Bodies are brace-counted. The first version matched a run of two-space lines, so **one blank line inside an interface hid a message and satisfied the count that was meant to prove coverage.**

`browserInboundRouting.test.mjs` — the parser resolves `| Name` to the declaring interface. Its pinned signatures now cover all five unions rather than the browser-inbound three: 58 bindings read like per-message coverage while pinning only a literal, and `ScreenshotRequest.requestId` / `DeviceBoot.sessionId` could both be made optional with everything green.

`protocolPayloadTypes.test.mjs` — messages are excluded from the duplicate-shape check (a message is identified by its literal, not its field set), and so is `SessionError` — but only because a *message* extends it. Excluding every base also excluded `DeviceReport`, which is a real payload.

## Two costs, recorded rather than reverted

Neither was visible to the equivalence proof, and both are in `packages/protocol/AGENTS.md`:

- **A named `interface` has no implicit index signature**, so a message is no longer assignable to `Record<string, unknown>`. Nothing breaks today — the three such sinks here only ever receive fresh object literals — and L4 is exactly the work that would hand one a typed value. The fix there is to type the sink, not to widen the message.
- **An `interface` can be reopened** by a consumer via `declare module`, which an anonymous union member could not.

## Review

Two design rounds and one code round, two channels each (protocol change → escalation): **11 findings, all dispositioned.**

The design round found a blocker I had missed — the equivalence net does not see names, which is the layer's entire output. The code round found three guards that passed while broken, each measured. One reviewer answer refuted my own analysis: I claimed moving a field into `SessionError` would be caught via the other seven signatures, and missed the reverse direction.

A conversion side effect is also fixed here: my generator's region parser swallowed four union JSDoc blocks, including 24 lines of rationale written for #503. Same failure as every other parser bug in this program — a region that does not know where it ends.

Record with dispositions and the 13 mutations: `.work/reviews/refactor__wire-l1-named-interfaces.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearly named protocol message types to improve integration clarity and tooling support.
  - Introduced shared session and generic error representations with more consistent message definitions.
  - Added validation to keep message names and protocol values aligned.

- **Bug Fixes**
  - Standardized clipboard error payload handling without changing runtime behavior.

- **Documentation**
  - Documented protocol message naming, inheritance, compatibility, and representation guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->