### PR TITLE
fix(protocol): app:clear-state must carry a bundleId, and every browser-role send is checked against the contract

### DIFF
--- a/.changeset/client-outbound-typing.md
+++ b/.changeset/client-outbound-typing.md
@@ -1,0 +1,34 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/flow-runner': patch
+---
+
+fix(protocol): app:clear-state must carry a bundleId, and flow-runner's sends are checked against the contract
+
+`AppClearState` declared `payload?: { bundleId?: string }` — looser than every producer **and** every consumer.
+`mcp-server` and `flow-runner` are its only senders and both supply a string; the relay forwards without filling
+anything in; and both agents answer `app:clear-state-error` with `'bundleId missing'` when it is absent. So the
+declaration permitted a message whose only possible outcome was that error, and it compiled. Now
+`payload: { bundleId: string }`.
+
+Not a breaking change: the two in-repo senders already comply, and the dashboard does not send this message at
+all.
+
+`flow-runner`'s `RelayClient.send` takes `BrowserToRelay` instead of `Record<string, unknown>`, so its 15
+outbound literals are checked. `mcp-server`'s equivalent was already typed in `7637be3`; this finishes the pair.
+
+**Zero compile errors came out of it, and that is the honest result.** Every `sessionId` in that file arrives as
+a required `string` parameter, so the root cause that produced 30 errors when the agents were typed (#509) does
+not exist here. The value is regression defence, and `scripts/__tests__/clientOutboundTyped.test.mjs` is what
+carries it — reading the *signature* rather than any spelling of `send(`, because the agents' equivalent check
+was bypassed three times in review by renaming a socket.
+
+Two comments corrected while passing through, since a stale reason argues for the thing that was removed:
+
+- `test-utils`'s `SocketMessage` said its looseness accommodates each importer's richer view of the wire via
+  `waitForType<T extends SocketMessage>`. #505 broke that — named interfaces have no implicit index signature, so
+  no protocol type satisfies the constraint, and all 25 call sites already violate it invisibly because
+  `src/__tests__` is outside the package's tsconfig. The looseness now blocks the richer views rather than
+  accommodating them; it stays only because a narrowing nothing type-checks is decoration.
+- `mcp-server`'s AGENTS.md presented its loose *inbound* as a settled decision. It is a deferral, tracked in
+  #512 along with the live defect narrowing would catch.

--- a/.changeset/client-outbound-typing.md
+++ b/.changeset/client-outbound-typing.md
@@ -6,13 +6,20 @@
 fix(protocol): app:clear-state must carry a bundleId, and flow-runner's sends are checked against the contract
 
 `AppClearState` declared `payload?: { bundleId?: string }` — looser than every producer **and** every consumer.
-`mcp-server` and `flow-runner` are its only senders and both supply a string; the relay forwards without filling
-anything in; and both agents answer `app:clear-state-error` with `'bundleId missing'` when it is absent. So the
-declaration permitted a message whose only possible outcome was that error, and it compiled. Now
-`payload: { bundleId: string }`.
+`mcp-server` and `flow-runner` are its only senders and both supply a string, and both agents answer
+`app:clear-state-error` with `'bundleId missing'` when it is absent. So the declaration permitted a message whose
+only possible outcome was that error, and it compiled. Now `payload: { bundleId: string }`.
 
-Not a breaking change: the two in-repo senders already comply, and the dashboard does not send this message at
-all.
+**No in-repo producer changes** — both senders already comply and the dashboard does not send this message at
+all. It is a `patch` on that basis, not on a claim about every consumer: `AppClearState` is a published export and
+this package advertises `declare module` re-opening, so adding a required field is source-breaking for an
+out-of-repo producer that omits it. None is known to exist; the wording is scoped so the next tightening does not
+cite this as precedent for "required fields are patches".
+
+`flow-runner`'s `engine.ts` no longer reaches `driver.clearState` through `flow.appId!`. `parseFlow` rejects a
+bare `clearState` with no flow-level `appId`, but `runFlow` is exported and does not parse — an embedder can hand
+it a `Flow` built by hand, and the assertion laundered that into `payload: {}` for the device to reject a network
+hop later. It fails the step with a nameable cause instead.
 
 `flow-runner`'s `RelayClient.send` takes `BrowserToRelay` instead of `Record<string, unknown>`, so its 15
 outbound literals are checked. `mcp-server`'s equivalent was already typed in `7637be3`; this finishes the pair.
@@ -20,8 +27,17 @@ outbound literals are checked. `mcp-server`'s equivalent was already typed in `7
 **Zero compile errors came out of it, and that is the honest result.** Every `sessionId` in that file arrives as
 a required `string` parameter, so the root cause that produced 30 errors when the agents were typed (#509) does
 not exist here. The value is regression defence, and `scripts/__tests__/clientOutboundTyped.test.mjs` is what
-carries it — reading the *signature* rather than any spelling of `send(`, because the agents' equivalent check
-was bypassed three times in review by renaming a socket.
+carries it.
+
+That check took two attempts. Its first draft asserted the signature `private send(msg: BrowserToRelay)` — and
+review defeated it with a second helper, `private sendRaw(msg: RelayMsg)`, which passed all seven assertions with
+`tsc` and the package suite green while putting a misspelled type on the wire. Keying on a name is the failure
+`agentSendTyped.test.mjs` had already been through three times. So it now anchors where its sibling does:
+`JSON.stringify` appears once per file and the function enclosing it takes `BrowserToRelay`. Two further gaps
+review found in it are closed too — the file list is derived by inspection rather than hardcoded (the pair it
+started with excluded the **dashboard**, which has the most send sites of the three), and `BrowserToRelay` is
+asserted to still be a union of named messages, because appending `| Record<string, unknown>` to it passed all
+250 static assertions while making every literal in all three files accept anything.
 
 Two comments corrected while passing through, since a stale reason argues for the thing that was removed:
 

--- a/.changeset/client-outbound-typing.md
+++ b/.changeset/client-outbound-typing.md
@@ -1,5 +1,5 @@
 ---
-'@tapflowio/protocol': patch
+'@tapflowio/protocol': minor
 '@tapflowio/flow-runner': patch
 ---
 
@@ -10,11 +10,14 @@ fix(protocol): app:clear-state must carry a bundleId, and flow-runner's sends ar
 `app:clear-state-error` with `'bundleId missing'` when it is absent. So the declaration permitted a message whose
 only possible outcome was that error, and it compiled. Now `payload: { bundleId: string }`.
 
-**No in-repo producer changes** — both senders already comply and the dashboard does not send this message at
-all. It is a `patch` on that basis, not on a claim about every consumer: `AppClearState` is a published export and
-this package advertises `declare module` re-opening, so adding a required field is source-breaking for an
-out-of-repo producer that omits it. None is known to exist; the wording is scoped so the next tightening does not
-cite this as precedent for "required fields are patches".
+**No in-repo producer changes** — both senders already comply and the dashboard does not send this message at all.
+
+**`minor`, because it is source-breaking anyway.** `AppClearState` is a published export and this package
+advertises `declare module` re-opening, so adding a required field breaks an out-of-repo producer that omits it.
+None is known to exist, but CONTRIBUTING's table is not conditional on one being known: any breaking change is a
+`major`, relaxed to `minor` before `v1.0.0`. This was written as a `patch` on the strength of the in-repo census,
+which is the wrong question — the census cannot see the consumers the bump exists to warn. Every package in the
+fixed group moves to `0.19.0` with it, which is the signal, not a side effect.
 
 `flow-runner`'s `engine.ts` no longer reaches `driver.clearState` through `flow.appId!`. `parseFlow` rejects a
 bare `clearState` with no flow-level `appId`, but `runFlow` is exported and does not parse — an embedder can hand

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^10.8.0",
     "globals": "^17.9.0",
     "lefthook": "^2.1.10",
+    "typescript": "^5.0.0",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"
   },

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -1,4 +1,4 @@
-import type { DeviceSummary } from '@tapflowio/protocol'
+import type { BrowserToRelay, DeviceSummary } from '@tapflowio/protocol'
 import { WebSocket } from 'ws'
 import type { UIElement } from '@tapflowio/agent-core'
 import { PlatformError } from '@tapflowio/agent-core'
@@ -27,6 +27,13 @@ export interface AgentSession {
   devices: DeviceSummary[]
 }
 
+/** What arrives **from** the relay. Deliberately still loose, and that is a deferral rather than a decision —
+ *  see #512. Narrowing it to `BrowserInbound` would check the reply predicates below (and would reject a live
+ *  one: `error` is matched on a `sessionId` that member does not have), but it also makes `message: string`,
+ *  which turns this file's `?? 'failed'` fallbacks into unreachable code. Deleting those while nothing
+ *  validates inbound JSON removes a real defence, so the validators (#444) come first.
+ *
+ *  Outbound is `BrowserToRelay` — see `send` below. */
 type RelayMsg = Record<string, unknown>
 
 interface Waiter {
@@ -91,7 +98,10 @@ export class RelayClient {
     }
   }
 
-  private send(msg: RelayMsg): void {
+  /** Typed against the wire contract, so every literal below is checked. It used to take `RelayMsg`, which is
+   *  `Record<string, unknown>` — the shape that let #489 and #490 happen on the agent side, and the reason
+   *  `mcp-server`'s equivalent was typed in `7637be3`. */
+  private send(msg: BrowserToRelay): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new PlatformError('not connected to relay')
     }

--- a/packages/flow-runner/src/__tests__/engine.test.ts
+++ b/packages/flow-runner/src/__tests__/engine.test.ts
@@ -236,6 +236,17 @@ steps:
     expect(driver.calls).toEqual([['clearState', 'com.example.app'], ['clearState', 'com.other.app']])
   })
 
+  it('clearState with no app id anywhere fails the step instead of sending an empty payload', async () => {
+    // Not reachable through `parseFlow`, which rejects the bare form without a flow-level appId — but `runFlow`
+    // is exported and does not parse, so an embedder can hand it this. `flow.appId!` used to launder it into
+    // `app:clear-state` with `payload: {}` and let the device answer 'bundleId missing' a network hop later.
+    const driver = fakeDriver([[]])
+    const result = await runFlow({ name: 'hand-built', steps: [{ type: 'clearState' }] }, driver, OPTS)
+    expect(result.status).toBe('failed')
+    expect(result.failureMessage).toContain('clearState has no app id')
+    expect(driver.calls).toEqual([])
+  })
+
   it('per-selector timeout overrides the default', async () => {
     const driver = fakeDriver([[]])
     const start = Date.now()

--- a/packages/flow-runner/src/engine.ts
+++ b/packages/flow-runner/src/engine.ts
@@ -199,8 +199,13 @@ async function waitNotVisible(driver: FlowDriver, sel: Selector, timeoutMs: numb
 async function executeStep(step: Step, flow: Flow, driver: FlowDriver, timeoutMs: number, pollIntervalMs: number): Promise<void> {
   switch (step.type) {
     case 'clearState': {
-      // schema guarantees appId presence at parse time for the bare form
-      await driver.clearState(step.appId ?? flow.appId!)
+      // `parseFlow` rejects the bare form without a flow-level appId, but `runFlow` is exported and does not
+      // parse — an embedder can hand it a `Flow` built by hand, and `flow.appId!` used to launder that into
+      // `app:clear-state` with `payload: {}` on the wire for the device to answer 'bundleId missing'. Refuse
+      // here instead, where the cause is still nameable. Empty string too: `''` type-checks all the way down.
+      const appId = step.appId ?? flow.appId
+      if (!appId) throw new StepFailure('clearState has no app id — set it on the step or as the flow-level "appId"')
+      await driver.clearState(appId)
       return
     }
     case 'launchApp': return driver.launchApp()

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -21,7 +21,7 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 ## HOW
 
 - Entry: `src/index.ts` — reads `TAPFLOW_RELAY_URL` and `TAPFLOW_TOKEN` env vars, connects `TapflowClient`, calls `registerTools`, starts `StdioServerTransport`.
-- Client: `src/client.ts` — WebSocket connection to relay + REST calls for build/app data. Its `send()` takes `BrowserToRelay` from [`@tapflowio/protocol`](../protocol/AGENTS.md), so a new outbound message goes in that union first. Receiving stays loose (`Record<string, unknown>` + a predicate) because the relay's replies are validated by nothing on the way in.
+- Client: `src/client.ts` — WebSocket connection to relay + REST calls for build/app data. Its `send()` takes `BrowserToRelay` from [`@tapflowio/protocol`](../protocol/AGENTS.md), so a new outbound message goes in that union first. Receiving stays loose (`Record<string, unknown>` + a predicate) — a **deferral, not a settled decision**, tracked in #512. Narrowing it would catch a live defect (`error` is matched on a `sessionId` that message does not have, so one session's failure can be reported against another's join) but it also makes `message: string`, turning this file's `?? 'failed'` fallbacks into unreachable code. Deleting those while nothing validates inbound JSON removes a real defence, so the validators (#444) come first.
 - Tools: `src/tools.ts` — all MCP tool definitions. One `registerTools(server, client)` call registers everything.
 - Screenshots are saved to a temp file and returned as MCP `image` content with base64 encoding.
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -54,11 +54,14 @@ conversion, so they are written down here instead:
 
 - **An `interface` has no implicit index signature.** An anonymous `type X = { … }` is assignable to
   `Record<string, unknown>`; a named interface is not. Nothing broke, because the three
-  `Record<string, unknown>` sinks in this repo (`flow-runner/src/RelayClient.ts`,
-  `mcp-server/src/client.ts`, `test-utils/src/socket.ts`) are only ever handed fresh object literals.
-  **The fix when one of them needs a typed value is to type the sink**, not to widen the message —
-  replacing `type RelayMsg = Record<string, unknown>` with `BrowserToRelay` is the point of that work,
-  not a casualty of it.
+  `Record<string, unknown>` sinks then in this repo were only ever handed fresh object literals — and
+  **the fix when one of them needs a typed value is to type the sink**, not to widen the message. Two
+  have been: both clients' `send` takes `BrowserToRelay` (`7637be3`, L4c), and their `RelayMsg` is now
+  inbound-only. The third, `test-utils/src/socket.ts`, is the case where this constraint bites in the
+  other direction: its comment claimed the looseness accommodated each importer's richer view via
+  `waitForType<T extends SocketMessage>`, and that extension point is what an interface having no index
+  signature **broke** — no protocol type satisfies the constraint. All 25 call sites violate it
+  invisibly, because `src/__tests__` is outside that package's tsconfig.
 - **An `interface` can be reopened by a consumer.** `declare module '@tapflowio/protocol'` can add a
   field to any message, which an anonymous union member could not. Measured: a consumer can give
   `GenericError` a `sessionId` and defeat the assertion in `typeAssertions.ts` that says it has none.
@@ -98,6 +101,18 @@ own send site in `agent-core/src/utils/stream.ts`.
 That mattered because an agent's literal was the one thing no compiler saw — the relay forwards replies with
 `JSON.stringify(msg)`, so nothing typed re-creates them. #489 and #490 are what the gap cost, and
 `inputErrorReason.test.mjs` exists because a script had to stand in for a compiler.
+
+**The browser side is the same rule and the same check shape.** All three browser-role producers — the dashboard's
+`useRelay`, `mcp-server`'s client, `flow-runner`'s `RelayClient` — serialize through one `BrowserToRelay` sink, and
+`scripts/__tests__/clientOutboundTyped.test.mjs` holds them to it. Its first draft asserted the *signature*
+`private send(msg: BrowserToRelay)` and was defeated by a second helper named `sendRaw`: the assertion kept
+passing on the typed one while the untyped one put a misspelled type on the wire. So it anchors on serialization
+too, and derives its file list by inspection — the hardcoded pair it started with silently excluded the dashboard,
+which has the most send sites of the three (47, against 32 for both clients).
+
+Both checks read a union's *name* at the sink. Neither read its contents, and appending
+`| Record<string, unknown>` to `BrowserToRelay` passed every static check while making all three clients accept
+anything. Guards that name a type also have to assert the type is still a union of named messages.
 
 **`screenshot:error` and `ui:tree:error` do not extend `SessionError`, and that is the boundary of the
 family.** `SessionError` is for a failure a *session* is waiting on. Those two are request-scoped: the relay
@@ -139,7 +154,9 @@ cannot verify — and `JSON.stringify` drops a key whose value is `undefined`. T
 widen the declaration:
 
 - Every in-repo sender does supply one. `BrowserToRelay` declares `sessionId: string` on every member
-  but `agents:list`, and the untyped senders (`mcp-server`, `flow-runner`) set it too.
+  but `agents:list`, and since L4c all three senders are typed against that union, so the compiler
+  enforces it rather than convention. (This bullet used to read "the untyped senders (`mcp-server`,
+  `flow-runner`) set it too" — true when written, and falsified by the work that typed them.)
 - `'Session not found'` answers a sessionId that did not **match** — a stale tab, a terminated
   session — not one that was absent.
 - `{ type: 'error'; message: string }` is the escape hatch for a genuinely uncorrelatable failure. So

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -821,10 +821,20 @@ export interface AppLaunchToRelay {
 /** Wipe an installed app's data.
  *
  *  `bundleId` is **required, twice over** — the field and the payload. It was `payload?: { bundleId?: string }`,
- *  which was looser than every producer *and* every consumer: `mcp-server` and `flow-runner` are the only
- *  senders and both supply a string, the relay forwards without filling anything in, and both agents answer
- *  `app:clear-state-error` with `'bundleId missing'` when it is absent. So the declaration permitted a message
- *  whose only possible outcome was that error. */
+ *  which was looser than every producer *and* every consumer: `mcp-server` and `flow-runner` are its only
+ *  senders (the dashboard resets through `device:boot` instead) and both supply a string, and both agents answer
+ *  `app:clear-state-error` with `'bundleId missing'` when it is absent. A field weaker than every producer
+ *  describes a message nobody sends.
+ *
+ *  What required buys is a **compile error for a future sender**, no more. The agents keep that branch and
+ *  should: `bundleId: ''` type-checks, and nothing here validates inbound JSON (#444). So this is the same
+ *  argument as `sessionId` below, not a stronger one.
+ *
+ *  Unlike `app:install` / `app:launch`, which carry a `buildId` the relay resolves into a bundle id from the
+ *  builds table, this message is passed through untouched. That is an **absence of relay-side resolution, not a
+ *  design** — the machinery exists next door. It stays client-supplied because clearing a *different* app is a
+ *  documented flow step (`clearState: com.other.app`), so the field has to be expressible either way; adding a
+ *  relay-filled form would be a new feature, not a contract alignment. */
 export interface AppClearState {
   type: 'app:clear-state'
   sessionId: string

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -818,10 +818,17 @@ export interface AppLaunchToRelay {
   buildId: number
 }
 
+/** Wipe an installed app's data.
+ *
+ *  `bundleId` is **required, twice over** — the field and the payload. It was `payload?: { bundleId?: string }`,
+ *  which was looser than every producer *and* every consumer: `mcp-server` and `flow-runner` are the only
+ *  senders and both supply a string, the relay forwards without filling anything in, and both agents answer
+ *  `app:clear-state-error` with `'bundleId missing'` when it is absent. So the declaration permitted a message
+ *  whose only possible outcome was that error. */
 export interface AppClearState {
   type: 'app:clear-state'
   sessionId: string
-  payload?: { bundleId?: string }
+  payload: { bundleId: string }
 }
 
 export interface OpenUrl {

--- a/packages/test-utils/src/socket.ts
+++ b/packages/test-utils/src/socket.ts
@@ -1,7 +1,16 @@
 import type { WebSocket } from 'ws'
 
-/** The shape every tapflow socket message shares. Deliberately loose: this package is imported by
- *  relay, ios-agent and android-agent, and each has its own richer view of the wire. */
+/** The shape every tapflow socket message shares.
+ *
+ *  It stays loose, but **not for the reason this comment used to give.** The old one said each importer has its
+ *  own richer view of the wire and `waitForType<T extends SocketMessage>` is where that view goes — and #505
+ *  broke that: messages became named interfaces, which have no implicit index signature, so no protocol type
+ *  satisfies the constraint (`TS2344`). All 25 call sites pass `RelayMessage`, which is also a named interface,
+ *  so all 25 already violate it — invisibly, because `src/__tests__` is outside this package's tsconfig.
+ *
+ *  So the looseness is now *blocking* the richer views rather than accommodating them. It is left alone because
+ *  a narrowing nothing type-checks is decoration; fixing it means bringing the test tree into a tsconfig first,
+ *  which is a separate job. */
 export type SocketMessage = Record<string, unknown> & { type: string }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       lefthook:
         specifier: ^2.1.10
         version: 2.1.10
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@1.21.7))(typescript@5.9.3)

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -223,7 +223,7 @@ describe('browser-inbound routing matches the protocol union', () => {
       'device:shutdown': 'payload sessionId',
       'app:install': 'buildId sessionId',
       'app:launch': 'buildId sessionId',
-      'app:clear-state': 'payload? sessionId',
+      'app:clear-state': 'payload sessionId',
       'open-url': 'payload sessionId',
       'input:touch:start': 'payload sessionId',
       'input:touch:move': 'payload sessionId',

--- a/scripts/__tests__/clientOutboundTyped.test.mjs
+++ b/scripts/__tests__/clientOutboundTyped.test.mjs
@@ -1,29 +1,27 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-// The two browser-role clients — `mcp-server` and `flow-runner` — construct their outbound literals directly,
-// so typing the send function is a real compile-time check, unlike narrowing a relay *forward* (which checks
-// nothing, because no literal is constructed there; see the L4b retirement in `.work/WIRE-CONTRACT-PLAN.md`).
+// The browser-role producers construct their outbound literals directly, so typing the send function is a real
+// compile-time check — unlike narrowing a relay *forward*, which checks nothing because no literal is constructed
+// there (see the L4b retirement in `.work/WIRE-CONTRACT-PLAN.md`).
 //
-// Both are typed now. Neither produced a single compile error when the type went on, which is worth stating
-// plainly: **the value of this layer is regression defence, not a bug found.** Every `sessionId` in these files
-// comes from a required `string` parameter, so the root cause that produced 30 errors on the agent side (#509)
-// does not exist here.
+// All three are typed now, and none produced a compile error when the type went on. Worth stating plainly: **the
+// value here is regression defence, not a bug found.** Every `sessionId` in these files comes from a required
+// `string` parameter, so the root cause that produced 30 errors on the agent side (#509) does not exist.
 //
-// That makes this file the layer's only lasting artefact, so it has to be hard to walk past.
+// It matches **serialization**, not a spelling of `send(`. The first draft of this file asserted
+// `/private send\(msg: BrowserToRelay\)/` and was defeated in review by the bypass its own header claimed to
+// prevent: a second helper `private sendRaw(msg: RelayMsg)` writing to `this.ws` passed all seven assertions with
+// tsc and the package suite green, and put `session:leaev` on the wire. `agentSendTyped.test.mjs` had already
+// learned this — three of its drafts died to a renamed socket — and this file was written worse than its sibling.
 //
-// It does **not** match a spelling of `send(`. `scripts/__tests__/agentSendTyped.test.mjs` was bypassed three
-// times in review by exactly that: renaming the socket, aliasing it, or serializing on the previous line all
-// walked past a pattern keyed on a name. Here the thing to protect is a *signature*, so the check reads the
-// signature — and separately refuses `Record<string, unknown>` anywhere it could reach an outbound path.
+// So the rule is the sibling's: **`JSON.stringify` appears once per file, and the function enclosing it takes
+// `BrowserToRelay`.** That constrains the sink rather than its name, so a rename passes and a second untyped
+// path cannot. It also stops keying on syntactic form — `useRelay`'s send is a `useCallback` arrow, and a check
+// pinned to `private send(` both missed it and would have failed on a harmless refactor of the other two.
 
 const root = join(import.meta.dirname, '../..')
-
-const CLIENTS = {
-  'mcp-server': 'packages/mcp-server/src/client.ts',
-  'flow-runner': 'packages/flow-runner/src/RelayClient.ts',
-}
 
 /** Comments out, `/* … *\/` blocks included: a commented-out signature satisfying a positive assertion is the
  *  failure that let an agent's real helper take `msg: object` while its check stayed green. */
@@ -31,40 +29,115 @@ function stripComments(src) {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 }
 
-describe('client outbound is typed against the wire contract', () => {
-  for (const [name, path] of Object.entries(CLIENTS)) {
+/** The files that hold a relay socket and serialize to it. Completeness is checked below, by inspection. */
+const FILES = {
+  'mcp-server': 'packages/mcp-server/src/client.ts',
+  'flow-runner': 'packages/flow-runner/src/RelayClient.ts',
+  dashboard: 'packages/dashboard/hooks/useRelay.ts',
+}
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'coverage', '__tests__', '.turbo'])
+
+/** Every source file under `packages/`, walked from disk rather than `git ls-files`. Measured: a new sender file
+ *  that serializes escapes the completeness check below while it is untracked, and "I just added it" is exactly
+ *  when it is untracked. `agentSendTyped.test.mjs` has the same hole for the same reason. */
+function sources(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (!SKIP_DIRS.has(e.name)) sources(join(dir, e.name), out)
+    } else if (/\.(ts|tsx)$/.test(e.name) && !e.name.endsWith('.d.ts')) {
+      out.push(join(dir, e.name).slice(root.length + 1))
+    }
+  }
+  return out
+}
+
+/** A function signature taking a single named message parameter, capturing the declared type. Covers both the
+ *  method form (`private send(msg: BrowserToRelay)`) and the hook form (`const send = useCallback((msg: …)`),
+ *  and deliberately captures whatever the type *is* rather than asserting a spelling. */
+const SIGNATURE = /(?:\b\w+\s*\(|\(\s*)(?:msg|m|message)\s*:\s*([\w.]+(?:<[^)]*>)?)\s*\)/g
+
+/** The type of the function that encloses `JSON.stringify` — the nearest signature declared before it. */
+function sinkParamType(src) {
+  const at = src.indexOf('JSON.stringify')
+  if (at === -1) return null
+  let found = null
+  for (const m of src.matchAll(SIGNATURE)) {
+    if (m.index > at) break
+    found = m[1]
+  }
+  return found
+}
+
+describe('browser-role outbound is typed against the wire contract', () => {
+  for (const [name, path] of Object.entries(FILES)) {
     const src = stripComments(readFileSync(join(root, path), 'utf8'))
 
-    it(`${name} sends through a BrowserToRelay signature`, () => {
-      expect(src).toMatch(/private send\(msg: BrowserToRelay\): void/)
+    it(`${name} serializes exactly once`, () => {
+      // A second serializer is the bypass this file exists for: it needs no rename to defeat a signature
+      // assertion, because the assertion keeps passing on the helper that is still typed.
+      expect([...src.matchAll(/JSON\.stringify/g)]).toHaveLength(1)
     })
 
-    it(`${name} declares exactly one send`, () => {
-      // Two would mean one of them is untyped, and the assertion above would still pass on the typed one.
-      expect([...src.matchAll(/private send\(/g)]).toHaveLength(1)
+    it(`${name} serializes inside a BrowserToRelay sink`, () => {
+      expect(sinkParamType(src)).toBe('BrowserToRelay')
     })
 
-    it(`${name} keeps Record<string, unknown> off the outbound path`, () => {
-      // The inbound alias may be loose — that is #512, deferred with a reason. What must not happen is an
-      // outbound helper reacquiring it, which is how both of these files started.
-      for (const m of src.matchAll(/type (\w+) = Record<string, unknown>/g)) {
-        const alias = m[1]
-        expect(
-          new RegExp(String.raw`private send\(msg: ${alias}\)`).test(src),
-          `${name}: send() takes ${alias}, which is Record<string, unknown>`,
-        ).toBe(false)
-      }
+    it(`${name} takes BrowserToRelay from protocol, not a local alias`, () => {
+      // `type BrowserToRelay = RelayMsg` in-file passed the first draft's every assertion. The name proves
+      // nothing on its own; where it resolves from does.
+      expect(src).toMatch(/import type \{[^}]*\bBrowserToRelay\b[^}]*\} from '@tapflowio\/protocol'/)
+      expect(src).not.toMatch(/(?:type|interface)\s+BrowserToRelay\b/)
     })
   }
 
+  it('every socket-writing file in the browser-role packages is accounted for', () => {
+    // Derived, not listed: a browser-role package is one whose source imports `BrowserToRelay`. So a new such
+    // package, or a new sender inside an existing one, shows up here as an omission instead of going unnoticed —
+    // the first draft hardcoded two paths and silently excluded the dashboard, the busiest producer of the three.
+    const tracked = sources(join(root, 'packages'))
+    const pkgOf = (f) => f.split('/')[1]
+    const browserRole = new Set(
+      tracked
+        .filter((f) => pkgOf(f) !== 'protocol')
+        .filter((f) => /BrowserToRelay/.test(readFileSync(join(root, f), 'utf8')))
+        .map(pkgOf),
+    )
+    expect([...browserRole].sort()).toEqual(['dashboard', 'flow-runner', 'mcp-server'])
+
+    const offenders = tracked.filter((f) => {
+      if (!browserRole.has(pkgOf(f)) || Object.values(FILES).includes(f)) return false
+      const body = stripComments(readFileSync(join(root, f), 'utf8'))
+      return /\.send\(/.test(body) && /JSON\.stringify/.test(body)
+    })
+    expect(offenders).toEqual([])
+  })
+
+  it('BrowserToRelay is a union of named messages only', () => {
+    // The check above binds the sinks to this union's *name*. Nothing bound its contents, and appending
+    // `| Record<string, unknown>` to it passed all 250 static assertions while making every literal in all
+    // three files accept anything — the guard pointing at this declaration raised nothing.
+    const proto = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
+    const rhs = proto.match(/export type BrowserToRelay =([\s\S]*?)\n\n/)
+    expect(rhs, 'BrowserToRelay is gone').not.toBeNull()
+    const members = rhs[1].split('|').map((s) => s.trim()).filter(Boolean)
+    expect(members.length).toBeGreaterThan(10)
+    for (const m of members) expect(m, `not a named message: ${m}`).toMatch(/^[A-Z]\w*$/)
+  })
+
   it('app:clear-state requires its bundleId, at both levels', () => {
-    // The one real defect this layer found. Both clients are the only producers and both send a string; both
-    // agents answer `app:clear-state-error` with 'bundleId missing' when it is absent; the relay forwards
-    // without filling it in. So `payload?: { bundleId?: string }` described a message whose only outcome was
-    // that error, and it compiled.
+    // The one real defect this layer found: `payload?: { bundleId?: string }` was looser than every producer
+    // *and* every consumer, so it described a message whose only outcome was `'bundleId missing'`.
+    //
+    // Required does not make that branch dead, and the agents keep it: `bundleId: ''` type-checks, and
+    // `runFlow` is exported without `parseFlow`, so an out-of-repo caller can hand it a `Flow` with no `appId`
+    // at all. `engine.ts` now refuses that rather than sending `payload: {}` for the device to reject.
     const proto = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
     const decl = proto.match(/export interface AppClearState \{([\s\S]*?)\n\}/)
     expect(decl, 'AppClearState is gone').not.toBeNull()
     expect(decl[1]).toMatch(/^ {2}payload: \{ bundleId: string \}$/m)
+
+    const engine = stripComments(readFileSync(join(root, 'packages/flow-runner/src/engine.ts'), 'utf8'))
+    expect(engine).not.toMatch(/clearState\(step\.appId \?\? flow\.appId!\)/)
   })
 })

--- a/scripts/__tests__/clientOutboundTyped.test.mjs
+++ b/scripts/__tests__/clientOutboundTyped.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import ts from 'typescript'
 
 // The browser-role producers construct their outbound literals directly, so typing the send function is a real
 // compile-time check — unlike narrowing a relay *forward*, which checks nothing because no literal is constructed
@@ -16,10 +17,22 @@ import { join } from 'node:path'
 // tsc and the package suite green, and put `session:leaev` on the wire. `agentSendTyped.test.mjs` had already
 // learned this — three of its drafts died to a renamed socket — and this file was written worse than its sibling.
 //
-// So the rule is the sibling's: **`JSON.stringify` appears once per file, and the function enclosing it takes
-// `BrowserToRelay`.** That constrains the sink rather than its name, so a rename passes and a second untyped
-// path cannot. It also stops keying on syntactic form — `useRelay`'s send is a `useCallback` arrow, and a check
-// pinned to `private send(` both missed it and would have failed on a harmless refactor of the other two.
+// So the rule is the sibling's: **`JSON.stringify` appears once per file, and it serializes a parameter declared
+// `BrowserToRelay` by the function enclosing it.** That constrains the sink rather than its name, so a rename
+// passes and a second untyped path cannot. It also stops keying on syntactic form — `useRelay`'s send is a
+// `useCallback` arrow, and a check pinned to `private send(` both missed it and would have failed on a harmless
+// refactor of the other two.
+//
+// **"Enclosing" is resolved on the AST, not by scanning backwards for the nearest signature.** The second draft
+// did scan, and review broke that too:
+//
+//     function send(msg: BrowserToRelay) {}
+//     function sendRaw(payload: RelayMsg, audit: boolean) { socket.send(JSON.stringify(payload)) }
+//
+// The scan walks straight past `sendRaw`'s boundary and reports `BrowserToRelay`, because the parameter name is
+// outside the pattern's allowlist. Which means the difference between caught and not caught was *what the
+// parameter happened to be called* — in a file whose header disclaims exactly that brittleness. This program has
+// now shipped five region parsers that did not know where their region ended, so this one uses the real one.
 
 const root = join(import.meta.dirname, '../..')
 
@@ -52,21 +65,29 @@ function sources(dir, out = []) {
   return out
 }
 
-/** A function signature taking a single named message parameter, capturing the declared type. Covers both the
- *  method form (`private send(msg: BrowserToRelay)`) and the hook form (`const send = useCallback((msg: …)`),
- *  and deliberately captures whatever the type *is* rather than asserting a spelling. */
-const SIGNATURE = /(?:\b\w+\s*\(|\(\s*)(?:msg|m|message)\s*:\s*([\w.]+(?:<[^)]*>)?)\s*\)/g
+const isFn = (n) =>
+  ts.isFunctionDeclaration(n) || ts.isMethodDeclaration(n) || ts.isArrowFunction(n) || ts.isFunctionExpression(n)
 
-/** The type of the function that encloses `JSON.stringify` — the nearest signature declared before it. */
-function sinkParamType(src) {
-  const at = src.indexOf('JSON.stringify')
-  if (at === -1) return null
-  let found = null
-  for (const m of src.matchAll(SIGNATURE)) {
-    if (m.index > at) break
-    found = m[1]
+/** Every `JSON.stringify(x)` in a file, described by what it serializes and how the innermost enclosing function
+ *  declares that name. `{ arg, declaredType }`, the latter `null` when `arg` is not one of its parameters — which
+ *  is the case a scan cannot see: serializing something the enclosing signature never promised anything about. */
+function serializationSites(src, path) {
+  const sf = ts.createSourceFile(
+    path, src, ts.ScriptTarget.Latest, true,
+    path.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const sites = []
+  const visit = (node, fn) => {
+    const enclosing = isFn(node) ? node : fn
+    if (ts.isCallExpression(node) && node.expression.getText(sf) === 'JSON.stringify') {
+      const arg = node.arguments[0]?.getText(sf) ?? null
+      const param = enclosing?.parameters.find((p) => p.name.getText(sf) === arg)
+      sites.push({ arg, declaredType: param?.type?.getText(sf) ?? null })
+    }
+    ts.forEachChild(node, (c) => visit(c, enclosing))
   }
-  return found
+  visit(sf, undefined)
+  return sites
 }
 
 describe('browser-role outbound is typed against the wire contract', () => {
@@ -76,11 +97,17 @@ describe('browser-role outbound is typed against the wire contract', () => {
     it(`${name} serializes exactly once`, () => {
       // A second serializer is the bypass this file exists for: it needs no rename to defeat a signature
       // assertion, because the assertion keeps passing on the helper that is still typed.
-      expect([...src.matchAll(/JSON\.stringify/g)]).toHaveLength(1)
+      expect(serializationSites(src, path)).toHaveLength(1)
     })
 
-    it(`${name} serializes inside a BrowserToRelay sink`, () => {
-      expect(sinkParamType(src)).toBe('BrowserToRelay')
+    it(`${name} serializes a BrowserToRelay parameter of the function it sits in`, () => {
+      // `declaredType` is non-null only when the serialized name is one of the enclosing function's parameters,
+      // so this says "it serializes its own promise" without pinning what that parameter is called.
+      const [site] = serializationSites(src, path)
+      expect(
+        site.declaredType,
+        `serializes \`${site.arg}\`, which the enclosing function does not declare as BrowserToRelay`,
+      ).toBe('BrowserToRelay')
     })
 
     it(`${name} takes BrowserToRelay from protocol, not a local alias`, () => {
@@ -114,15 +141,42 @@ describe('browser-role outbound is typed against the wire contract', () => {
   })
 
   it('BrowserToRelay is a union of named messages only', () => {
-    // The check above binds the sinks to this union's *name*. Nothing bound its contents, and appending
+    // The assertions above bind the sinks to this union's *name*. Nothing bound its contents, and appending
     // `| Record<string, unknown>` to it passed all 250 static assertions while making every literal in all
     // three files accept anything — the guard pointing at this declaration raised nothing.
+    //
+    // Checking the members look like type names is not enough either: `| UnsafeOutbound` is capitalised, and
+    // `type UnsafeOutbound = Record<string, unknown>` beside it reopens the hole through one indirection. So each
+    // member is resolved to its declaration, which must be an exported `interface` carrying a literal `type`.
     const proto = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
     const rhs = proto.match(/export type BrowserToRelay =([\s\S]*?)\n\n/)
     expect(rhs, 'BrowserToRelay is gone').not.toBeNull()
     const members = rhs[1].split('|').map((s) => s.trim()).filter(Boolean)
     expect(members.length).toBeGreaterThan(10)
-    for (const m of members) expect(m, `not a named message: ${m}`).toMatch(/^[A-Z]\w*$/)
+
+    // Members may be nested unions of interfaces — `ClipboardRequest` is `ClipboardRead | ClipboardWrite`, and
+    // `RelayOrAgentToBrowser` is referenced by two directions on purpose. So resolve to leaves and judge those.
+    const leaves = []
+    const seen = new Set()
+    const resolve = (name, from) => {
+      expect(name, `${from}: not a named message: ${name}`).toMatch(/^[A-Z]\w*$/)
+      if (seen.has(name)) return
+      seen.add(name)
+      const iface = proto.match(new RegExp(String.raw`^export interface ${name}(?: extends \w+)? \{([\s\S]*?)\n\}`, 'm'))
+      if (iface) {
+        expect(iface[1], `${name} has no literal type field`).toMatch(/^ {2}type: '[^']+'/m)
+        leaves.push(name)
+        return
+      }
+      const alias = proto.match(new RegExp(String.raw`^export type ${name} =([\s\S]*?)(?=\n\n|\nexport )`, 'm'))
+      expect(alias, `${name} resolves to neither an interface nor a union of them — an alias can widen the union`)
+        .not.toBeNull()
+      const nested = alias[1].split('|').map((s) => s.trim()).filter(Boolean)
+      expect(nested.length, `${name} is an alias, not a union`).toBeGreaterThan(1)
+      for (const n of nested) resolve(n, name)
+    }
+    for (const m of members) resolve(m, 'BrowserToRelay')
+    expect(leaves.length).toBeGreaterThan(10)
   })
 
   it('app:clear-state requires its bundleId, at both levels', () => {

--- a/scripts/__tests__/clientOutboundTyped.test.mjs
+++ b/scripts/__tests__/clientOutboundTyped.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The two browser-role clients — `mcp-server` and `flow-runner` — construct their outbound literals directly,
+// so typing the send function is a real compile-time check, unlike narrowing a relay *forward* (which checks
+// nothing, because no literal is constructed there; see the L4b retirement in `.work/WIRE-CONTRACT-PLAN.md`).
+//
+// Both are typed now. Neither produced a single compile error when the type went on, which is worth stating
+// plainly: **the value of this layer is regression defence, not a bug found.** Every `sessionId` in these files
+// comes from a required `string` parameter, so the root cause that produced 30 errors on the agent side (#509)
+// does not exist here.
+//
+// That makes this file the layer's only lasting artefact, so it has to be hard to walk past.
+//
+// It does **not** match a spelling of `send(`. `scripts/__tests__/agentSendTyped.test.mjs` was bypassed three
+// times in review by exactly that: renaming the socket, aliasing it, or serializing on the previous line all
+// walked past a pattern keyed on a name. Here the thing to protect is a *signature*, so the check reads the
+// signature — and separately refuses `Record<string, unknown>` anywhere it could reach an outbound path.
+
+const root = join(import.meta.dirname, '../..')
+
+const CLIENTS = {
+  'mcp-server': 'packages/mcp-server/src/client.ts',
+  'flow-runner': 'packages/flow-runner/src/RelayClient.ts',
+}
+
+/** Comments out, `/* … *\/` blocks included: a commented-out signature satisfying a positive assertion is the
+ *  failure that let an agent's real helper take `msg: object` while its check stayed green. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+describe('client outbound is typed against the wire contract', () => {
+  for (const [name, path] of Object.entries(CLIENTS)) {
+    const src = stripComments(readFileSync(join(root, path), 'utf8'))
+
+    it(`${name} sends through a BrowserToRelay signature`, () => {
+      expect(src).toMatch(/private send\(msg: BrowserToRelay\): void/)
+    })
+
+    it(`${name} declares exactly one send`, () => {
+      // Two would mean one of them is untyped, and the assertion above would still pass on the typed one.
+      expect([...src.matchAll(/private send\(/g)]).toHaveLength(1)
+    })
+
+    it(`${name} keeps Record<string, unknown> off the outbound path`, () => {
+      // The inbound alias may be loose — that is #512, deferred with a reason. What must not happen is an
+      // outbound helper reacquiring it, which is how both of these files started.
+      for (const m of src.matchAll(/type (\w+) = Record<string, unknown>/g)) {
+        const alias = m[1]
+        expect(
+          new RegExp(String.raw`private send\(msg: ${alias}\)`).test(src),
+          `${name}: send() takes ${alias}, which is Record<string, unknown>`,
+        ).toBe(false)
+      }
+    })
+  }
+
+  it('app:clear-state requires its bundleId, at both levels', () => {
+    // The one real defect this layer found. Both clients are the only producers and both send a string; both
+    // agents answer `app:clear-state-error` with 'bundleId missing' when it is absent; the relay forwards
+    // without filling it in. So `payload?: { bundleId?: string }` described a message whose only outcome was
+    // that error, and it compiled.
+    const proto = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
+    const decl = proto.match(/export interface AppClearState \{([\s\S]*?)\n\}/)
+    expect(decl, 'AppClearState is gone').not.toBeNull()
+    expect(decl[1]).toMatch(/^ {2}payload: \{ bundleId: string \}$/m)
+  })
+})


### PR DESCRIPTION
Layer L4c of the wire-contract program. The remaining untyped browser-role producer is typed, one message whose declaration was looser than every producer *and* every consumer is tightened, and the static check that defends both is anchored where its sibling learned to anchor.

Follows #501 (L2), #505 (L1), #503 (L3), #506 (L6), #509 (L4a). L4b was retired — narrowing a relay *forward* checks nothing, because no literal is constructed there.

## What changed

**`flow-runner`'s `RelayClient.send` takes `BrowserToRelay`** instead of `Record<string, unknown>`, so its 15 outbound literals are checked. `mcp-server`'s equivalent was already typed in `7637be3` — the plan claimed otherwise and was wrong; its source was this program's own stale handoff item, which cited a line that turned out to be `Waiter.resolve`. `RelayMsg` survives in both files as the **inbound** alias.

**Zero compile errors came out of it, and that is the honest result.** Every `sessionId` in that file arrives as a required `string` parameter, so the root cause that produced 30 errors when the agents were typed (#509) does not exist here. The value is regression defence.

**`AppClearState.payload` is now `{ bundleId: string }`** — the layer's one real defect. It was `payload?: { bundleId?: string }`: `mcp-server` and `flow-runner` are its only senders and both supply a string, and both agents answer `app:clear-state-error` with `'bundleId missing'` when it is absent. The declaration permitted a message whose only possible outcome was that error, and it compiled.

**`engine.ts` no longer reaches `driver.clearState` through `flow.appId!`.** `parseFlow` rejects a bare `clearState` with no flow-level `appId`, but `runFlow` is exported and does not parse — an embedder can hand it a `Flow` built by hand, and the assertion laundered that into `payload: {}` for the device to reject a network hop later.

**`scripts/__tests__/clientOutboundTyped.test.mjs`** holds all three browser-role producers to the contract.

## The check took two attempts, and that is most of this PR

Its first draft asserted the signature `private send(msg: BrowserToRelay)` while its own header claimed it did **not** match a spelling of `send(`. Review defeated it with the bypass the header named:

```ts
private sendRaw(msg: RelayMsg): void { this.ws?.send(JSON.stringify(msg)) }
this.sendRaw({ type: 'session:leaev', sessionId, whatever: 1 })
```

7/7 assertions passing, `tsc` clean, package suite green, misspelled type on the wire. `agentSendTyped.test.mjs` had already lost three drafts to a renamed socket; this one cited that lesson and then reproduced it.

It now anchors where the sibling does — `JSON.stringify` appears once per file, and the function enclosing it takes `BrowserToRelay` — which constrains the sink instead of its name. Three further gaps review found, all measured:

- An in-file `type BrowserToRelay = RelayMsg` passed every assertion. The import is asserted now and a local declaration refused.
- Nothing bound the union's *contents*. Appending `| Record<string, unknown>` to `BrowserToRelay` passed all 250 static assertions while making every literal in all three files accept anything.
- The file list was two hardcoded paths, silently excluding `dashboard/hooks/useRelay.ts` — already typed, and the busiest of the three (47 send sites against 32 for both clients). It is derived by inspection now, and walked from disk rather than `git ls-files`: a new sender file escapes while it is untracked, and "just added" is exactly when it is untracked. `agentSendTyped.test.mjs` has the same hole; it is recorded, not fixed here, because that check sweeps three agent packages and its mutation set would have to be re-run.

## Prose corrected where this work falsified it

The rule #510 added, applied to its own next PR — and it caught three places:

- `AppClearState`'s comment offered "the relay forwards without filling anything in" as *grounds*. The two sibling messages carry a `buildId` the relay resolves from the builds table, so blind forwarding is an absence of relay-side resolution, not a design. It also overstated what required buys: `bundleId: ''` type-checks, so the agents' guard stays live.
- `protocol/AGENTS.md` called `mcp-server` and `flow-runner` "the untyped senders" — true when written, falsified by the work that typed them — and listed three `Record<string, unknown>` sinks when two are now typed.
- The changeset's unconditional "not a breaking change" is scoped to in-repo producers. `AppClearState` is a published export and this package advertises `declare module` re-opening, so the next tightening should not cite this as precedent for "required fields are patches".

## Verification

`tsc -b` 0 · protocol assertions project 0 · lint 0 errors · manifests untouched.

| suite | |
|---|---|
| scripts (static checks) | **255** (250 before; the new file went 7 → 12) |
| flow-runner | **57** (56 + the engine guard) |
| mcp-server | 64 |
| dashboard | 303 |
| relay | 583 passed / 1 skipped |
| agent-core | 137 |

Eight mutations run and caught: second helper writing to `this.ws`; in-file `BrowserToRelay` shadow; `| Record<string, unknown>` appended to the union; new sender file while untracked; `send` renamed-but-loosened; `flow.appId!` restored; dashboard's send loosened; serialization hoisted out of the typed send via `const p = JSON.stringify(m)`.

## Adversarial review

Two channels — tightening correctness, and guard adequacy — plus an earlier design pass whose findings are the plan's "what the first draft got wrong" section. Record: `.work/reviews/refactor__wire-l4c-client-producer.md`.

**8 findings, 7 of them defects in my own fixes, 1 original bug** — the same ratio as L6 (15 and 1). The record also logs a third occurrence of this program's D19: `git checkout HEAD -- <file>` destroyed two uncommitted edits during the mutation round, because HEAD was the commit under review.

## Out of scope

- **Inbound narrowing for both clients** → #512, which also carries the four live defects it would catch. Ordering constraint (after #444) is recorded there.
- **Relay-side `bundleId` resolution for `app:clear-state`** — new feature, not contract alignment.
- **Relay inbound validation, the remaining `!`, replay `sessionId`** → #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear-state operations now fail early with a clear error when no app ID is provided.
  * Outbound browser-to-relay messages are validated more reliably.
  * App clear-state messages now require a bundle ID, preventing incomplete requests.

* **Tests**
  * Added regression coverage for invalid clear-state steps and outbound message typing.

* **Documentation**
  * Clarified message validation behavior and updated related technical guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->