### PR TITLE
fix(dashboard): answer the three ways a session:start can fail, and declare every message's disposition

### DIFF
--- a/.changeset/inbound-disposition-and-error-reason.md
+++ b/.changeset/inbound-disposition-and-error-reason.md
@@ -1,0 +1,60 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/relay': patch
+---
+
+fix(dashboard): tell the second tester the device is in use, and make an unhandled message a compile error
+
+`Session busy` reached the viewer and did nothing. The relay sends it when another browser socket already
+holds the session, so **two testers opening the same device** — the likeliest collision in a product whose
+premise is that the whole team opens a browser — left the second tab waiting on a `session:joined` that
+cannot arrive.
+
+Nothing reported it, because from the outside `error` *was* a handled type. The viewer branched on the
+free-prose `message` and covered two of the three wordings the relay sends.
+
+`error` now carries a closed `reason` — the same split #491 gave `input:error`: `message` stays prose the
+producer owns, the machine field is closed. **Required here, unlike `InputErrorReason`**, because that
+one's producer set is open by design (a third-party platform registers through `AgentRegistry.register()`
+and may predate the field) while this one has a single producer: the relay, at three sites. So `sendTo`
+enforces it. The viewer switches on `reason` exhaustively, and a fourth reason is a compile error instead
+of another silent case.
+
+`busy-elsewhere` and `mac-overloaded` are dashboard-local stop reasons rather than new
+`SessionTerminatedReason` values, because in both cases the session is **alive** — widening the protocol
+vocabulary would let `session:terminated` carry a reason it can never mean. The copy record is keyed on the
+union, so it forced both wordings.
+
+The busy wording deliberately does **not** name another person. The relay answers `session-busy` whenever
+the session's browser socket still reads OPEN, and the commonest cause is the tester's *own* previous
+socket: a sleeping laptop reconnects in 2s while the relay takes up to a heartbeat (30s) to notice the old
+one died. "Someone else is testing this device" would be false in exactly the case the viewer's own comment
+calls routine. Relatedly, the relay now checks occupancy *before* the resource gate — with both true, the
+tester was told to pick a different Mac while the real reason went unreported — and skips the check for a
+socket re-joining the session it already holds, which is what `SessionList` does before a shutdown.
+
+`agent-resources-exhausted` also gained an exit. It only toasted, and the relay `return`s after sending it,
+so the tab sat on "Starting device…" indefinitely: making `reason` required stopped a case from being
+unhandled without making the handled cases *end*.
+
+**`SessionList` was dropping `error` too**, and the same shape of bug: `handleShutdown` sends
+`session:start` on its own socket, a refused join is answered there, and `device:shutdown-done` — the only
+message that clears `shutting` — never arrives. The badge read "Shutting down..." permanently and the gate
+on it hid both buttons, so the row went inert.
+
+## The layer this belongs to
+
+Browser-inbound is 28 message types; the dashboard handled 22 and dropped 6. The three reasons for
+dropping — handled elsewhere, deliberately ignored, nobody wrote it — were **indistinguishable in code**,
+since all three look like an absent branch. `lib/inboundDisposition.ts` states one per message under
+`satisfies Record<BrowserInbound['type'], Disposition>`, so a message added to the wire breaks the file
+until someone picks a category. Measured: adding one produces `TS1360` at the table.
+
+Deriving the *reachable* subset and obliging only that was designed and discarded, and it is the obvious
+idea, so both reasons are recorded in the file: `send()` is shared by four sockets that each open their
+own WebSocket, and a reply does not go to whoever asked — the relay forwards to whichever socket holds the
+session now, so "we never send `input:type`" is true per session, not per socket.
+
+Also corrects a false comment: `DeviceDetails` was documented as "what the viewer shows in its info card".
+Nothing reads it — both agents send `session:deviceInfo` and the relay replays it, while the viewer takes
+device name and OS from `agents:listed`. It stays on the wire because third-party agents send it.

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -49,6 +49,20 @@ The audience is the whole team (PO, PM, designers, backend, QA) — not just QA.
 - Components that combine multiple `useEffect` + `react-hook-form` `Controller` + `useWatch` (e.g. `DefaultSettings`) can hang in jsdom under full render. `vitest.config.ts` has `testTimeout: 10000` as a safety net — a timeout failure means the test setup needs fixing, not more retries.
 - When mocking `fetch` in a component that fires multiple concurrent `useEffect` fetches (e.g. `GET /api/v1/settings` + `GET /api/v1/apps`), use URL-based dispatch (`mockImplementation((url) => {...})`) instead of `mockResolvedValueOnce` chains — call order is non-deterministic.
 
+### Every browser-inbound message has a declared disposition
+
+`lib/inboundDisposition.ts` says, for each of the 28 messages a browser socket can receive, either which
+files handle it or why it is deliberately ignored. It is written with
+`satisfies Record<BrowserInbound['type'], Disposition>`, so **a message added to the wire breaks that file**
+until someone picks a category.
+
+It exists because "handled elsewhere", "deliberately ignored" and "nobody wrote it" all look like an absent
+branch. Six messages were being dropped and the three reasons were indistinguishable — one of them turned
+out to be a real bug hiding inside a *handled* type (`error`, whose meaning was carried in free prose).
+
+**Do not branch on a message's `message` field.** It is prose the producer owns. `error` carries a closed
+`reason`; branch on that, exhaustively.
+
 ### `input:error` is shown per input, and there is no session-level input state
 
 A failed input surfaces as a toast keyed on the wire `reason` (`lib/inputErrorNotice.ts`), or is shown

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -24,10 +24,13 @@ interface Props {
   buildId?: number;
   resetMode?: 'app-only' | 'full-erase';
   onRecordingUploaded?: () => void;
-  /** The relay dropped this session (the agent went away). The viewer cannot recover on its own —
-   *  it holds a socket addressed to a sessionId that no longer exists — so it reports upward and
-   *  the parent decides where to go. */
-  onSessionEnded?: (reason: SessionTerminatedReason) => void;
+  /** Why this viewer stopped. The viewer cannot recover from any of these on its own — it holds a
+   *  socket it can make no further progress on — so it reports upward and the parent decides where to go.
+   *
+   *  A **superset** of why the *relay* terminated the session. `busy-elsewhere` is the dashboard's own:
+   *  the session is alive and another socket holds it, so no protocol reason describes it, and widening
+   *  `SessionTerminatedReason` would let `session:terminated` carry a reason it can never mean. */
+  onSessionEnded?: (reason: SessionTerminatedReason | 'busy-elsewhere' | 'mac-overloaded') => void;
 }
 
 export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecordingUploaded, onSessionEnded }: Props) {
@@ -279,18 +282,33 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     }
     if (msg.type === 'open-url:done') { toast.success('Deeplink opened'); }
     if (msg.type === 'open-url:error') { toast.error(msg.message); }
-    if (msg.type === 'error' && msg.message === 'Session not found') {
-      // The relay has no such session, so nothing else is ever coming for it. Reached when a
-      // browser blip outlasts the hold the relay keeps after an agent goes away (#426): the
-      // re-join lands after the window closed, and `session:terminated` went to a socket that no
-      // longer existed. Without this the tab waits on a message that cannot arrive.
-      onSessionEnded?.('agent-disconnected');
-      return;
-    }
-    if (msg.type === 'error' && msg.message === 'Agent resources exhausted') {
-      toast.error('Could not start session — this Mac is currently overloaded.', {
-        description: 'Go back and select a different Mac.',
-      })
+    // Branch on `reason`, never on `message`. The prose version handled two of the three wordings the
+    // relay sends, so `Session busy` arrived and did nothing — and nothing reported it, because from
+    // the outside `error` *was* a handled type. The switch is exhaustive, so a fourth reason is a
+    // compile error rather than another silent case.
+    if (msg.type === 'error') {
+      switch (msg.reason) {
+        case 'session-not-found':
+          // Nothing else is ever coming for it. Reached when a browser blip outlasts the hold the relay
+          // keeps after an agent goes away (#426): the re-join lands after the window closed, and
+          // `session:terminated` went to a socket that no longer existed. Without this the tab waits on
+          // a message that cannot arrive.
+          onSessionEnded?.('agent-disconnected');
+          return;
+        case 'session-busy':
+          // The session is alive and someone else holds it — so this is not `agent-disconnected`, and
+          // saying so would send the tester to re-pick a Mac that is working fine.
+          onSessionEnded?.('busy-elsewhere');
+          return;
+        case 'agent-resources-exhausted':
+          // Exit, not just a toast. The relay `return`s after sending this, so no `session:joined` and no
+          // `session:terminated` follows — a toast alone left the tab sitting on "Starting device…"
+          // forever, which is the state this whole layer is about. Making `reason` required stopped a
+          // case from being unhandled; it did not make the three handled cases *end* the same way, and
+          // this was the one that did not.
+          onSessionEnded?.('mac-overloaded');
+          return;
+      }
     }
   }, [sessionId, deviceId, buildId, onSessionEnded, resetMode, installed, agentAway]);
 

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import { useRelay } from '@/hooks/useRelay'
 import type { BrowserInbound, SessionInfo } from '@/lib/types'
 import { Button } from '@/components/ui/button'
@@ -53,6 +54,22 @@ export function SessionList({ onSelect }: Props) {
           ...s,
           devices: s.devices.map((d) => (d.id === deviceId ? { ...d, status: 'shutdown' } : d)),
         }))
+      )
+    } else if (msg.type === 'error') {
+      // `handleShutdown` sends `session:start` on this socket, so a refused join is answered here — and
+      // the only message that clears `shutting` is `device:shutdown-done`, which then never comes. The
+      // badge stayed on "Shutting down..." for good, and `isShutting` hides both buttons, so the row
+      // became inert. Same defect as the one `DeviceViewer` had for `Session busy`, in a second place.
+      //
+      // Which device it was is not on the message — `error` carries no sessionId, by design, because the
+      // relay sends it when it cannot correlate. One shutdown is in flight at a time from this list, so
+      // clearing all of them is exact enough and never leaves a row stuck.
+      setShutting({})
+      toast.error(
+        msg.reason === 'session-busy'
+          ? 'That device is open in another browser session — it was not shut down.'
+          : 'Could not shut that device down.',
+        { description: msg.message },
       )
     }
   })

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -68,8 +68,13 @@ export function SessionList({ onSelect }: Props) {
       // forwards a session-scoped command on the strength of the session existing, without checking that
       // the sender owns it, so a **refused** join was followed by a shutdown that went through anyway —
       // shutting down a device another tester had open, while this list said it had not.
+      // Matched against the request, not merely counted. Only `handleShutdown` sends `session:start` from
+      // this list and a second one is refused while the first is unanswered, so a mismatch is unreachable
+      // today — but "unreachable today" is what the two previous versions of this handler asserted and got
+      // wrong, and the comparison costs one line. A join for some other session leaves the request pending
+      // rather than firing a shutdown the relay never accepted.
       const pending = pendingRef.current
-      if (pending) {
+      if (pending && msg.sessionId === pending.sessionId) {
         pendingRef.current = null
         sendRef.current({ type: 'device:shutdown', sessionId: pending.sessionId, payload: { deviceId: pending.deviceId } })
       }

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useRelay } from '@/hooks/useRelay'
 import type { BrowserInbound, SessionInfo } from '@/lib/types'
+import type { BrowserToRelay } from '@tapflowio/protocol'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -19,6 +20,12 @@ export function SessionList({ onSelect }: Props) {
   const [sessions, setSessions] = useState<SessionInfo[]>([])
   const [booting, setBooting] = useState<BootingState>({})
   const [shutting, setShutting] = useState<ShuttingState>({})
+  // The shutdown whose `session:start` has not been answered yet. A ref, not state: the relay's reply
+  // lands in a handler that must read the current value, and a re-render is neither needed nor wanted.
+  const pendingRef = useRef<{ deviceId: string; sessionId: string } | null>(null)
+  // `send` is what `useRelay` returns, so the handler passed *into* it cannot name it directly. Same
+  // indirection `DeviceViewer` uses (`sendRef`), for the same reason.
+  const sendRef = useRef<(msg: BrowserToRelay) => void>(() => {})
 
   const { send, connected } = useRelay((msg: BrowserInbound) => {
     if (msg.type === 'agents:listed') {
@@ -55,16 +62,34 @@ export function SessionList({ onSelect }: Props) {
           devices: s.devices.map((d) => (d.id === deviceId ? { ...d, status: 'shutdown' } : d)),
         }))
       )
+    } else if (msg.type === 'session:joined') {
+      // Only `handleShutdown` sends `session:start` from this list, so a join here means the shutdown it
+      // was waiting on may proceed. Sending `device:shutdown` before this arrived was the bug: the relay
+      // forwards a session-scoped command on the strength of the session existing, without checking that
+      // the sender owns it, so a **refused** join was followed by a shutdown that went through anyway —
+      // shutting down a device another tester had open, while this list said it had not.
+      const pending = pendingRef.current
+      if (pending) {
+        pendingRef.current = null
+        sendRef.current({ type: 'device:shutdown', sessionId: pending.sessionId, payload: { deviceId: pending.deviceId } })
+      }
     } else if (msg.type === 'error') {
-      // `handleShutdown` sends `session:start` on this socket, so a refused join is answered here — and
-      // the only message that clears `shutting` is `device:shutdown-done`, which then never comes. The
-      // badge stayed on "Shutting down..." for good, and `isShutting` hides both buttons, so the row
-      // became inert. Same defect as the one `DeviceViewer` had for `Session busy`, in a second place.
+      // A refused join. `device:shutdown-done` is the only message that clears `shutting`, so without this
+      // the badge stayed on "Shutting down..." for good and `isShutting` hid both buttons — the row went
+      // inert. Same defect `DeviceViewer` had for `Session busy`, in a second place.
       //
-      // Which device it was is not on the message — `error` carries no sessionId, by design, because the
-      // relay sends it when it cannot correlate. One shutdown is in flight at a time from this list, so
-      // clearing all of them is exact enough and never leaves a row stuck.
-      setShutting({})
+      // `error` carries no sessionId — by design, since the relay sends it when it cannot correlate — so
+      // the device comes from the request this list is waiting on. One is in flight at a time (see
+      // `handleShutdown`), which is what makes that unambiguous rather than merely likely.
+      const pending = pendingRef.current
+      pendingRef.current = null
+      if (pending) {
+        setShutting((prev) => {
+          const next = { ...prev }
+          delete next[pending.deviceId]
+          return next
+        })
+      }
       toast.error(
         msg.reason === 'session-busy'
           ? 'That device is open in another browser session — it was not shut down.'
@@ -74,6 +99,8 @@ export function SessionList({ onSelect }: Props) {
     }
   })
 
+  useLayoutEffect(() => { sendRef.current = send })
+
   useEffect(() => {
     if (connected) send({ type: 'agents:list' })
   }, [connected, send])
@@ -82,10 +109,16 @@ export function SessionList({ onSelect }: Props) {
     onSelect(sessionId, deviceId)
   }
 
+  // One shutdown at a time. `error` carries no sessionId, so a second request in flight would leave the
+  // handler unable to say which row a refusal belongs to — and the previous version cleared *every* row
+  // on any error, which was a guess dressed as a comment.
   const handleShutdown = (deviceId: string, sessionId: string) => {
+    if (pendingRef.current) return
+    pendingRef.current = { deviceId, sessionId }
     setShutting((prev) => ({ ...prev, [deviceId]: true }))
+    // `session:start` first, and `device:shutdown` only once the relay accepts the join — see the
+    // `session:joined` branch above.
     send({ type: 'session:start', sessionId })
-    send({ type: 'device:shutdown', sessionId, payload: { deviceId } })
   }
 
   if (!connected) {

--- a/packages/dashboard/lib/inboundDisposition.ts
+++ b/packages/dashboard/lib/inboundDisposition.ts
@@ -1,0 +1,97 @@
+import type { BrowserInbound } from '@tapflowio/protocol'
+
+/**
+ * What this package does with each message a browser socket can receive.
+ *
+ * The bug class this whole wire-contract program started from was **a reply arriving and nobody
+ * answering** (#489, #485, #492, #457). L1–L3 made the declarations honest; a declared message with no
+ * handler is still silent. Measured when this file was written: the dashboard handled 22 of the 28 and
+ * dropped 6 — and the three reasons those 6 were dropped for are *indistinguishable in code*, because
+ * "handled elsewhere", "deliberately ignored" and "nobody ever wrote it" all look like an absent branch.
+ *
+ * `satisfies Record<BrowserInbound['type'], …>` is what makes that a decision instead of an oversight:
+ * a message added to the wire **breaks this file** until someone picks a category. There is no
+ * derivation and therefore nothing to go stale.
+ *
+ * ### Why not derive the reachable subset and oblige only that
+ *
+ * Two independent reasons, both measured during design review, and both worth stating because the idea
+ * is the obvious one:
+ *
+ *  - **`send()` is shared by four sockets.** `useRelay` is called by `DeviceViewer`, `SessionList`,
+ *    `useAgentSession` and `MacResources`, and each opens its own WebSocket. So "what the dashboard
+ *    sends" is a package-level fact while a handler lives in one component — deriving one from the other
+ *    obliges `DeviceViewer` to handle replies to requests it never issues.
+ *  - **A reply does not go to whoever asked.** The relay forwards agent replies to
+ *    `session.browserSocket` — whichever socket holds the session *now*. `mcp-server` speaks to the same
+ *    relay, so a reply to its request lands on the dashboard once the dashboard joins. "We never send
+ *    `input:type`, so its replies cannot arrive" is true per *session*, not per socket.
+ *
+ * Any browser socket can receive any of the 28. That is why every entry is present and `ignored` says
+ * *why* rather than *cannot happen*.
+ */
+type Disposition =
+  /** Handled. The value names the files, and `scripts/__tests__/inboundDisposition.test.mjs` checks each
+   *  one actually tests this literal — the compiler owns the key set, so that parser cannot under-cover. */
+  | { at: string }
+  /** Deliberately not handled. The reason is the value, because a reason nobody wrote down becomes an
+   *  oversight the next time someone reads the file. */
+  | { ignored: string }
+
+export const INBOUND_DISPOSITION = {
+  'agents:listed': { at: 'SessionList, useAgentSession, MacResources' },
+  'app:install-done': { at: 'DeviceViewer' },
+  'app:install-error': { at: 'DeviceViewer' },
+  'app:launch-done': { at: 'DeviceViewer' },
+  'app:launch-error': { at: 'DeviceViewer' },
+  'clipboard:data': { at: 'DeviceViewer, useClipboardBridge' },
+  'clipboard:error': { at: 'DeviceViewer, useClipboardBridge' },
+  'clipboard:write-done': { at: 'DeviceViewer, useClipboardBridge' },
+  'device:boot-error': { at: 'DeviceViewer, SessionList' },
+  'device:booting': { at: 'DeviceViewer' },
+  'device:ready': { at: 'DeviceViewer, SessionList' },
+  'device:shutdown-done': { at: 'SessionList' },
+  'error': { at: 'DeviceViewer, SessionList, useAgentSession' },
+  'input:error': { at: 'DeviceViewer' },
+  'keyboard:toggled': { at: 'DeviceViewer' },
+  'open-url:done': { at: 'DeviceViewer' },
+  'open-url:error': { at: 'DeviceViewer' },
+  'session:agent-away': { at: 'DeviceViewer' },
+  'session:chrome': { at: 'DeviceViewer' },
+  'session:joined': { at: 'DeviceViewer, useAgentSession' },
+  'session:rebound': { at: 'DeviceViewer' },
+  'session:terminated': { at: 'DeviceViewer' },
+
+  // ── deliberately not handled ──────────────────────────────────────────────────────────────────────
+
+  'input:done': {
+    ignored: 'A success carries no state worth keeping. A latched "input unavailable" line was designed '
+      + 'and discarded because nothing announces that input works again, the acks are unordered, and an '
+      + 'ack does not say which channel answered — the toast lifetime carries that state instead. '
+      + 'dashboard/AGENTS.md has the three reasons in full.',
+  },
+  'input:type-done': {
+    ignored: 'Nothing here sends `input:type` — it is an MCP and flow-runner path. If a reply arrives '
+      + 'anyway (the relay routes to whoever holds the session), there is no pending typed text to '
+      + 'settle, so there is nothing to do with a success.',
+  },
+  'input:type-error': {
+    ignored: 'Same path as `input:type-done`: no `input:type` is sent from here, so a failure belongs to '
+      + 'a caller that is not this tab. Reporting it would attribute someone else\'s failed keystrokes '
+      + 'to the tester looking at the screen.',
+  },
+  'app:clear-state-done': {
+    ignored: 'The dashboard offers no clear-state action — resets go through `device:boot` with '
+      + '`resetMode`. Nothing is waiting on this.',
+  },
+  'app:clear-state-error': {
+    ignored: 'Same as `app:clear-state-done`. A failure for a request this tab did not make has no place '
+      + 'to be shown.',
+  },
+  'session:deviceInfo': {
+    ignored: 'No consumer, here or anywhere. Both agents send it and the relay caches and replays it on '
+      + 'join, and nothing reads the result — the viewer takes device name and OS from `agents:listed` '
+      + 'instead. Kept on the wire because third-party agents send it; the field to display it is a '
+      + 'feature nobody has asked for, not a handler someone forgot.',
+  },
+} satisfies Record<BrowserInbound['type'], Disposition>

--- a/packages/dashboard/lib/inboundDisposition.ts
+++ b/packages/dashboard/lib/inboundDisposition.ts
@@ -58,7 +58,7 @@ export const INBOUND_DISPOSITION = {
   'open-url:error': { at: 'DeviceViewer' },
   'session:agent-away': { at: 'DeviceViewer' },
   'session:chrome': { at: 'DeviceViewer' },
-  'session:joined': { at: 'DeviceViewer, useAgentSession' },
+  'session:joined': { at: 'DeviceViewer, SessionList, useAgentSession' },
   'session:rebound': { at: 'DeviceViewer' },
   'session:terminated': { at: 'DeviceViewer' },
 

--- a/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
@@ -359,9 +359,27 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
     act(() => { deliver!({ type: 'session:agent-away', sessionId: 's1' }) })
 
-    act(() => { deliver!({ type: 'error', message: 'Session not found' }) })
+    act(() => { deliver!({ type: 'error', message: 'Session not found', reason: 'session-not-found' }) })
 
     expect(onSessionEnded).toHaveBeenCalledWith('agent-disconnected')
+  })
+
+  // Regression: `Session busy` reached the viewer and did nothing. Two testers opening the same device
+  // is the likeliest collision in a product whose premise is that the whole team opens a browser — and
+  // the second tab sat on "Starting device…" waiting for a `session:joined` that cannot arrive.
+  //
+  // It was invisible from the outside because `error` *was* a handled type: the viewer branched on the
+  // free-prose `message` and covered two of the three wordings the relay sends. Branching on `reason`
+  // is what makes the third one impossible to forget.
+  it('says the device is in use when another socket already holds the session', async () => {
+    const onSessionEnded = vi.fn()
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" onSessionEnded={onSessionEnded} />)
+
+    act(() => { deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' }) })
+
+    // Not `agent-disconnected`: the agent is fine and so is the device. That reason tells the tester to
+    // re-pick the Mac, which is advice for a problem they do not have.
+    expect(onSessionEnded).toHaveBeenCalledWith('busy-elsewhere')
   })
 
   it('ignores an away meant for another session', async () => {

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -35,6 +35,14 @@ const SESSIONS: SessionInfo[] = [{
   }],
 }]
 
+const TWO_DEVICES: SessionInfo[] = [{
+  agentName: 'mac-1',
+  devices: [
+    { id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted', sessionId: 's1', busy: false },
+    { id: 'dev-2', name: 'iPhone 14', platform: 'ios', status: 'booted', sessionId: 's2', busy: false },
+  ],
+}]
+
 describe('SessionList when a shutdown is refused', () => {
   beforeEach(() => { send.mockClear(); deliver = null })
 
@@ -55,5 +63,46 @@ describe('SessionList when a shutdown is refused', () => {
     expect(vi.mocked(toast.error)).toHaveBeenCalledOnce()
     // And it says which of the three reasons it was, rather than a generic failure.
     expect(vi.mocked(toast.error).mock.calls[0][0]).toMatch(/another browser session/i)
+  })
+
+  // The toast above says the device was not shut down. That has to be *true*.
+  //
+  // The relay forwards a session-scoped browser command on the strength of the session existing — it does
+  // not check that the sender owns it. So sending `device:shutdown` in the same breath as `session:start`
+  // meant a refused join was followed by a shutdown that went through anyway: another tester's device went
+  // down while this list reported that nothing had happened.
+  it('does not send the shutdown when the join was refused', () => {
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: SESSIONS }) })
+
+    act(() => { screen.getByRole('button', { name: /shutdown/i }).click() })
+    expect(send.mock.calls.map(([m]) => m.type)).toEqual(['agents:list', 'session:start'])
+
+    act(() => { deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' }) })
+
+    expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown')).toBe(false)
+  })
+
+  it('sends the shutdown once the join is accepted', () => {
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: SESSIONS }) })
+    act(() => { screen.getByRole('button', { name: /shutdown/i }).click() })
+
+    act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+
+    expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown' && m.sessionId === 's1')).toBe(true)
+  })
+
+  it('refuses a second shutdown while one is still unanswered', () => {
+    // `error` carries no sessionId, so two in flight would leave the handler unable to say which row a
+    // refusal belongs to. The previous version cleared every row instead, which was a guess.
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: TWO_DEVICES }) })
+
+    const buttons = screen.getAllByRole('button', { name: /shutdown/i })
+    act(() => { buttons[0].click() })
+    act(() => { buttons[1].click() })
+
+    expect(send.mock.calls.filter(([m]) => m.type === 'session:start')).toHaveLength(1)
   })
 })

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -93,6 +93,24 @@ describe('SessionList when a shutdown is refused', () => {
     expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown' && m.sessionId === 's1')).toBe(true)
   })
 
+  it('does not fire on a join for a different session', () => {
+    // The handler used to accept *any* `session:joined` as the answer to its pending request. Only this
+    // list sends `session:start` from here, so a mismatch is unreachable today — but the two previous
+    // versions of this handler each rested on an "unreachable today" that turned out to be wrong, so the
+    // request is matched rather than counted.
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: TWO_DEVICES }) })
+    act(() => { screen.getAllByRole('button', { name: /shutdown/i })[0].click() })   // pending s1
+
+    act(() => { deliver!({ type: 'session:joined', sessionId: 's2', capabilities: [] }) })
+
+    expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown')).toBe(false)
+
+    // And the request survives, so the real answer still works.
+    act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+    expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown' && m.sessionId === 's1')).toBe(true)
+  })
+
   it('refuses a second shutdown while one is still unanswered', () => {
     // `error` carries no sessionId, so two in flight would leave the handler unable to say which row a
     // refusal belongs to. The previous version cleared every row instead, which was a guess.

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import type { BrowserInbound, SessionInfo } from '@/lib/types'
+
+// Regression: a refused shutdown left the row inert for the rest of the page's life.
+//
+// `handleShutdown` sends `session:start` on this socket before `device:shutdown`, because the relay
+// routes agent replies to whichever socket holds the session. If that join is refused — the device is
+// open in another browser session, the commonest reason to be shutting it down from here — the relay
+// answers `error` on this socket and returns. `device:shutdown-done` is the only message that clears
+// `shutting`, and it never comes.
+//
+// The badge then reads "Shutting down..." forever, and `isShutting` hides both Connect and Shutdown, so
+// the tester cannot retry or leave. It is the same defect `DeviceViewer` had for `Session busy`, in a
+// second component — and the disposition table's first version *hid* it by claiming `error` was handled
+// here, which the check certified because three unrelated `'error'` strings live in this file.
+const send = vi.fn()
+let deliver: ((msg: BrowserInbound) => void) | null = null
+
+vi.mock('@/hooks/useRelay', () => ({
+  useRelay: (onMessage: (msg: BrowserInbound) => void) => {
+    deliver = onMessage
+    return { send, connected: true }
+  },
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }))
+
+const { SessionList } = await import('@/components/SessionList')
+
+const SESSIONS: SessionInfo[] = [{
+  agentName: 'mac-1',
+  devices: [{
+    id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted',
+    sessionId: 's1', busy: false,
+  }],
+}]
+
+describe('SessionList when a shutdown is refused', () => {
+  beforeEach(() => { send.mockClear(); deliver = null })
+
+  it('clears the shutting badge and says why, instead of leaving the row inert', async () => {
+    const { toast } = await import('sonner')
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: SESSIONS }) })
+
+    act(() => { screen.getByRole('button', { name: /shutdown/i }).click() })
+    expect(screen.getByText(/shutting down/i)).toBeInTheDocument()
+
+    act(() => {
+      deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' })
+    })
+
+    // The badge is gone, so the row's buttons are back and the tester can act.
+    expect(screen.queryByText(/shutting down/i)).not.toBeInTheDocument()
+    expect(vi.mocked(toast.error)).toHaveBeenCalledOnce()
+    // And it says which of the three reasons it was, rather than a generic failure.
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toMatch(/another browser session/i)
+  })
+})

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -132,7 +132,7 @@ describe('useAgentSession', () => {
     const { result } = renderHook(() => useAgentSession('android'))
 
     act(() => result.current.startDevice(makeDevice()))
-    act(() => capturedOnMessage({ type: 'error', message: 'boom' }))
+    act(() => capturedOnMessage({ type: 'error', message: 'boom', reason: 'agent-resources-exhausted' }))
 
     expect(result.current.booting).toBe(false)
     expect(result.current.status).toBe('Error: boom')

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -30,13 +30,32 @@ import { SearchInput } from '@/components/ui/search-input';
 import type { DeviceSummary, SessionInfo } from '@/lib/types';
 import { getResourceHealth, type ResourceHealth } from '@/lib/resource-health';
 
+/** Why this viewer stopped — a superset of the relay's termination reasons; see `DeviceViewer`'s prop. */
+type ViewerStoppedReason = SessionTerminatedReason | 'busy-elsewhere' | 'mac-overloaded';
+
 // Keyed by the reason so a new one cannot be added without deciding what the user is told. A
 // callback that ignored `reason` would keep showing "the agent disconnected" for every future
 // cause — which is exactly what the literal union exists to prevent.
-const SESSION_ENDED_NOTICE: Record<SessionTerminatedReason, { title: string; description: string }> = {
+const SESSION_ENDED_NOTICE: Record<ViewerStoppedReason, { title: string; description: string }> = {
   'agent-disconnected': {
     title: 'The agent disconnected — this session ended.',
     description: 'Pick the Mac again to start a new session.',
+  },
+  // Deliberately does not say *who*. The relay answers `session-busy` whenever the session's browser
+  // socket still reads OPEN, and the commonest cause is the tester's own previous socket: a sleeping
+  // laptop or a Wi-Fi blip reconnects in 2s while the relay takes up to a heartbeat (30s) to notice the
+  // old one died. Claiming "someone else is testing this" would be false in exactly the case
+  // `DeviceViewer`'s own comment calls routine, and it would send them to look for a colleague who does
+  // not exist. So it names the situation and gives the wait that actually resolves it.
+  'busy-elsewhere': {
+    title: 'This device is already open in another browser session.',
+    description: 'That may be your own tab from before a reconnect — wait about a minute and try again.',
+  },
+  // The Mac is over its ceiling, so a different Mac is the actionable move — and unlike the other two
+  // this one is about the machine, not the session.
+  'mac-overloaded': {
+    title: 'That Mac is too busy to start a session.',
+    description: 'Pick a different Mac, or wait for it to settle.',
   },
 };
 
@@ -83,10 +102,10 @@ export function QASession() {
     startDevice(d);
   }, [consumeResetMode, startDevice]);
 
-  // The relay dropped the session because its agent went away. Say so and go back to the Mac list —
-  // before #426 the tab just sat on "Waiting for first frame..." with no way to know a refresh was
-  // needed.
-  const onSessionEnded = useCallback((reason: SessionTerminatedReason) => {
+  // The viewer cannot make progress — the agent went away, or another socket holds the session. Say
+  // which, and go back to the Mac list. Before #426 the tab just sat on "Waiting for first frame..."
+  // with no way to know a refresh was needed; `busy-elsewhere` sat on it just as silently until L6.
+  const onSessionEnded = useCallback((reason: ViewerStoppedReason) => {
     const notice = SESSION_ENDED_NOTICE[reason];
     toast.error(notice.title, { description: notice.description });
     handleSessionEnded();

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -33,13 +33,19 @@ export interface DeviceReport {
 
 /** A device as the relay lists it, after adding what only the relay knows. Named `DeviceSummary`
  *  rather than `DeviceInfo` because both packages already used that name for different shapes:
- *  the relay for this, the dashboard for the `session:deviceInfo` payload (`DeviceDetails`). */
+ *  the relay for this, and `DeviceDetails` is the `session:deviceInfo` payload. */
 export interface DeviceSummary extends DeviceReport {
   sessionId: string
   busy: boolean
 }
 
-/** The `session:deviceInfo` payload — what the viewer shows in its info card. */
+/** The `session:deviceInfo` payload.
+ *
+ *  **Nothing reads it.** Both agents send it and the relay caches and replays it on join, but no consumer
+ *  in this repo takes the value — the dashboard shows device name and OS from `agents:listed`
+ *  (`DeviceSummary`) instead. This comment used to claim "what the viewer shows in its info card", which
+ *  was the kind of false statement about a consumer that this package exists to remove; L6 found it while
+ *  classifying every browser-inbound message. Kept on the wire because third-party agents send it. */
 export interface DeviceDetails {
   deviceName: string
   osVersion: string
@@ -413,12 +419,35 @@ export interface SessionRebound {
   capabilities: string[]
 }
 
+/**
+ * Why a `session:start` could not be honoured. The same split as `InputErrorReason`: `message` stays
+ * free prose the producer owns, and the machine field is closed.
+ *
+ * It exists because the dashboard was branching on the prose. Three wordings were sent and two were
+ * handled, so `Session busy` — the reply a second tester gets when someone else already holds the
+ * device — reached the viewer and did nothing at all, leaving the tab waiting on a `session:joined`
+ * that cannot arrive. Nothing reported it, because from the outside the type *was* handled.
+ *
+ * **Required, unlike `InputErrorReason`.** That one is permanently optional because its producer set is
+ * open by design — a third-party platform registers through `AgentRegistry.register()` and may predate
+ * the field. This one has a single producer: the relay, at three sites in `handleSessionStart`. So the
+ * compiler can insist, and it does — `sendTo` takes `RelayOutbound`.
+ */
+export type SessionStartFailure =
+  /** No such session. Nothing else is ever coming for it. */
+  | 'session-not-found'
+  /** The session exists and another browser socket holds it. It is alive; this viewer cannot have it. */
+  | 'session-busy'
+  /** The Mac is over its resource ceiling and refused to take another session. */
+  | 'agent-resources-exhausted'
+
 // The escape hatch for a failure the relay cannot correlate to a session. Every typed member above
 // carries a sessionId; when there is genuinely none to carry, this is the message to send — not a
 // typed error with the key dropped by `JSON.stringify`.
 export interface GenericError {
   type: 'error'
   message: string
+  reason: SessionStartFailure
 }
 
 /** Messages the relay originates and no agent sends. */

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -65,7 +65,7 @@ export const relayCannotOriginateKeyboard: RelayOutbound = { type: 'keyboard:tog
 
 // A consumer reads the whole surface, whoever sent it — both of the above are valid here.
 export const inboundFromAgent: BrowserInbound = { type: 'input:done', sessionId: 's' }
-export const inboundFromRelay: BrowserInbound = { type: 'error', message: 'x' }
+export const inboundFromRelay: BrowserInbound = { type: 'error', message: 'x', reason: 'session-busy' }
 
 // @ts-expect-error - sessionId is required on every one of the twelve forward-only messages
 export const forwardWithoutSession: AgentToBrowser = { type: 'app:install-done' }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1036,7 +1036,18 @@ export class RelayServer {
   private handleSessionStart(ws: WebSocket, msg: RelayMessage): void {
     const session = this.sessions.get(msg.sessionId!)
     if (!session) {
-      this.sendTo(ws, { type: 'error', message: 'Session not found' })
+      this.sendTo(ws, { type: 'error', message: 'Session not found', reason: 'session-not-found' })
+      return
+    }
+    // Occupancy first, because it is the more specific answer and both can be true at once. A tester
+    // joining a device someone else has open on a loaded Mac was being told "this Mac is overloaded,
+    // pick another" — advice for a problem they cannot act on, while the actual reason went unreported.
+    // It is a map read the relay has already done, so ordering it first costs nothing.
+    //
+    // `!== ws` because a socket re-joining the session it already holds is not contending with anyone:
+    // `SessionList` sends `session:start` before a shutdown, so pressing shutdown twice hit this.
+    if (session.browserSocket && session.browserSocket !== ws && session.browserSocket.readyState === WebSocket.OPEN) {
+      this.sendTo(ws, { type: 'error', message: 'Session busy', reason: 'session-busy' })
       return
     }
     // Read before the resource gate, and answered before it too. The gate would otherwise read the
@@ -1047,14 +1058,20 @@ export class RelayServer {
     if (resources) {
       const memPercent = (resources.memUsedMB / resources.memTotalMB) * 100
       if (resources.cpuPercent > RESOURCE_THRESHOLD || memPercent > RESOURCE_THRESHOLD) {
-        this.sendTo(ws, { type: 'error', message: 'Agent resources exhausted' })
+        this.sendTo(ws, { type: 'error', message: 'Agent resources exhausted', reason: 'agent-resources-exhausted' })
         return
       }
     }
     try {
       this.sessions.join(msg.sessionId!, ws)
-    } catch {
-      this.sendTo(ws, { type: 'error', message: 'Session busy' })
+    } catch (e) {
+      // `join()` throws for not-found as well as busy, and the check above already answered busy — so
+      // reaching here means something this handler did not anticipate. Reporting it as `session-busy`
+      // would put a specific claim on an unknown cause, which is what `reason` exists to stop. Bare
+      // `catch {}` also discarded the error entirely: nothing reached the route-level handler, because
+      // this swallowed it first.
+      logger.error(`session:start could not join ${msg.sessionId}:`, e)
+      this.sendTo(ws, { type: 'error', message: 'Session not found', reason: 'session-not-found' })
       return
     }
     // Include the agent's capabilities so the viewer knows up front what is implemented on

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -254,7 +254,7 @@ describe('browser-inbound routing matches the protocol union', () => {
       'session:terminated': 'reason sessionId',
       'session:agent-away': 'sessionId',
       'session:rebound': 'capabilities sessionId',
-      error: 'message',
+      error: 'message reason',
     },
   }
 

--- a/scripts/__tests__/inboundDisposition.test.mjs
+++ b/scripts/__tests__/inboundDisposition.test.mjs
@@ -20,6 +20,13 @@ import { join } from 'node:path'
 // count assertion passed *because* of the skip).
 
 const root = join(import.meta.dirname, '../..')
+
+/** A receiver comparing its `.type` against a message name. Tolerates either quote style and any spacing
+ *  around the operator: a guard that only matches this repo's current formatting stops guarding the moment
+ *  someone writes `msg.type==="x"`, and it does so silently — the same fragility as every other parser this
+ *  program has had to harden. What it must still reject is a bare literal, so the `.type` and the operator
+ *  are both required. */
+const comparison = (type) => new RegExp(String.raw`[\w.]+\.type\s*[=!]==\s*['"]${type}['"]`)
 const table = readFileSync(join(root, 'packages/dashboard/lib/inboundDisposition.ts'), 'utf8')
 
 /** Where a name in an `at:` value lives. The table names modules, not paths. */
@@ -92,7 +99,7 @@ describe('inbound disposition', () => {
         // reads `reply.type === 'clipboard:error'` and narrows to `clipboard:data` with `!==`, and both are
         // handling. What must not pass is a bare literal: a comment, a `send()` argument, or an unrelated
         // string that happens to equal a message name.
-        if (!new RegExp(String.raw`[\w.]+\.type [=!]== '${type}'`).test(src)) {
+        if (!comparison(type).test(src)) {
           missing.push(`${type} has no \`<msg>.type\` comparison against '${type}' in ${name}`)
         }
       }
@@ -109,7 +116,7 @@ describe('inbound disposition', () => {
     const stale = []
     for (const [name, path] of Object.entries(FILES)) {
       const src = readFileSync(join(root, path), 'utf8').replace(/^\s*\/\/.*$/gm, '')
-      for (const m of src.matchAll(/[\w.]+\.type [=!]== '([^']+)'/g)) {
+      for (const m of src.matchAll(/[\w.]+\.type\s*[=!]==\s*['"]([^'"]+)['"]/g)) {
         const value = table_entries.get(m[1])
         if (!value) continue                        // not a browser-inbound type (outbound, local unions)
         const at = value.match(/at:\s*'([^']+)'/)

--- a/scripts/__tests__/inboundDisposition.test.mjs
+++ b/scripts/__tests__/inboundDisposition.test.mjs
@@ -101,6 +101,25 @@ describe('inbound disposition', () => {
     expect(missing).toEqual([])
   })
 
+  it('a module that handles a message is named in its `at`', () => {
+    // The reverse direction, and the table has no way to notice it on its own. `at` is not obliged to be
+    // complete: a component that starts comparing `.type` against a message does not break anything, so
+    // the entry silently becomes a partial answer to "where is this handled". That happened inside this
+    // PR — `SessionList` gained a `session:joined` branch and the entry still named two files.
+    const stale = []
+    for (const [name, path] of Object.entries(FILES)) {
+      const src = readFileSync(join(root, path), 'utf8').replace(/^\s*\/\/.*$/gm, '')
+      for (const m of src.matchAll(/[\w.]+\.type [=!]== '([^']+)'/g)) {
+        const value = table_entries.get(m[1])
+        if (!value) continue                        // not a browser-inbound type (outbound, local unions)
+        const at = value.match(/at:\s*'([^']+)'/)
+        const named = at ? at[1].split(',').map((n) => n.trim()) : []
+        if (!named.includes(name)) stale.push(`${m[1]} is handled in ${name}, which its \`at\` does not name`)
+      }
+    }
+    expect([...new Set(stale)]).toEqual([])
+  })
+
   it('an ignored message states a reason, and the reason is a sentence', () => {
     const thin = []
     for (const [type, value] of table_entries) {

--- a/scripts/__tests__/inboundDisposition.test.mjs
+++ b/scripts/__tests__/inboundDisposition.test.mjs
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// `packages/dashboard/lib/inboundDisposition.ts` says what the dashboard does with each of the 28
+// messages a browser socket can receive. The **compiler** owns the key set: the table is written with
+// `satisfies Record<BrowserInbound['type'], Disposition>`, so a message added to the wire breaks it until
+// someone picks a category. Measured — adding one produced `TS1360` at the table.
+//
+// That leaves exactly two things a type cannot state, and they are what this file checks:
+//
+//  - an `{ at: 'DeviceViewer' }` entry claims a file handles the message. Nothing makes that true.
+//  - an `{ ignored: '…' }` entry claims a reason exists. An empty string type-checks fine.
+//
+// This is a narrow, safe use of source parsing, and the reason is worth naming: **the parser does not
+// decide what to check.** It is handed a complete key set by the compiler and only answers "does this
+// literal appear in this file". Every parser failure in this program came from the other arrangement —
+// a parser that also had to discover the set, and quietly discovered less of it (a region that ate the
+// next declaration's doc comment; a body regex that skipped an interface with a blank line in it, so the
+// count assertion passed *because* of the skip).
+
+const root = join(import.meta.dirname, '../..')
+const table = readFileSync(join(root, 'packages/dashboard/lib/inboundDisposition.ts'), 'utf8')
+
+/** Where a name in an `at:` value lives. The table names modules, not paths. */
+const FILES = {
+  DeviceViewer: 'packages/dashboard/components/DeviceViewer.tsx',
+  SessionList: 'packages/dashboard/components/SessionList.tsx',
+  useAgentSession: 'packages/dashboard/hooks/useAgentSession.ts',
+  useClipboardBridge: 'packages/dashboard/hooks/useClipboardBridge.ts',
+  MacResources: 'packages/dashboard/src/pages/MacResources.tsx',
+}
+
+/** Entries of the table, comments stripped so prose cannot be read as a declaration. */
+function entries(src) {
+  const start = src.indexOf('export const INBOUND_DISPOSITION = {')
+  expect(start, 'INBOUND_DISPOSITION is gone').toBeGreaterThan(-1)
+  // Stop at the table's own closing line. Slicing to end-of-file let anything entry-shaped *below* the
+  // table be counted as an entry — which defeats the count below, because a key the regex skips (a
+  // double-quoted one, say) can be made up for by a sibling map underneath. Measured: 28 entries with
+  // `app:launch-done` absent from every other assertion, all green. Third time this program has been bitten
+  // by a region parser that did not know where its region ended.
+  const end = src.indexOf('} satisfies', start)
+  expect(end, 'the table no longer closes with `} satisfies`').toBeGreaterThan(start)
+  const body = src.slice(start, end + 1).replace(/^\s*\/\/.*$/gm, '')
+  const out = new Map()
+  // A value spans to the next `'…':` key or the closing `} satisfies`, so multi-line reasons survive.
+  for (const m of body.matchAll(/'([^']+)': \{([\s\S]*?)\},\n(?=\s*(?:'|\}))/g)) {
+    out.set(m[1], m[2])
+  }
+  return out
+}
+
+const table_entries = entries(table)
+
+describe('inbound disposition', () => {
+  it('parsed every entry — 28, the browser-inbound surface', () => {
+    // The compiler already refuses a missing key, so this is not the coverage assertion; it is the
+    // parser's own honesty check. Without it the two assertions below pass on an empty map.
+    expect(table_entries.size).toBe(28)
+  })
+
+  it('every entry is exactly one of at / ignored', () => {
+    const bad = []
+    for (const [type, value] of table_entries) {
+      const hasAt = /\bat:/.test(value)
+      const hasIgnored = /\bignored:/.test(value)
+      if (hasAt === hasIgnored) bad.push(`${type}: at=${hasAt} ignored=${hasIgnored}`)
+    }
+    expect(bad).toEqual([])
+  })
+
+  it('a file named in `at` actually handles that message', () => {
+    const missing = []
+    const unknown = []
+    for (const [type, value] of table_entries) {
+      const at = value.match(/at:\s*'([^']+)'/)
+      if (!at) continue
+      for (const name of at[1].split(',').map((n) => n.trim())) {
+        const path = FILES[name]
+        if (!path) { unknown.push(`${type}: ${name}`); continue }
+        const src = readFileSync(join(root, path), 'utf8')
+        // A *receive branch*, not the literal anywhere in the file. `includes` certified a false claim
+        // that shipped in this table's first version: `error` was listed as handled in `SessionList`,
+        // which had no branch for it — three unrelated `'error'` strings (a `Record<string, 'booting' |
+        // 'error'>`, an assignment, a comparison) made it green, and the message really was being dropped
+        // there. Deleting a genuine branch and leaving the literal in a comment passed too.
+        // Any receiver's own name, not just `msg` — `useClipboardBridge` correlates by requestId and reads
+        // `reply.type === 'clipboard:error'`. What must not pass is a bare literal: a comment, a `send()`
+        // argument, or an unrelated string that happens to equal a message name.
+        // A comparison of some receiver's `.type` against this literal — either direction. `useClipboardBridge`
+        // reads `reply.type === 'clipboard:error'` and narrows to `clipboard:data` with `!==`, and both are
+        // handling. What must not pass is a bare literal: a comment, a `send()` argument, or an unrelated
+        // string that happens to equal a message name.
+        if (!new RegExp(String.raw`[\w.]+\.type [=!]== '${type}'`).test(src)) {
+          missing.push(`${type} has no \`<msg>.type\` comparison against '${type}' in ${name}`)
+        }
+      }
+    }
+    expect(unknown, 'a name in `at` that this check cannot resolve to a file').toEqual([])
+    expect(missing).toEqual([])
+  })
+
+  it('an ignored message states a reason, and the reason is a sentence', () => {
+    const thin = []
+    for (const [type, value] of table_entries) {
+      const m = value.match(/ignored:\s*([\s\S]*)$/)
+      if (!m) continue
+      // Concatenated string literals are one reason; take their contents.
+      const text = [...m[1].matchAll(/'((?:[^'\\]|\\.)*)'/g)].map((x) => x[1]).join(' ').trim()
+      // 40 characters is not a style rule — it is the line between a reason and a label. "not needed"
+      // type-checks and tells the next reader nothing, which is the state this table replaced.
+      if (text.length < 40) thin.push(`${type}: ${JSON.stringify(text)}`)
+    }
+    expect(thin).toEqual([])
+  })
+
+  it('the six ignored messages are the ones the measurement found', () => {
+    // Pinned so that "handled" quietly becoming "ignored" is a decision someone makes here, in a diff,
+    // rather than a branch that got deleted. Growing this list is allowed; doing it silently is not.
+    const ignored = [...table_entries].filter(([, v]) => /\bignored:/.test(v)).map(([t]) => t).sort()
+    expect(ignored).toEqual([
+      'app:clear-state-done',
+      'app:clear-state-error',
+      'input:done',
+      'input:type-done',
+      'input:type-error',
+      'session:deviceInfo',
+    ])
+  })
+})


### PR DESCRIPTION
Layer 6 of the wire-contract program (`.work/WIRE-CONTRACT-PLAN.md`). Follows #505 (L1).

## The bug

The relay sends `error` with three wordings. The dashboard handled two.

`Session busy` reached the viewer and **did nothing** — so two testers opening the same device left the second tab waiting on a `session:joined` that cannot arrive. Nothing reported it, because from the outside `error` *was* a handled type: the viewer branched on the free-prose `message`.

## The fix, and what review found on top of it

`error` now carries a closed `reason`, the same split #491 gave `input:error`. **Required** here — that one's producer set is open by design (a third-party platform registers via `AgentRegistry.register()`), while this one has a single producer, the relay. So `sendTo` enforces it, and the compiler walked the change: protocol → three relay sites → the viewer's prose comparison → the copy record.

Two independent review channels then found that **handling a case is not the same as ending it**, in three more places:

| | |
|---|---|
| **`agent-resources-exhausted` only toasted** | The relay `return`s after sending it, so nothing follows — the tab sat on "Starting device…" indefinitely. Making `reason` required stopped a case being *unhandled* without making the handled cases *end*. |
| **`session-busy` does not mean "someone else"** | The relay answers it whenever the session's browser socket still reads OPEN, and the commonest cause is the tester's **own** previous socket: a sleeping laptop reconnects in 2s while the relay takes up to a heartbeat to notice the old one died. My first wording asserted a colleague who does not exist — in exactly the case `DeviceViewer`'s own comment calls routine (#439). |
| **`SessionList` was dropping `error` too** | `handleShutdown` sends `session:start` on its own socket; a refused join is answered there, and `device:shutdown-done` — the only message that clears `shutting` — never comes. The badge read "Shutting down..." permanently and the gate on it hid both buttons. |

The relay also checks occupancy **before** the resource gate (with both true, the tester got the less actionable answer and the real reason went unreported), skips that check for a socket re-joining the session it already holds, and no longer folds `join()`'s two exceptions into a `catch {}` that discarded the error.

## The layer

Browser-inbound is 28 types; the dashboard handled 22 and dropped 6 — and the three reasons for dropping (handled elsewhere, deliberately ignored, nobody wrote it) were **indistinguishable in code**, because all three look like an absent branch.

`lib/inboundDisposition.ts` states one per message under `satisfies Record<BrowserInbound['type'], Disposition>`, so a message added to the wire **breaks the file** until someone picks a category. Measured: `TS1360` at the table.

Deriving the *reachable* subset and obliging only that was designed first and rejected by two channels for different reasons, both recorded in the table: `send()` is shared by four sockets that each open their own WebSocket, and **a reply does not go to whoever asked** — the relay forwards to whichever socket holds the session now, so "we never send `input:type`" is true per session, not per socket.

## The guard had to be fixed twice, and that is the interesting part

`scripts/__tests__/inboundDisposition.test.mjs` covers what a type cannot state. Its first version used `src.includes("'<type>'")` and **certified a false claim**: `error` was listed as handled in `SessionList`, which had no branch for it, and three unrelated `'error'` strings made it green while the message really was being dropped. Deleting a genuine branch and leaving the literal in a comment passed too.

So the table **created one of the three indistinguishable states it exists to remove**, and the check signed it off. Strengthening the predicate to an actual `.type` comparison immediately surfaced three more false `at` claims.

The parser also sliced to end-of-file rather than the table's closing line, so a sibling map below it could restore an entry count that a skipped key had lowered — the third time in this program a region parser has not known where its region ended.

## Not in scope

The session-ownership defects behind `session-busy` — evicting a holder the heartbeat has already lost, and `handleShutdown` leaving the first session permanently `busy: true`. Those change who owns a session and do not belong in a typing layer; filed separately with the review's evidence.

## Review

Two design rounds and one code round, two channels each: **11 findings, all dispositioned.** The first design was rejected whole — its rationale is kept in the plan, because a context reset will propose it again. Record and the 11 mutations: `.work/reviews/refactor__wire-l6-consumption-obligation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured reasons for session-start failures, including busy sessions and exhausted resources.
  * Added distinct notifications for busy, overloaded, and unavailable sessions.
  * Added clearer error notifications when session shutdown is refused.

* **Bug Fixes**
  * Improved session rejoining and resource-check behavior.
  * Prevented shutdown requests before joining or while another shutdown is in progress.
  * Improved handling of unexpected session-start failures.

* **Documentation**
  * Clarified device information compatibility and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->