### PR TITLE
refactor(protocol): declare the agent→relay direction, and type every agent send

### DIFF
--- a/.changeset/agent-producer-typing.md
+++ b/.changeset/agent-producer-typing.md
@@ -15,7 +15,8 @@ and `scripts/__tests__/inputErrorReason.test.mjs` exists because a script had to
 
 Seven message types were declared nowhere: `agent:register`, `agent:resources`, `screenshot:done`,
 `screenshot:error`, `stream:register`, `ui:tree:response`, `ui:tree:error` — the last undeclared direction.
-They are now `AgentToRelay` and `StreamToRelay`, and `AgentOutbound` is what a typed send takes.
+They are now `AgentToRelay` and `StreamToRelay`, and `AgentControlOutbound` is what the agents' typed send
+helpers take.
 
 `stream:register` is its own direction rather than part of `AgentToRelay`, mirroring `RelayToStream`: the
 relay assigns the role `'stream'` from it, not `'agent'`, so folding it in would make the union's name
@@ -25,8 +26,8 @@ inbound is narrowed by role.
 ## Two helpers, and why not one
 
 ```ts
-private sendMsg(msg: AgentOutbound): void { this.ws?.send(JSON.stringify(msg)) }
-private sendOn(ws: WebSocket, msg: AgentOutbound): void { ws.send(JSON.stringify(msg)) }
+private sendMsg(msg: AgentControlOutbound): void { this.ws?.send(JSON.stringify(msg)) }
+private sendOn(ws: WebSocket, msg: AgentControlOutbound): void { ws.send(JSON.stringify(msg)) }
 ```
 
 `sendOn` takes the socket **as an argument**. Seven call sites sit behind an entry guard (`if (!this.ws)

--- a/.changeset/agent-producer-typing.md
+++ b/.changeset/agent-producer-typing.md
@@ -1,0 +1,80 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/agent-core': patch
+'@tapflowio/ios-agent': patch
+'@tapflowio/android-agent': patch
+'@tapflowio/mcp-server': patch
+---
+
+refactor(protocol): declare the agent→relay direction, and type every agent send
+
+An agent's outbound literal was the one part of the wire contract no compiler could see. The relay forwards
+replies with `JSON.stringify(msg)`, so nothing typed ever re-creates them, and each agent handed its literal
+straight to `ws.send`. #489 (an agent answering nobody) and #490 (a missing `reason`) both came out of that,
+and `scripts/__tests__/inputErrorReason.test.mjs` exists because a script had to stand in for a compiler.
+
+Seven message types were declared nowhere: `agent:register`, `agent:resources`, `screenshot:done`,
+`screenshot:error`, `stream:register`, `ui:tree:response`, `ui:tree:error` — the last undeclared direction.
+They are now `AgentToRelay` and `StreamToRelay`, and `AgentOutbound` is what a typed send takes.
+
+`stream:register` is its own direction rather than part of `AgentToRelay`, mirroring `RelayToStream`: the
+relay assigns the role `'stream'` from it, not `'agent'`, so folding it in would make the union's name
+disagree with the runtime role — and would let a control socket claim to be a session's stream socket once
+inbound is narrowed by role.
+
+## Two helpers, and why not one
+
+```ts
+private sendMsg(msg: AgentOutbound): void { this.ws?.send(JSON.stringify(msg)) }
+private sendOn(ws: WebSocket, msg: AgentOutbound): void { ws.send(JSON.stringify(msg)) }
+```
+
+`sendOn` takes the socket **as an argument**. Seven call sites sit behind an entry guard (`if (!this.ws)
+return`) and are therefore compiler-proven non-null; reading `this.ws` inside a helper — or asserting it with
+`!` — would make those guards optional to the compiler and turn deleting one from a compile error into a
+runtime `TypeError`. One of them has a test whose subject is the window that guard covers.
+
+## What the compiler found once it could see
+
+- **30 sends passed an optional `sessionId` into a field declared required.** The agents' dispatcher took
+  `{ sessionId?: string }` while every message it dispatches is session-scoped. It now takes a required one,
+  with the check moved to the socket boundary — a message with no `sessionId` did not come from the relay's
+  forward path, which resolves the session before forwarding.
+- **`requestId` was read as optional in the clipboard cases and required in the screenshot and ui:tree ones**,
+  for the same wire guarantee, in the same file. Now consistent. It is still an assertion about unvalidated
+  JSON, as the other two always were; that is #444.
+- **The clipboard `respond` helper took `object`**, so all three clipboard replies were unchecked. Typed with
+  `ClipboardReplyBody`, which is `ClipboardReply` minus the ids the helper merges.
+
+**Twenty-five `msg.sessionId!` assertions went away as a consequence**, along with the now-unreachable
+`if (!sessionId) return` inside each agent's `ackNoSession`. That is the same payoff #444 is after on the relay
+side, arriving here first: once the declaration is required, the assertion has nothing left to assert.
+
+`screenshot:error` and `ui:tree:error` are the first `*-error` messages that do **not** extend `SessionError`.
+They are request-scoped — the relay resolves them by `requestId` alone — and the convention check names them,
+which draws the family's boundary rather than widening it. `SessionError` is for a failure a *session* is
+waiting on.
+
+Their `sessionId` is **required**, like every other producer field. A draft made it optional on the grounds
+that the agents pass through an optional id; that was true when written and false by the end of this change,
+which required it on both dispatchers. A field weaker than every producer describes a message nobody sends —
+and here it would also have removed the one field a symmetric ownership check could read, since the clipboard
+replies beside these verify `session.agentSocket === ws` before resolving and these two do not.
+
+The agents' helpers take `AgentControlOutbound = AgentToRelay | AgentToBrowser`, **not** a union that also
+includes `StreamToRelay`. An earlier draft merged all three, which handed back the exact hazard the direction
+split exists to avoid: `case 'stream:register'` calls `setStreamSocket(session.id, ws)` with no role gate, so a
+control socket that could type-check that message could take over the session's video path.
+
+`UIElement`, `UIElementRole` and `UIElementFrame` moved from `agent-core` to `protocol` — `ui:tree:response`
+cannot be typed without them and protocol is a leaf that cannot import agent-core. `mcp-server` had a
+hand-written mirror with a comment saying so; it is now a re-export.
+
+`scripts/__tests__/agentSendTyped.test.mjs` asserts nothing goes around the helpers, and it matches
+**serialization** rather than any spelling of `.send`. Three drafts keyed on `this.ws` were bypassed in review
+by renaming the socket — `streamWs.send(JSON.stringify(…))` walks past them, and that is not hypothetical:
+`streamWs` is in scope in `startBinaryStream` and the relay dispatches a text frame from a stream socket
+through the same agent cases. A commented-out copy of the canonical helper also satisfied the positive
+assertion while the real one took `msg: object`, leaving all 66 of that agent's sends unchecked with the check
+green. Both are closed, and a file in the agent packages that writes to a socket *and* serializes now has to
+be listed with a reason.

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -1,4 +1,6 @@
-import type { AndroidButton, AgentResources, ClipboardErrorPayload, Point } from '@tapflowio/protocol'
+import type {
+  AndroidButton, AgentResources, ClipboardErrorPayload, Point, UIElement, UIElementFrame, UIElementRole,
+} from '@tapflowio/protocol'
 
 // These three are **wire** payload types, so `@tapflowio/protocol` owns them — it is the leaf both
 // consumers that read them can reach, and this package is not one of them (neither `dashboard` nor
@@ -7,7 +9,7 @@ import type { AndroidButton, AgentResources, ClipboardErrorPayload, Point } from
 //
 // `export type`, not a bare `export { … } from`: the latter is a real runtime import of protocol's
 // `dist`, which would drag this package into the source-resolution rule in the root AGENTS.md.
-export type { AndroidButton, AgentResources, ClipboardErrorPayload, Point }
+export type { AndroidButton, AgentResources, ClipboardErrorPayload, Point, UIElement, UIElementFrame, UIElementRole }
 
 export type Platform = string
 
@@ -25,39 +27,6 @@ export interface Device {
 
 
 // Android physical button descriptor sent via session:chrome payload
-
-// Closed role vocabulary shared by all platforms. Unmappable native roles
-// become 'other'; the platform-native string is preserved in rawRole.
-export type UIElementRole =
-  | 'button'
-  | 'text'
-  | 'input'
-  | 'image'
-  | 'checkbox'
-  | 'switch'
-  | 'slider'
-  | 'list'
-  | 'cell'
-  | 'tab'
-  | 'other'
-
-// Normalized to 0-1 in the same coordinate space the touch input path
-// consumes, so a frame center can be fed straight into tap without conversion.
-export interface UIElementFrame {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
-export interface UIElement {
-  role: UIElementRole
-  label: string
-  identifier?: string
-  frame: UIElementFrame
-  enabled: boolean
-  rawRole?: string
-}
 
 // ── Agent capabilities ──────────────────────────────────────────────────────
 // Advertised in `agent:register` so a viewer can tell what the agent on the other

--- a/packages/agent-core/src/utils/stream.ts
+++ b/packages/agent-core/src/utils/stream.ts
@@ -1,3 +1,4 @@
+import type { StreamToRelay } from '@tapflowio/protocol'
 import { WebSocket } from 'ws'
 import type { Logger } from '../logger.js'
 
@@ -137,7 +138,10 @@ export function registerStreamWs(ws: WebSocket, sessionId: string): Promise<void
   return new Promise((resolve, reject) => {
     ws.once('open', () => {
       disableNagle(ws) // stream socket carries the video frames — keep it un-delayed on LAN
-      ws.send(JSON.stringify({ type: 'stream:register', sessionId }))
+      // Typed at the send site rather than through an agent helper: this is the stream socket, handed in as
+      // an argument, and it is the only agent send that does not go through `this.ws`.
+      const register: StreamToRelay = { type: 'stream:register', sessionId }
+      ws.send(JSON.stringify(register))
     })
 
     const onMsg = (data: Buffer) => {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -2,6 +2,7 @@ import os from 'os'
 import { randomUUID } from 'crypto'
 import { WebSocket } from 'ws'
 import type { AndroidButton, ClipboardErrorPayload, Device, DeviceAgent, UIElement } from '@tapflowio/agent-core'
+import type { AgentControlOutbound, ClipboardReplyBody } from '@tapflowio/protocol'
 import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 import { outcomeMessage, wireReason, type InputOutcome } from './inputOutcome.js'
 import {
@@ -220,6 +221,25 @@ export class AndroidAgent implements DeviceAgent {
   private readonly adb: AdbWrapper
   private readonly launcher: EmulatorLauncher
   private ws: WebSocket | null = null
+
+  /** Send on the control socket, if there is one. The `?.` is the point: 66 call sites relied on a send
+   *  being a no-op between reconnects, and this preserves that exactly.
+   *
+   *  Typed with `AgentControlOutbound`, which is why this exists — an agent's literal used to reach `ws.send`
+   *  with nothing checking it, and #489/#490 are what that cost. */
+  private sendMsg(msg: AgentControlOutbound): void {
+    this.ws?.send(JSON.stringify(msg))
+  }
+
+  /** Send on a socket the caller has already established. Takes the socket **as an argument** rather than
+   *  reading `this.ws`, and that is deliberate: the call sites that use it sit behind an entry guard
+   *  (`if (!this.ws) return`), and today deleting one of those guards is a compile error. Reading
+   *  `this.ws` here — or asserting it with `!` — would make the guard optional to the compiler and turn
+   *  its removal into a runtime `TypeError` instead. It also serves the `agent:register` send, which runs
+   *  inside `onopen` on a local socket. */
+  private sendOn(ws: WebSocket, msg: AgentControlOutbound): void {
+    ws.send(JSON.stringify(msg))
+  }
   private deviceStates = new Map<string, DeviceState>()
   // Holds a macOS power assertion while connected so the host doesn't idle-throttle the
   // emulator (its software H.264 encoder starves badly when the Mac idles). No-op off macOS.
@@ -273,7 +293,7 @@ export class AndroidAgent implements DeviceAgent {
 
       ws.once('open', () => {
         disableNagle(ws)
-        ws.send(JSON.stringify({
+        this.sendOn(ws, {
           type: 'agent:register',
           platform: 'android',
           // Lets a viewer tell a clipboard-capable agent from one that predates the
@@ -288,7 +308,7 @@ export class AndroidAgent implements DeviceAgent {
             status: d.status,
             osVersion: d.osVersion,
           })),
-        }))
+        })
       })
 
       ws.once('message', (data) => {
@@ -311,7 +331,15 @@ export class AndroidAgent implements DeviceAgent {
             msg.registeredSessions as Array<{ deviceId: string; sessionId: string }>,
           )
           ws.on('message', (d) => {
-            try { this.handleRelayMessage(JSON.parse(d.toString())) } catch { /* ignore malformed */ }
+            try {
+              const m = JSON.parse(d.toString()) as { type?: unknown; sessionId?: unknown }
+              // Every type `handleRelayMessage` dispatches is session-scoped, and the relay resolves the
+              // session before forwarding — so a message without one did not come from that path. Rejecting
+              // it here is what lets the dispatcher declare `sessionId: string` instead of threading an
+              // optional through 30 sends and asserting it with `!` at each one.
+              if (typeof m.type !== 'string' || typeof m.sessionId !== 'string') return
+              this.handleRelayMessage(m as { type: string; sessionId: string; payload?: unknown })
+            } catch { /* ignore malformed */ }
           })
           this.reportResources()
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
@@ -423,7 +451,7 @@ export class AndroidAgent implements DeviceAgent {
     const bootedCount = Array.from(this.deviceStates.values()).filter((s) => s.scrcpySession !== null || s.emulatorVideo !== null).length
     const slotsTotal = this.deviceStates.size
     const { memUsedMB, memTotalMB } = this.resources.getMemoryUsage()
-    this.ws.send(JSON.stringify({
+    this.sendOn(this.ws, {
       type: 'agent:resources',
       resources: {
         cpuPercent: this.resources.getCpuPercent(),
@@ -433,7 +461,7 @@ export class AndroidAgent implements DeviceAgent {
         slotsTotal,
         reportedAt: Date.now(),
       },
-    }))
+    })
   }
 
   private cleanupDeviceState(state: DeviceState): void {
@@ -457,14 +485,14 @@ export class AndroidAgent implements DeviceAgent {
 
   private sendDeviceInfo(state: DeviceState, device: Device): void {
     if (!this.ws) return
-    this.ws.send(JSON.stringify({
+    this.sendOn(this.ws, {
       type: 'session:deviceInfo',
       sessionId: state.sessionId,
       payload: {
         deviceName: device.name,
         osVersion: device.osVersion ?? '',
       },
-    }))
+    })
   }
 
   private forceScrcpy(): boolean {
@@ -787,11 +815,11 @@ export class AndroidAgent implements DeviceAgent {
       await this.startVideoStream(state, streamWs)
     } catch (err) {
       logger.error(`scrcpy restart failed: ${err}`)
-      this.ws?.send(JSON.stringify({
+      this.sendMsg({
         type: 'device:boot-error',
         sessionId: state.sessionId,
         message: 'scrcpy failed to restart',
-      }))
+      })
     } finally {
       state.restarting = false
     }
@@ -822,7 +850,7 @@ export class AndroidAgent implements DeviceAgent {
 
     this.cleanupDeviceState(state)
     if (tier) { state.secureContext = tier.secureContext; state.external = tier.external }
-    this.ws.send(JSON.stringify({ type: 'device:booting', sessionId }))
+    this.sendOn(this.ws, { type: 'device:booting', sessionId })
 
     try {
       const avdName = avdId.replace(/^avd:/, '')
@@ -863,7 +891,7 @@ export class AndroidAgent implements DeviceAgent {
 
       await this.startVideoStream(state, streamWs)
       if (seq !== state.bootSeq) return
-      this.ws?.send(JSON.stringify({
+      this.sendMsg({
         type: 'session:chrome',
         sessionId: state.sessionId,
         payload: {
@@ -873,14 +901,14 @@ export class AndroidAgent implements DeviceAgent {
           screenHeight: state.displayHeight,
           cornerRadius: state.cornerRadius,
         },
-      }))
+      })
       state.booted = true
-      this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: avdId } }))
+      this.sendMsg({ type: 'device:ready', sessionId, payload: { deviceId: avdId } })
     } catch (e) {
       if (seq !== state.bootSeq) return
       const message = e instanceof Error ? e.message : String(e)
       logger.error('boot failed:', message)
-      this.ws?.send(JSON.stringify({ type: 'device:boot-error', sessionId, message }))
+      this.sendMsg({ type: 'device:boot-error', sessionId, message })
     }
   }
 
@@ -899,11 +927,11 @@ export class AndroidAgent implements DeviceAgent {
       })
       this.adb.clearSerial(avdId)
     }
-    this.ws?.send(JSON.stringify({
+    this.sendMsg({
       type: 'device:shutdown-done',
       sessionId,
       payload: { deviceId: avdId },
-    }))
+    })
   }
 
   // Ack a terminal input. `input:done` = the input reached a live channel on a booted device (not a
@@ -921,22 +949,23 @@ export class AndroidAgent implements DeviceAgent {
       ? outcome
       : (state.booted || (await this.isBooted(state.deviceId))) ? 'delivered' : 'not-booted'
     if (resolved === 'delivered' && seq === state.bootSeq) state.booted = true // cache the verify
-    this.ws?.send(JSON.stringify(
+    this.sendMsg(
       resolved === 'delivered'
         ? { type: 'input:done', sessionId: state.sessionId }
-        : { type: 'input:error', sessionId: state.sessionId, message: outcomeMessage(resolved), reason: wireReason(resolved) },
-    ))
+        : { type: 'input:error', sessionId: state.sessionId, message: outcomeMessage(resolved), reason: wireReason(resolved) })
   }
 
   // A terminal input naming a session this agent holds no state for. `deviceStates` is never
   // deleted, so this is an unregistered sessionId rather than an evicted one — and the relay only
   // answers on an agent's behalf when the agent is *offline*, so nothing else would answer at all
   // and the caller would wait out its own timeout.
-  private ackNoSession(sessionId: string | undefined): void {
-    if (!sessionId) return
-    this.ws?.send(JSON.stringify({
+  private ackNoSession(sessionId: string): void {
+    // The `if (!sessionId) return` this used to open with is gone: the dispatcher now declares
+    // `sessionId: string`, so there is no undefined to guard against and the guard would have been a
+    // silent drop with nothing left that could reach it.
+    this.sendMsg({
       type: 'input:error', sessionId, message: outcomeMessage('no-session'), reason: wireReason('no-session'),
-    }))
+    })
   }
 
   // Await a pointer-channel write and turn it into an outcome. scrcpy's methods are synchronous and
@@ -966,17 +995,17 @@ export class AndroidAgent implements DeviceAgent {
     } catch { return false }
   }
 
-  private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
+  private handleRelayMessage(msg: { type: string; sessionId: string; payload?: unknown }): void {
     switch (msg.type) {
       case 'device:boot': {
         const { deviceId, secureContext, external } = msg.payload as { deviceId: string; secureContext?: boolean; external?: boolean }
-        this.handleDeviceBoot(msg.sessionId!, deviceId, { secureContext: !!secureContext, external: !!external })
+        this.handleDeviceBoot(msg.sessionId, deviceId, { secureContext: !!secureContext, external: !!external })
           .catch((e) => logger.error('handleDeviceBoot failed:', e))
         break
       }
       case 'device:shutdown': {
         const { deviceId } = msg.payload as { deviceId: string }
-        this.handleDeviceShutdown(msg.sessionId!, deviceId)
+        this.handleDeviceShutdown(msg.sessionId, deviceId)
           .catch((e) => logger.error('handleDeviceShutdown failed:', e))
         break
       }
@@ -986,15 +1015,15 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'app:install-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'app:install-error', sessionId, message: 'No booted device' })
           break
         }
         if (filePath.endsWith('.app.zip') || filePath.endsWith('.app')) {
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'app:install-error',
             sessionId,
             message: '.app.zip is an iOS simulator build — upload a .apk file for Android.',
-          }))
+          })
           break
         }
         const doInstall = async () => {
@@ -1002,10 +1031,10 @@ export class AndroidAgent implements DeviceAgent {
           await this.adb.installApp(serial, filePath)
         }
         doInstall()
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:install-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'app:install-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:install-error', sessionId, message }))
+            this.sendMsg({ type: 'app:install-error', sessionId, message })
           })
         break
       }
@@ -1015,19 +1044,19 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'app:launch-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'app:launch-error', sessionId, message: 'No booted device' })
           break
         }
         this.adb.launchApp(serial, bundleId)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:launch-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'app:launch-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:launch-error', sessionId, message }))
+            this.sendMsg({ type: 'app:launch-error', sessionId, message })
           })
         break
       }
       case 'input:touch:start': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const { x, y } = msg.payload as { x: number; y: number }
         const pc = this.pointerControl(state)
@@ -1042,7 +1071,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:touch:move': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const { x, y } = msg.payload as { x: number; y: number }
         const pc = this.pointerControl(state)
@@ -1057,7 +1086,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:touch:end': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         const pc = this.pointerControl(state)
         const helper = state.touchHelper
@@ -1072,7 +1101,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:start': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
         const pc = this.pointerControl(state)
@@ -1086,7 +1115,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:move': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
         const pc = this.pointerControl(state)
@@ -1100,7 +1129,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:end': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         const pc = this.pointerControl(state)
         const helper = state.touchHelper
@@ -1114,7 +1143,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:rotate': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const serial = this.adb.getSerial(state.deviceId)
         if (!serial) break
@@ -1128,7 +1157,7 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:button': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         // Buttons go through the adb helper on BOTH backends — this is the path that actually runs
         // a command in production, so its outcome is the one that matters most here.
@@ -1147,7 +1176,7 @@ export class AndroidAgent implements DeviceAgent {
       case 'stream:request-idr': {
         // Relay drop-to-keyframe / join recovery: reset the encoder so it re-emits SPS/PPS + IDR,
         // resyncing fast instead of waiting for the periodic IDR. Throttled by the relay.
-        const st = this.deviceStates.get(msg.sessionId!)
+        const st = this.deviceStates.get(msg.sessionId)
         st?.scrcpySession?.control.resetVideo()
         st?.emulatorVideo?.requestIdr()
         break
@@ -1158,14 +1187,14 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'open-url:error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'open-url:error', sessionId, message: 'No booted device' })
           break
         }
         this.adb.openUrl(serial, url)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'open-url:done', sessionId })))
+          .then(() => this.sendMsg({ type: 'open-url:done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'open-url:error', sessionId, message }))
+            this.sendMsg({ type: 'open-url:error', sessionId, message })
           })
         break
       }
@@ -1179,7 +1208,7 @@ export class AndroidAgent implements DeviceAgent {
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         const { text } = (msg.payload ?? {}) as { text?: string }
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'input:type-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'input:type-error', sessionId, message: 'No booted device' })
           break
         }
         // Empty text is a successful no-op, not a failure: the caller asked for nothing and nothing
@@ -1189,16 +1218,16 @@ export class AndroidAgent implements DeviceAgent {
         // Ack on completion so a following input step (e.g. pressKey Enter) is
         // only sent after the text has actually landed.
         Promise.resolve(text ? this.adb.inputText(serial, text) : undefined)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'input:type-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'input:type-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
             logger.error('input:type failed:', e)
-            this.ws?.send(JSON.stringify({ type: 'input:type-error', sessionId, message }))
+            this.sendMsg({ type: 'input:type-error', sessionId, message })
           })
         break
       }
       case 'input:key': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         const seq = state.bootSeq
         void (async () => {
@@ -1219,20 +1248,20 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message: 'No booted device' }))
+          this.sendMsg({ type: 'screenshot:error', sessionId, requestId, message: 'No booted device' })
           break
         }
         this.adb.screenshot(serial)
-          .then((buf) => this.ws?.send(JSON.stringify({
+          .then((buf) => this.sendMsg({
             type: 'screenshot:done',
             sessionId,
             requestId,
             format: format ?? 'png',
             data: buf.toString('base64'),
-          })))
+          }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message }))
+            this.sendMsg({ type: 'screenshot:error', sessionId, requestId, message })
           })
         break
       }
@@ -1242,14 +1271,14 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial || !bundleId) {
-          this.ws?.send(JSON.stringify({ type: 'app:clear-state-error', sessionId, message: !serial ? 'No booted device' : 'bundleId missing' }))
+          this.sendMsg({ type: 'app:clear-state-error', sessionId, message: !serial ? 'No booted device' : 'bundleId missing' })
           break
         }
         this.adb.clearAppData(serial, bundleId)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:clear-state-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'app:clear-state-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:clear-state-error', sessionId, message }))
+            this.sendMsg({ type: 'app:clear-state-error', sessionId, message })
           })
         break
       }
@@ -1259,7 +1288,15 @@ export class AndroidAgent implements DeviceAgent {
       // the PREVIOUS clipboard, a stale value the user would never notice.
       case 'clipboard:read':
       case 'clipboard:write': {
-        const { requestId } = msg as unknown as { requestId?: string }
+        // `requestId: string`, matching the screenshot and ui:tree casts a few cases below — clipboard was
+        // the only one reading it as optional, for the same wire guarantee. `ClipboardRequest.requestId` is
+        // required and the only requester goes through a typed `send()`, so nothing in-repo omits it.
+        //
+        // It is still an assertion about unvalidated JSON, as those other two are: a third-party client
+        // could omit it, and then the reply would carry `undefined` and be uncorrelatable. That is inbound
+        // validation (#444), not producer typing, and making it optional here instead would just move the
+        // same hole into every reply this case sends.
+        const { requestId } = msg as unknown as { requestId: string }
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
@@ -1267,13 +1304,13 @@ export class AndroidAgent implements DeviceAgent {
         // on the same device may still hold a marker — and the chord the viewer would press in
         // response does not go through the queue. So report the device, not the caller.
         const fail = (message: string, unsupported = false) =>
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'clipboard:error', sessionId, requestId, message,
             payload: {
               unsupported,
               sentinelParked: state ? this.sentinelParked(state.deviceId) : false,
             } satisfies ClipboardErrorPayload,
-          }))
+          })
         // Distinguish the three ways this can be unavailable — they need different fixes.
         if (!state || !serial) { fail('No booted device'); break }
         if (!state.grpcClient) {
@@ -1293,8 +1330,8 @@ export class AndroidAgent implements DeviceAgent {
           // the `catch` that replies, so the viewer hears back as soon as the outcome is known.
           // The queue is still held until the restore lands — that is what stops the next
           // operation seeing a sentinel. Mirrors the iOS read path.
-          const respond = (body: object) =>
-            this.ws?.send(JSON.stringify({ sessionId, requestId, ...body }))
+          const respond = (body: ClipboardReplyBody) =>
+            this.sendMsg({ sessionId, requestId, ...body })
           // The ceiling applies to whatever leaves the device, not just the sentinel path —
           // iOS gets this from getPasteboard's maxBuffer, so Android is the only side that
           // could put a multi-MB guest clipboard on the socket the video shares.
@@ -1401,7 +1438,7 @@ export class AndroidAgent implements DeviceAgent {
           }
           // Ack only once the write (and the paste, when asked for) actually landed.
           this.clipboardQueue(state.deviceId, write)
-            .then(() => this.ws?.send(JSON.stringify({ type: 'clipboard:write-done', sessionId, requestId })))
+            .then(() => this.sendMsg({ type: 'clipboard:write-done', sessionId, requestId }))
             .catch(onError)
         }
         break
@@ -1413,19 +1450,19 @@ export class AndroidAgent implements DeviceAgent {
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         if (!serial) {
-          this.ws?.send(JSON.stringify({ type: 'ui:tree:error', sessionId, requestId, message: 'No booted device' }))
+          this.sendMsg({ type: 'ui:tree:error', sessionId, requestId, message: 'No booted device' })
           break
         }
         this.adb.dumpUiHierarchy(serial)
-          .then((xml) => this.ws?.send(JSON.stringify({
+          .then((xml) => this.sendMsg({
             type: 'ui:tree:response',
             sessionId,
             requestId,
             elements: parseUiAutomatorDump(xml),
-          })))
+          }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'ui:tree:error', sessionId, requestId, message }))
+            this.sendMsg({ type: 'ui:tree:error', sessionId, requestId, message })
           })
         break
       }

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -7,7 +7,7 @@ import { spawnSync } from 'child_process'
 import { WebSocket } from 'ws'
 import type { ClipboardErrorPayload, Device, DeviceAgent, UIElement } from '@tapflowio/agent-core'
 import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
-import type { InputErrorReason } from '@tapflowio/protocol'
+import type { AgentControlOutbound, InputErrorReason, ClipboardReplyBody } from '@tapflowio/protocol'
 
 const logger = createLogger('ios-agent')
 
@@ -144,6 +144,25 @@ export class IOSAgent implements DeviceAgent {
   private readonly token?: string
   private readonly handshakeTimeoutMs: number
   private ws: WebSocket | null = null
+
+  /** Send on the control socket, if there is one. The `?.` is the point: 66 call sites relied on a send
+   *  being a no-op between reconnects, and this preserves that exactly.
+   *
+   *  Typed with `AgentControlOutbound`, which is why this exists — an agent's literal used to reach `ws.send`
+   *  with nothing checking it, and #489/#490 are what that cost. */
+  private sendMsg(msg: AgentControlOutbound): void {
+    this.ws?.send(JSON.stringify(msg))
+  }
+
+  /** Send on a socket the caller has already established. Takes the socket **as an argument** rather than
+   *  reading `this.ws`, and that is deliberate: the call sites that use it sit behind an entry guard
+   *  (`if (!this.ws) return`), and today deleting one of those guards is a compile error. Reading
+   *  `this.ws` here — or asserting it with `!` — would make the guard optional to the compiler and turn
+   *  its removal into a runtime `TypeError` instead. It also serves the `agent:register` send, which runs
+   *  inside `onopen` on a local socket. */
+  private sendOn(ws: WebSocket, msg: AgentControlOutbound): void {
+    ws.send(JSON.stringify(msg))
+  }
   private deviceStates = new Map<string, DeviceState>()
   // Last app launched per device (deviceId → bundleId). The XCUITest tree backend
   // queries by bundleId; kept outside DeviceState so it survives a relay reconnect
@@ -205,7 +224,7 @@ export class IOSAgent implements DeviceAgent {
 
       ws.once('open', () => {
         disableNagle(ws)
-        ws.send(JSON.stringify({
+        this.sendOn(ws, {
           type: 'agent:register',
           platform: 'ios',
           // Lets a viewer tell a clipboard-capable agent from one that predates the
@@ -220,7 +239,7 @@ export class IOSAgent implements DeviceAgent {
             status: d.status,
             osVersion: d.osVersion,
           })),
-        }))
+        })
       })
 
       ws.once('message', (data) => {
@@ -243,7 +262,15 @@ export class IOSAgent implements DeviceAgent {
             msg.registeredSessions as Array<{ deviceId: string; sessionId: string }>,
           )
           ws.on('message', (d) => {
-            try { this.handleRelayMessage(JSON.parse(d.toString())) } catch { /* ignore malformed */ }
+            try {
+              const m = JSON.parse(d.toString()) as { type?: unknown; sessionId?: unknown }
+              // Every type `handleRelayMessage` dispatches is session-scoped, and the relay resolves the
+              // session before forwarding — so a message without one did not come from that path. Rejecting
+              // it here is what lets the dispatcher declare `sessionId: string` instead of threading an
+              // optional through 30 sends and asserting it with `!` at each one.
+              if (typeof m.type !== 'string' || typeof m.sessionId !== 'string') return
+              this.handleRelayMessage(m as { type: string; sessionId: string; payload?: unknown })
+            } catch { /* ignore malformed */ }
           })
           this.reportResources()
           this.resourcesTimer = setInterval(() => this.reportResources(), 5000)
@@ -354,7 +381,7 @@ export class IOSAgent implements DeviceAgent {
     const bootedCount = Array.from(this.deviceStates.values()).filter((s) => s.streamReader !== null).length
     const slotsTotal = this.deviceStates.size
     const { memUsedMB, memTotalMB } = this.resources.getMemoryUsage()
-    this.ws.send(JSON.stringify({
+    this.sendOn(this.ws, {
       type: 'agent:resources',
       resources: {
         cpuPercent: this.resources.getCpuPercent(),
@@ -364,7 +391,7 @@ export class IOSAgent implements DeviceAgent {
         slotsTotal,
         reportedAt: Date.now(),
       },
-    }))
+    })
   }
 
   private cleanupDeviceState(state: DeviceState): void {
@@ -397,21 +424,21 @@ export class IOSAgent implements DeviceAgent {
     state.touchHelper?.stop()
     state.touchHelper = new TouchHelper(device.id)
     state.touchHelper.start()
-    this.ws.send(JSON.stringify({
+    this.sendOn(this.ws, {
       type: 'session:deviceInfo',
       sessionId: state.sessionId,
       payload: {
         deviceName: device.name,
         osVersion: device.osVersion ?? '',
       },
-    }))
+    })
     state.loadedChrome = this.chromeLoader.load(device.typeId ?? device.name)
     if (!state.loadedChrome) return
-    this.ws.send(JSON.stringify({
+    this.sendOn(this.ws, {
       type: 'session:chrome',
       sessionId: state.sessionId,
       payload: state.loadedChrome,
-    }))
+    })
   }
 
   private startBinaryStream(state: DeviceState, streamWs: WebSocket): void {
@@ -524,7 +551,7 @@ export class IOSAgent implements DeviceAgent {
     state.streamWs?.close()
     state.streamWs = null
 
-    this.ws.send(JSON.stringify({ type: 'device:booting', sessionId }))
+    this.sendOn(this.ws, { type: 'device:booting', sessionId })
 
     try {
       const devices = await this.simctl.listDevices()
@@ -603,7 +630,7 @@ export class IOSAgent implements DeviceAgent {
       // — never blocks/affects the video path.
       if (this.audioEnabled()) this.startAudioCapture(state, streamWs, deviceId)
       state.booted = true
-      this.ws?.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId } }))
+      this.sendMsg({ type: 'device:ready', sessionId, payload: { deviceId } })
 
       // Sync AppleKeyboards after ready — fire-and-forget so streaming isn't delayed.
       // hw=Automatic lets the hardware layout follow the active input source on LANG1/CapsLock.
@@ -615,7 +642,7 @@ export class IOSAgent implements DeviceAgent {
     } catch (e) {
       if (seq !== state.bootSeq) return
       const message = e instanceof Error ? e.message : String(e)
-      this.ws?.send(JSON.stringify({ type: 'device:boot-error', sessionId, message }))
+      this.sendMsg({ type: 'device:boot-error', sessionId, message })
     }
   }
 
@@ -653,11 +680,11 @@ export class IOSAgent implements DeviceAgent {
 
     try {
       await this.simctl.shutdown(deviceId)
-      this.ws?.send(JSON.stringify({
+      this.sendMsg({
         type: 'device:shutdown-done',
         sessionId,
         payload: { deviceId },
-      }))
+      })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       logger.error('shutdown failed:', message)
@@ -699,13 +726,15 @@ export class IOSAgent implements DeviceAgent {
   // device can now sit behind two sessions, which leaves the second unseeded. Answering costs four
   // lines; staying silent costs a terminal input swallowed and the caller's own fallback reporting
   // success. Android already answers, and `channel-unavailable` is what it maps this to.
-  private ackNoSession(sessionId: string | undefined): void {
-    if (!sessionId) return
-    this.ws?.send(JSON.stringify({
+  private ackNoSession(sessionId: string): void {
+    // The `if (!sessionId) return` this used to open with is gone: the dispatcher now declares
+    // `sessionId: string`, so there is no undefined to guard against and the guard would have been a
+    // silent drop with nothing left that could reach it.
+    this.sendMsg({
       type: 'input:error', sessionId,
       message: INPUT_ERROR_MESSAGES['channel-unavailable'],
       reason: 'channel-unavailable' satisfies InputErrorReason,
-    }))
+    })
   }
 
   /**
@@ -748,11 +777,10 @@ export class IOSAgent implements DeviceAgent {
       ? outcome
       : (state.booted || (await this.isBooted(state.deviceId))) ? null : 'not-booted'
     if (reason === null) state.booted = true // cache the post-reconnect verify so later inputs skip simctl
-    this.ws?.send(JSON.stringify(
+    this.sendMsg(
       reason === null
         ? { type: 'input:done', sessionId: state.sessionId }
-        : { type: 'input:error', sessionId: state.sessionId, message: INPUT_ERROR_MESSAGES[reason], reason },
-    ))
+        : { type: 'input:error', sessionId: state.sessionId, message: INPUT_ERROR_MESSAGES[reason], reason })
   }
 
   private async isBooted(deviceId: string): Promise<boolean> {
@@ -762,18 +790,18 @@ export class IOSAgent implements DeviceAgent {
     } catch { return false }
   }
 
-  private handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void {
+  private handleRelayMessage(msg: { type: string; sessionId: string; payload?: unknown }): void {
     switch (msg.type) {
       case 'device:boot': {
         const { deviceId, resetMode, acceptH264, secureContext, external } = msg.payload as { deviceId: string; resetMode?: string; acceptH264?: boolean; secureContext?: boolean; external?: boolean }
-        const sessionId = msg.sessionId!
+        const sessionId = msg.sessionId
         this.handleDeviceBoot(sessionId, deviceId, resetMode === 'full-erase', acceptH264 === true, { secureContext: !!secureContext, external: !!external })
           .catch((e) => logger.error('handleDeviceBoot failed:', e))
         break
       }
       case 'device:shutdown': {
         const { deviceId } = msg.payload as { deviceId: string }
-        const sessionId = msg.sessionId!
+        const sessionId = msg.sessionId
         this.handleDeviceShutdown(sessionId, deviceId)
           .catch((e) => logger.error('handleDeviceShutdown failed:', e))
         break
@@ -783,14 +811,14 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const installState = this.deviceStates.get(sessionId!)
         if (!installState) {
-          this.ws?.send(JSON.stringify({ type: 'app:install-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'app:install-error', sessionId, message: 'No booted device' })
           break
         }
         this.installBuild(installState.deviceId, filePath, bundleId)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:install-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'app:install-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:install-error', sessionId, message }))
+            this.sendMsg({ type: 'app:install-error', sessionId, message })
           })
         break
       }
@@ -799,7 +827,7 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const launchState = this.deviceStates.get(sessionId!)
         if (!launchState) {
-          this.ws?.send(JSON.stringify({ type: 'app:launch-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'app:launch-error', sessionId, message: 'No booted device' })
           break
         }
         this.simctl.launchApp(launchState.deviceId, bundleId)
@@ -808,16 +836,16 @@ export class IOSAgent implements DeviceAgent {
             this.lastBundleIds.set(launchState.deviceId, bundleId)
             // Audio: the whole-sim tap's poll picks up the launched app process within one interval;
             // no per-launch helper needed.
-            this.ws?.send(JSON.stringify({ type: 'app:launch-done', sessionId }))
+            this.sendMsg({ type: 'app:launch-done', sessionId })
           })
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:launch-error', sessionId, message }))
+            this.sendMsg({ type: 'app:launch-error', sessionId, message })
           })
         break
       }
       case 'input:touch:start': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         this.ensureTouchHelper(state)
         const { x, y } = msg.payload as { x: number; y: number }
@@ -825,14 +853,14 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:touch:move': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state?.touchHelper) break
         const { x, y } = msg.payload as { x: number; y: number }
         state.touchHelper.touchMove(x, y)
         break
       }
       case 'input:touch:end': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         // The helper's answer, not its existence: a helper whose process has died reports every
         // write as dropped, and that is what the caller needs to hear (#482).
@@ -842,7 +870,7 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:start': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         this.ensureTouchHelper(state)
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
@@ -850,21 +878,21 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:move': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state?.touchHelper) break
         const { f0, f1 } = msg.payload as { f0: { x: number; y: number }; f1: { x: number; y: number } }
         state.touchHelper.pinchMove(f0.x, f0.y, f1.x, f1.y)
         break
       }
       case 'input:pinch:end': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         const pinchHelper = state.touchHelper
         void this.ackInput(state, pinchHelper?.pinchEnd() ? 'delivered' : this.refusalReason(pinchHelper, 'continuation'))
         break
       }
       case 'input:rotate': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         state.orientation = state.orientation === 'portrait' ? 'landscapeRight' : 'portrait'
         this.simctl.rotate(state.deviceId, state.orientation)
@@ -873,11 +901,11 @@ export class IOSAgent implements DeviceAgent {
       }
       case 'stream:request-idr': {
         // Relay drop-to-keyframe recovery: force an IDR so the stream resyncs fast.
-        this.deviceStates.get(msg.sessionId!)?.captureStreamer?.requestKeyframe()
+        this.deviceStates.get(msg.sessionId)?.captureStreamer?.requestKeyframe()
         break
       }
       case 'input:keyboard:toggle': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) break
         const showing = !state.softKeyboardVisible
         const op = showing
@@ -885,11 +913,11 @@ export class IOSAgent implements DeviceAgent {
           : this.simctl.hideSoftwareKeyboard(state.deviceId)
         op.then(() => {
           state.softKeyboardVisible = showing
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'keyboard:toggled',
             sessionId: state.sessionId,
             payload: { visible: showing },
-          }))
+          })
         }).catch((e: unknown) => {
           logger.error('keyboard toggle failed:', e)
         })
@@ -901,7 +929,7 @@ export class IOSAgent implements DeviceAgent {
         if (state) this.ensureTouchHelper(state)
         const { text } = (msg.payload ?? {}) as { text?: string }
         if (!state?.touchHelper) {
-          this.ws?.send(JSON.stringify({ type: 'input:type-error', sessionId, message: 'No booted device' }))
+          this.sendMsg({ type: 'input:type-error', sessionId, message: 'No booted device' })
           break
         }
         // simctl pbcopy → Cmd+V paste. Works for arbitrary Unicode (unlike a
@@ -930,16 +958,16 @@ export class IOSAgent implements DeviceAgent {
         // Shares the clipboard queue: this writes the pasteboard, so running it alongside a
         // clipboard:read would overwrite that read's sentinel and be returned as "copied".
         this.clipboardQueue(state.deviceId, doType)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'input:type-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'input:type-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
             logger.error('input:type (pbcopy+paste) failed:', e)
-            this.ws?.send(JSON.stringify({ type: 'input:type-error', sessionId, message }))
+            this.sendMsg({ type: 'input:type-error', sessionId, message })
           })
         break
       }
       case 'input:key': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         this.ensureTouchHelper(state)
         const { code, modifiers } = msg.payload as { code: string; modifiers?: number }
@@ -947,10 +975,10 @@ export class IOSAgent implements DeviceAgent {
         if (usage === undefined) {
           // Prose preserved (it names the code), reason added: `unsupported` tells a caller never to
           // retry, which the message alone could not.
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'input:error', sessionId: msg.sessionId,
             message: `unknown key code: ${code}`, reason: 'unsupported' satisfies InputErrorReason,
-          }))
+          })
           break
         }
         if (state.softKeyboardVisible) {
@@ -974,7 +1002,7 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:button': {
-        const state = this.deviceStates.get(msg.sessionId!)
+        const state = this.deviceStates.get(msg.sessionId)
         if (!state) { this.ackNoSession(msg.sessionId); break }
         this.ensureTouchHelper(state)
         const { name, phase } = msg.payload as { name: string; phase?: 'down' | 'up' }
@@ -1016,14 +1044,14 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (!state) {
-          this.ws?.send(JSON.stringify({ type: 'open-url:error', sessionId, message: 'no booted device' }))
+          this.sendMsg({ type: 'open-url:error', sessionId, message: 'no booted device' })
           break
         }
         this.simctl.openUrl(state.deviceId, url)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'open-url:done', sessionId })))
+          .then(() => this.sendMsg({ type: 'open-url:done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'open-url:error', sessionId, message }))
+            this.sendMsg({ type: 'open-url:error', sessionId, message })
           })
         break
       }
@@ -1033,7 +1061,7 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const shotState = this.deviceStates.get(sessionId!)
         if (!shotState) {
-          this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message: 'No booted device' }))
+          this.sendMsg({ type: 'screenshot:error', sessionId, requestId, message: 'No booted device' })
           break
         }
         // Note for anyone widening this signature again: before the udid parameter existed this
@@ -1041,16 +1069,16 @@ export class IOSAgent implements DeviceAgent {
         // type error — the format string simply became the device id. The compiler cannot help
         // here; the test that scans exec arguments is what does.
         this.simctl.screenshot(shotState.deviceId, format ?? 'png')
-          .then((buf) => this.ws?.send(JSON.stringify({
+          .then((buf) => this.sendMsg({
             type: 'screenshot:done',
             sessionId,
             requestId,
             format: format ?? 'png',
             data: buf.toString('base64'),
-          })))
+          }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'screenshot:error', sessionId, requestId, message }))
+            this.sendMsg({ type: 'screenshot:error', sessionId, requestId, message })
           })
         break
       }
@@ -1059,14 +1087,14 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (!state || !bundleId) {
-          this.ws?.send(JSON.stringify({ type: 'app:clear-state-error', sessionId, message: !state ? 'No booted device' : 'bundleId missing' }))
+          this.sendMsg({ type: 'app:clear-state-error', sessionId, message: !state ? 'No booted device' : 'bundleId missing' })
           break
         }
         this.simctl.clearAppData(state.deviceId, bundleId)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'app:clear-state-done', sessionId })))
+          .then(() => this.sendMsg({ type: 'app:clear-state-done', sessionId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'app:clear-state-error', sessionId, message }))
+            this.sendMsg({ type: 'app:clear-state-error', sessionId, message })
           })
         break
       }
@@ -1075,14 +1103,22 @@ export class IOSAgent implements DeviceAgent {
       // await hideSoftwareKeyboard first), and reading too early returns the PREVIOUS
       // pasteboard — a stale value the user would never notice.
       case 'clipboard:read': {
-        const { requestId } = msg as unknown as { requestId?: string }
+        // `requestId: string`, matching the screenshot and ui:tree casts a few cases below — clipboard was
+        // the only one reading it as optional, for the same wire guarantee. `ClipboardRequest.requestId` is
+        // required and the only requester goes through a typed `send()`, so nothing in-repo omits it.
+        //
+        // It is still an assertion about unvalidated JSON, as those other two are: a third-party client
+        // could omit it, and then the reply would carry `undefined` and be uncorrelatable. That is inbound
+        // validation (#444), not producer typing, and making it optional here instead would just move the
+        // same hole into every reply this case sends.
+        const { requestId } = msg as unknown as { requestId: string }
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (!state) {
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'clipboard:error', sessionId, requestId, message: 'No booted device',
             payload: { sentinelParked: false } satisfies ClipboardErrorPayload,
-          }))
+          })
           break
         }
         const { press } = (msg.payload ?? {}) as { press?: 'copy' | 'cut' }
@@ -1090,8 +1126,8 @@ export class IOSAgent implements DeviceAgent {
         // executes AFTER this — so the viewer hears back as soon as the outcome is known and
         // does not wait out the restore window. The queue is still held until the restore
         // finishes, which is what actually matters: the next operation must not see a sentinel.
-        const respond = (body: object) =>
-          this.ws?.send(JSON.stringify({ sessionId, requestId, ...body }))
+        const respond = (body: ClipboardReplyBody) =>
+          this.sendMsg({ sessionId, requestId, ...body })
         const read = async (): Promise<void> => {
           if (!press) {
             respond({ type: 'clipboard:data', payload: { text: await this.simctl.getPasteboard(state.deviceId) } })
@@ -1199,23 +1235,31 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'clipboard:write': {
-        const { requestId } = msg as unknown as { requestId?: string }
+        // `requestId: string`, matching the screenshot and ui:tree casts a few cases below — clipboard was
+        // the only one reading it as optional, for the same wire guarantee. `ClipboardRequest.requestId` is
+        // required and the only requester goes through a typed `send()`, so nothing in-repo omits it.
+        //
+        // It is still an assertion about unvalidated JSON, as those other two are: a third-party client
+        // could omit it, and then the reply would carry `undefined` and be uncorrelatable. That is inbound
+        // validation (#444), not producer typing, and making it optional here instead would just move the
+        // same hole into every reply this case sends.
+        const { requestId } = msg as unknown as { requestId: string }
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (!state) {
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'clipboard:error', sessionId, requestId, message: 'No booted device',
             payload: { sentinelParked: false } satisfies ClipboardErrorPayload,
-          }))
+          })
           break
         }
         const { text, pasteAfter } = (msg.payload ?? {}) as { text?: string; pasteAfter?: boolean }
         if (clipboardByteLength(text ?? '') > MAX_CLIPBOARD_BYTES) {
-          this.ws?.send(JSON.stringify({
+          this.sendMsg({
             type: 'clipboard:error', sessionId, requestId,
             message: `Clipboard is too large (max ${Math.floor(MAX_CLIPBOARD_BYTES / 1024)} KB)`,
             payload: { sentinelParked: this.sentinelParked(state.deviceId) } satisfies ClipboardErrorPayload,
-          }))
+          })
           break
         }
         const write = async (): Promise<void> => {
@@ -1246,13 +1290,13 @@ export class IOSAgent implements DeviceAgent {
         }
         // Ack only once the write (and the paste, when asked for) actually landed.
         this.clipboardQueue(state.deviceId, write)
-          .then(() => this.ws?.send(JSON.stringify({ type: 'clipboard:write-done', sessionId, requestId })))
+          .then(() => this.sendMsg({ type: 'clipboard:write-done', sessionId, requestId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({
+            this.sendMsg({
               type: 'clipboard:error', sessionId, requestId, message,
               payload: { sentinelParked: this.sentinelParked(state.deviceId) } satisfies ClipboardErrorPayload,
-            }))
+            })
           })
         break
       }
@@ -1262,14 +1306,14 @@ export class IOSAgent implements DeviceAgent {
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (!state) {
-          this.ws?.send(JSON.stringify({ type: 'ui:tree:error', sessionId, requestId, message: 'No booted device' }))
+          this.sendMsg({ type: 'ui:tree:error', sessionId, requestId, message: 'No booted device' })
           break
         }
         this.readUITree(state)
-          .then((elements) => this.ws?.send(JSON.stringify({ type: 'ui:tree:response', sessionId, requestId, elements })))
+          .then((elements) => this.sendMsg({ type: 'ui:tree:response', sessionId, requestId, elements }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
-            this.ws?.send(JSON.stringify({ type: 'ui:tree:error', sessionId, requestId, message }))
+            this.sendMsg({ type: 'ui:tree:error', sessionId, requestId, message })
           })
         break
       }

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -370,6 +370,41 @@ describe('IOSAgent', () => {
       return { browser, agent }
     }
 
+    // The socket boundary requires a string `sessionId` before dispatching, and that is what lets the
+    // dispatcher declare it required — which removed 25 `msg.sessionId!` assertions. Without a test the guard
+    // could be deleted and nothing would notice until one of those `!` was needed again.
+    //
+    // Driven by emitting on the agent's own socket rather than sending through the relay, because **the relay
+    // already blocks this**: its forward gate resolves `sessions.get(msg.sessionId)` and answers the browser
+    // itself for a terminal input, so a frame with no sessionId never reaches an agent by that path. That is
+    // the same fact the required declaration rests on — and it means the guard exists for a client that
+    // connects to the agent directly, which no relay-level test can simulate. Two earlier versions of this
+    // test went through the relay and passed the mutation for exactly that reason.
+    it('does not dispatch a frame with no sessionId', async () => {
+      const { browser, agent } = await joinBootlessSession()
+      const ws = internals(agent).ws
+      const sent = vi.spyOn(ws, 'send')
+
+      for (const frame of [
+        { type: 'input:touch:end', payload: { x: 0.4, y: 0.6 } },
+        { type: 'input:touch:end', sessionId: 42, payload: { x: 0.4, y: 0.6 } },
+      ]) ws.emit('message', Buffer.from(JSON.stringify(frame)))
+
+      const answers = () => sent.mock.calls
+        .map(([f]) => JSON.parse(String(f)) as { type: string })
+        .filter((m) => m.type === 'input:error' || m.type === 'input:done')
+      expect(answers()).toEqual([])
+
+      // A well-formed frame on the same path is still dispatched, so the guard is not rejecting everything.
+      ws.emit('message', Buffer.from(JSON.stringify(
+        { type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.4, y: 0.6 } },
+      )))
+      await vi.waitFor(() => expect(answers()).toHaveLength(1), { timeout: 500 })
+
+      agent.disconnect()
+      browser.close()
+    })
+
     it('lazily creates TouchHelper when input arrives with no device:boot for the session', async () => {
       const { browser, agent } = await joinBootlessSession()
 

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,4 +1,4 @@
-import type { BrowserToRelay, DeviceSummary, InputErrorReason } from '@tapflowio/protocol'
+import type { BrowserToRelay, DeviceSummary, InputErrorReason, UIElement } from '@tapflowio/protocol'
 
 // Protocol owns the wire shape; this file used to declare an identical copy under a name the
 // relay uses for a *different* shape. Kept exported as `DeviceInfo` because that is this
@@ -29,16 +29,10 @@ export interface AppInfo {
   builds: BuildInfo[]
 }
 
-// Unified element schema produced agent-side (mirrors @tapflowio/agent-core UIElement).
-// Frames are normalized 0-1 in the same coordinate space the tap path consumes.
-export interface UIElement {
-  role: 'button' | 'text' | 'input' | 'image' | 'checkbox' | 'switch' | 'slider' | 'list' | 'cell' | 'tab' | 'other'
-  label: string
-  identifier?: string
-  frame: { x: number; y: number; width: number; height: number }
-  enabled: boolean
-  rawRole?: string
-}
+// One node of `ui:tree:response`. This used to be a hand-written mirror of `agent-core`'s `UIElement`,
+// with a comment saying so — the drift `@tapflowio/protocol` exists to remove. L4a moved the type into
+// protocol (a leaf both this package and the agents can reach) and this re-export is what is left.
+export type { UIElement } from '@tapflowio/protocol'
 
 type RelayMsg = Record<string, unknown>
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -81,6 +81,23 @@ The per-message bindings in `typeAssertions.ts` (`_InputDone: InputDone['type'] 
 two copies of one fact, so they catch an author who edits one of them; measured, editing both left every
 assertion green.
 
+## Every direction is declared, and an agent's send is typed
+
+The six unions cover the whole wire: `BrowserToRelay`, `AgentToRelay`, `RelayToAgent`, `RelayToBrowser`,
+`AgentToBrowser`, `RelayToStream` / `StreamToRelay`. `AgentOutbound` is the union an agent sends over either of
+its sockets, and both agents route every send through two typed helpers rather than touching `ws.send`
+(`scripts/__tests__/agentSendTyped.test.mjs` holds them to it).
+
+That mattered because an agent's literal was the one thing no compiler saw — the relay forwards replies with
+`JSON.stringify(msg)`, so nothing typed re-creates them. #489 and #490 are what the gap cost, and
+`inputErrorReason.test.mjs` exists because a script had to stand in for a compiler.
+
+**`screenshot:error` and `ui:tree:error` do not extend `SessionError`, and that is the boundary of the
+family.** `SessionError` is for a failure a *session* is waiting on. Those two are request-scoped: the relay
+resolves the pending promise by `requestId` alone and never reads their `sessionId`. Declaring it required
+would also be false, since the agents pass through an optional one — so the only way to satisfy it would be
+the `msg.sessionId!` that #444 exists to remove.
+
 ## Browser-inbound messages are split by producer, and one union is shared
 
 A browser receives 28 message types. They come from two producers, and the difference matters to the

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -84,9 +84,16 @@ assertion green.
 ## Every direction is declared, and an agent's send is typed
 
 The six unions cover the whole wire: `BrowserToRelay`, `AgentToRelay`, `RelayToAgent`, `RelayToBrowser`,
-`AgentToBrowser`, `RelayToStream` / `StreamToRelay`. `AgentOutbound` is the union an agent sends over either of
-its sockets, and both agents route every send through two typed helpers rather than touching `ws.send`
-(`scripts/__tests__/agentSendTyped.test.mjs` holds them to it).
+`AgentToBrowser`, `RelayToStream` / `StreamToRelay`. Both agents route every send through two typed helpers
+rather than touching `ws.send`, and `scripts/__tests__/agentSendTyped.test.mjs` holds them to it — by matching
+**serialization**, because three drafts keyed on the spelling `this.ws` were bypassed simply by giving the socket
+another name.
+
+**The helpers take `AgentControlOutbound = AgentToRelay | AgentToBrowser`, which excludes `StreamToRelay`.** A
+union covering both sockets is the obvious thing to write and it undoes the direction split: the relay's
+`case 'stream:register'` calls `setStreamSocket(session.id, ws)` with no role gate, so a control socket able to
+type-check that message could take over the session's video path. The stream socket's one message is typed at its
+own send site in `agent-core/src/utils/stream.ts`.
 
 That mattered because an agent's literal was the one thing no compiler saw — the relay forwards replies with
 `JSON.stringify(msg)`, so nothing typed re-creates them. #489 and #490 are what the gap cost, and
@@ -94,9 +101,13 @@ That mattered because an agent's literal was the one thing no compiler saw — t
 
 **`screenshot:error` and `ui:tree:error` do not extend `SessionError`, and that is the boundary of the
 family.** `SessionError` is for a failure a *session* is waiting on. Those two are request-scoped: the relay
-resolves the pending promise by `requestId` alone and never reads their `sessionId`. Declaring it required
-would also be false, since the agents pass through an optional one — so the only way to satisfy it would be
-the `msg.sessionId!` that #444 exists to remove.
+resolves the pending promise by `requestId` alone and never reads their `sessionId`.
+
+Their `sessionId` is nevertheless **required**, like every other producer field. A draft made it optional because
+the agents passed through an optional id — true when written, and false by the end of the same change, which
+required it on both dispatchers. A field weaker than every producer describes a message nobody sends, and here it
+would also have removed the one field a symmetric ownership check could read: the clipboard replies beside these
+verify `session.agentSocket === ws` before resolving, and these two do not.
 
 ## Browser-inbound messages are split by producer, and one union is shared
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -51,6 +51,43 @@ export interface DeviceDetails {
   osVersion: string
 }
 
+/** Closed role vocabulary shared by all platforms. An unmappable native role becomes `'other'` and the
+ *  platform-native string is preserved in `rawRole`, so a consumer can still branch on it without the
+ *  vocabulary having to grow for every platform. */
+export type UIElementRole =
+  | 'button'
+  | 'text'
+  | 'input'
+  | 'image'
+  | 'checkbox'
+  | 'switch'
+  | 'slider'
+  | 'list'
+  | 'cell'
+  | 'tab'
+  | 'other'
+
+/** Normalized to 0–1 in the same coordinate space the touch input path consumes, so a frame centre can
+ *  be fed straight into a tap without conversion. */
+export interface UIElementFrame {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** One node of `ui:tree:response`. Lived in `agent-core` until L4a needed it to type that message —
+ *  protocol is a leaf and cannot import agent-core, and the alternative was a copy. There was already
+ *  one: `mcp-server` carried a hand-written mirror, which is the drift this package exists to remove. */
+export interface UIElement {
+  role: UIElementRole
+  label: string
+  identifier?: string
+  frame: UIElementFrame
+  enabled: boolean
+  rawRole?: string
+}
+
 /** `agents:listed` groups devices by agent machine. */
 export interface SessionInfo {
   agentName?: string
@@ -582,6 +619,121 @@ export type RelayToStream =
 /** Everything the relay originates. Messages it merely forwards keep their inbound type — they are
  *  not re-created, so they are not checked against this union. */
 export type RelayOutbound = RelayToAgent | RelayToBrowser | RelayToStream
+
+// ── agent → relay ────────────────────────────────────────────────────────────
+//
+// The last direction to be declared. Until L4a an agent built these literals and handed them to
+// `ws.send` with nothing checking the result, which is where #489 (an agent answering nobody) and #490
+// (a missing `reason`) came from — and why `scripts/__tests__/inputErrorReason.test.mjs` exists at all:
+// the compiler could not see an agent's literal, so a script had to.
+
+/** The agent's opening message on its control socket, sent from inside `onopen`. */
+export interface AgentRegister {
+  type: 'agent:register'
+  /** Open on purpose — **not** `'ios' | 'android'`. A third-party platform registers through
+   *  `AgentRegistry.register()` (root AGENTS.md, OCP), and narrowing this would stop it producing a
+   *  valid registration. `agent-core`'s own `Platform` is `string` for the same reason. */
+  platform: string
+  /** What this agent implements, as plain strings on the wire. `agent-core`'s `AgentCapability` is
+   *  assignable to it; the wire does not close the set. */
+  capabilities: string[]
+  /** Stable per-machine id (macOS IOPlatformUUID). **Optional because `getMachineId()` returns
+   *  `undefined` off darwin**, and the relay falls back to `agentName` for dedup. */
+  agentId?: string
+  agentName: string
+  devices: DeviceReport[]
+}
+
+/** Periodic load report. The relay gates new sessions on it. */
+export interface AgentResourceReport {
+  type: 'agent:resources'
+  resources: AgentResources
+}
+
+export interface ScreenshotDone {
+  type: 'screenshot:done'
+  sessionId: string
+  requestId: string
+  /** What the agent says it produced — the relay turns this into the HTTP `Content-Type`. Android
+   *  currently echoes the *requested* format while always producing PNG (#508). */
+  format: 'png' | 'jpeg'
+  /** base64. */
+  data: string
+}
+
+/** A screenshot that failed.
+ *
+ *  **Does not extend `SessionError`**, unlike every other `*-error`, because it is not addressed to a
+ *  session: the relay resolves the pending promise by `requestId` alone. `SessionError` is for a failure
+ *  a *session* is waiting on, and drawing that line is what keeps the base meaningful.
+ *
+ *  `sessionId` is still **required**, because every producer has one. An earlier draft made it optional
+ *  on the grounds that the agents pass through an optional id — true when written, and false by the end
+ *  of the same change, which required it on both dispatchers. A field weaker than every producer
+ *  describes a message nobody sends, and here it would also remove the one field a symmetric ownership
+ *  check could read: the clipboard replies beside these verify `session.agentSocket === ws` before
+ *  resolving, and these two do not. */
+export interface ScreenshotError {
+  type: 'screenshot:error'
+  sessionId: string
+  requestId: string
+  message: string
+}
+
+export interface UiTreeResponse {
+  type: 'ui:tree:response'
+  sessionId: string
+  requestId: string
+  elements: UIElement[]
+}
+
+/** Request-scoped, for the same reasons as `ScreenshotError`. */
+export interface UiTreeError {
+  type: 'ui:tree:error'
+  sessionId: string
+  requestId: string
+  message: string
+}
+
+export type AgentToRelay =
+  | AgentRegister
+  | AgentResourceReport
+  | ScreenshotDone
+  | ScreenshotError
+  | UiTreeResponse
+  | UiTreeError
+
+// ── stream socket → relay ────────────────────────────────────────────────────
+
+/** Its own direction, mirroring `RelayToStream`. The relay assigns the role `'stream'` from this
+ *  message rather than `'agent'` (`RelayServer.ts:554-557`), so putting it in `AgentToRelay` would make
+ *  that union's name disagree with the runtime role — and would let a control socket claim to be a
+ *  session's stream socket once L4b narrows inbound by role. */
+export interface StreamRegister {
+  type: 'stream:register'
+  sessionId: string
+}
+
+export type StreamToRelay = StreamRegister
+
+/** The three replies a clipboard request can get. Both agents build these through a local `respond`
+ *  helper that merges the correlation ids, and that helper took `object` — so the replies were the last
+ *  send path in the clipboard code that nothing checked. The consumer side names the same set
+ *  (`useClipboardBridge`), so it lives here rather than in either. */
+export type ClipboardReply = ClipboardData | ClipboardWriteDone | ClipboardError
+
+/** A `ClipboardReply` minus the ids the sender merges in. Distributive, so each member keeps its own
+ *  payload — a plain `Omit` would collapse them into one shape and stop checking which goes with which. */
+export type ClipboardReplyBody<T = ClipboardReply> = T extends unknown ? Omit<T, 'sessionId' | 'requestId'> : never
+
+/** What an agent's **control** socket carries. This is what the agents' send helpers take.
+ *
+ *  `StreamToRelay` is deliberately *not* in it. Splitting `stream:register` into its own direction was
+ *  justified above by the hazard of a control socket claiming to be a session's stream socket — and a
+ *  union that re-merged them would have handed that hazard straight back, since `case 'stream:register'`
+ *  calls `setStreamSocket(session.id, ws)` with no role gate. The stream socket's one message is typed
+ *  at its own send site in `agent-core/src/utils/stream.ts`. */
+export type AgentControlOutbound = AgentToRelay | AgentToBrowser
 
 // ── browser → relay ──────────────────────────────────────────────────────────
 

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -7,16 +7,17 @@
 // the failure mode this whole package was built to remove.
 
 import type {
-  AgentRegistered, AgentToBrowser, AgentsList, AgentsListed, AppClearState, AppClearStateDone,
-  AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent, AppInstallToRelay, AppLaunchDone,
-  AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound, BrowserToRelay, ClipboardData,
-  ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone, DeviceBoot, DeviceBootError,
-  DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone, GenericError, InputButton, InputDone,
-  InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove, InputPinchStart, InputRotate,
-  InputTouchEnd, InputTouchMove, InputTouchStart, InputType, InputTypeDone, InputTypeError, KeyboardToggled,
-  OpenUrl, OpenUrlDone, OpenUrlError, RelayOutbound, ScreenshotRequest, SessionAgentAway, SessionChrome,
-  SessionDeviceInfo, SessionEnd, SessionJoined, SessionLeave, SessionRebound, SessionStart,
-  SessionTerminated, StreamRegistered, StreamRequestIdr, UiTreeRequest,
+  AgentRegister, AgentRegistered, AgentResourceReport, AgentToBrowser, AgentsList, AgentsListed,
+  AppClearState, AppClearStateDone, AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent,
+  AppInstallToRelay, AppLaunchDone, AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound,
+  BrowserToRelay, ClipboardData, ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone,
+  DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone, GenericError,
+  InputButton, InputDone, InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove,
+  InputPinchStart, InputRotate, InputTouchEnd, InputTouchMove, InputTouchStart, InputType, InputTypeDone,
+  InputTypeError, KeyboardToggled, OpenUrl, OpenUrlDone, OpenUrlError, RelayOutbound, ScreenshotDone,
+  ScreenshotError, ScreenshotRequest, SessionAgentAway, SessionChrome, SessionDeviceInfo, SessionEnd,
+  SessionJoined, SessionLeave, SessionRebound, SessionStart, SessionTerminated, StreamRegister,
+  StreamRegistered, StreamRequestIdr, UiTreeError, UiTreeRequest, UiTreeResponse,
 } from './index.js'
 
 // ── must NOT compile ─────────────────────────────────────────────────────────
@@ -160,3 +161,10 @@ export const _SessionTerminated: SessionTerminated['type'] = 'session:terminated
 export const _StreamRegistered: StreamRegistered['type'] = 'stream:registered'
 export const _StreamRequestIdr: StreamRequestIdr['type'] = 'stream:request-idr'
 export const _UiTreeRequest: UiTreeRequest['type'] = 'ui:tree:request'
+export const _AgentRegister: AgentRegister['type'] = 'agent:register'
+export const _AgentResourceReport: AgentResourceReport['type'] = 'agent:resources'
+export const _ScreenshotDone: ScreenshotDone['type'] = 'screenshot:done'
+export const _ScreenshotError: ScreenshotError['type'] = 'screenshot:error'
+export const _StreamRegister: StreamRegister['type'] = 'stream:register'
+export const _UiTreeResponse: UiTreeResponse['type'] = 'ui:tree:response'
+export const _UiTreeError: UiTreeError['type'] = 'ui:tree:error'

--- a/scripts/__tests__/agentSendTyped.test.mjs
+++ b/scripts/__tests__/agentSendTyped.test.mjs
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// An agent's outbound literal is the one place in the wire contract the compiler could not see. The relay
+// forwards with `JSON.stringify(msg)`, so a reply is never re-created by anything typed, and an agent used
+// to hand its literal straight to `ws.send`. #489 (an agent answering nobody) and #490 (a missing `reason`)
+// both came out of that gap, and `inputErrorReason.test.mjs` exists because a script had to stand in for a
+// compiler.
+//
+// L4a closed it with two typed helpers per agent. This file's only job is that nothing goes **around** them.
+//
+// It matches **serialization**, not a spelling of `.send`. Three earlier drafts of this check were bypassed
+// in review by renaming the socket: `streamWs.send(JSON.stringify(…))` and `const alias = this.ws;
+// alias?.send(…)` both walked past a pattern keyed on `this.ws`, and the first is not hypothetical —
+// `streamWs` is in scope in `startBinaryStream`, and the relay dispatches a text frame from a stream socket
+// through the same agent cases. `const p = JSON.stringify(m); alias?.send(p)` defeated it too.
+//
+// So the rule is: in a file that writes to a socket, `JSON.stringify` appears only inside a send helper.
+// Binary frames do not serialize, and files that stringify for other reasons (shell quoting in
+// `DeviceChromeLoader`) never touch `.send(`.
+
+const root = join(import.meta.dirname, '../..')
+
+/** Comments out, including `/* … *\/` blocks. A commented-out copy of the canonical helper satisfied the
+ *  positive assertion below while the real one took `msg: object` — 66 sends unchecked, check green. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+/** Files in the agent packages that hold a socket, and the helper bodies allowed to serialize. */
+const AGENTS = {
+  'ios-agent': 'packages/ios-agent/src/IOSAgent.ts',
+  'android-agent': 'packages/android-agent/src/AndroidAgent.ts',
+}
+
+const HELPER_BODIES = [
+  /private sendMsg\(msg: AgentControlOutbound\): void \{\n {4}this\.ws\?\.send\(JSON\.stringify\(msg\)\)\n {2}\}/,
+  /private sendOn\(ws: WebSocket, msg: AgentControlOutbound\): void \{\n {4}ws\.send\(JSON\.stringify\(msg\)\)\n {2}\}/,
+]
+
+describe('agent sends go through the typed helpers', () => {
+  for (const [name, path] of Object.entries(AGENTS)) {
+    const src = stripComments(readFileSync(join(root, path), 'utf8'))
+
+    it(`${name} declares both helpers`, () => {
+      // Read from the comment-stripped source, so a decoy in a comment cannot satisfy it.
+      for (const rx of HELPER_BODIES) expect(src).toMatch(rx)
+    })
+
+    it(`${name} serializes nothing outside them`, () => {
+      let rest = src
+      for (const rx of HELPER_BODIES) rest = rest.replace(rx, '')
+      expect([...rest.matchAll(/JSON\.stringify/g)].map((m) => rest.slice(Math.max(0, m.index - 60), m.index + 30))).toEqual([])
+    })
+  }
+
+  it('the control socket bound excludes StreamToRelay', () => {
+    // Re-merging them would hand back the hazard the direction split exists to avoid: the relay's
+    // `case 'stream:register'` calls `setStreamSocket(session.id, ws)` with no role gate, so a control
+    // socket that could type-check that message could take over the session's video path.
+    const proto = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
+    expect(proto).toContain('export type AgentControlOutbound = AgentToRelay | AgentToBrowser')
+    expect(proto).not.toMatch(/AgentControlOutbound = [^\n]*StreamToRelay/)
+  })
+
+  it('every other socket-holding file in the agent packages is accounted for', () => {
+    // The two agents above are not the whole surface: `stream.ts` sends on the stream socket, and a new file
+    // could add another. Anything that both writes to a socket and serializes has to be listed here with a
+    // reason, so adding one is a decision rather than an omission.
+    const ALLOWED = new Map([
+      ['packages/agent-core/src/utils/stream.ts',
+        'the stream socket, handed in as an argument; typed at its send site as StreamToRelay'],
+    ])
+    const offenders = []
+    for (const pkg of ['packages/ios-agent/src', 'packages/android-agent/src', 'packages/agent-core/src']) {
+      const files = execFileSync('git', ['ls-files', pkg], { cwd: root, encoding: 'utf8' })
+        .split('\n').filter((f) => f.endsWith('.ts') && !f.includes('__tests__'))
+      for (const f of files) {
+        if (Object.values(AGENTS).includes(f) || ALLOWED.has(f)) continue
+        const body = stripComments(readFileSync(join(root, f), 'utf8'))
+        if (/\.send\(/.test(body) && /JSON\.stringify/.test(body)) offenders.push(f)
+      }
+    }
+    expect(offenders).toEqual([])
+    // And the listed one really is what its reason says.
+    const stream = stripComments(readFileSync(join(root, 'packages/agent-core/src/utils/stream.ts'), 'utf8'))
+    expect(stream).toMatch(/const register: StreamToRelay = \{ type: 'stream:register', sessionId \}/)
+    expect([...stream.matchAll(/JSON\.stringify/g)]).toHaveLength(1)
+  })
+})

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -35,7 +35,7 @@ const assertions = assertionsRaw.replace(/^\s*\/\/.*$/gm, '')
 /** Every `export interface` that declares a `type: '<literal>'` — i.e. every wire message.
  *
  *  Bodies are found by counting braces, not by matching a run of two-space lines. The regex version
- *  skipped any interface with a blank line in its body — and `expect(messages.size).toBe(58)` was then
+ *  skipped any interface with a blank line in its body — and `expect(messages.size).toBe(65)` was then
  *  satisfied *because* of the skip, so a new message with no binding passed all seventeen assertions.
  *  A count is only coverage if the parser cannot lose a declaration. */
 function messageInterfaces(text) {
@@ -73,6 +73,10 @@ function derivedName(literal) {
 // `Error` would shadow the global.
 const NAME_EXCEPTIONS = new Map([
   ['GenericError', 'error'],
+  // `agent:resources` derives `AgentResources`, which protocol already exports — as the *payload* shape
+  // this message carries. Renaming that one is a breaking change to a published type that `agent-core`,
+  // `relay` and `dashboard` all re-export, so the message takes a different name instead.
+  ['AgentResourceReport', 'agent:resources'],
   ['AppInstallToAgent', 'app:install'],
   ['AppInstallToRelay', 'app:install'],
   ['AppLaunchToAgent', 'app:launch'],
@@ -86,8 +90,9 @@ describe('protocol message interfaces', () => {
     // Without this the two assertions below pass on an empty map. The count is pinned rather than
     // derived so that a parser that stops matching says so, instead of reporting full coverage of
     // nothing. L2 shipped that exact failure in the other direction. 58 is 57 from L1's conversion plus
-    // `InputKey`, which was already named and is a message like any other.
-    expect(messages.size).toBe(58)
+    // `InputKey`, which was already named and is a message like any other. L4a added the seven agent→relay
+    // messages, the last direction that had none.
+    expect(messages.size).toBe(65)
     // `InputKey` predates L1 and has always been named; it must be in here too.
     expect(messages.has('InputKey')).toBe(true)
   })
@@ -120,13 +125,18 @@ describe('protocol message interfaces', () => {
     }
     expect(offenders).toEqual([])
     // Pinned so an exception cannot be added quietly to make a rename compile.
-    expect(NAME_EXCEPTIONS.size).toBe(5)
+    expect(NAME_EXCEPTIONS.size).toBe(6)
   })
+
+  // Failures addressed to a *request*, not to a session: the relay resolves both by `requestId` alone
+  // (`RelayServer.ts:1293-1312`). Listing them draws the boundary of `SessionError` rather than widening it —
+  // the base is for a failure a session is waiting on.
+  const REQUEST_SCOPED = new Set(['screenshot:error', 'ui:tree:error'])
 
   it('a session-scoped failure declares extends SessionError', () => {
     const offenders = []
     for (const [name, { literal, extends: base, body }] of messages) {
-      const isFailure = /error$/.test(literal)
+      const isFailure = /error$/.test(literal) && !REQUEST_SCOPED.has(literal)
       const hasSession = /^ {2}sessionId[?]?:/m.test(body) || base === 'SessionError'
       // `error` is the escape hatch for a failure that cannot be attributed to a session, so it has no
       // `sessionId` and cannot be a `SessionError`. That is the member's nature, not an exception.
@@ -135,8 +145,19 @@ describe('protocol message interfaces', () => {
     }
     expect(offenders).toEqual([])
     expect([...messages].filter(([, m]) => m.extends === 'SessionError')).toHaveLength(8)
-    // The one failure that deliberately does not inherit.
+    // The failures that deliberately do not inherit, each for its own reason.
     expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: null })
+    expect(REQUEST_SCOPED.size).toBe(2)
+    for (const literal of REQUEST_SCOPED) {
+      const entry = [...messages].find(([, m]) => m.literal === literal)
+      expect(entry, `${literal} is gone`).toBeDefined()
+      expect(entry[1].extends, `${literal} now extends something`).toBeNull()
+      // What makes them request-scoped is `requestId`, not a weak `sessionId`. An earlier draft asserted
+      // the field was *optional* and took that as the evidence — but every producer has one, so declaring
+      // it optional described a message nobody sends. Required, and out of the family.
+      expect(entry[1].body).toMatch(/^ {2}sessionId: string$/m)
+      expect(entry[1].body).toMatch(/^ {2}requestId: string$/m)
+    }
     // What the base carries, pinned. `browserInboundRouting`'s signatures resolve `extends` and sort,
     // so they cannot tell an inherited field from an own-declared one: moving `sessionId` out of the
     // base and into all eight subclasses leaves every signature identical and every check green.


### PR DESCRIPTION
Layer 4a of the wire-contract program (`.work/WIRE-CONTRACT-PLAN.md`). Follows #506 (L6).

## The gap

An agent's outbound literal was **the one part of the wire contract no compiler could see.** The relay forwards replies with `JSON.stringify(msg)`, so nothing typed ever re-creates them, and each agent handed its literal straight to `ws.send`.

#489 (an agent answering nobody) and #490 (a missing `reason`) both came out of that, and `scripts/__tests__/inputErrorReason.test.mjs` exists because a script had to stand in for a compiler.

Seven message types were declared nowhere at all — `agent:register`, `agent:resources`, `screenshot:done`, `screenshot:error`, `stream:register`, `ui:tree:response`, `ui:tree:error`. **With this, every direction on the wire is declared.**

## What the compiler found the moment it could see

| | |
|---|---|
| **30 sends passed an optional `sessionId` into a required field** | The dispatcher took `{ sessionId?: string }` while every type it dispatches is session-scoped. Now required, with the check at the socket boundary — and **25 `msg.sessionId!` assertions went away as a consequence**, plus the now-unreachable `if (!sessionId) return` in each `ackNoSession`. That is the payoff #444 is after on the relay side, arriving here first. |
| **`requestId` was optional in the clipboard cases, required in the screenshot and ui:tree ones** | Same wire guarantee, same file, two spellings. |
| **`respond` took `object`** | So all three clipboard replies were unchecked — the last unchecked send path in that code. |

## Two decisions worth reading

**`AgentControlOutbound = AgentToRelay | AgentToBrowser`** — `StreamToRelay` is deliberately outside the bound the agents' helpers take. A draft merged all three and handed back the exact hazard the direction split exists to avoid: `case 'stream:register'` calls `setStreamSocket(session.id, ws)` with no role gate, so a control socket that could type-check that message could take over the session's video path. Both review channels found this independently.

**`sendOn(ws, msg)` takes the socket as an argument.** Its call sites sit behind an entry guard and are compiler-proven non-null; reading `this.ws` inside the helper — or asserting it with `!` — would make those guards optional to the compiler and turn deleting one from a compile error into a runtime `TypeError`. One of them has a test whose subject is the window it covers.

`screenshot:error` and `ui:tree:error` are the first `*-error` messages that do **not** extend `SessionError`: they are request-scoped, resolved by `requestId` alone. `SessionError` is for a failure a *session* is waiting on, and naming these draws the boundary rather than widening it.

## The guard had to be rewritten four times

`agentSendTyped.test.mjs` matches **serialization**, not any spelling of `.send`. Three drafts keyed on `this.ws` were bypassed in review by renaming the socket — and `streamWs.send(JSON.stringify(…))` is not hypothetical: `streamWs` is in scope in `startBinaryStream`, and the relay dispatches a text frame from a stream socket through the same agent cases. A commented-out copy of the canonical helper also satisfied the positive assertion while the real one took `msg: object`, leaving all 66 of that agent's sends unchecked with the check green.

## Two mistakes the record keeps

Inserting the helpers before rewriting the call sites let the rewrite hit the helper bodies, so `sendMsg` called itself. **The suite hung rather than failed**, and it was found by establishing that the baseline passed rather than by assuming the tests were at fault.

And the boundary guard's test took three attempts. The first asserted a non-terminal input does nothing — true with or without the guard, which is the Potemkin shape the plan itself warned about. The second used a terminal input and still passed, because **the relay's own forward gate already blocks that frame** — the same fact the required declaration rests on. So the guard is for a client that reaches an agent without going through the relay, and the test now drives it that way.

## Not in scope

Relay forward narrowing (L4b), the untyped `Record<string, unknown>` sinks (L4c), and enforcement for third-party platform agents — a source scan cannot reach another package, and the structural answer is a shared helper in `agent-core`, which `DeviceAgent` being an interface rules out for now.

## Review

Two design rounds and one code round, two channels each: **14 findings, all dispositioned.** The design round found **both of the plan's premises false**, including a correction I had already made myself that was also wrong. Record and the 10 mutations: `.work/reviews/refactor__wire-l4a-agent-producer.md`.

Byproducts filed separately: #507 (session ownership) and #508 (Android returns PNG bytes labelled `image/jpeg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared protocol support for agent, stream, screenshot, UI-tree, clipboard, and resource messages.
  * Improved validation for session and request identifiers.
  * Added typed handling for control and streaming communication.
  * Standardized UI element types across integrations.

* **Bug Fixes**
  * Invalid or sessionless relay messages are now ignored safely.

* **Tests**
  * Added coverage for message validation and communication serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->