### PR TITLE
perf(dashboard): split large vendor bundles

### DIFF
--- a/.changeset/dashboard-vendor-chunks.md
+++ b/.changeset/dashboard-vendor-chunks.md
@@ -2,4 +2,4 @@
 '@tapflowio/relay': patch
 ---
 
-Improve dashboard loading performance by splitting large application and vendor bundles.
+Split stable dashboard vendor dependencies into smaller chunks to reduce maximum bundle size and improve cache reuse across releases.

--- a/.changeset/dashboard-vendor-chunks.md
+++ b/.changeset/dashboard-vendor-chunks.md
@@ -1,0 +1,5 @@
+---
+'@tapflowio/relay': patch
+---
+
+Improve dashboard loading performance by splitting large application and vendor bundles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve dashboard loading performance by splitting large application and vendor bundles.
+
 ### Fixed
 
 - **A scrcpy server process error could take down every Android device the agent manages, not just the one session.** The scrcpy server process spawned for a real-device session had no error handler; an unhandled error on it (e.g. the server process failing to spawn, or a permission error on kill) crashed the whole android-agent process, ending every session it was managing. It's now logged instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve dashboard loading performance by splitting large application and vendor bundles.
+- Split stable dashboard vendor dependencies into smaller chunks to reduce maximum bundle size and improve cache reuse across releases.
 
 ### Fixed
 

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -27,17 +27,11 @@ export default defineConfig({
             return 'vendor-router'
           }
 
-          if (id.includes('/react-hook-form/') || id.includes('/@hookform/') || id.includes('/zod/')) {
-            return 'vendor-forms'
-          }
-
-          if (id.includes('/@radix-ui/') || id.includes('/lucide-react/') || id.includes('/sonner/')) {
-            return 'vendor-ui'
-          }
-
           if (id.includes('/@visx/') || id.includes('/d3-array/')) {
             return 'vendor-charts'
           }
+
+          return undefined
         },
       },
     },

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     outDir: 'dist',
     rollupOptions: {
       output: {
+        // Only split families the app shell already loads synchronously, plus charts.
+        // Grouping @radix-ui / react-hook-form here was measured and reverted: it turned
+        // lazy dialog and form code into modulepreloads, adding ~14 kB Brotli to first paint.
         manualChunks(id) {
           if (!id.includes('/node_modules/')) return undefined
 

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -14,6 +14,33 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('/node_modules/')) return undefined
+
+          if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/scheduler/')) {
+            return 'vendor-react'
+          }
+
+          if (id.includes('/react-router/') || id.includes('/react-router-dom/')) {
+            return 'vendor-router'
+          }
+
+          if (id.includes('/react-hook-form/') || id.includes('/@hookform/') || id.includes('/zod/')) {
+            return 'vendor-forms'
+          }
+
+          if (id.includes('/@radix-ui/') || id.includes('/lucide-react/') || id.includes('/sonner/')) {
+            return 'vendor-ui'
+          }
+
+          if (id.includes('/@visx/') || id.includes('/d3-array/')) {
+            return 'vendor-charts'
+          }
+        },
+      },
+    },
   },
   // ESM worker (tinyh264.worker imports tinyh264) — 'es' format so the worker chunk
   // can code-split its static imports. Default 'iife' breaks on code-split workers.

--- a/scripts/__tests__/dashboardFirstLoadBudget.test.mjs
+++ b/scripts/__tests__/dashboardFirstLoadBudget.test.mjs
@@ -1,0 +1,95 @@
+// Protect the metric #168 actually cares about: JavaScript fetched before first paint.
+//
+// Vite's large-chunk warning only watches individual raw chunks. The first vendor split looked
+// good by that signal while adding eager modulepreloads. Build the real dashboard output, read
+// index.html, and budget the precompressed Brotli bytes that the relay serves.
+import { beforeAll, describe, expect, it } from 'vitest'
+import { execFileSync } from 'child_process'
+import { existsSync, readFileSync, statSync } from 'fs'
+import { dirname, relative, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const DASHBOARD_DIST = resolve(ROOT, 'packages', 'dashboard', 'dist')
+const INDEX_HTML = resolve(DASHBOARD_DIST, 'index.html')
+const FIRST_LOAD_BROTLI_BUDGET = 155_000
+
+function buildDashboardDist() {
+  const env = { ...process.env, NODE_ENV: 'production' }
+  execFileSync('pnpm', ['--filter', '@tapflowio/protocol', 'build'], { cwd: ROOT, env, stdio: 'inherit' })
+  execFileSync('pnpm', ['--filter', '@tapflowio/dashboard', 'build'], { cwd: ROOT, env, stdio: 'inherit' })
+}
+
+function attributes(tag) {
+  const out = new Map()
+  const pattern = /([:\w-]+)\s*=\s*(['"])(.*?)\2/g
+  for (const match of tag.matchAll(pattern)) out.set(match[1].toLowerCase(), match[3])
+  return out
+}
+
+function distAssetPath(assetPath) {
+  const withoutOrigin = assetPath.replace(/^[a-z]+:\/\/[^/]+/i, '')
+  const withoutQuery = withoutOrigin.split(/[?#]/, 1)[0]
+  const relativeAsset = withoutQuery.replace(/^\/+/, '')
+  const resolved = resolve(DASHBOARD_DIST, relativeAsset)
+  if (relative(DASHBOARD_DIST, resolved).startsWith('..')) {
+    throw new Error(`First-load asset escapes dashboard dist: ${assetPath}`)
+  }
+  return resolved
+}
+
+function firstLoadJavascriptAssets(html) {
+  const assets = new Set()
+
+  for (const match of html.matchAll(/<script\b[^>]*>/gi)) {
+    const attrs = attributes(match[0])
+    const src = attrs.get('src')
+    if (src?.endsWith('.js')) assets.add(distAssetPath(src))
+  }
+
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const attrs = attributes(match[0])
+    const rel = attrs.get('rel')?.toLowerCase().split(/\s+/) ?? []
+    const href = attrs.get('href')
+    if (rel.includes('modulepreload') && href?.endsWith('.js')) assets.add(distAssetPath(href))
+  }
+
+  return [...assets].sort()
+}
+
+function firstLoadBrotliReport() {
+  if (!existsSync(INDEX_HTML)) {
+    throw new Error('packages/dashboard/dist/index.html is missing after dashboard build')
+  }
+
+  const assets = firstLoadJavascriptAssets(readFileSync(INDEX_HTML, 'utf8'))
+  if (assets.length === 0) throw new Error('No first-load JavaScript assets found in packages/dashboard/dist/index.html')
+
+  let total = 0
+  const lines = []
+  for (const asset of assets) {
+    const brotliAsset = `${asset}.br`
+    if (!existsSync(brotliAsset)) {
+      throw new Error(`Missing Brotli asset for first-load JavaScript: ${relative(ROOT, brotliAsset)}`)
+    }
+    const size = statSync(brotliAsset).size
+    total += size
+    lines.push(`- ${relative(ROOT, brotliAsset)}: ${size} B`)
+  }
+
+  return { total, details: lines.join('\n') }
+}
+
+describe('dashboard first-load JavaScript budget', () => {
+  beforeAll(() => {
+    buildDashboardDist()
+  }, 180_000)
+
+  it('keeps first-load Brotli JS below budget', () => {
+    const { total, details } = firstLoadBrotliReport()
+    expect(
+      total,
+      `First-load Brotli JS is ${total} B, budget is ${FIRST_LOAD_BROTLI_BUDGET} B.\n\nAssets:\n${details}`,
+    ).toBeLessThanOrEqual(FIRST_LOAD_BROTLI_BUDGET)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #168

This reduces the dashboard's largest production JavaScript bundle by splitting only the stable third-party dependency families that stay on the right loading path with Vite/Rollup `manualChunks`.

The dashboard already lazy-loads most routes, and the narrowed chunking keeps route/UI/form code lazy while moving stable app-shell and chart dependencies into reusable vendor chunks.

The final groups are:

- `vendor-react`
- `vendor-router`
- `vendor-charts`

Application code, lazy route chunks and the tinyh264 worker are left to the existing build behaviour rather than being forced into generic vendor chunks.

## Build result

Original base (`a61d9d5d1cb660bd166b3ef4efad7b6c4f97d20d`):

- largest JavaScript chunk: 541.99 kB
- first-load JavaScript: 541,990 B raw / 145,181 B Brotli
- Vite large-chunk warning: present
- JavaScript chunks: 20

Current narrowed solution:

- largest JavaScript chunk: 285.08 kB
- first-load JavaScript: 540,934 B raw / 147,099 B Brotli
- first-load Brotli delta vs base: +1,918 B (+1.32%)
- Vite large-chunk warning: absent
- JavaScript chunks: 23
- largest-chunk reduction vs base: 256.91 kB (~47.4%)

Significant final chunks included:

- application entry: ~285.08 kB
- `vendor-react`: ~217.28 kB
- `tinyh264.worker`: ~173.47 kB
- `QASession`: ~109.80 kB
- `vendor-charts`: ~77.25 kB
- `vendor-router`: ~38.58 kB
- `dialog`: ~25.16 kB
- `AppCenter`: ~14.89 kB
- `MacResources`: ~7.20 kB
- `tabs`: ~4.15 kB
- `alert-dialog`: ~3.75 kB

`vendor-charts` is emitted separately and is not modulepreloaded by `index.html`; it remains lazy and keeps `@visx` out of duplicated route chunks. `vendor-ui` and `vendor-forms` are intentionally not split because they made lazy UI/form code part of first load.

Generated filenames/hashes may vary between builds.

## Regression guard

Added `scripts/__tests__/dashboardFirstLoadBudget.test.mjs`, which builds the production dashboard, parses `packages/dashboard/dist/index.html`, collects the entry script plus `modulepreload` JavaScript assets, sums the `.br` files served by the relay, and enforces a 155,000 B first-load Brotli budget.

The guard passed at 147,099 B for the current solution. Temporarily restoring the earlier eager `vendor-ui` / `vendor-forms` split made it fail at 159,588 B, with those chunks listed as first-load assets.

## Validation

- `pnpm exec vitest run --config scripts/vitest.config.mjs scripts/__tests__/dashboardFirstLoadBudget.test.mjs`
- negative guard check against commit `252262bad79766fbffe52682a6c7c9eed57f73ee`'s `packages/dashboard/vite.config.ts`: failed as expected at 159,588 B / 155,000 B budget
- temporary base measurement against `a61d9d5d1cb660bd166b3ef4efad7b6c4f97d20d`'s `packages/dashboard/vite.config.ts`
- `pnpm test`
- `pnpm --filter @tapflowio/protocol build`
- `pnpm --filter @tapflowio/dashboard build`
- `pnpm --filter @tapflowio/dashboard test` (31 files / 310 tests passed)
- `pnpm --filter @tapflowio/dashboard typecheck`
- `pnpm --filter @tapflowio/dashboard lint`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @tapflowio/relay build`
- `pnpm changeset:check`
- `git diff --check`

The existing root lint still reports two warnings outside this change.

No router source was changed. Existing lazy route chunks continue to be emitted separately. The `tinyh264.worker` output remains isolated from dashboard `manualChunks`.

## Release notes

- added a patch changeset for `@tapflowio/relay`, which ships the dashboard
- updated the root `[Unreleased]` changelog

## Checklist

- [x] Tests passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved dashboard loading by splitting vendor dependencies into smaller, optimized chunks.
  * Organized React, routing, and charting libraries into dedicated bundles for more efficient loading.
  * Improved cache reuse across releases, reducing the amount of data downloaded after updates.
  * Added safeguards to help keep the dashboard’s initial load within its performance budget.

* **Changelog**
  * Documented the dashboard bundle and caching improvements in the upcoming release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->