### PR TITLE
fix(relay): stamp sessionId on the session-state replay so two of the three can require it

### DIFF
--- a/.changeset/browser-inbound-directions.md
+++ b/.changeset/browser-inbound-directions.md
@@ -17,9 +17,10 @@ more were missing outright.
 
 - `AgentToBrowser` — the twelve forward-only messages, shapes derived from both agents' send literals.
 - `RelayOrAgentToBrowser` — the ten with both producers, declared **once** and referenced by both
-  directions rather than written into each. `session:chrome`, `session:deviceInfo` and `device:ready`
-  carry `sessionId?` here because the two producers genuinely differ: both agents stamp it, and the
-  relay's replay to a re-joining viewer does not.
+  directions rather than written into each. `device:ready` carries `sessionId?` here because the two
+  producers genuinely differ: both agents stamp it, and the relay's replay to a re-joining viewer does
+  not. (`session:chrome` and `session:deviceInfo` were in the same position and are required now — the
+  relay stamps them; see the entry for that change.)
 - `BrowserInbound` — what a consumer should use. The dashboard's `RelayMessage` is gone; view code
   imports this.
 - `RelayToStream` — `stream:registered` goes to an agent's stream socket, not a browser.

--- a/.changeset/relay-replay-session-id.md
+++ b/.changeset/relay-replay-session-id.md
@@ -3,7 +3,7 @@
 '@tapflowio/relay': patch
 ---
 
-fix(relay): the session-state replay carries a sessionId, so the three messages that shared a declaration can require it
+fix(relay): the session-state replay carries a sessionId, so two of the three can require it
 
 `session:chrome`, `session:deviceInfo` and `device:ready` were declared `sessionId?: string` while both
 agents stamped the field on every copy they sent. The relay was the only producer that did not: its
@@ -12,22 +12,37 @@ share one declaration with the forwarded copies, so `optional` was the honest th
 could say about two producers that disagreed.
 
 **The disagreement was the defect.** When this surface was consolidated, two ways to tighten the
-*declaration* were weighed and rejected — declaring the three twice (drift, the finding that work
-existed to remove), and mapping the union through `Omit<T,'sessionId'> & { sessionId: string }` (turns
-them into intersections, so `Extract<BrowserInbound, …>` stops yielding one member, which
-`useClipboardBridge` reads its replies through without a cast). The third option was not considered:
-fix the producer. The relay stamps it now and the field is required.
+*declaration* were weighed and rejected. The third option was not considered: fix the producer. The relay
+stamps `session:chrome` and `session:deviceInfo` now and both are required. Closes the Major deferred
+on #503 for those two.
 
-This closes the Major deferred on #503.
+**`device:ready` is deliberately left optional, and that is the interesting half.** Its `sessionId?` is
+doing correlation work by accident: `mcp-server` and `flow-runner` gate a pending `device:boot` on
+`msg.sessionId === sessionId` with no truthiness escape, so the unstamped replay is invisible to them.
+Stamping it makes a *replayed* `device:ready` satisfy an in-flight boot — measured on a real relay with a
+silent agent, `boot_device` answers `{booted: true}` having received nothing, where the same harness
+reports still-waiting without the stamp. The replay is cached state addressed to a **join**, not an answer
+to a **boot**, and `readySent` is cleared by nothing while an agent is wedged-but-connected, which is
+exactly when a boot hangs — so the value is stalest precisely when it would be consumed.
 
-`minor`, not `patch`: the three are published exports and adding a required field is source-breaking for
-an out-of-repo producer that omits it. `CONTRIBUTING.md` makes any breaking change a `major`, relaxed to
-`minor` before `v1.0.0`, and that is not conditional on a consumer being known.
+The defect underneath is that leaving a session does not clear its waiters: a *real* `device:ready` after
+a re-join already satisfies the stale one, so this is pre-existing and stamping only widens the trigger.
+Filed separately. What makes this message tightenable is a request correlator, not another field.
+
+`minor`, because the two that changed are published exports and adding a required field is source-breaking
+for an out-of-repo producer that omits it. `CONTRIBUTING.md` makes any breaking change a `major`, relaxed
+to `minor` before `v1.0.0`, and that is not conditional on a consumer being known.
 
 **The dashboard's session gate got stricter as a consequence.** It read
-`'sessionId' in msg && msg.sessionId && msg.sessionId !== sessionId`, and the middle truthiness check
-existed to let the unstamped replay through. Nothing validates inbound messages (#444), so
-`sessionId: ''` type-checks and arrives — and a falsy sessionId *passed* that gate and was applied to
-whichever viewer was mounted, which is the unattributed-message defect #445 exists to prevent, reachable
-through the hole that existed for the replay. With the replay stamped the check is gone, and an empty
-sessionId is now simply a mismatch.
+`'sessionId' in msg && msg.sessionId && msg.sessionId !== sessionId`. The middle check was never what
+carried the replay — the relay omits the key, so `'sessionId' in msg` already lets those through — it only
+ever admitted a key that was *present and falsy*. With it gone, `sessionId: ''` is a mismatch rather than
+a pass. That is defence in depth against the unvalidated-inbound gap (#444), not a live hole: measured, an
+agent-sent `''` never reaches a viewer, because every agent→browser forward resolves
+`sessions.get(msg.sessionId!)` against a `randomUUID` key and breaks on the miss.
+
+One correction to a reason recorded three times in this package: rejecting the `Omit`-mapping alternative
+was justified by "it breaks `useClipboardBridge`, which reads its replies through `Extract<>`". It does
+not — that hook takes the three replies as named members and says so in its own comment, and its only
+`Extract` is over `ClipboardRequest`, an outbound union the mapping would never touch. The outcome is
+unchanged, since fixing the producer made both alternatives unnecessary.

--- a/.changeset/relay-replay-session-id.md
+++ b/.changeset/relay-replay-session-id.md
@@ -1,0 +1,33 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': patch
+---
+
+fix(relay): the session-state replay carries a sessionId, so the three messages that shared a declaration can require it
+
+`session:chrome`, `session:deviceInfo` and `device:ready` were declared `sessionId?: string` while both
+agents stamped the field on every copy they sent. The relay was the only producer that did not: its
+replay of cached session state to a re-joining viewer (`handleSessionStart`) omitted it, and the three
+share one declaration with the forwarded copies, so `optional` was the honest thing that declaration
+could say about two producers that disagreed.
+
+**The disagreement was the defect.** When this surface was consolidated, two ways to tighten the
+*declaration* were weighed and rejected — declaring the three twice (drift, the finding that work
+existed to remove), and mapping the union through `Omit<T,'sessionId'> & { sessionId: string }` (turns
+them into intersections, so `Extract<BrowserInbound, …>` stops yielding one member, which
+`useClipboardBridge` reads its replies through without a cast). The third option was not considered:
+fix the producer. The relay stamps it now and the field is required.
+
+This closes the Major deferred on #503.
+
+`minor`, not `patch`: the three are published exports and adding a required field is source-breaking for
+an out-of-repo producer that omits it. `CONTRIBUTING.md` makes any breaking change a `major`, relaxed to
+`minor` before `v1.0.0`, and that is not conditional on a consumer being known.
+
+**The dashboard's session gate got stricter as a consequence.** It read
+`'sessionId' in msg && msg.sessionId && msg.sessionId !== sessionId`, and the middle truthiness check
+existed to let the unstamped replay through. Nothing validates inbound messages (#444), so
+`sessionId: ''` type-checks and arrives — and a falsy sessionId *passed* that gate and was applied to
+whichever viewer was mounted, which is the unattributed-message defect #445 exists to prevent, reachable
+through the hole that existed for the replay. With the replay stamped the check is gone, and an empty
+sessionId is now simply a mismatch.

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -109,15 +109,19 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     // narrowing rather than the widening it used to be — it was `in msg` because the local copy of
     // this union omitted the field on messages the wire always stamped it on.
     //
-    // Three messages still reach here without one: `device:ready`, `session:chrome` and
-    // `session:deviceInfo` are `sessionId?` because the relay *replays* them to a re-joining viewer
-    // from its own cache and does not stamp them, while both agents do. The `&& msg.sessionId`
-    // truthiness check is what lets those through, and they are safe to accept unscoped for the same
-    // reason the gate is safe at all: the relay only ever sends a session-scoped message to that
-    // session's own `browserSocket`, so a mismatch means a stale socket, not normal traffic.
-    // If that ever stops holding, a dropped `session:terminated` strands the tab — which is the
-    // defect #426 existed to fix, so there is a test for exactly that below.
-    if ('sessionId' in msg && msg.sessionId && msg.sessionId !== sessionId) return;
+    // `'sessionId' in msg` stays, because some members genuinely carry none — `agents:listed` and
+    // `error`, whose whole point is a failure the relay could not attribute.
+    //
+    // There used to be a `&& msg.sessionId` truthiness check too, for three messages that arrived
+    // without one: the relay *replayed* `device:ready`, `session:chrome` and `session:deviceInfo` to a
+    // re-joining viewer from its own cache and did not stamp them, while both agents did. The relay
+    // stamps them now, so the three are scoped by this gate like everything else.
+    //
+    // Dropping that check also closes what it opened: nothing validates inbound messages (#444), so
+    // `sessionId: ''` reaches here — and a falsy sessionId used to *pass* the gate and be applied to
+    // whichever viewer was mounted. That is the unattributed-message defect #445 exists to prevent,
+    // reachable through the hole that let the replay in. Now it is simply a mismatch and ignored.
+    if ('sessionId' in msg && msg.sessionId !== sessionId) return;
 
     if (msg.type === 'session:joined') {
       // A join starts a boot cycle of its own (socket blip, re-entry). Any rebind still waiting for

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -109,18 +109,27 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     // narrowing rather than the widening it used to be — it was `in msg` because the local copy of
     // this union omitted the field on messages the wire always stamped it on.
     //
-    // `'sessionId' in msg` stays, because some members genuinely carry none — `agents:listed` and
-    // `error`, whose whole point is a failure the relay could not attribute.
+    // `'sessionId' in msg` stays, because two members genuinely carry none — `agents:listed` and
+    // `error`, whose whole point is a failure the relay could not attribute. Both are the *only* two,
+    // checked against the union.
     //
-    // There used to be a `&& msg.sessionId` truthiness check too, for three messages that arrived
-    // without one: the relay *replayed* `device:ready`, `session:chrome` and `session:deviceInfo` to a
-    // re-joining viewer from its own cache and did not stamp them, while both agents did. The relay
-    // stamps them now, so the three are scoped by this gate like everything else.
+    // **Why this gate is safe at all**: the relay only ever sends a session-scoped message to that
+    // session's own `browserSocket`, so a mismatch means a stale socket rather than normal traffic. If
+    // that stops holding, a dropped `session:terminated` strands the tab — the defect #426 exists to
+    // fix, and there is a test for exactly that in `DeviceViewer.sessionScope.test.tsx`.
     //
-    // Dropping that check also closes what it opened: nothing validates inbound messages (#444), so
-    // `sessionId: ''` reaches here — and a falsy sessionId used to *pass* the gate and be applied to
-    // whichever viewer was mounted. That is the unattributed-message defect #445 exists to prevent,
-    // reachable through the hole that let the replay in. Now it is simply a mismatch and ignored.
+    // There used to be a `&& msg.sessionId` truthiness check as well, for messages the relay *replayed*
+    // to a re-joining viewer from its own cache without stamping. It sent those with the key absent, so
+    // `'sessionId' in msg` already lets them through and the check was never what carried them — it only
+    // ever admitted a key that was *present and falsy*. Two of the three are stamped now
+    // (`device:ready` is not; see the protocol note), so it is gone.
+    //
+    // Dropping it means `sessionId: ''` is a mismatch rather than a pass. That is defence in depth, not
+    // a live hole: `''` cannot reach a viewer today, because every agent→browser forward resolves
+    // `sessions.get(msg.sessionId!)` against a `randomUUID` key and breaks on the miss. It matters for
+    // the unvalidated-inbound gap (#444) — `mcp-server`'s tool schemas are bare `z.string()`, so an LLM
+    // can put `''` on the wire, and a future producer echoing it back should not be applied to whichever
+    // viewer happens to be mounted.
     if ('sessionId' in msg && msg.sessionId !== sessionId) return;
 
     if (msg.type === 'session:joined') {

--- a/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
@@ -47,7 +47,7 @@ const installs = () => send.mock.calls.filter(([m]) => m.type === 'app:install')
 function live(buildId?: number) {
   render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={buildId} />)
   act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
-  act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+  act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
   act(() => { deliver!({ type: 'session:chrome', sessionId: 's1', payload: CHROME }) })
   if (buildId) act(() => { deliver!({ type: 'app:install-done', sessionId: 's1' }) })
 }
@@ -137,7 +137,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
 
     rebound()
     act(() => { deliver!({ type: 'device:booting', sessionId: 's1' }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
     act(() => { deliver!({ type: 'session:chrome', sessionId: 's1', payload: CHROME }) })
 
     expect(installs()).toHaveLength(0)
@@ -152,10 +152,10 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     live(7)
     rebound()
     act(() => { deliver!({ type: 'device:booting', sessionId: 's1' }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
     send.mockClear()
 
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
 
     expect(installs()).toHaveLength(1)
   })
@@ -167,7 +167,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     act(() => { deliver!({ type: 'device:boot-error', sessionId: 's1', message: 'nope' }) })
     send.mockClear()
 
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
 
     expect(installs()).toHaveLength(1)
   })
@@ -192,13 +192,13 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     // hands the tester a Launch button for an app that is not on the device.
     render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
     expect(installs()).toHaveLength(1) // in flight — no `app:install-done`
     send.mockClear()
 
     rebound()
     act(() => { deliver!({ type: 'device:booting', sessionId: 's1' }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
     act(() => { deliver!({ type: 'session:chrome', sessionId: 's1', payload: CHROME }) })
 
     expect(installs()).toHaveLength(1)
@@ -219,7 +219,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     send.mockClear()
 
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
 
     expect(installs()).toHaveLength(1)
   })
@@ -233,8 +233,8 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
 
     rebound()
     rebound()
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
 
     expect(boots()).toHaveLength(2)
     expect(installs()).toHaveLength(0)
@@ -256,7 +256,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
     // `live()` minus a conforming join.
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1' } as unknown as BrowserInbound) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
     act(() => { deliver!({ type: 'session:chrome', sessionId: 's1', payload: CHROME }) })
 
     // Streaming at all: an unguarded `.includes` on `undefined` throws while the platform viewer

--- a/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
@@ -35,7 +35,7 @@ describe('DeviceViewer ignores messages addressed to another session (#445)', ()
     act(() => { deliver!({ type: 'session:joined', sessionId: 'mine', capabilities: [] }) })
     // The card shows "Starting device…" until this arrives, and that would mask the install error
     // regardless of the filter — the two tests have to sit past it to mean anything.
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 'mine', payload: { deviceId: 'dev-1' } }) })
 
     act(() => {
       deliver!({ type: 'app:install-error', sessionId: 'someone-else', message: 'Build not found' })
@@ -47,13 +47,31 @@ describe('DeviceViewer ignores messages addressed to another session (#445)', ()
   it('does show one that is its own', () => {
     render(<DeviceViewer sessionId="mine" deviceId="dev-1" />)
     act(() => { deliver!({ type: 'session:joined', sessionId: 'mine', capabilities: [] }) })
-    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 'mine', payload: { deviceId: 'dev-1' } }) })
 
     act(() => {
       deliver!({ type: 'app:install-error', sessionId: 'mine', message: 'Build not found' })
     })
 
     expect(screen.getByText(/Install failed: Build not found/)).toBeInTheDocument()
+  })
+
+  it('ignores a device:ready whose session id is empty', () => {
+    // The discriminating case for dropping `&& msg.sessionId` from the gate. An empty sessionId is
+    // falsy, so the truthiness check let it *pass* and the message was applied to whichever viewer was
+    // mounted — the unattributed-message defect #426 exists to prevent, reachable through the hole that
+    // existed to let the relay's unstamped replay in. `''` type-checks against the now-required field
+    // and nothing validates inbound messages (#444), so this is a shape that can arrive.
+    //
+    // A foreign-but-non-empty id is *not* the test for this: `'someone-else'` is truthy, so the old
+    // gate rejected it too and such a test would pass either way.
+    render(<DeviceViewer sessionId="mine" deviceId="dev-1" />)
+    act(() => { deliver!({ type: 'session:joined', sessionId: 'mine', capabilities: [] }) })
+
+    act(() => { deliver!({ type: 'device:ready', sessionId: '', payload: { deviceId: 'dev-1' } }) })
+
+    // Still waiting on its own device — the unattributed ready did not stand in for it.
+    expect(screen.getByText(/Starting device/)).toBeInTheDocument()
   })
 
   it('still accepts messages that carry no session at all', () => {

--- a/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
@@ -59,12 +59,14 @@ describe('DeviceViewer ignores messages addressed to another session (#445)', ()
   it('ignores a device:ready whose session id is empty', () => {
     // The discriminating case for dropping `&& msg.sessionId` from the gate. An empty sessionId is
     // falsy, so the truthiness check let it *pass* and the message was applied to whichever viewer was
-    // mounted — the unattributed-message defect #426 exists to prevent, reachable through the hole that
-    // existed to let the relay's unstamped replay in. `''` type-checks against the now-required field
-    // and nothing validates inbound messages (#444), so this is a shape that can arrive.
+    // mounted — the unattributed-message defect #445 exists to prevent.
     //
     // A foreign-but-non-empty id is *not* the test for this: `'someone-else'` is truthy, so the old
     // gate rejected it too and such a test would pass either way.
+    //
+    // This is defence in depth rather than a reachable bug today: measured, an agent-sent `''` never
+    // reaches a viewer, because every agent→browser forward resolves `sessions.get(msg.sessionId!)`
+    // against a `randomUUID` key and breaks on the miss. It guards the unvalidated-inbound gap (#444).
     render(<DeviceViewer sessionId="mine" deviceId="dev-1" />)
     act(() => { deliver!({ type: 'session:joined', sessionId: 'mine', capabilities: [] }) })
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -215,4 +215,6 @@ sends through `sendTo(socket, msg: RelayOutbound)`, so its literal is checked by
 
 ## Consuming it
 
-The relay is composite (TS project references), so it needs both the dependency **and** a `references` entry pointing here — see [`contributing/monorepo-project-references.md`](../../contributing/monorepo-project-references.md). `dashboard` and `mcp-server` are not composite; they resolve `src` directly through the `source` export condition and need only the dependency.
+The relay is composite (TS project references), so it needs both the dependency **and** a `references` entry pointing here — see [`contributing/monorepo-project-references.md`](../../contributing/monorepo-project-references.md). `dashboard` and `mcp-server` are not composite and need only the dependency — but they do **not** read `src` under `tsc`. Neither sets `customConditions` (`dashboard` is `moduleResolution: bundler`, `mcp-server` is `Node16`), so both take the first key in this package's `exports`, which is `./dist/index.d.ts`. The `source` condition is wired into **vitest** only, via `vitest.shared.ts`'s `ssr.resolve.conditions`.
+
+That has a consequence worth knowing before measuring anything: **`pnpm typecheck` lies about these two until this package is rebuilt.** Tightening a field here and running the dashboard's typecheck against a stale `dist` reports 0 errors. And `tsc -b` never sees them at all — neither is in the root `references`, so a change whose fallout is entirely in `dashboard` builds clean.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -316,29 +316,32 @@ export type InputErrorReason =
  *  Declared once here and referenced by both directions rather than written into each, because two
  *  copies of one message drift. That is not hypothetical: the dashboard kept a hand-copy of this
  *  whole surface and four members had diverged from it, with nothing reporting the difference. */
-// `sessionId` is optional on these three and required on the errors below, because here the two
-// producers genuinely disagree. Both agents stamp it on every one of these
-// (`IOSAgent.ts:401,411,606`, `AndroidAgent.ts:461,867,878`) and the forward gate resolves the
-// session before forwarding, so a *forwarded* copy always carries it — but the relay's own replay
-// to a re-joining viewer does not (`RelayServer.ts:1079,1082,1089`), and it is the same declaration.
-// Optional is what one declaration can honestly say about two producers that differ. Bringing the
-// replay up to the agents' shape, and tightening this to required, belongs with L4 — the layer that
-// types the relay's own sends.
+// These three were `sessionId?` because the two producers disagreed, and the honest thing one
+// declaration could say about a disagreement is "optional". Both agents stamped it on every copy
+// (`IOSAgent.ts:401,411,606`, `AndroidAgent.ts:461,867,878`); the relay's own replay to a re-joining
+// viewer did not, and it is the same declaration.
+//
+// **The disagreement was the defect, not the declaration.** Two alternatives were weighed when this
+// surface was consolidated — declaring the three twice, or mapping the shared union through
+// `Omit<T,'sessionId'> & { sessionId: string }` — and both were rejected for good reasons (drift, and
+// `Extract<BrowserInbound, …>` stops resolving to one member, which `useClipboardBridge` depends on).
+// The third option was not considered: **fix the producer.** The relay now stamps it
+// (`RelayServer.ts` `handleSessionStart`), so one declaration can say `required` about both.
 export interface SessionChrome {
   type: 'session:chrome'
-  sessionId?: string
+  sessionId: string
   payload: ChromePayload
 }
 
 export interface SessionDeviceInfo {
   type: 'session:deviceInfo'
-  sessionId?: string
+  sessionId: string
   payload: DeviceDetails
 }
 
 export interface DeviceReady {
   type: 'device:ready'
-  sessionId?: string
+  sessionId: string
   payload: { deviceId: string }
 }
 
@@ -351,8 +354,9 @@ export interface DeviceReady {
  * Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
  * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
  * through `msg.sessionId!` — `JSON.stringify` then drops the key. Seven sites do this
- * (`RelayServer.ts:719,743,752,786,803,1109,1138`). No in-repo client omits a sessionId, so the
- * gap is reachable only from a third-party one.
+ * (`RelayServer.ts:721,743,752,786,803,1125,1154`). No in-repo client omits a sessionId, so the
+ * gap is reachable only from a third-party one — with one exception measured since: `sessionId: ''`
+ * type-checks and `mcp-server`'s tools take `z.string()`, so an LLM can produce it.
  *
  * Optional would describe that wire accurately and still be the wrong contract: an MCP caller that
  * receives an uncorrelatable `input:error` has nothing it can do with it — it waits out the
@@ -571,22 +575,16 @@ export interface ClipboardWriteDone {
  *  include it in every send literal, and the relay's forward gate resolves `sessions.get(msg.sessionId!)`
  *  before forwarding, so a message with no sessionId never reaches a browser by this path.
  *
- *  The ten inherited from `RelayOrAgentToBrowser` are **not** all required — three are `sessionId?`,
- *  which is looser than what an agent actually sends. Tightening them here needs the three declared
- *  twice, or the shared union mapped through `Omit<T,'sessionId'> & { sessionId: string }`. Both were
- *  weighed and rejected for this layer:
+ *  The ten inherited from `RelayOrAgentToBrowser` now carry it too. Three of them
+ *  (`session:chrome`, `session:deviceInfo`, `device:ready`) were `sessionId?` for as long as the relay's
+ *  replay omitted what both agents stamped. Two ways to tighten the declaration were weighed and
+ *  rejected — declaring the three twice (drift, which is the finding this surface exists to remove), and
+ *  mapping the union through `Omit<T,'sessionId'> & { sessionId: string }` (turns them into
+ *  intersections, so `Extract<BrowserInbound, …>` stops yielding one member, which `useClipboardBridge`
+ *  reads its three replies through without a cast).
  *
- *  - Declaring them twice reintroduces the thing this layer exists to remove. Two copies of one
- *    message drift; that is the whole finding — four of them, between this file and the dashboard's.
- *  - The mapped version turns those members into intersections, so `Extract<BrowserInbound, …>` stops
- *    yielding a single member. `useClipboardBridge` depends on that (its three replies are read
- *    without a cast because each `Extract` resolves to one declaration).
- *
- *  And no consumer could read the stricter claim today: `BrowserInbound` merges both directions, and a
- *  union merge collapses to the looser field. Nothing consumes `AgentToBrowser` on its own — the relay
- *  forwards untyped. **L4 is where it pays**: once the relay's forward path is narrowed to this union,
- *  required `sessionId` is checkable, and the relay's replay (`RelayServer.ts:1079,1082,1089`) is
- *  brought up to the agents' shape in the same change. Tracked there rather than left implicit. */
+ *  Both are ways to make one declaration describe two producers that disagree. The disagreement was the
+ *  defect: the relay stamps it now, so neither is needed. See the note above the three declarations. */
 export type AgentToBrowser =
   | RelayOrAgentToBrowser
   | DeviceBooting

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -317,16 +317,28 @@ export type InputErrorReason =
  *  copies of one message drift. That is not hypothetical: the dashboard kept a hand-copy of this
  *  whole surface and four members had diverged from it, with nothing reporting the difference. */
 // These three were `sessionId?` because the two producers disagreed, and the honest thing one
-// declaration could say about a disagreement is "optional". Both agents stamped it on every copy
-// (`IOSAgent.ts:401,411,606`, `AndroidAgent.ts:461,867,878`); the relay's own replay to a re-joining
+// declaration could say about a disagreement is "optional". Both agents stamp it on every copy
+// (`IOSAgent.ts:428,438,633`, `AndroidAgent.ts:489,895,906`); the relay's own replay to a re-joining
 // viewer did not, and it is the same declaration.
 //
 // **The disagreement was the defect, not the declaration.** Two alternatives were weighed when this
 // surface was consolidated — declaring the three twice, or mapping the shared union through
-// `Omit<T,'sessionId'> & { sessionId: string }` — and both were rejected for good reasons (drift, and
-// `Extract<BrowserInbound, …>` stops resolving to one member, which `useClipboardBridge` depends on).
-// The third option was not considered: **fix the producer.** The relay now stamps it
-// (`RelayServer.ts` `handleSessionStart`), so one declaration can say `required` about both.
+// `Omit<T,'sessionId'> & { sessionId: string }` — and both were rejected. The third option was not
+// considered: **fix the producer.** The relay stamps the two above now, so one declaration says
+// `required` about both.
+//
+// **`device:ready` is the exception, and it is a deferral rather than an oversight.** Its `sessionId?`
+// is doing correlation work by accident: `mcp-server` and `flow-runner` gate a pending `device:boot`
+// on `msg.sessionId === sessionId` with no truthiness escape, so the unstamped replay is invisible to
+// them. Stamping it makes a *replayed* ready satisfy an in-flight boot — measured: `boot_device`
+// answers `{booted: true}` with the agent having sent nothing. The replay is cached state addressed to
+// a **join**, not an answer to a **boot**, and `readySent` is cleared by nothing while an agent is
+// wedged-but-connected, which is exactly when a boot hangs. So the value is stalest when it would be
+// consumed.
+//
+// The real defect underneath is that leaving a session does not clear its waiters — a *real* ready
+// after a re-join already satisfies the stale one. That is filed separately. The mechanism that makes
+// this message tightenable is a request correlator, not another field.
 export interface SessionChrome {
   type: 'session:chrome'
   sessionId: string
@@ -341,7 +353,7 @@ export interface SessionDeviceInfo {
 
 export interface DeviceReady {
   type: 'device:ready'
-  sessionId: string
+  sessionId?: string
   payload: { deviceId: string }
 }
 
@@ -354,7 +366,7 @@ export interface DeviceReady {
  * Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
  * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
  * through `msg.sessionId!` — `JSON.stringify` then drops the key. Seven sites do this
- * (`RelayServer.ts:721,743,752,786,803,1125,1154`). No in-repo client omits a sessionId, so the
+ * (`RelayServer.ts:721,743,752,786,803,1129,1158`). No in-repo client omits a sessionId, so the
  * gap is reachable only from a third-party one — with one exception measured since: `sessionId: ''`
  * type-checks and `mcp-server`'s tools take `z.string()`, so an LLM can produce it.
  *
@@ -575,16 +587,21 @@ export interface ClipboardWriteDone {
  *  include it in every send literal, and the relay's forward gate resolves `sessions.get(msg.sessionId!)`
  *  before forwarding, so a message with no sessionId never reaches a browser by this path.
  *
- *  The ten inherited from `RelayOrAgentToBrowser` now carry it too. Three of them
+ *  Nine of the ten inherited from `RelayOrAgentToBrowser` now carry it too. Three of them
  *  (`session:chrome`, `session:deviceInfo`, `device:ready`) were `sessionId?` for as long as the relay's
- *  replay omitted what both agents stamped. Two ways to tighten the declaration were weighed and
+ *  replay omitted what both agents stamped. Two ways to tighten the *declaration* were weighed and
  *  rejected — declaring the three twice (drift, which is the finding this surface exists to remove), and
- *  mapping the union through `Omit<T,'sessionId'> & { sessionId: string }` (turns them into
- *  intersections, so `Extract<BrowserInbound, …>` stops yielding one member, which `useClipboardBridge`
- *  reads its three replies through without a cast).
+ *  mapping the union through `Omit<T,'sessionId'> & { sessionId: string }`.
  *
- *  Both are ways to make one declaration describe two producers that disagree. The disagreement was the
- *  defect: the relay stamps it now, so neither is needed. See the note above the three declarations. */
+ *  The recorded reason for rejecting the second one does not survive checking, and it is worth saying so
+ *  rather than deleting it: it claimed the mapping breaks `useClipboardBridge`, which reads its replies
+ *  through `Extract<>`. It does not — that hook takes the three replies as **named members**
+ *  (`ClipboardData | ClipboardWriteDone | ClipboardError`) and says so in its own comment, and its only
+ *  `Extract` is over `ClipboardRequest`, an outbound union this mapping would never touch.
+ *
+ *  It does not change the outcome, because both alternatives are ways to make one declaration describe
+ *  two producers that disagree, and the disagreement was the defect. The relay stamps the first two now.
+ *  `device:ready` stays optional for a different reason — see the note above the declarations. */
 export type AgentToBrowser =
   | RelayOrAgentToBrowser
   | DeviceBooting

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1107,7 +1107,7 @@ export class RelayServer {
     // simulator that was already running would fire this before the agent had done anything —
     // telling the viewer a stream exists when none does (#440).
     if (session.readySent) {
-      this.sendTo(ws, { type: 'device:ready', sessionId: session.id, payload: { deviceId: session.deviceId } })
+      this.sendTo(ws, { type: 'device:ready', payload: { deviceId: session.deviceId } })
       // (Re)joining a live stream: ask the agent for an IDR so this viewer gets a decodable
       // keyframe immediately, instead of waiting for the next periodic one — and so it isn't
       // left blank when the encoder is static-skipping an unchanged screen. Agents that don't

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1092,18 +1092,22 @@ export class RelayServer {
       this.sendTo(ws, { type: 'session:agent-away', sessionId: msg.sessionId! })
       return
     }
+    // These three replay a session's cached state to a re-joining viewer. They carry `sessionId`
+    // because both agents stamp it on every copy they send, and the relay was the only producer that
+    // did not — so the shared declaration had to be `sessionId?` to stay honest about the two of us.
+    // Stamping it here is what let that be tightened to required.
     if (session.chromeData) {
-      this.sendTo(ws, { type: 'session:chrome', payload: session.chromeData })
+      this.sendTo(ws, { type: 'session:chrome', sessionId: session.id, payload: session.chromeData })
     }
     if (session.deviceInfo) {
-      this.sendTo(ws, { type: 'session:deviceInfo', payload: session.deviceInfo })
+      this.sendTo(ws, { type: 'session:deviceInfo', sessionId: session.id, payload: session.deviceInfo })
     }
     // Replay device:ready only if this session actually announced one (browser WS blip reconnect).
     // Not `deviceStatus`: that starts from the agent's `simctl list` snapshot, so a session for a
     // simulator that was already running would fire this before the agent had done anything —
     // telling the viewer a stream exists when none does (#440).
     if (session.readySent) {
-      this.sendTo(ws, { type: 'device:ready', payload: { deviceId: session.deviceId } })
+      this.sendTo(ws, { type: 'device:ready', sessionId: session.id, payload: { deviceId: session.deviceId } })
       // (Re)joining a live stream: ask the agent for an IDR so this viewer gets a decodable
       // keyframe immediately, instead of waiting for the next periodic one — and so it isn't
       // left blank when the encoder is static-skipping an unchanged screen. Agents that don't

--- a/packages/relay/src/__tests__/deviceReadyReplay.test.ts
+++ b/packages/relay/src/__tests__/deviceReadyReplay.test.ts
@@ -73,6 +73,36 @@ describe('device:ready replay tracks the session, not the device (#440)', () => 
     agent.close(); browser.close()
   })
 
+  it('stamps the replayed session state with the session it belongs to', async () => {
+    // `tsc` enforces that `sessionId` is *present* on these two — deleting a stamp is three TS2345s.
+    // Nothing enforces that the value is right, and the plausible wrong value is on the same line:
+    // `session.deviceId` is a `string` and appears in `payload: { deviceId: session.deviceId }`.
+    //
+    // A wrong-but-present id is worse than the absent one it replaced. Absent passed the dashboard's
+    // gate; wrong is dropped by it, and the symptom is a re-joining tab stuck on "Starting device…" —
+    // which is the defect (#440) the replay exists to prevent, so nothing else would report it.
+    const { agent, sessionId } = await registerAgent('shutdown')
+    agent.send(JSON.stringify({ type: 'session:chrome', sessionId, payload: { framePng: 'x' } }))
+    agent.send(JSON.stringify({ type: 'session:deviceInfo', sessionId, payload: { deviceName: 'A', osVersion: '18.0' } }))
+    await barrier(agent)
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+
+    // Both waits are created **before** the send, and that is load-bearing rather than style: the
+    // recording `waitForType` reads from is attached by its first call, so a reply that arrives before
+    // that call is not queued anywhere and the wait hangs. `handleSessionStart` sends the join and both
+    // replays in one turn, so awaiting them one after the other flakes — measured, once.
+    const chrome = waitForType(browser, 'session:chrome')
+    const info = waitForType(browser, 'session:deviceInfo')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+
+    expect((await chrome).sessionId).toBe(sessionId)
+    expect((await info).sessionId).toBe(sessionId)
+
+    agent.close(); browser.close()
+  })
+
   it('replays for a session that is actually streaming', async () => {
     // The reason replay exists: a Wi-Fi blip drops the browser socket mid-session, and the viewer
     // must not sit blank until the next boot. Without this case, deleting the replay outright

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -175,8 +175,9 @@ describe('browser-inbound routing matches the protocol union', () => {
   // does not object either, because the dashboard's consumers compare `msg.sessionId === sessionId`
   // and that still compiles against `string | undefined`.
   //
-  // `sessionId` is required on all twelve forwarded messages and on the seven shared errors; it is
-  // optional on exactly the three the relay also replays without one (see the note in the union).
+  // `sessionId` is required on all twelve forwarded messages and on the seven shared errors, and on two
+  // of the three the relay also replays. `device:ready` is the one exception, and it is deliberate —
+  // see the note above the declarations for the measurement.
   //
   // All five message unions are here, not just the browser-inbound three. The bindings in
   // `typeAssertions.ts` pin 58 literals and read like per-message coverage, but a literal is all they
@@ -205,7 +206,7 @@ describe('browser-inbound routing matches the protocol union', () => {
     RelayOrAgentToBrowser: {
       'session:chrome': 'payload sessionId',
       'session:deviceInfo': 'payload sessionId',
-      'device:ready': 'payload sessionId',
+      'device:ready': 'payload sessionId?',
       'app:install-error': 'message sessionId',
       'app:launch-error': 'message sessionId',
       'device:boot-error': 'message sessionId',

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -203,9 +203,9 @@ describe('browser-inbound routing matches the protocol union', () => {
       'clipboard:write-done': 'requestId sessionId',
     },
     RelayOrAgentToBrowser: {
-      'session:chrome': 'payload sessionId?',
-      'session:deviceInfo': 'payload sessionId?',
-      'device:ready': 'payload sessionId?',
+      'session:chrome': 'payload sessionId',
+      'session:deviceInfo': 'payload sessionId',
+      'device:ready': 'payload sessionId',
       'app:install-error': 'message sessionId',
       'app:launch-error': 'message sessionId',
       'device:boot-error': 'message sessionId',


### PR DESCRIPTION
The relay's replay of cached session state to a re-joining viewer omitted a field both agents stamp, so the shared declaration had to be `sessionId?` to stay honest about two producers that disagreed. The relay stamps it now and two of the three are required. Closes the Major deferred on #503 for those two.

Part of the wire-contract program (#501, #505, #503, #506, #509, #513). It is **not** the reply-site half of #444 — that turned out to belong after request/response correlation, and the reasoning is below.

## What changed

`RelayServer.handleSessionStart` stamps `sessionId: session.id` on `session:chrome` and `session:deviceInfo`, and both are `sessionId: string` in `@tapflowio/protocol` instead of `sessionId?: string`.

Two ways to tighten the *declaration* were weighed when this surface was consolidated and both were rejected for good reasons. The third option was not considered: **fix the producer.** Three lines — the session is already in hand.

## `device:ready` is deliberately left out, and that is the useful half of this PR

Its `sessionId?` was doing correlation work by accident. `mcp-server` and `flow-runner` gate a pending `device:boot` on `msg.sessionId === sessionId` with no truthiness escape, so the unstamped replay is invisible to them. Stamping it makes a **replayed** `device:ready` satisfy an in-flight boot — measured on a real relay with a registered but silent agent:

```
with the stamp     device:ready sid="d91f0bea…"  → boot_device answers {booted: true}
without it         device:ready sid=undefined    → still waiting
```

The agent had sent nothing. Reachable from a real MCP client rather than only a harness: the SDK dispatches each request detached, so parallel tool calls produce that interleaving.

The replay is cached state addressed to a **join**, not an answer to a **boot** — and `readySent` is cleared by nothing while an agent is wedged-but-connected, which is exactly when a boot hangs, so the value is stalest precisely when it would be consumed. The relay's own comment three lines above makes this argument for why `deviceStatus` cannot answer readiness (#440).

The defect underneath is that leaving a session does not clear its waiters: a *real* `device:ready` after a re-join already satisfies the stale one, so this is pre-existing and stamping only widens the trigger. Filed as #514. What makes this message tightenable is a request correlator, not another field — so it waits for that work rather than getting a field or a message of its own.

Narrowing costs almost nothing, which is why it is the right call rather than a retreat: `device:ready` is the only one of the three with a correlating consumer (zero hits for the other two across `mcp-server`, `flow-runner`, `cli`), and the dashboard change below closes independently.

## The dashboard's session gate got stricter

It read `'sessionId' in msg && msg.sessionId && msg.sessionId !== sessionId`. The middle check was never what carried the replay — the relay omits the key, so `'sessionId' in msg` already let those through. It only ever admitted a key that was **present and falsy**, so removing it makes `sessionId: ''` a mismatch rather than a pass.

That is defence in depth for the unvalidated-inbound gap (#444), **not** a live hole — measured: an agent-sent `''` never reaches a viewer, because every agent→browser forward resolves `sessions.get(msg.sessionId!)` against a `randomUUID` key and breaks on the miss. The first draft of this PR claimed otherwise and review corrected it.

## The stamped value was pinned by nothing

The compiler enforces presence only. Deleting the stamps is three `TS2345`s; `sessionId: 'WRONG-ID'` and `sessionId: session.deviceId` both compile with the relay suite green. The second is not contrived — `session.deviceId` is a `string` on the same line, inside `payload: { deviceId: session.deviceId }`.

And this change makes a wrong id **worse** than the absent one it replaced: absent passed the dashboard gate, wrong is dropped by it, and the symptom is a re-joining tab stuck on "Starting device…" — the #440 defect the replay exists to prevent, so nothing else would report it. There is a test now and it fails on both mutations.

That test was flaky on its first writing, which is recorded in its comment: `waitForType` attaches its recording on first call, and `handleSessionStart` sends the join and both replays in one turn, so awaiting them one after the other loses them. The waits are created before the send. Five consecutive runs.

## Verification

`tsc -b` 0 · `pnpm typecheck` 0 · lint 0 errors · manifests untouched · `changeset:check` passes.

| suite | |
|---|---|
| scripts (static checks) | 255 |
| relay | **584** passed / 1 skipped (+1) |
| dashboard | **304** (+1) |
| mcp-server · flow-runner | 64 · 57 |
| ios-agent · android-agent · agent-core | 368 · 251 · 137 |

**Measurement order changes the answer here.** The dashboard resolves `protocol` through `dist`, so tightening a field and running its typecheck against a stale `dist` reports 0. And `tsc -b` never sees `dashboard` or `mcp-server` at all — neither is in the root `references` — so a change whose fallout is entirely in the dashboard builds clean. `protocol/AGENTS.md` claimed the opposite (that both resolve `src` through the `source` condition, which is wired into vitest only); this PR corrects it, since it is the change that disproves it.

Six mutations run and caught.

## Adversarial review

A design pass ran before any code, across two channels, and reversed all three judgments in the first draft of the plan — including the one that sent this work at #444's reply sites at all. A second pair of channels reviewed the diff, isolated in their own worktrees.

The two review channels **disagreed on the central fact**: one filed the `device:ready` behaviour as a blocker, the other filed the same mechanism as a bonus fix, on the grounds that the waiters' blindness to the replay was itself a bug. Both are right about the mechanism; the deciding factor is that the prerequisite (#514) is not in place.

Record: `.work/reviews/fix__relay-replay-session-id.md`.

Prose corrected where review found it false — including a design reason recorded three times in this package (`Omit`-mapping "breaks `useClipboardBridge`, which reads its replies through `Extract<>`" — it does not; that hook takes them as named members, and its only `Extract` is over an outbound union). Corrected rather than deleted, so the next reader does not reconstruct it. Also a pending changeset that would have rendered a contradiction into the same changelog section, and two line references this PR's own inserted comment shifted by four.

## Follow-ups filed

- **#514** — leaving a session does not clear its waiters. Blocks `device:ready`.
- **#515** — re-joining a session the socket already holds answers `session-not-found` for a live session it owns. Reachable by pressing shutdown twice. Found independently by two channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session message filtering so mismatched or empty session IDs are ignored.
  * Replayed browser and device information now remains correctly associated with the active session.
  * Preserved support for unscoped messages and boot-time device readiness correlation.

* **Protocol Updates**
  * Session identifiers are now required for browser and device information messages.
  * Device readiness messages may still omit a session identifier when needed for startup correlation.

* **Documentation**
  * Clarified session identifier behavior and TypeScript declaration resolution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->