### PR TITLE
feat(protocol): correlate device:boot and device:shutdown

### DIFF
--- a/.changeset/lifecycle-correlation.md
+++ b/.changeset/lifecycle-correlation.md
@@ -15,8 +15,16 @@ whole design — `device:ready`, `device:boot-error` and `device:shutdown-done` 
 request at all, so absence has a real and permanent meaning: *this frame is not the answer to anything*.
 
 Consumers correlate when the id is present and fall back to `sessionId` + type when it is not
-(`mcp-server`, `flow-runner`). That fallback is not compatibility slack that expires — it is what lets the
-relay's own replay and Android's mid-session stream failure keep reaching the surfaces that report them.
+(`mcp-server`, `flow-runner`). Precisely what that fallback carries is worth separating, because the two
+id-less cases arrive by different routes and only one of them is permanent:
+
+- **Android's mid-session `device:boot-error`** carries a `sessionId`, so it reaches a client waiter through
+  the fallback. There is no request behind it and never will be, so this half does not expire.
+- **An agent predating the echo** likewise, on either reply. This half is compatibility slack.
+- **The relay's `device:ready` replay** does *not* reach a client at all — it carries no `sessionId`, so the
+  comparison ahead of the fallback excludes it, which is the point of the "not satisfied by the replay" test
+  in both clients. It reaches the **dashboard**, and it gets there because `'sessionId' in msg` is false, not
+  because of anything the correlator or the fallback does.
 
 What correlation buys on this pair is narrower than the obvious claim, and review caught the first draft
 making the obvious one. It does **not** let two concurrent boots both resolve: the agents answer a

--- a/.changeset/lifecycle-correlation.md
+++ b/.changeset/lifecycle-correlation.md
@@ -1,0 +1,112 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': patch
+'@tapflowio/ios-agent': patch
+'@tapflowio/android-agent': patch
+'@tapflowio/mcp-server': patch
+'@tapflowio/flow-runner': patch
+---
+
+feat(protocol): correlate device:boot and device:shutdown, with an optional correlator
+
+The lifecycle pair joins the four already correlated by `requestId` (`screenshot`, `ui:tree`, `clipboard`, the
+app commands). It is the first one whose correlator is **optional on every reply**, and that difference is the
+whole design — `device:ready`, `device:boot-error` and `device:shutdown-done` all have producers that answer no
+request at all, so absence has a real and permanent meaning: *this frame is not the answer to anything*.
+
+Consumers correlate when the id is present and fall back to `sessionId` + type when it is not
+(`mcp-server`, `flow-runner`). That fallback is not compatibility slack that expires — it is what lets the
+relay's own replay and Android's mid-session stream failure keep reaching the surfaces that report them.
+
+What correlation buys on this pair is narrower than the obvious claim, and review caught the first draft
+making the obvious one. It does **not** let two concurrent boots both resolve: the agents answer a
+superseded boot with nothing at all (`bootSeq` returns silently at every checkpoint), so one of two
+overlapping boots times out either way. Both clients' `dispatch` resolves the first waiter whose predicate
+matches and then stops — so on `sessionId` + type alone, that single reply went to the boot registered
+**first**, the superseded one, and the boot that actually happened was reported as a failure. The
+correlator sends the reply to the request it answers. Same one timeout, correct attribution.
+
+## What the design review changed
+
+The first draft made `DeviceReady.sessionId` required and had the relay stamp its replay, then argued the pair
+faced a forced choice: correlate strictly and break every agent predating the field, or keep a fallback and
+let a replayed ready satisfy an in-flight boot. Measured against a real `RelayServer`, that choice was
+manufactured by the draft itself. **The discriminator today is that the replay carries no `sessionId`**, and
+both boot waiters already depend on it — so requiring and stamping it is what deletes the working guard.
+Dropped from this change; `sessionId` on `device:ready` stays optional, and closing #516's deferral is its own
+later slice, which must carry a test pinning the *value* stamped. There is none: with the stamp mutated to
+`session.deviceId` — a plausible slip on a line whose payload reads `{ deviceId: session.deviceId }` — the
+relay's 591 tests, the dashboard's 317 and the entire static suite still pass.
+
+The review also found the producer inventory wrong. `AndroidAgent.restartVideoStream` sends
+`device:boot-error` for a video stream that died mid-session and failed to restart, with no `device:boot`
+anywhere behind it. So that message qualifies for an optional correlator **on its own merits**, and the
+consumer that reads it — `DeviceViewer`, the only surface reporting a dead stream — must not gate on the
+correlator at all, or #426's symptom comes back.
+
+## Optional means tests are the entire enforcement
+
+`<Pair>ReplyBody` cannot be built for a field an object may omit: `Omit<T,'sessionId'|'requestId'>` is
+satisfied by an object with no correlator, so the excess-property trick that catches a freshly minted id has
+nothing to bite on. And `scripts/__tests__/correlatedRequestsGated.test.mjs` derives its set from *required*
+declarations, so it does not see this pair — including the position that matters most: **the relay is itself a
+producer of `device:boot-error`**, answering a boot it cannot hand to an agent. An uncorrelated diagnosis
+there is read as unsolicited and discarded, and the caller waits out its deadline instead of failing. That
+exact defect shipped twice from agent code (`open-url:error`, then `clipboard:error` a slice later); here it
+sits where no check can reach, so a relay test holds it.
+
+Every echo, prohibition and fallback added here was verified by mutation — 23 of them, each failing only the
+tests that claim it: 5 on the relay, 7 across the two agents, 5 on the dashboard, 6 across the two clients.
+Two are worth naming. A *strict* correlator gate on `device:boot-error` and a mere *presence* check fail
+**different** tests, which is why both prohibition cases exist. And replacing an echoed id with a freshly
+minted one fails the echo test **and** the absence test — a shape that, one slice earlier, only the first of
+those caught.
+
+Those 23 shared a blind spot, and review found it: they all probed what the gate does **with** an id, so
+nothing held how ids enter or leave `bootIdsRef`. Four mutations survived the whole suite. The sharpest is
+`bootIdsRef.current.clear()` added to the `device:booting` branch — invited by the comment above it, since
+that is where every other per-cycle record is dropped, and fatal because both agents send `device:booting`
+*before* the ready answering the same boot. Every real ready is then rejected while `setDeviceReady(true)`
+has already run: spinner cleared, device apparently healthy, app never installed, on the primary
+manual-testing path. The other three: the rebind boot's id never registered (so #426's recovery keeps the
+picture and loses the controls), the `session:joined` cross-cycle clear removed, and `mcp-server`'s
+`shutdownDevice` correlator left off the wire — where `toMatchObject` ignored the absent key and the
+mismatch test still passed against a hardcoded foreign id. All four are pinned now, each by one test.
+
+## `DeviceBoot.requestId` is required, and 42 test fixtures said nothing about it
+
+The request side is asymmetric on purpose, and for a mechanical reason rather than a stylistic one: a
+request passes *through* the relay, so one door gates and logs every sender at once, while a reply does not
+— the relay forwards it with `JSON.stringify` without inspecting it. Absence also has no legitimate meaning
+on a boot: nothing originates one but a browser. So `device:boot` is the pair's one required correlator,
+which is what puts it inside `correlatedRequestsGated` and makes the door gate reachable. `device:shutdown`
+stays optional because the relay sends that one itself, from its idle timer.
+
+Promoting it produced no compile error, and the reason is worth stating precisely, because the convenient
+version of it is false. It is **not** that the compiler cannot see the request side: all four `device:boot`
+senders go through a sink typed `BrowserToRelay` (`DeviceViewer.tsx:38`, `mcp-server/src/client.ts:182`,
+`flow-runner/src/RelayClient.ts:126`), so every one of them would have errored. They did not error because
+the earlier hunks of this same commit had already added the ids. The request side is exactly where the
+compiler works.
+
+What it produced instead was **two hung agent suites**. 42 fixtures across `IOSAgent.test.ts` and
+`AndroidAgent.test.ts` send `device:boot` through a real `RelayServer`; the door now drops them, and each
+test waited for a `device:ready` that never came. None was a type error, and typechecking the test folders
+would not have found them: those literals sit inside `JSON.stringify({ … })` at an untyped `ws.send`, so
+there is no annotation for a compiler to check. Three *documented* recipes had the same shape and were
+updated too — `ios-agent/AGENTS.md`, `test-utils/src/socket.ts` and `test-utils/AGENTS.md` — because that
+first one is the file the 42 were copied from, so leaving it would hand the next contributor the same
+30-second mystery. The dashboard has a rule against untyped injected fixtures ("not `as never`, not a local
+shape") and the agent packages have no equivalent; worth one, and out of scope here.
+
+`case 'device:boot': case 'device:shutdown':` was one fall-through clause and is now two. Not cosmetic: the
+correlator on `device:shutdown` cannot be required, because the relay originates that message from its idle
+timer with no browser behind it — so a gate written into the shared body would have stopped the dashboard's
+four senders and the relay's own from reaching the agent, silently, in the one direction nothing replies to.
+
+`DeviceViewer` correlates `device:ready` only past the line that clears the spinner, which newly rejects a
+straggler ready from an earlier boot cycle — it used to release the current rebind and install on top of an
+install already in flight. It does **not** close the duplicate-install-on-re-join case that branch's comment
+describes: the replayed ready carries no id, so it is still accepted, and it has to be while an agent
+predating the echo answers the same way. Separating those two needs the replay to be identifiable on its own,
+which is the deferred `sessionId` tightening.

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -818,6 +818,10 @@ export class AndroidAgent implements DeviceAgent {
       await this.startVideoStream(state, streamWs)
     } catch (err) {
       logger.error(`scrcpy restart failed: ${err}`)
+      // **No `requestId`, and that is the contract rather than an omission.** This is the unsolicited
+      // producer of `device:boot-error`: a stream that died mid-session and failed to come back, with
+      // no `device:boot` behind it. It is why the correlator on this message is optional, and why a
+      // consumer that gates on the correlator drops the only report a dead stream gets.
       this.sendMsg({
         type: 'device:boot-error',
         sessionId: state.sessionId,
@@ -845,7 +849,10 @@ export class AndroidAgent implements DeviceAgent {
     return streamWs
   }
 
-  private async handleDeviceBoot(sessionId: string, avdId: string, tier?: { secureContext: boolean; external: boolean }): Promise<void> {
+  // `requestId` is a parameter, never a field on `state`: `bootSeq` exists because two boots overlap,
+  // and a correlator hoisted onto shared state would answer the first request with the second's id.
+  // Optional because the relay's idle timer boots nothing — but every *browser* boot carries one.
+  private async handleDeviceBoot(sessionId: string, avdId: string, tier?: { secureContext: boolean; external: boolean }, requestId?: string): Promise<void> {
     const state = this.deviceStates.get(sessionId)
     if (!state || !this.ws) return
 
@@ -906,16 +913,16 @@ export class AndroidAgent implements DeviceAgent {
         },
       })
       state.booted = true
-      this.sendMsg({ type: 'device:ready', sessionId, payload: { deviceId: avdId } })
+      this.sendMsg({ type: 'device:ready', sessionId, requestId, payload: { deviceId: avdId } })
     } catch (e) {
       if (seq !== state.bootSeq) return
       const message = e instanceof Error ? e.message : String(e)
       logger.error('boot failed:', message)
-      this.sendMsg({ type: 'device:boot-error', sessionId, message })
+      this.sendMsg({ type: 'device:boot-error', sessionId, requestId, message })
     }
   }
 
-  private async handleDeviceShutdown(sessionId: string, avdId: string): Promise<void> {
+  private async handleDeviceShutdown(sessionId: string, avdId: string, requestId?: string): Promise<void> {
     const state = this.deviceStates.get(sessionId)
     if (!state) return
 
@@ -933,6 +940,7 @@ export class AndroidAgent implements DeviceAgent {
     this.sendMsg({
       type: 'device:shutdown-done',
       sessionId,
+      requestId,
       payload: { deviceId: avdId },
     })
   }
@@ -1002,13 +1010,13 @@ export class AndroidAgent implements DeviceAgent {
     switch (msg.type) {
       case 'device:boot': {
         const { deviceId, secureContext, external } = msg.payload as { deviceId: string; secureContext?: boolean; external?: boolean }
-        this.handleDeviceBoot(msg.sessionId, deviceId, { secureContext: !!secureContext, external: !!external })
+        this.handleDeviceBoot(msg.sessionId, deviceId, { secureContext: !!secureContext, external: !!external }, msg.requestId)
           .catch((e) => logger.error('handleDeviceBoot failed:', e))
         break
       }
       case 'device:shutdown': {
         const { deviceId } = msg.payload as { deviceId: string }
-        this.handleDeviceShutdown(msg.sessionId, deviceId)
+        this.handleDeviceShutdown(msg.sessionId, deviceId, msg.requestId)
           .catch((e) => logger.error('handleDeviceShutdown failed:', e))
         break
       }

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -273,6 +273,7 @@ describe('AndroidAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-1',
         sessionId: agent.sessionId,
         payload: { deviceId: 'avd:Pixel_8_API_34' },
       }))
@@ -283,6 +284,87 @@ describe('AndroidAgent', () => {
 
       agent.disconnect()
       browser.close()
+    })
+
+    // ── L5b′: the lifecycle pair correlates, and the correlator is optional ────────────────────
+    //
+    // Optional means the compiler enforces nothing — `<Pair>ReplyBody` cannot be built for a field an
+    // object is allowed to omit — and `correlatedRequestsGated` derives only required declarations, so
+    // it does not see this pair either. These tests are the entire enforcement of the echo here.
+    describe('lifecycle replies echo the boot/shutdown correlator', () => {
+      async function joined(adb: AdbWrapper) {
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = new WebSocket(`ws://localhost:${port}`)
+        await waitForOpen(browser)
+        browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+        await waitForType(browser, 'session:joined')
+        return { agent, browser }
+      }
+
+      it('device:ready carries the requestId of the boot it answers', async () => {
+        const { agent, browser } = await joined(mockAdb(false))
+
+        const ready = waitForType(browser, 'device:ready')
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-1',
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        expect((await ready)['requestId']).toBe('boot-1')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('device:boot-error carries the requestId of the boot it answers', async () => {
+        // The failure exit is what a caller actually waits on: an uncorrelatable diagnosis is
+        // discarded by a correlating consumer, so the boot fails by deadline instead of by error.
+        const adb = mockAdb(false)
+        const { agent, browser } = await joined(adb)
+        // Mocked **after** the join: `connect()` enumerates devices through this same call, so failing
+        // it earlier takes the registration down and never reaches a boot at all.
+        ;(adb.listDevices as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('adb exploded'))
+
+        const err = waitForType(browser, 'device:boot-error')
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-2',
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        const msg = await err
+        expect(msg['requestId']).toBe('boot-2')
+        expect(msg['message']).toContain('adb exploded')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('device:shutdown-done carries the requestId of the shutdown it answers', async () => {
+        const { agent, browser } = await joined(mockAdb(true))
+
+        const done = waitForType(browser, 'device:shutdown-done')
+        browser.send(JSON.stringify({
+          type: 'device:shutdown', sessionId: agent.sessionId, requestId: 'down-1',
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        expect((await done)['requestId']).toBe('down-1')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('answers a correlator-less request without inventing one', async () => {
+        // The relay originates `device:shutdown` from its idle timer with no id, so this is a live
+        // wire shape. A minted id would be worse than none: the consumer's fallback accepts an absent
+        // correlator and rejects a mismatched one, so inventing one turns a reply that lands today
+        // into one that is silently dropped.
+        const { agent, browser } = await joined(mockAdb(true))
+
+        const done = waitForType(browser, 'device:shutdown-done')
+        browser.send(JSON.stringify({
+          type: 'device:shutdown', sessionId: agent.sessionId,
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        expect((await done)['requestId']).toBeUndefined()
+
+        agent.disconnect(); browser.close()
+      })
     })
 
     it('sends session:chrome with buttons (no framePng)', async () => {
@@ -299,6 +381,7 @@ describe('AndroidAgent', () => {
       const chromePromise = waitForType(browser, 'session:chrome')
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-2',
         sessionId: agent.sessionId,
         payload: { deviceId: 'avd:Pixel_8_API_34' },
       }))
@@ -325,8 +408,8 @@ describe('AndroidAgent', () => {
       await waitForType(browser, 'session:joined')
 
       // Send two boot requests rapidly
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'avd:Pixel_8_API_34' } }))
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'avd:Pixel_8_API_34' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-3', sessionId: agent.sessionId, payload: { deviceId: 'avd:Pixel_8_API_34' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-4', sessionId: agent.sessionId, payload: { deviceId: 'avd:Pixel_8_API_34' } }))
 
       // Should still get exactly one device:ready eventually
       const ready = await waitForType(browser, 'device:ready')
@@ -350,6 +433,7 @@ describe('AndroidAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-5',
         sessionId: agent.sessionId,
         payload: { deviceId: 'avd:Pixel_8_API_34' },
       }))
@@ -454,6 +538,7 @@ describe('AndroidAgent', () => {
 
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-6',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -467,6 +552,7 @@ describe('AndroidAgent', () => {
 
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-7',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -485,6 +571,7 @@ describe('AndroidAgent', () => {
 
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-8',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -502,6 +589,7 @@ describe('AndroidAgent', () => {
       it('marks codec=H.264 + per-AU keyframe so the relay stays keyframe-aware', async () => {
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-9',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -533,6 +621,7 @@ describe('AndroidAgent', () => {
       it('resets the scrcpy video encoder to force an on-demand IDR', async () => {
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-10',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -562,6 +651,7 @@ describe('AndroidAgent', () => {
       beforeEach(async () => {
         browser.send(JSON.stringify({
           type: 'device:boot',
+          requestId: 'rq-fix-11',
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34' },
         }))
@@ -591,6 +681,40 @@ describe('AndroidAgent', () => {
         await internals(agent).restartVideoStream(state)
 
         expect(state.restarting).toBe(false)
+      })
+
+      // **This is why the correlator on `device:boot-error` is optional at all.** The message below
+      // answers no request: a stream died mid-session and failed to come back, and there is no
+      // `device:boot` anywhere behind it to take an id from. Everything downstream follows from that —
+      // the declaration cannot be required, `correlatedRequestsGated` cannot cover the pair, and
+      // `DeviceViewer` must not gate this branch on a correlator, since it is the only surface that
+      // reports a dead stream. A boot carrying an id happens first here on purpose: that is the state
+      // in which an implementation reaching for "the session's current requestId" would look correct.
+      it('sends the unsolicited boot-error with no correlator, even after a correlated boot', async () => {
+        vi.useFakeTimers()
+
+        const reReady = waitForType(browser, 'device:ready')
+        browser.send(JSON.stringify({
+          type: 'device:boot',
+          sessionId: agent.sessionId,
+          requestId: 'boot-with-id',
+          payload: { deviceId: 'avd:Pixel_8_API_34' },
+        }))
+        await vi.runAllTimersAsync()
+        expect((await reReady)['requestId']).toBe('boot-with-id')
+
+        scrcpyStartError = new Error('encoder stall')
+        const state = getState()
+        state.restarting = true
+
+        const bootErrPromise = waitForType(browser, 'device:boot-error')
+        const restartPromise = internals(agent).restartVideoStream(state)
+        await vi.runAllTimersAsync()
+        await restartPromise
+
+        const err = await bootErrPromise
+        expect(err['message']).toBe('scrcpy failed to restart')
+        expect(err['requestId']).toBeUndefined()
       })
 
       it('sends device:boot-error and resets flag when startVideoStream throws', async () => {
@@ -703,6 +827,7 @@ describe('AndroidAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-12',
         sessionId: agent.sessionId,
         payload: { deviceId: 'avd:Pixel_8_API_34' },
       }))
@@ -1257,6 +1382,7 @@ describe('AndroidAgent', () => {
       await waitForType(browser, 'session:joined')
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-13',
         sessionId: agent.sessionId,
         payload: { deviceId: 'avd:Pixel_8_API_34' },
       }))

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -63,6 +63,38 @@ out to be a real bug hiding inside a *handled* type (`error`, whose meaning was 
 **Do not branch on a message's `message` field.** It is prose the producer owns. `error` carries a closed
 `reason`; branch on that, exhaustively.
 
+### The lifecycle replies are correlated **selectively**, and the exceptions are the point
+
+`DeviceViewer` mints a `requestId` for every `device:boot` it sends and gates on it — but not uniformly,
+and the disposition table above cannot show the difference. Three rules, each holding a defect shut:
+
+- **`device:boot-error` is never correlated.** `AndroidAgent.restartVideoStream` sends it for a stream
+  that died mid-session, with no `device:boot` behind it and so no id it could carry, and this branch is
+  the only surface that reports it. Gate it and a dead stream becomes a picture that has quietly stopped
+  updating — #426's symptom.
+- **`setDeviceReady(true)` runs before the gate.** The relay replays a cached `device:ready` to a
+  re-joining viewer as `{ type, payload }` — no `sessionId`, no correlator — and clearing the spinner is
+  what that replay is *for* (#440).
+- **Everything else on `device:ready` is gated, with absent accepted.** A mismatched id is rejected; an
+  absent one is not, because both the replay and an agent predating the echo arrive that way — and while
+  the correlator is optional those two are indistinguishable. So what this newly catches is a straggler
+  from an earlier boot cycle releasing the current rebind, and *not* the replayed ready firing a duplicate
+  install, which stays as it was.
+
+And a fourth rule, about the set rather than the gate — **`bootIdsRef` is cleared on `session:joined` and
+nowhere else.** Not on `device:booting`, even though that branch is where every other per-cycle record is
+dropped and its comment says so: both agents send `device:booting` *before* the `device:ready` answering the
+same boot, so a boot id has to span it. Clearing it there rejects every real ready, and the failure is quiet
+in the worst way — the spinner clears, the device looks healthy, and the app is never installed. That one
+was found by review after the first three were already pinned: the tests held what the gate did **with** an
+id and nothing held how ids entered or left the set.
+
+Getting any of the three the other way round passes typecheck and most of the suite:
+`src/__tests__/DeviceViewer.lifecycleCorrelation.test.tsx` is what fails. Nothing else can — the
+correlator on these replies is optional, so neither the compiler nor
+`scripts/__tests__/correlatedRequestsGated.test.mjs` sees this pair at all. Background:
+「Lifecycle correlation」 in [protocol/AGENTS.md](../protocol/AGENTS.md).
+
 ### `input:error` is shown per input, and there is no session-level input state
 
 A failed input surfaces as a toast keyed on the wire `reason` (`lib/inputErrorNotice.ts`), or is shown

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -86,6 +86,10 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
   // What the agent on the other end implements. Absent ⇒ an agent predating the capability,
   // so the viewer degrades on purpose rather than inferring anything from a timeout.
   const [agentCapabilities, setAgentCapabilities] = useState<string[]>([]);
+  // In-flight `device:boot` ids for this mount. A Set, for the same reason `rebindRef.pending` is a
+  // counter: a crash-looping agent issues several boots and each gets its own reply. Cleared on
+  // `session:joined` and nowhere else — see the `device:booting` branch for why not there.
+  const bootIdsRef = useRef<Set<string>>(new Set());
   // Deeplinks this viewer asked for. A reply does not go to whoever asked — the relay forwards it to
   // whichever socket holds the session now — so before `open-url` carried a `requestId` this viewer
   // toasted "Deeplink opened" for an `mcp-server` deeplink it knew nothing about.
@@ -160,7 +164,12 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       // re-erase the device the user is currently looking at — with no click involved (#439).
       const reset = resetSentRef.current ? 'app-only' : resetMode;
       resetSentRef.current = true;
-      sendRef.current({ type: 'device:boot', sessionId, payload: { deviceId, resetMode: reset, acceptH264: canDecodeH264(), secureContext: window.isSecureContext } });
+      // Cleared with `rebindRef` just above and for the same reason: an earlier cycle's boot will
+      // never be answered now, and keeping its id would let a straggler release this cycle's rebind.
+      bootIdsRef.current.clear();
+      const bootId = newRequestId();
+      bootIdsRef.current.add(bootId);
+      sendRef.current({ type: 'device:boot', sessionId, requestId: bootId, payload: { deviceId, resetMode: reset, acceptH264: canDecodeH264(), secureContext: window.isSecureContext } });
     }
     if (msg.type === 'session:agent-away') {
       // Everything on screen describes an agent that is no longer there. Drop the frame so the
@@ -207,13 +216,21 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       // only because a rebind cannot precede a join on the same mount — and would silently become
       // a wipe the day that stops holding.
       resetSentRef.current = true;
-      sendRef.current({ type: 'device:boot', sessionId, payload: { deviceId, resetMode: 'app-only', acceptH264: canDecodeH264(), secureContext: window.isSecureContext } });
+      const rebootId = newRequestId();
+      bootIdsRef.current.add(rebootId);
+      sendRef.current({ type: 'device:boot', sessionId, requestId: rebootId, payload: { deviceId, resetMode: 'app-only', acceptH264: canDecodeH264(), secureContext: window.isSecureContext } });
       // Only when the status card has not been saying it already — otherwise the toast lands at the
       // exact moment that message is replaced by the reconnect, saying the same thing twice.
       if (!wasAnnounced) toast.info('The agent restarted — reconnecting to the device.');
       return;
     }
     if (msg.type === 'device:boot-error') {
+      // **Deliberately uncorrelated, and this is the one prohibition in the pair.** Android's
+      // `restartVideoStream` sends this message for a stream that died mid-session, with no
+      // `device:boot` behind it and so no id it could ever carry. This branch is the only surface that
+      // reports it. Gating it on `bootIdsRef` would turn a dead stream back into a picture that has
+      // simply stopped updating — the symptom #426 was opened about.
+      //
       // Joining a session whose agent is away answers `session:joined`, and the branch above sends
       // `device:boot` on the strength of it — which the relay refuses with `agent offline`. The
       // waiting state already says what is happening, and recording a boot failure on top of it
@@ -286,10 +303,32 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
       // install the same build, so the first reply clearing `installing` is imprecise rather than wrong.
       appInstallIdsRef.current.clear();
       appLaunchIdsRef.current.clear();
+      // **`bootIdsRef` is deliberately not cleared here, and it is the one id set that must not be.**
+      // The reasoning above is about records outliving their cycle, which invites adding it — but a boot
+      // id has to *span* this message: both agents send `device:booting` before the `device:ready` that
+      // answers the same boot (`IOSAgent.ts:560` → `:639`, `AndroidAgent.ts:863` → `:916`). Clearing it
+      // here rejects every real ready, and the failure is quiet in the worst way: `setDeviceReady(true)`
+      // still runs, so the spinner clears and the device looks healthy while the app is never installed.
+      // Pinned by the "agent's real boot sequence" case in DeviceViewer.lifecycleCorrelation.test.tsx.
       setChrome(null); // causes active viewer to unmount → cleanup
     }
     if (msg.type === 'device:ready') {
+      // **Before the correlator, deliberately.** The relay replays this message from cache to a
+      // re-joining viewer and sends it with the key absent, so it answers no boot of this mount — and
+      // clearing the spinner is exactly what it is for (#440). Gating this line on the correlator would
+      // reinstate the defect the replay exists to prevent.
       setDeviceReady(true);
+      // Everything below is a reaction to *our* boot, so it is gated. Absent is accepted, so what this
+      // rejects is exactly one thing: a ready **carrying** an id that is not one this mount is waiting
+      // for. That is a straggler from an earlier boot cycle, which would otherwise release the current
+      // rebind and install on top of an install already in flight.
+      //
+      // It does **not** cover the case the comment two branches up describes. The relay's replayed ready
+      // has no id, so it lands here as before — and it has to, because that is also how an agent
+      // predating the echo answers, and the two are indistinguishable while the correlator is optional.
+      // Telling them apart needs the replay to be identifiable in its own right, which is the deferred
+      // `sessionId` tightening; until then that case is unchanged rather than fixed.
+      if (msg.requestId !== undefined && !bootIdsRef.current.delete(msg.requestId)) return;
       if (rebindRef.current.pending > 0) {
         const { appInstalled } = rebindRef.current;
         rebindRef.current = { pending: rebindRef.current.pending - 1, appInstalled };

--- a/packages/dashboard/hooks/useAgentSession.ts
+++ b/packages/dashboard/hooks/useAgentSession.ts
@@ -31,6 +31,13 @@ export function useAgentSession(os: string) {
     activeSessionRef.current = { sessionId: activeSessionId, deviceId }
   }, [activeSessionId, deviceId])
 
+  // These three `device:shutdown` sends carry **no `requestId`, on purpose.** Nothing in this hook reads
+  // `device:shutdown-done` — the correlator would be minted for a reply no one is waiting for, and one of
+  // the three fires from unmount teardown, where there is nothing left to resolve. That is safe
+  // permanently rather than for now: the relay originates this message itself, so its correlator is
+  // optional by contract and can never be gated at the door. A consumer that later wants to correlate a
+  // shutdown adds the id at the sender it cares about. See 「Lifecycle correlation」 in protocol/AGENTS.md.
+  //
   // unmount cleanup — runs before useRelay's ws.close
   useEffect(() => {
     return () => {

--- a/packages/dashboard/src/__tests__/DeviceViewer.lifecycleCorrelation.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.lifecycleCorrelation.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import type { DeviceBoot, BrowserToRelay } from '@tapflowio/protocol'
+import type { BrowserInbound } from '@/lib/types'
+
+// L5b′. The viewer mints a correlator for every `device:boot` it sends, and then treats the three
+// lifecycle replies **differently from each other** — which is the whole content of this file.
+//
+// `device:ready` is correlated, but with a fallback and only past the first line: an absent correlator
+// is accepted, because the relay replays a cached ready to a re-joining viewer and that replay is what
+// clears "Starting device…" (#440). `device:boot-error` is not correlated at all, because Android sends
+// it for a stream that died mid-session with no boot behind it, and this viewer is the only surface
+// that reports it. Getting either of those the other way round reinstates a defect that has already
+// shipped: a tab stuck on "Starting device…", or a picture that has simply stopped updating (#426).
+const send = vi.fn<(msg: BrowserToRelay) => void>()
+let deliver: ((msg: BrowserInbound) => void) | null = null
+
+vi.mock('@/hooks/useRelay', () => ({
+  useRelay: (onMessage: (msg: BrowserInbound) => void) => {
+    deliver = onMessage
+    return { send, connected: true }
+  },
+}))
+vi.mock('@/hooks/usePerfMode', () => ({ usePerfMode: () => ({ perfMode: false, visible: false }) }))
+vi.mock('@/hooks/useAudioPlayback', () => ({ useAudioPlayback: () => ({ pushFrame: vi.fn() }) }))
+vi.mock('@/lib/decoders/pickDecoder', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/decoders/pickDecoder')>()),
+  canDecodeH264: () => false,
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+
+const { DeviceViewer } = await import('@/components/DeviceViewer')
+
+const boots = () =>
+  send.mock.calls.map(([m]) => m).filter((m): m is DeviceBoot => m.type === 'device:boot')
+
+const installs = () => send.mock.calls.filter(([m]) => m.type === 'app:install')
+
+/** The correlator on the most recent boot. Read back rather than invented — a made-up id would only
+ *  prove the gate rejects made-up ids, which is a different claim. */
+const lastBootId = (): string => {
+  const id = boots().at(-1)?.requestId
+  expect(id, 'the viewer sent a device:boot with no correlator').toBeTruthy()
+  return id!
+}
+
+const join = () => act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+
+describe('DeviceViewer correlates the lifecycle replies, selectively', () => {
+  beforeEach(() => { send.mockClear(); deliver = null })
+
+  it('mints a correlator on the boot it sends after joining', () => {
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+    join()
+
+    expect(boots()).toHaveLength(1)
+    expect(typeof boots()[0]!.requestId).toBe('string')
+    expect(boots()[0]!.requestId).not.toBe('')
+  })
+
+  it('mints a distinct correlator on the re-boot after an agent restart', () => {
+    // The two boots are different requests and a rebind can leave the first still in flight, so
+    // sharing one id would make the second's reply satisfy the first's record.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+    join()
+    act(() => { deliver!({ type: 'session:rebound', sessionId: 's1', capabilities: [] }) })
+
+    const ids = boots().map((b) => b.requestId)
+    expect(ids).toHaveLength(2)
+    expect(ids[0]).not.toBe(ids[1])
+  })
+
+  it('clears "Starting device…" on a replayed ready that carries no session and no correlator', () => {
+    // The relay's replay frame is `{ type, payload }` — no `sessionId`, no `requestId`. This is the
+    // defect the replay exists to prevent (#440), so gating the spinner on the correlator would put it
+    // straight back, and nothing else in the product would report it.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+    join()
+    expect(screen.getByText('Starting device…')).toBeTruthy()
+
+    act(() => { deliver!({ type: 'device:ready', payload: { deviceId: 'dev-1' } }) })
+
+    expect(screen.queryByText('Starting device…')).toBeNull()
+  })
+
+  it('reports an uncorrelated boot-error, because that is the only kind Android sends unsolicited', () => {
+    // `AndroidAgent.restartVideoStream` sends this for a stream that died mid-session. There is no
+    // `device:boot` behind it, so it can never carry an id — and this branch is the only surface that
+    // reports it. Gate it on `bootIdsRef` and a dead stream becomes a picture that has stopped
+    // updating with nothing said, which is what #426 was opened about.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+    join()
+
+    act(() => { deliver!({ type: 'device:boot-error', sessionId: 's1', message: 'scrcpy failed to restart' }) })
+
+    expect(screen.getByText(/Boot failed: scrcpy failed to restart/)).toBeTruthy()
+  })
+
+  it('reports a boot-error whose correlator matches nothing this viewer sent', () => {
+    // The same prohibition stated so that it fails under a *correlating* gate rather than only under a
+    // presence check: a gate keyed on `bootIdsRef` would drop this and the case above alike.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" />)
+    join()
+
+    act(() => {
+      deliver!({ type: 'device:boot-error', sessionId: 's1', requestId: 'not-ours', message: 'agent offline' })
+    })
+
+    expect(screen.getByText(/Boot failed: agent offline/)).toBeTruthy()
+  })
+
+  it('acts on a ready that answers its own boot', () => {
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+
+    act(() => {
+      deliver!({ type: 'device:ready', sessionId: 's1', requestId: lastBootId(), payload: { deviceId: 'dev-1' } })
+    })
+
+    expect(installs()).toHaveLength(1)
+  })
+
+  it('installs after the agent\'s real boot sequence — booting, then the correlated ready', () => {
+    // **The production ordering, which no other test here exercises.** Both agents send `device:booting`
+    // before the `device:ready` that answers the same boot (`IOSAgent.ts:560` → `:639`,
+    // `AndroidAgent.ts:863` → `:916`), so the boot id has to survive that message. Adding
+    // `bootIdsRef.current.clear()` to that branch — which the comment above it invites, since it is where
+    // every other per-cycle record is dropped — rejects every real ready. And the failure is silent:
+    // `setDeviceReady(true)` runs ahead of the gate, so the spinner clears and the device looks healthy
+    // while the app is never installed and the Launch control never appears.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+    const id = lastBootId()
+
+    act(() => { deliver!({ type: 'device:booting', sessionId: 's1' }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', requestId: id, payload: { deviceId: 'dev-1' } }) })
+
+    expect(installs()).toHaveLength(1)
+  })
+
+  it('releases the rebind on the re-boot\'s own reply', () => {
+    // The sibling test compares the two minted ids by reading `send`, so it cannot see whether the second
+    // was ever *recorded*. Drop `bootIdsRef.current.add(rebootId)` and every assertion there still passes
+    // while #426's recovery stops working: the new agent's ready is rejected as a straggler,
+    // `rebindRef.pending` never falls, and the viewer keeps the picture but loses its controls.
+    //
+    // Staged as a rebind landing mid-install, so `appInstalled` is false and the reply falls through to a
+    // reinstall — an observable second `app:install` rather than a flag with no surface here.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+    act(() => {
+      deliver!({ type: 'device:ready', sessionId: 's1', requestId: lastBootId(), payload: { deviceId: 'dev-1' } })
+    })
+    expect(installs()).toHaveLength(1)
+
+    act(() => { deliver!({ type: 'session:rebound', sessionId: 's1', capabilities: [] }) })
+    act(() => {
+      deliver!({ type: 'device:ready', sessionId: 's1', requestId: lastBootId(), payload: { deviceId: 'dev-1' } })
+    })
+
+    expect(installs()).toHaveLength(2)
+  })
+
+  it('stops accepting an earlier cycle\'s ready once a new join has started one', () => {
+    // `session:joined` arrives again on every socket reconnect, and it clears the set for the same reason
+    // it resets `rebindRef`: a boot from the cycle that just ended will never be answered now. Without
+    // the clear, that cycle's straggling ready passes the gate after the new join and fires a second
+    // `app:install` on top of one already in flight.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+    const stale = lastBootId()
+
+    join() // a reconnect: same mount, new cycle, new boot
+    expect(lastBootId()).not.toBe(stale)
+
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', requestId: stale, payload: { deviceId: 'dev-1' } }) })
+
+    expect(installs()).toHaveLength(0)
+  })
+
+  it('ignores a ready carrying a correlator from some other boot', () => {
+    // A straggler from an earlier boot cycle: without this it releases the current rebind and installs
+    // on top of an install already in flight. Only a *mismatched* id is rejected — absent is still
+    // accepted (the test below), so the relay's replayed ready is **not** covered by this and the
+    // duplicate-install-on-re-join case the `device:booting` comment describes is unchanged.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+
+    act(() => {
+      deliver!({ type: 'device:ready', sessionId: 's1', requestId: 'stale-cycle', payload: { deviceId: 'dev-1' } })
+    })
+
+    expect(installs()).toHaveLength(0)
+    // The spinner still clears: that line sits ahead of the correlator on purpose, so a stale ready is
+    // ignored without leaving the tester staring at a device that is in fact up.
+    expect(screen.queryByText('Starting device…')).toBeNull()
+  })
+
+  it('accepts a ready with no correlator at all, so an agent predating the echo still works', () => {
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' } }) })
+
+    expect(installs()).toHaveLength(1)
+  })
+
+  it('answers only once when the same boot is answered twice', () => {
+    // The correlator is consumed by the reply that matches it — `delete`, not `has` — so a duplicate
+    // carrying the same id is rejected by the second lookup. Distinct from the replay case: that one is
+    // id-less and still gets through, which the two tests above this one hold in place.
+    render(<DeviceViewer sessionId="s1" deviceId="dev-1" buildId={7} />)
+    join()
+    const id = lastBootId()
+
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', requestId: id, payload: { deviceId: 'dev-1' } }) })
+    act(() => { deliver!({ type: 'device:ready', sessionId: 's1', requestId: id, payload: { deviceId: 'dev-1' } }) })
+
+    expect(installs()).toHaveLength(1)
+  })
+})

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -37,6 +37,27 @@ export interface AgentSession {
  *  Outbound is `BrowserToRelay` — see `send` below. */
 type RelayMsg = Record<string, unknown>
 
+/**
+ * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId`
+ * means "this frame answers no request", which for `device:ready` / `device:boot-error` is a real and
+ * permanent case rather than an old agent, so it is accepted and logged rather than dropped. A present
+ * one must match. Not that it tells two concurrent boots apart — the agents answer a superseded boot not
+ * at all (`bootSeq`), so one waiter times out either way. `dispatch` resolves the first matching waiter and
+ * stops, so on `sessionId` + type alone the single reply went to whichever boot registered first, and the
+ * boot that actually happened was the one that timed out. The correlator fixes the attribution.
+ *
+ * Deliberately not used for the app commands, whose correlator is required: lending them this fallback
+ * would restore the ambiguity that work removed. See protocol/AGENTS.md.
+ */
+function correlatesWith(msg: RelayMsg, requestId: string): boolean {
+  const id = msg['requestId']
+  if (id === undefined) {
+    console.error(`[tapflow] ${String(msg['type'])} carried no requestId — matched on sessionId instead`)
+    return true
+  }
+  return id === requestId
+}
+
 interface Waiter {
   predicate: (msg: RelayMsg) => boolean
   resolve: (msg: RelayMsg) => void
@@ -143,9 +164,10 @@ export class RelayClient {
   }
 
   async bootDevice(sessionId: string, deviceId: string): Promise<void> {
-    this.send({ type: 'device:boot', sessionId, payload: { deviceId } })
+    const requestId = randomUUID()
+    this.send({ type: 'device:boot', sessionId, requestId, payload: { deviceId } })
     const msg = await this.waitFor(
-      (m) => (m['type'] === 'device:ready' || m['type'] === 'device:boot-error') && m['sessionId'] === sessionId,
+      (m) => (m['type'] === 'device:ready' || m['type'] === 'device:boot-error') && m['sessionId'] === sessionId && correlatesWith(m, requestId),
       120_000,
       'device boot',
     )

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -38,9 +38,12 @@ export interface AgentSession {
 type RelayMsg = Record<string, unknown>
 
 /**
- * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId`
- * means "this frame answers no request", which for `device:ready` / `device:boot-error` is a real and
- * permanent case rather than an old agent, so it is accepted and logged rather than dropped. A present
+ * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId` means
+ * "this frame answers no request". Two ways that reaches this client, and only one is permanent: Android's
+ * mid-session `device:boot-error` has no request behind it and never will, while an id-less `device:ready`
+ * here can only be an agent predating the echo. Both are accepted and logged rather than dropped. The
+ * relay's replayed `device:ready` does not arrive here at all — no `sessionId`, so the comparison ahead of
+ * this call excludes it, which the "not satisfied by the replay" test pins. A present
  * one must match. Not that it tells two concurrent boots apart — the agents answer a superseded boot not
  * at all (`bootSeq`), so one waiter times out either way. `dispatch` resolves the first matching waiter and
  * stops, so on `sessionId` + type alone the single reply went to whichever boot registered first, and the

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
+import { WebSocketServer, WebSocket } from 'ws'
 import { RelayClient } from '../RelayClient.js'
 import { TransientQueryError } from '../errors.js'
 
@@ -58,5 +59,110 @@ describe('RelayClient.queryUITree — transient vs permanent classification', ()
   it('carries the server error message', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(502, { error: 'is the app running in the foreground?' }))
     await expect(client().queryUITree('s1')).rejects.toThrow('is the app running in the foreground?')
+  })
+})
+
+
+// L5b′. `bootDevice` correlates by `requestId` when the reply carries one and by `sessionId` + type
+// when it does not. Both halves are tested here rather than assumed from `mcp-server`, because
+// `correlatesWith` is duplicated between the two clients — protocol cannot host it (its main entry has
+// to erase under `import type`), so the one thing keeping the copies honest is that each has tests.
+//
+// Nothing else covers it: the correlator is optional, so `<Pair>ReplyBody` cannot exist for it and
+// `correlatedRequestsGated` derives only required declarations.
+describe('RelayClient.bootDevice — an optional correlator, with a fallback', () => {
+  let wss: WebSocketServer | null = null
+
+  afterEach(async () => {
+    const s = wss
+    wss = null
+    if (!s) return
+    // `close()` waits for every connection to go away, and the client keeps its socket open — so
+    // without terminating them first this hook times out rather than the test failing, which reads as
+    // five broken tests instead of one broken teardown.
+    for (const c of s.clients) c.terminate()
+    await new Promise<void>((r) => s.close(() => r()))
+  })
+
+  /** A relay that answers `device:boot` however the test asks it to, and records what it received. */
+  async function relay(reply: (msg: Record<string, unknown>) => Record<string, unknown> | null) {
+    const received: Record<string, unknown>[] = []
+    wss = new WebSocketServer({ port: 0 })
+    wss.on('connection', (ws) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        received.push(msg)
+        if (msg['type'] === 'session:start') {
+          ws.send(JSON.stringify({ type: 'session:joined', sessionId: msg['sessionId'], capabilities: [] }))
+          return
+        }
+        if (msg['type'] !== 'device:boot') return
+        const answer = reply(msg)
+        if (answer) ws.send(JSON.stringify(answer))
+      })
+    })
+    const port = (wss.address() as { port: number }).port
+    const client = new RelayClient(`ws://localhost:${port}`, '')
+    await client.connect()
+    await client.joinSession('s1')
+    return { client, received }
+  }
+
+  const pendingAfter = (p: Promise<unknown>, ms = 150) =>
+    Promise.race([
+      p.then(() => 'resolved').catch(() => 'rejected'),
+      new Promise<string>((r) => setTimeout(() => r('still-waiting'), ms)),
+    ])
+
+  it('mints a correlator on the boot it sends', async () => {
+    const { client, received } = await relay((m) => ({
+      type: 'device:ready', sessionId: 's1', requestId: m['requestId'], payload: { deviceId: 'dev-1' },
+    }))
+    await client.bootDevice('s1', 'dev-1')
+
+    const boot = received.find((m) => m['type'] === 'device:boot')!
+    expect(typeof boot['requestId']).toBe('string')
+    expect(boot['requestId']).not.toBe('')
+  })
+
+  it('is not satisfied by a ready carrying another boot\'s correlator', async () => {
+    const { client } = await relay(() => ({
+      type: 'device:ready', sessionId: 's1', requestId: 'someone-elses', payload: { deviceId: 'dev-1' },
+    }))
+    expect(await pendingAfter(client.bootDevice('s1', 'dev-1'))).toBe('still-waiting')
+  })
+
+  it('is satisfied by a ready with no correlator, so an agent predating the echo still boots', async () => {
+    // Rejecting this would trade a misattribution for the full 120s deadline — and this waiter is the
+    // only thing between a flow run and that deadline.
+    const { client } = await relay(() => ({
+      type: 'device:ready', sessionId: 's1', payload: { deviceId: 'dev-1' },
+    }))
+    await expect(client.bootDevice('s1', 'dev-1')).resolves.toBeUndefined()
+  })
+
+  it('is not satisfied by the relay\'s replay, which carries no sessionId', async () => {
+    // Staged as an answer to the boot rather than during the join, because in the ordinary sequence the
+    // waiter does not exist yet when the replay goes out — so a test that only joins would pass with
+    // the `sessionId` comparison deleted. That comparison, not the correlator, is what excludes this
+    // frame: an optional field can make a match more precise, never make it fail.
+    const { client } = await relay(() => ({ type: 'device:ready', payload: { deviceId: 'dev-1' } }))
+    expect(await pendingAfter(client.bootDevice('s1', 'dev-1'))).toBe('still-waiting')
+  })
+
+  it('waits through a boot-error raised for some other boot', async () => {
+    // The mirror of the deadline defect: accepting a diagnosis that answers a different request fails a
+    // boot still perfectly capable of succeeding.
+    const { client } = await relay(() => ({
+      type: 'device:boot-error', sessionId: 's1', requestId: 'not-mine', message: 'other',
+    }))
+    expect(await pendingAfter(client.bootDevice('s1', 'dev-1'))).toBe('still-waiting')
+  })
+
+  it('fails on the boot-error that does answer it', async () => {
+    const { client } = await relay((m) => ({
+      type: 'device:boot-error', sessionId: 's1', requestId: m['requestId'], message: 'emulator gone',
+    }))
+    await expect(client.bootDevice('s1', 'dev-1')).rejects.toThrow('emulator gone')
   })
 })

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -424,7 +424,9 @@ signature only with evidence.
 ```typescript
 browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
 await waitForType(browser, 'session:joined')
-browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+// `requestId` is **required** on device:boot and the relay drops a boot without one at the door —
+// silently, since an uncorrelatable request gets no reply. Omit it and this wait simply times out.
+browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, requestId: 'rq-1', payload: { deviceId: 'dev-1' } }))
 await waitForType(browser, 'device:ready')
 // device:ready alone does not mean the mock exists yet — see below. Sync on the mock itself.
 await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterThan(0))

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -537,7 +537,10 @@ export class IOSAgent implements DeviceAgent {
     return streamWs
   }
 
-  private async handleDeviceBoot(sessionId: string, deviceId: string, fullErase = false, acceptH264 = false, tier?: { secureContext: boolean; external: boolean }): Promise<void> {
+  // `requestId` is a parameter, never a field on `state`: `bootSeq` exists because two boots overlap,
+  // and a correlator hoisted onto shared state would answer the first request with the second's id.
+  // Optional because the relay's idle timer boots nothing — but every *browser* boot carries one.
+  private async handleDeviceBoot(sessionId: string, deviceId: string, fullErase = false, acceptH264 = false, tier?: { secureContext: boolean; external: boolean }, requestId?: string): Promise<void> {
     const state = this.deviceStates.get(sessionId)
     if (!state || !this.ws) return
 
@@ -633,7 +636,7 @@ export class IOSAgent implements DeviceAgent {
       // — never blocks/affects the video path.
       if (this.audioEnabled()) this.startAudioCapture(state, streamWs, deviceId)
       state.booted = true
-      this.sendMsg({ type: 'device:ready', sessionId, payload: { deviceId } })
+      this.sendMsg({ type: 'device:ready', sessionId, requestId, payload: { deviceId } })
 
       // Sync AppleKeyboards after ready — fire-and-forget so streaming isn't delayed.
       // hw=Automatic lets the hardware layout follow the active input source on LANG1/CapsLock.
@@ -645,7 +648,7 @@ export class IOSAgent implements DeviceAgent {
     } catch (e) {
       if (seq !== state.bootSeq) return
       const message = e instanceof Error ? e.message : String(e)
-      this.sendMsg({ type: 'device:boot-error', sessionId, message })
+      this.sendMsg({ type: 'device:boot-error', sessionId, requestId, message })
     }
   }
 
@@ -663,7 +666,7 @@ export class IOSAgent implements DeviceAgent {
     }
   }
 
-  private async handleDeviceShutdown(sessionId: string, deviceId: string): Promise<void> {
+  private async handleDeviceShutdown(sessionId: string, deviceId: string, requestId?: string): Promise<void> {
     const state = this.deviceStates.get(sessionId)
     if (!state) return
 
@@ -686,6 +689,7 @@ export class IOSAgent implements DeviceAgent {
       this.sendMsg({
         type: 'device:shutdown-done',
         sessionId,
+        requestId,
         payload: { deviceId },
       })
     } catch (e) {
@@ -798,14 +802,14 @@ export class IOSAgent implements DeviceAgent {
       case 'device:boot': {
         const { deviceId, resetMode, acceptH264, secureContext, external } = msg.payload as { deviceId: string; resetMode?: string; acceptH264?: boolean; secureContext?: boolean; external?: boolean }
         const sessionId = msg.sessionId
-        this.handleDeviceBoot(sessionId, deviceId, resetMode === 'full-erase', acceptH264 === true, { secureContext: !!secureContext, external: !!external })
+        this.handleDeviceBoot(sessionId, deviceId, resetMode === 'full-erase', acceptH264 === true, { secureContext: !!secureContext, external: !!external }, msg.requestId)
           .catch((e) => logger.error('handleDeviceBoot failed:', e))
         break
       }
       case 'device:shutdown': {
         const { deviceId } = msg.payload as { deviceId: string }
         const sessionId = msg.sessionId
-        this.handleDeviceShutdown(sessionId, deviceId)
+        this.handleDeviceShutdown(sessionId, deviceId, msg.requestId)
           .catch((e) => logger.error('handleDeviceShutdown failed:', e))
         break
       }

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -450,7 +450,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-1', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       const done = waitForType(browser, 'input:done')
@@ -471,7 +471,7 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
       // Boot first (per the device:boot guideline → booted flag true, TouchHelper set up).
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-2', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       // Power the device off: shutdown clears the booted flag, and simctl now reports it shut down.
@@ -580,7 +580,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-3', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       // device:ready is not a sync point for the helper — wait on the mock itself.
       await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterThan(0), { timeout: 500 })
@@ -840,7 +840,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const booting = waitForType(browser, 'device:booting')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-4', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await booting
       await vi.waitFor(() => expect(simctl.boot).toHaveBeenCalled(), { timeout: 500 })
 
@@ -882,7 +882,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const booting = waitForType(browser, 'device:booting')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-5', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await booting
       await vi.waitFor(() => expect(simctl.boot).toHaveBeenCalled(), { timeout: 500 })
       expect(MockTouchHelper.mock.results).toHaveLength(0)
@@ -946,7 +946,7 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
 
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-6', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       // device:ready is sent as the stream is handed off, which is not the same instant the helper
@@ -966,7 +966,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-7', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
       const thInstance = MockTouchHelper.mock.results[0].value
@@ -995,7 +995,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-8', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
 
@@ -1079,7 +1079,7 @@ describe('IOSAgent', () => {
 
       const bootingPromise = waitForType(browser, 'device:booting')
       const readyPromise = waitForType(browser, 'device:ready')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-9', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
 
       await bootingPromise
       const ready = await readyPromise
@@ -1105,6 +1105,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-10',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1120,6 +1121,111 @@ describe('IOSAgent', () => {
 
       agent.disconnect()
       browser.close()
+    })
+
+    // ── L5b′: the lifecycle pair correlates, and the correlator is optional ────────────────────
+    //
+    // Optional means `<Pair>ReplyBody` cannot exist for it — `Omit<T,'sessionId'|'requestId'>` is
+    // satisfied by an object with no correlator at all, so the excess-property trick that catches a
+    // freshly minted id has nothing to bite on. Nor does `correlatedRequestsGated` derive this pair.
+    // These tests are the entire enforcement of the echo on this agent.
+    describe('lifecycle replies echo the boot/shutdown correlator', () => {
+      async function joined(simctl: SimctlWrapper) {
+        const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = new WebSocket(`ws://localhost:${port}`)
+        await waitForOpen(browser)
+        browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+        await waitForType(browser, 'session:joined')
+        return { agent, browser }
+      }
+
+      it('device:ready carries the requestId of the boot it answers', async () => {
+        const { agent, browser } = await joined(mockSimctl(false))
+
+        const ready = waitForType(browser, 'device:ready')
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-1',
+          payload: { deviceId: 'dev-1' },
+        }))
+        expect((await ready)['requestId']).toBe('boot-1')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('device:boot-error carries the requestId of the boot it answers', async () => {
+        // The failure exit is the one that matters most and the one a happy-path test cannot reach:
+        // a caller that gets an uncorrelatable diagnosis waits out its deadline instead of failing,
+        // so the error arrives and is discarded. That is the defect this file's `open-url` block
+        // already records as having shipped twice.
+        const simctl = mockSimctl(false)
+        ;(simctl.boot as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boot exploded'))
+        const { agent, browser } = await joined(simctl)
+
+        const err = waitForType(browser, 'device:boot-error')
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-2',
+          payload: { deviceId: 'dev-1' },
+        }))
+        const msg = await err
+        expect(msg['requestId']).toBe('boot-2')
+        expect(msg['message']).toContain('boot exploded')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('device:shutdown-done carries the requestId of the shutdown it answers', async () => {
+        const { agent, browser } = await joined(mockSimctl(true))
+
+        const done = waitForType(browser, 'device:shutdown-done')
+        browser.send(JSON.stringify({
+          type: 'device:shutdown', sessionId: agent.sessionId, requestId: 'down-1',
+          payload: { deviceId: 'dev-1' },
+        }))
+        expect((await done)['requestId']).toBe('down-1')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('answers a correlator-less request without inventing one', async () => {
+        // The relay originates `device:shutdown` from its idle timer with no id, so this is a live
+        // wire shape rather than a legacy one. A minted id here would be worse than none: the
+        // consumer's fallback accepts an absent correlator and rejects one that does not match, so an
+        // invented id turns a reply that lands today into one that is silently dropped.
+        const { agent, browser } = await joined(mockSimctl(true))
+
+        const done = waitForType(browser, 'device:shutdown-done')
+        browser.send(JSON.stringify({
+          type: 'device:shutdown', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' },
+        }))
+        expect((await done)['requestId']).toBeUndefined()
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('does not answer a boot that a newer boot superseded', async () => {
+        // `bootSeq` makes a superseded boot return silently, and the correlator is what lets a caller
+        // see that: exactly one `device:ready` arrives and it carries the newer id. A correlator read
+        // from shared device state would pass every test above and fail this one — which is why the
+        // agents take it as a parameter.
+        const { agent, browser } = await joined(mockSimctl(false))
+
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-old',
+          payload: { deviceId: 'dev-1' },
+        }))
+        browser.send(JSON.stringify({
+          type: 'device:boot', sessionId: agent.sessionId, requestId: 'boot-new',
+          payload: { deviceId: 'dev-1' },
+        }))
+
+        const ready = await waitForType(browser, 'device:ready')
+        expect(ready['requestId']).toBe('boot-new')
+        // And nothing answers the superseded one afterwards.
+        expect(await waitForTypeOrNull(browser, 'device:ready', 300)).toBeNull()
+
+        agent.disconnect(); browser.close()
+      })
     })
 
     // #440: simctl's `booted` alias means "whichever device is up", so with two simulators running
@@ -1146,7 +1252,7 @@ describe('IOSAgent', () => {
         browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
         await waitForType(browser, 'session:joined')
         browser.send(JSON.stringify({
-          type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' },
+          type: 'device:boot', requestId: 'rq-fix-11', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' },
         }))
         await ready
         return { simctl, agent, browser }
@@ -1169,7 +1275,7 @@ describe('IOSAgent', () => {
         browser.send(JSON.stringify({ type: 'session:start', sessionId: second[0] }))
         await waitForType(browser, 'session:joined')
         browser.send(JSON.stringify({
-          type: 'device:boot', sessionId: second[0], payload: { deviceId: 'dev-2' },
+          type: 'device:boot', requestId: 'rq-fix-12', sessionId: second[0], payload: { deviceId: 'dev-2' },
         }))
         await ready
 
@@ -1421,6 +1527,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-13',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1447,6 +1554,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-14',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1474,6 +1582,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-15',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1507,6 +1616,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-16',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1531,6 +1641,7 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-17',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', resetMode: 'full-erase' },
       }))
@@ -1557,7 +1668,7 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
 
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-18', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       expect(simctl.erase).not.toHaveBeenCalled()
@@ -1578,7 +1689,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const readyPromise = waitForType(browser, 'device:ready')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-19', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await readyPromise
       expect(simctl.boot).not.toHaveBeenCalled()
 
@@ -1604,7 +1715,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const readyPromise = waitForType(browser, 'device:ready')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-20', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await readyPromise
 
       expect(simctl.erase).toHaveBeenCalledWith('dev-1')
@@ -1630,7 +1741,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const errPromise = waitForType(browser, 'device:boot-error')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-21', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       const err = await errPromise
 
       expect(simctl.erase).not.toHaveBeenCalled()
@@ -1652,7 +1763,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
 
       const errPromise = waitForType(browser, 'device:boot-error')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-22', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await errPromise
 
       // exactly one erase + one retry — bounded, no infinite loop
@@ -1758,7 +1869,7 @@ describe('IOSAgent', () => {
         })
       )
 
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-23', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       const frame = await framePromise
@@ -1779,7 +1890,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-24', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       await vi.waitFor(() => expect(MockTouchHelper.mock.results).toHaveLength(1), { timeout: 500 })
       const thInstance = MockTouchHelper.mock.results[0].value
@@ -1833,7 +1944,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-25', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       return { browser, agent, sim }
     }
@@ -1990,6 +2101,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'session:joined')
       browser.send(JSON.stringify({
         type: 'device:boot',
+        requestId: 'rq-fix-26',
         sessionId: agent.sessionId,
         payload: { deviceId: 'dev-1', ...bootPayload },
       }))
@@ -2088,7 +2200,7 @@ describe('IOSAgent', () => {
       await waitForOpen(browser)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-27', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
 
       agent.disconnect()
@@ -2162,7 +2274,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-28', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       return { agent, browser }
     }
@@ -2208,7 +2320,7 @@ describe('IOSAgent', () => {
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
-      browser.send(JSON.stringify({ type: 'device:boot', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-29', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:ready')
       return { agent, browser }
     }

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { WebSocketServer, WebSocket } from 'ws'
 import { TapflowClient, REASON_ADVICE, reasonAdvice } from '../client.js'
 
@@ -415,6 +415,156 @@ describe('TapflowClient', () => {
       })
       const settled = await Promise.race([
         client.clearState('sess-1', 'com.example.app').then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+      ])
+      expect(settled).toBe('still-waiting')
+    })
+
+    // ── L5b′: the lifecycle pair, whose correlator is optional ─────────────────────────────────
+    //
+    // Different from the four above: an absent `requestId` is **accepted** here, because
+    // `device:ready` and `device:boot-error` have producers that answer no request — the relay replays
+    // a cached ready to a re-joining viewer, and an Android stream that dies mid-session reports it as
+    // a boot error. What the correlator buys is the rejection of a *mismatched* id.
+
+    it('mints a correlator on device:boot', async () => {
+      setTimeout(() => relay.send({ type: 'device:ready', sessionId: 'sess-1' }), 10)
+      await client.bootDevice('sess-1', 'dev-1')
+      const bootMsg = await waitForMessage(relay, 'device:boot')
+      expect(typeof bootMsg['requestId']).toBe('string')
+      expect(bootMsg['requestId']).not.toBe('')
+    })
+
+    it('does not resolve a boot on a ready carrying another request\'s correlator', async () => {
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:boot') return
+        ws.send(JSON.stringify({ type: 'device:ready', sessionId: 'sess-1', requestId: 'someone-elses' }))
+      })
+      const settled = await Promise.race([
+        client.bootDevice('sess-1', 'dev-1').then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+      ])
+      expect(settled).toBe('still-waiting')
+    })
+
+    it('resolves a boot on the ready that answers it', async () => {
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:boot') return
+        ws.send(JSON.stringify({ type: 'device:ready', sessionId: 'sess-1', requestId: msg['requestId'] }))
+      })
+      await expect(client.bootDevice('sess-1', 'dev-1')).resolves.toBeUndefined()
+    })
+
+    it('rejects a boot on the boot-error that answers it, and not on one that does not', async () => {
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:boot') return
+        // A diagnosis for someone else's boot first. Accepting it would fail a boot that is still
+        // perfectly capable of succeeding, which is the mirror image of the deadline defect.
+        ws.send(JSON.stringify({ type: 'device:boot-error', sessionId: 'sess-1', requestId: 'not-mine', message: 'other' }))
+        setTimeout(() => ws.send(JSON.stringify({
+          type: 'device:boot-error', sessionId: 'sess-1', requestId: msg['requestId'], message: 'mine',
+        })), 20)
+      })
+      await expect(client.bootDevice('sess-1', 'dev-1')).rejects.toThrow('mine')
+    })
+
+    it('accepts a ready with no correlator, and says so', async () => {
+      // An agent predating the echo, and the relay's own replay. Dropping these would trade a
+      // misattribution for a 30s hang, so the fallback stands — but silently falling back is how a
+      // half-upgraded fleet stays invisible, so it is logged.
+      const logged: string[] = []
+      const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+      try {
+        setTimeout(() => relay.send({ type: 'device:ready', sessionId: 'sess-1' }), 10)
+        await expect(client.bootDevice('sess-1', 'dev-1')).resolves.toBeUndefined()
+      } finally { spy.mockRestore() }
+      expect(logged.some((l) => l.includes('device:ready') && l.includes('no requestId'))).toBe(true)
+    })
+
+    it('is not satisfied by the relay\'s replay, which carries no sessionId at all', async () => {
+      // The replay frame is `{ type, payload }`. It is cached state addressed to a **join**, not an
+      // answer to a **boot**, and `readySent` is cleared by nothing while an agent is wedged-but-
+      // connected — which is exactly when a boot hangs, so the value is stalest when it would be
+      // consumed. What keeps it out is the `sessionId` comparison, not the correlator: an optional
+      // field can make a frame match more precisely, never make it fail to match.
+      //
+      // Staged genuinely mid-boot, which matters. In the ordinary sequence this client registers its
+      // boot waiter only after `session:start` resolves, and the relay sends its replays during that
+      // join — so the replay is dropped before any waiter exists and a test that merely joins first
+      // would pass with the comparison deleted.
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:boot') return
+        ws.send(JSON.stringify({ type: 'device:ready', payload: { deviceId: 'dev-1' } }))
+      })
+      const settled = await Promise.race([
+        client.bootDevice('sess-1', 'dev-1').then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+      ])
+      expect(settled).toBe('still-waiting')
+    })
+
+    it('sends the one reply to the boot it answers, not to whichever waited first', async () => {
+      // **The correlator\'s actual payoff on this pair, and it is not "both boots resolve".** A superseded
+      // boot is answered by nothing at all — `bootSeq` makes every checkpoint in the agent return silently
+      // — so one of two overlapping boots times out either way. What the correlator changes is which.
+      // `dispatch` resolves the first waiter whose predicate matches and then stops, so on `sessionId` +
+      // type alone that single reply went to the boot registered **first**, i.e. the superseded one, and
+      // the boot that actually happened was reported as a failure.
+      const ws = relay.lastClient()
+      const ids: string[] = []
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:boot') return
+        ids.push(msg['requestId'] as string)
+        // Answer only the second, the way a real agent does once `bootSeq` has moved on.
+        if (ids.length === 2) {
+          ws.send(JSON.stringify({ type: 'device:ready', sessionId: 'sess-1', requestId: ids[1] }))
+        }
+      })
+
+      const first = client.bootDevice('sess-1', 'dev-1')
+      const second = client.bootDevice('sess-1', 'dev-1')
+
+      await expect(second).resolves.toBeUndefined()
+      expect(await Promise.race([
+        first.then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+      ])).toBe('still-waiting')
+      first.catch(() => { /* it times out on its own deadline; nothing here waits for that */ })
+    })
+
+    it('mints a correlator on device:shutdown', async () => {
+      // `bootDevice` has this and `shutdownDevice` did not, and the two tests either side of it cannot
+      // stand in: `toMatchObject` ignores a key that is absent, and the mismatch case below still passes
+      // against a hardcoded foreign id even when nothing was sent. Leave the id off the wire and the agent
+      // has nothing to echo, so `correlatesWith` falls back and resolves `shutdown_device` on *any*
+      // shutdown-done for the session — the relay's idle timer or the dashboard's unmount teardown can
+      // satisfy a shutdown that has not happened. It also logs "carried no requestId" on every call,
+      // blaming the agent for the client's omission.
+      setTimeout(() => relay.send({ type: 'device:shutdown-done', sessionId: 'sess-1' }), 10)
+      await client.shutdownDevice('sess-1', 'dev-1')
+      const msg = await waitForMessage(relay, 'device:shutdown')
+      expect(typeof msg['requestId']).toBe('string')
+      expect(msg['requestId']).not.toBe('')
+    })
+
+    it('does not resolve a shutdown on a done carrying another request\'s correlator', async () => {
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'device:shutdown') return
+        ws.send(JSON.stringify({ type: 'device:shutdown-done', sessionId: 'sess-1', requestId: 'someone-elses' }))
+      })
+      const settled = await Promise.race([
+        client.shutdownDevice('sess-1', 'dev-1').then(() => 'resolved').catch(() => 'rejected'),
         new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
       ])
       expect(settled).toBe('still-waiting')

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -37,6 +37,31 @@ export type { UIElement } from '@tapflowio/protocol'
 
 type RelayMsg = Record<string, unknown>
 
+/**
+ * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId`
+ * means "this frame answers no request", which for `device:ready` / `device:boot-error` is a real and
+ * permanent case rather than an old agent, so it is accepted and logged rather than dropped. A present
+ * one must match, and what that buys is narrower than it looks — worth stating exactly, because the
+ * obvious claim ("it tells two concurrent boots apart") is false. The agents answer a **superseded** boot
+ * not at all: `bootSeq` makes every checkpoint after a newer boot return silently. So of two overlapping
+ * boots only the winner ever replies, and one waiter times out either way. What changes is *which*.
+ * `dispatch` resolves the first waiter whose predicate matches and stops, so on `sessionId` + type alone
+ * that single reply went to the boot registered **first** — the superseded one — and the boot that
+ * actually happened timed out. The correlator sends it to the request it answers.
+ *
+ * Deliberately **not** used for the app commands or clipboard. Their correlator is required, and
+ * lending them this fallback would restore the ambiguity that work removed — see
+ * 「No fallback, and one policy at the door」 in protocol/AGENTS.md.
+ */
+function correlatesWith(msg: RelayMsg, requestId: string): boolean {
+  const id = msg['requestId']
+  if (id === undefined) {
+    console.error(`[tapflow] ${String(msg['type'])} carried no requestId — matched on sessionId instead`)
+    return true
+  }
+  return id === requestId
+}
+
 interface Waiter {
   predicate: (msg: RelayMsg) => boolean
   resolve: (msg: RelayMsg) => void
@@ -193,12 +218,20 @@ export class TapflowClient {
     this.send({ type: 'session:leave', sessionId })
   }
 
+  // Correlated by `requestId` when the reply carries one, and by `sessionId` + type when it does not.
+  // The fallback is not compatibility slack, it is the contract: `device:ready` and `device:boot-error`
+  // have producers that answer no request at all — the relay replays a cached ready to a re-joining
+  // viewer, and an Android stream that dies mid-session reports it as a boot error. A strict match
+  // would be the wrong shape for those, and dropping them is not free either: this waiter is the only
+  // thing between `boot_device` and its 30s deadline. See 「Lifecycle correlation」 in protocol/AGENTS.md.
   async bootDevice(sessionId: string, deviceId: string): Promise<void> {
-    this.send({ type: 'device:boot', sessionId, payload: { deviceId } })
+    const requestId = randomUUID()
+    this.send({ type: 'device:boot', sessionId, requestId, payload: { deviceId } })
     const msg = await this.waitFor(
       (m) =>
         (m['type'] === 'device:ready' || m['type'] === 'device:boot-error') &&
-        m['sessionId'] === sessionId,
+        m['sessionId'] === sessionId &&
+        correlatesWith(m, requestId),
       30_000,
     )
     if (msg['type'] === 'device:boot-error') {
@@ -210,9 +243,13 @@ export class TapflowClient {
   // payload carries deviceId, matching the agent handler and the relay's own shutdown path. There is no
   // shutdown-error message: Android replies done regardless, iOS surfaces a failed shutdown as a wait timeout.
   async shutdownDevice(sessionId: string, deviceId: string): Promise<void> {
-    this.send({ type: 'device:shutdown', sessionId, payload: { deviceId } })
+    const requestId = randomUUID()
+    this.send({ type: 'device:shutdown', sessionId, requestId, payload: { deviceId } })
     await this.waitFor(
-      (m) => m['type'] === 'device:shutdown-done' && m['sessionId'] === sessionId,
+      (m) =>
+        m['type'] === 'device:shutdown-done' &&
+        m['sessionId'] === sessionId &&
+        correlatesWith(m, requestId),
       30_000,
     )
   }

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -38,9 +38,13 @@ export type { UIElement } from '@tapflowio/protocol'
 type RelayMsg = Record<string, unknown>
 
 /**
- * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId`
- * means "this frame answers no request", which for `device:ready` / `device:boot-error` is a real and
- * permanent case rather than an old agent, so it is accepted and logged rather than dropped. A present
+ * Matches a reply whose correlator is **optional** — the lifecycle pair only. An absent `requestId` means
+ * "this frame answers no request", and the two ways that reaches *this* client are worth telling apart:
+ * `device:boot-error` has a producer that never has a request behind it (Android reporting a stream that
+ * died mid-session), so that half is permanent; an id-less `device:ready` here can only be an agent
+ * predating the echo, so that half is compatibility slack. Both are accepted and logged rather than
+ * dropped. What does **not** arrive here is the relay's replayed `device:ready`: it carries no `sessionId`,
+ * so the comparison ahead of this call excludes it — see the "not satisfied by the replay" test. A present
  * one must match, and what that buys is narrower than it looks — worth stating exactly, because the
  * obvious claim ("it tells two concurrent boots apart") is false. The agents answer a **superseded** boot
  * not at all: `bootSeq` makes every checkpoint after a newer boot return silently. So of two overlapping

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -134,15 +134,60 @@ slice later), so it is checked rather than asserted in prose:
 `scripts/__tests__/correlatedRequestsGated.test.mjs` derives the request set from this file and fails if one
 is ungated.
 
-**Two properties put a pair *outside* this shape**, and both were found by trying:
+**Two properties make a correlator `optional` rather than absent**, and both were found by trying. They were
+first written here as putting a pair *outside* correlation, which was wrong by one step: what they rule out is
+`required`, and the pair still correlates — see 「Lifecycle correlation」 below.
 
 - **The relay originates the request.** `device:shutdown` is sent by the relay itself when a browser socket
   closes, and it is one interface shared by both directions — so a required correlator would force the relay
   to invent an id for a request nobody made.
 - **The reply is also sent unsolicited.** `device:shutdown-done` is read by `SessionList` as a device-status
-  broadcast, and the relay replays `device:ready` from cache on a re-join. A consumer that discards on a
-  correlator mismatch stops learning about state it did not ask about — the cross-requester delivery that is
-  a bug for `open-url` is the feature here.
+  broadcast, the relay replays `device:ready` from cache on a re-join, and `AndroidAgent.restartVideoStream`
+  sends `device:boot-error` for a stream that died mid-session. A consumer that discards on a correlator
+  mismatch stops learning about state it did not ask about — the cross-requester delivery that is a bug for
+  `open-url` is the feature here.
+
+## Lifecycle correlation — where the correlator is optional, and what that costs
+
+`device:boot` / `device:shutdown` correlate, but not in the shape above: the **request** side of `device:boot`
+is required and every reply is `requestId?`. Absence has exactly one meaning, and it is the one worth stating
+at each declaration: **this frame is not the answer to a request.** Not "an old agent" — that reading is what
+made the first draft of this pair wrong.
+
+**Optional means the reply's echo is enforced by tests alone.** `<Pair>ReplyBody` cannot be built for an
+optional field — `Omit<T,'sessionId'|'requestId'>` is satisfied by an object that simply has no correlator, so
+the excess-property trick that catches a freshly minted id has nothing to bite on. Everything the compiler does
+for the app commands, tests do here. D24 applies at full strength, and the surface it applies to is wider than
+the reply declarations, because **almost none of the fixtures constructing these five messages are typed.**
+Deliberately no count here: three different greps for them disagree, and a number in this paragraph was wrong
+within one commit of being written. The structural fact is what holds. The dashboard's are typed and checked —
+its test channel is `useRef<(msg: BrowserToRelay) => void>` and its injected replies are annotated
+`BrowserInbound`, which is why that package has a rule against `as never` and local shapes. Everyone else's
+are `JSON.stringify({ … })` literals at an untyped `ws.send`, so they are `any` at the call site; the agent and
+`mcp-server` tsconfigs also exclude `src/__tests__`, but typechecking those folders would not have helped,
+because there is no annotation for a compiler to check against. The consequence is concrete: promoting
+`DeviceBoot.requestId` to required produced no error in those files and instead **hung two agent suites**, and
+several of those fixtures send `device:ready` with no `payload` at all — a shape the wire cannot produce.
+
+**Because the correlator is optional, `correlatedRequestsGated` cannot see it.** That check derives its set
+from *required* declarations (`/^ {2}requestId: string$/`), so every door gate and echo obligation on this pair
+is outside its reach. The one that matters most is the relay's own: the relay answers a `device:boot` itself
+when the agent is offline or the session is unknown, and that `device:boot-error` must echo the id or an MCP
+caller reads a diagnosis as unsolicited and waits out its deadline instead. That is the defect this file already
+records as having shipped twice, in a position no check reaches. A test is the only thing holding it.
+
+**A consumer correlating one of these replies is a bug, and one of them is load-bearing.** The dashboard must
+**not** gate `device:boot-error` on the correlator — it is the sole surface reporting a mid-session stream
+death, which carries no id by construction. `device:booting` is not correlated for a stronger reason than
+"nobody waits on it": `DeviceViewer` **must** act on a boot another client requested, tearing down chrome and
+in-flight install records whoever asked, so correlating it would suppress the case the message exists for.
+What the correlator does buy on the consumer side is narrower and real — `DeviceViewer` decrements a pending
+rebind on `device:ready`, and a replayed ready currently consumes one and fires a duplicate `app:install`.
+
+**The request side is asymmetric for a mechanical reason, not a stylistic one.** A request passes *through* the
+relay, so one door gates and logs every sender at once. A reply does not — the relay forwards it with
+`JSON.stringify` without inspecting it — so "log the uncorrelatable frame" has to be written once per consuming
+client, and one of those clients must not drop at all.
 
 ## Every direction is declared, and an agent's send is typed
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -214,9 +214,14 @@ export interface StreamRequestIdr {
   sessionId: string
 }
 
+// Optional, unlike every other correlated request, because **the relay originates this one** — the
+// idle timer at `RelayServer.ts` shuts a device down with no browser behind it. This is one interface
+// serving both `BrowserToRelay` and `RelayToAgent`, so required here would be unsatisfiable there.
+// See 「Lifecycle correlation」 in AGENTS.md.
 export interface DeviceShutdown {
   type: 'device:shutdown'
   sessionId: string
+  requestId?: string
   payload: { deviceId: string }
 }
 
@@ -341,6 +346,20 @@ export type InputErrorReason =
 // The real defect underneath is that leaving a session does not clear its waiters — a *real* ready
 // after a re-join already satisfies the stale one. That is filed separately. The mechanism that makes
 // this message tightenable is a request correlator, not another field.
+//
+// **That correlator landed and `device:ready` is still `sessionId?` — deliberately.** The correlator
+// is `requestId?` below, and it is optional, so it cannot *replace* the sessionId comparison; it can
+// only run ahead of it. Which means the unstamped replay is still what the two boot waiters discriminate
+// on, and stamping it now would delete the working discriminator rather than make a tightened one
+// redundant. Tightening this field and having the relay stamp its replay is therefore one later slice
+// of its own — and it must carry a test pinning the **value** stamped, because there is none: with the
+// stamp mutated to `session.deviceId`, a plausible slip on a line whose `payload` reads
+// `{ deviceId: session.deviceId }`, every relay test, every dashboard test and the whole static suite
+// still passed — measured on `1bf47c8`, before the tests in this pair existed. Deliberately no totals:
+// they move every slice, and a stale number here reads as a reason to doubt the measurement.
+// `deviceReadyReplay.test.ts` scopes itself out of that value in writing, and states the cost: a
+// wrong-but-present id is dropped by the dashboard's gate, and the symptom is #440 — the very defect the
+// replay exists to prevent, so nothing else would report it.
 export interface SessionChrome {
   type: 'session:chrome'
   sessionId: string
@@ -356,6 +375,8 @@ export interface SessionDeviceInfo {
 export interface DeviceReady {
   type: 'device:ready'
   sessionId?: string
+  /** Absent = this is not the answer to a `device:boot`. See 「Lifecycle correlation」 in AGENTS.md. */
+  requestId?: string
   payload: { deviceId: string }
 }
 
@@ -393,8 +414,14 @@ export interface AppLaunchError extends SessionError {
   requestId: string
 }
 
+// The only error on this surface whose correlator is optional, and it is not for compatibility.
+// `AndroidAgent.restartVideoStream` sends this message with **no `device:boot` behind it** — a stream
+// that died mid-session and failed to come back, reported through the one field the dashboard renders.
+// So an unsolicited producer is not a possibility here, it is in the repo with a test on it, and a
+// consumer that correlates this message drops the only report of a dead stream. See AGENTS.md.
 export interface DeviceBootError extends SessionError {
   type: 'device:boot-error'
+  requestId?: string
 }
 
 export interface OpenUrlError extends SessionError {
@@ -526,6 +553,8 @@ export interface DeviceBooting {
 
 export interface DeviceShutdownDone {
   type: 'device:shutdown-done'
+  /** Absent = this shutdown was not requested by a browser — the relay's idle timer ran. */
+  requestId?: string
   sessionId: string
   payload: { deviceId: string }
 }
@@ -871,6 +900,15 @@ export interface SessionLeave {
 export interface DeviceBoot {
   type: 'device:boot'
   sessionId: string
+  /**
+   * Required, unlike every reply in this pair. Absence has no legitimate meaning on the request side —
+   * nothing originates a boot but a browser, so there is no producer for an id-less one to belong to.
+   * This is what puts `device:boot` inside 「No fallback, and one policy at the door」: required is what
+   * `correlatedRequestsGated` derives its set from, and what makes the relay's door gate reachable.
+   *
+   * `device:shutdown` below stays optional for the opposite reason — the relay sends that one itself.
+   */
+  requestId: string
   payload: { deviceId: string; resetMode?: 'app-only' | 'full-erase'; acceptH264?: boolean; secureContext?: boolean }
 }
 

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -727,29 +727,54 @@ export class RelayServer {
       }
 
       // ── Browser → Agent ────────────────────────────────────────────────────
-      case 'device:boot':
-      case 'device:shutdown': {
+      //
+      // These two shared one fall-through clause. Separated because the sharing is the trap for
+      // whoever adds the door gate: an `isCorrelated(msg)` written into a shared body would gate
+      // `device:shutdown` too, and the relay originates that message with no id — so the dashboard's
+      // four senders and the relay's own idle timer would stop reaching the agent, silently, in the
+      // one direction no reply reports. `correlatedRequestsGated` resolves fall-through by sharing the
+      // next non-empty body, so it would have read the gate as covering both and passed.
+      case 'device:boot': {
+        // At the door, before the session lookup — one policy for the whole request, the same shape as
+        // `open-url` next door. Both things the relay could do with an id-less boot are downstream of
+        // here (forward it, or answer it with a `device:boot-error`), and gating only one of them leaves
+        // the guarantee resting on whichever branch was not gated.
+        if (!isCorrelated(msg)) break
         const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState !== WebSocket.OPEN && msg.type === 'device:boot') {
+        if (session?.agentSocket.readyState !== WebSocket.OPEN) {
           // A boot the agent never receives leaves the viewer on "Waiting for first frame…" with
           // nothing said. `device:shutdown` gets no such reply: nothing waits on it, and inventing
           // a `device:shutdown-error` would grow the contract for a message no one reads.
           //
           // The two are worth telling apart: `bootDevice` is the first call an MCP caller makes, so
           // reporting a stale session id as a dead Mac sends the reader after the wrong problem.
+          //
+          // **The relay is a producer of this reply, so it echoes the correlator itself.** An MCP
+          // caller that receives this diagnosis uncorrelated reads it as unsolicited and waits out
+          // its deadline — the diagnosis arrives and is discarded. That defect shipped twice from
+          // agent code (`open-url:error`, then `clipboard:error`); here the producer is the relay,
+          // where `correlatedRequestsGated` cannot see it because the field is optional.
           this.sendTo(ws, {
             type: 'device:boot-error',
             sessionId: msg.sessionId!,
+            requestId: msg.requestId,
             message: session ? 'agent offline' : 'Session not found',
           })
           break
         }
+        // Tag the boot with whether the viewer is external (public IP) so the agent can pick the
+        // downscale tier. The browser already reports secureContext in the payload.
+        if (msg.payload && typeof msg.payload === 'object') {
+          (msg.payload as Record<string, unknown>).external = this.wsExternal.get(ws) ?? false
+        }
+        session.agentSocket.send(JSON.stringify(msg))
+        break
+      }
+      case 'device:shutdown': {
+        // Deliberately ungated: the relay sends this itself from the idle timer, with no browser and
+        // no id behind it, so a correlator cannot be required and an absent one is not an error.
+        const session = this.sessions.get(msg.sessionId!)
         if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          // Tag the boot with whether the viewer is external (public IP) so the agent can pick the
-          // downscale tier. The browser already reports secureContext in the payload.
-          if (msg.type === 'device:boot' && msg.payload && typeof msg.payload === 'object') {
-            (msg.payload as Record<string, unknown>).external = this.wsExternal.get(ws) ?? false
-          }
           session.agentSocket.send(JSON.stringify(msg))
         }
         break

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -385,7 +385,7 @@ describe('RelayServer', () => {
     await waitForMessage(browser)
 
     const bootPromise = waitForMessage(agent)
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, requestId: 'rq-route', payload: { deviceId: 'devA' } }))
     const boot = await bootPromise
     expect(boot.type).toBe('device:boot')
     expect((boot.payload as { deviceId: string }).deviceId).toBe('devA')

--- a/packages/relay/src/__tests__/agentReconnectGrace.test.ts
+++ b/packages/relay/src/__tests__/agentReconnectGrace.test.ts
@@ -223,7 +223,7 @@ describe('a session outlives its agent socket long enough to be reclaimed (#426)
     await closeAndSettle(first.agent)
     await waitForType(browser, 'session:terminated')
 
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'devA' } }))
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, requestId: 'rq-grace', payload: { deviceId: 'devA' } }))
 
     expect((await waitForType<RelayMessage>(browser, 'device:boot-error')).message).toBe('Session not found')
 

--- a/packages/relay/src/__tests__/appCommandErrors.test.ts
+++ b/packages/relay/src/__tests__/appCommandErrors.test.ts
@@ -182,7 +182,7 @@ describe('app command failures reach the caller (#445)', () => {
     await closed
     await untilAgentLeavesTheList(browser)
 
-    browser.send(JSON.stringify({ type: 'device:boot', sessionId, payload: { deviceId: 'dev-1' } }))
+    browser.send(JSON.stringify({ type: 'device:boot', sessionId, requestId: 'rq-boot-offline', payload: { deviceId: 'dev-1' } }))
     // Without this the viewer sits on "Waiting for first frame…" with nothing said.
     const msg = await waitForTypeOrNull(browser, 'device:boot-error')
 
@@ -280,7 +280,7 @@ describe('app command failures reach the caller (#445)', () => {
     const { agent, browser } = await connectAgentAndBrowser()
 
     browser.send(JSON.stringify({
-      type: 'device:boot', sessionId: 'no-such-session', payload: { deviceId: 'dev-1' },
+      type: 'device:boot', sessionId: 'no-such-session', requestId: 'rq-boot-unknown', payload: { deviceId: 'dev-1' },
     }))
     const msg = await waitForTypeOrNull(browser, 'device:boot-error')
 

--- a/packages/relay/src/__tests__/lifecycleCorrelation.test.ts
+++ b/packages/relay/src/__tests__/lifecycleCorrelation.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type { RelayMessage } from '../types'
+
+// L5b′. `device:boot` / `device:shutdown` correlate by `requestId`, and unlike the app commands the
+// correlator on every reply is **optional** — `device:ready`, `device:boot-error` and
+// `device:shutdown-done` all have producers that answer no request at all.
+//
+// That optionality is why this file exists. `<Pair>ReplyBody` cannot be built for an optional field, so
+// the compiler enforces nothing here; and `correlatedRequestsGated` derives its set from *required*
+// declarations, so it cannot see this pair either. Every guarantee below is held by a test or by nothing.
+describe('lifecycle correlation (device:boot / device:shutdown)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-lifecycle-corr-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  async function registerAgent(status: 'booted' | 'shutdown' = 'shutdown') {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      devices: [{ id: 'devA', name: 'iPhone A', platform: 'ios', status }],
+    }))
+    const reply = await waitForType<RelayMessage>(agent, 'agent:registered')
+    return { agent, sessionId: reply.registeredSessions![0]!.sessionId }
+  }
+
+  async function joinAs(sessionId: string) {
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return browser
+  }
+
+  // ── the relay is itself a producer of device:boot-error ──────────────────────────────────────────
+  //
+  // This is the position no static check reaches. The relay answers a `device:boot` on its own when it
+  // cannot hand it to an agent, and an MCP caller that receives that diagnosis without the correlator
+  // reads it as unsolicited and waits out its 30s instead — the diagnosis arrives and is thrown away.
+  // The same defect shipped twice from agent code (`open-url:error`, then `clipboard:error` a slice
+  // later); here the producer is the relay and the field is optional, so a test is the only thing
+  // between it and a third recurrence.
+
+  it('echoes the correlator on the boot-error it originates for an unknown session', async () => {
+    const { agent } = await registerAgent()
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+
+    browser.send(JSON.stringify({
+      type: 'device:boot', sessionId: 'no-such-session', requestId: 'rq-unknown',
+      payload: { deviceId: 'devA' },
+    }))
+    const err = await waitForType<RelayMessage>(browser, 'device:boot-error')
+
+    expect(err.message).toBe('Session not found')
+    expect(err.requestId).toBe('rq-unknown')
+
+    agent.close(); browser.close()
+  })
+
+  it('echoes the correlator on the boot-error it originates when the agent is gone', async () => {
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    const closed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await closed
+
+    browser.send(JSON.stringify({
+      type: 'device:boot', sessionId, requestId: 'rq-offline', payload: { deviceId: 'devA' },
+    }))
+    const err = await waitForType<RelayMessage>(browser, 'device:boot-error')
+
+    // The two diagnoses are deliberately different — reporting a stale session id as a dead Mac sends
+    // the reader after the wrong problem — so both exits need the echo, not just one.
+    expect(err.message).toBe('agent offline')
+    expect(err.requestId).toBe('rq-offline')
+
+    browser.close()
+  })
+
+  it('carries the correlator through to the agent, so the reply can be attributed', async () => {
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    const forwarded = waitForType<RelayMessage>(agent, 'device:boot')
+    browser.send(JSON.stringify({
+      type: 'device:boot', sessionId, requestId: 'rq-fwd', payload: { deviceId: 'devA' },
+    }))
+
+    // The relay mutates `payload` on the way through (it adds `external`), so this frame is not simply
+    // relayed verbatim — the correlator surviving that is worth an assertion of its own.
+    expect((await forwarded).requestId).toBe('rq-fwd')
+
+    agent.close(); browser.close()
+  })
+
+  it('carries the correlator through on a shutdown a browser asked for', async () => {
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    const forwarded = waitForType<RelayMessage>(agent, 'device:shutdown')
+    browser.send(JSON.stringify({
+      type: 'device:shutdown', sessionId, requestId: 'rq-down', payload: { deviceId: 'devA' },
+    }))
+
+    expect((await forwarded).requestId).toBe('rq-down')
+
+    agent.close(); browser.close()
+  })
+
+  // ── device:boot is gated at the door ─────────────────────────────────────────────────────────────
+  //
+  // `DeviceBoot.requestId` is required, so an id-less boot is a frame no in-repo sender can build — it
+  // reaches here only from a third-party client or the unvalidated-inbound gap (#444). The policy is the
+  // same as `open-url`'s: not forwarded, not answered, logged. Answering it would ship a
+  // `device:boot-error` whose required correlator `JSON.stringify` erases, which every correlating
+  // consumer then discards — turning a diagnosis into a caller waiting out its deadline.
+
+  /** Sends `raw` from the browser and reports what, if anything, each side saw.
+   *
+   *  Two barriers, and both are needed. The trigger travels on the **browser** socket, so that is what
+   *  proves the relay has processed it; the observation is on the **agent** socket, so that one proves a
+   *  forward would already have been recorded. An earlier version of this shape in the app-command tests
+   *  used a 0ms deadline with no barrier at all and passed on the next tick regardless — and a later one
+   *  barriered only the agent, which orders nothing against a browser-sent trigger. */
+  async function bootAndWatch(build: (sessionId: string) => Record<string, unknown>) {
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    // The session is **real** and its agent socket is open, so with the gate removed this boot is
+    // forwarded and `forwarded` goes non-null. Using a bogus session id instead would also fail without
+    // the gate, but by producing a `Session not found` — a pass keyed on the branch after the one under
+    // test, which would keep passing if the gate moved below the lookup.
+    browser.send(JSON.stringify(build(sessionId)))
+    await barrier(browser)
+    await barrier(agent)
+
+    const forwarded = await waitForTypeOrNull<RelayMessage>(agent, 'device:boot', 0)
+    const answered = await waitForTypeOrNull<RelayMessage>(browser, 'device:boot-error', 0)
+    agent.close(); browser.close()
+    return { forwarded, answered }
+  }
+
+  it('drops a boot with no correlator, and does not answer it either', async () => {
+    const { forwarded, answered } = await bootAndWatch((sessionId) => ({
+      type: 'device:boot', sessionId, payload: { deviceId: 'devA' },
+    }))
+    expect(forwarded).toBeNull()
+    expect(answered).toBeNull()
+  })
+
+  it('drops a boot whose correlator is the empty string', async () => {
+    // The other half of the shared predicate. `''` type-checks against `requestId: string`, and
+    // `mcp-server`'s tool schemas are bare `z.string()`, so a model can put it on the wire. A gate
+    // written as `!== undefined` would pass it through and every other test here would stay green.
+    const { forwarded, answered } = await bootAndWatch((sessionId) => ({
+      type: 'device:boot', sessionId, requestId: '', payload: { deviceId: 'devA' },
+    }))
+    expect(forwarded).toBeNull()
+    expect(answered).toBeNull()
+  })
+
+  // ── device:shutdown is deliberately ungated ──────────────────────────────────────────────────────
+
+  it('forwards a shutdown that carries no correlator', async () => {
+    // The relay originates this message itself from the idle timer, with no browser and no id behind
+    // it, so an absent correlator is not an error and the door cannot gate on it. The two live in one
+    // `case` block away from each other: they shared a fall-through clause until this slice split them,
+    // and an `isCorrelated(msg)` written into the shared body would have taken this path down with it —
+    // silently, since nothing replies to a shutdown. `correlatedRequestsGated` resolves fall-through by
+    // sharing the next non-empty body, so it would have read that gate as covering both and passed.
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    const forwarded = waitForType<RelayMessage>(agent, 'device:shutdown')
+    browser.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'devA' } }))
+
+    const msg = await forwarded
+    expect(msg.sessionId).toBe(sessionId)
+    expect(msg.requestId).toBeUndefined()
+
+    agent.close(); browser.close()
+  })
+
+  // ── the replay answers no boot, and nothing else says so ─────────────────────────────────────────
+
+  it('replays device:ready with neither a sessionId nor a correlator', async () => {
+    // **This is the invariant the whole pair rests on**, and before this test it was held by nothing:
+    // with the replay mutated to stamp `sessionId`, all 591 relay tests, the dashboard's 317 and the
+    // entire static suite still passed.
+    //
+    // Both boot waiters (`mcp-server`, `flow-runner`) compare `msg.sessionId === sessionId` with no
+    // truthiness escape, so the *absence* of the key is what stops a cached ready from satisfying an
+    // in-flight boot — measured once as `boot_device` answering `{booted:true}` with the agent having
+    // sent nothing. Stamping it would delete that, and the optional correlator cannot replace it: an
+    // optional field cannot make a frame fail to match, only make it match more precisely.
+    //
+    // So this asserts an absence, which D25 says is worth only as much as the mutation that creates it.
+    // Verified both ways: adding `sessionId: session.id` to the replay fails the first expectation, and
+    // adding `requestId` to it is not even expressible — the relay has no request to take one from,
+    // which is the point the second expectation records.
+    const { agent, sessionId } = await registerAgent()
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'devA' } }))
+    await barrier(agent)
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    await barrier(browser)
+    const ready = await waitForTypeOrNull<RelayMessage>(browser, 'device:ready', 0)
+
+    expect(ready).not.toBeNull()
+    expect('sessionId' in ready!).toBe(false)
+    expect('requestId' in ready!).toBe(false)
+
+    agent.close(); browser.close()
+  })
+
+  it('forwards an agent reply with its correlator intact and does not invent one', async () => {
+    // The relay forwards agent→browser replies with `JSON.stringify(msg)` and never inspects them, so
+    // it can neither add a correlator nor drop one. Both halves matter: the echo obligation lives
+    // entirely in the agents, and a relay that "helpfully" stamped a reply would make every consumer's
+    // correlator meaningless while every test still passed.
+    const { agent, sessionId } = await registerAgent()
+    const browser = await joinAs(sessionId)
+
+    const ready = waitForType<RelayMessage>(browser, 'device:ready')
+    agent.send(JSON.stringify({
+      type: 'device:ready', sessionId, requestId: 'rq-echoed', payload: { deviceId: 'devA' },
+    }))
+    expect((await ready).requestId).toBe('rq-echoed')
+
+    const done = waitForType<RelayMessage>(browser, 'device:shutdown-done')
+    agent.send(JSON.stringify({
+      type: 'device:shutdown-done', sessionId, payload: { deviceId: 'devA' },
+    }))
+    // An agent that predates the echo, or the unsolicited path: absent stays absent on the way through.
+    expect((await done).requestId).toBeUndefined()
+
+    agent.close(); browser.close()
+  })
+})

--- a/packages/test-utils/AGENTS.md
+++ b/packages/test-utils/AGENTS.md
@@ -25,7 +25,7 @@ These record from the moment the socket opens and answer from the recording, so 
 ```ts
 const ws = new WebSocket(url)
 await waitForOpen(ws)          // recording starts here
-ws.send(JSON.stringify({ type: 'device:boot', … }))
+ws.send(JSON.stringify({ type: 'device:boot', requestId, … }))   // required, or the relay drops it
 await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
 ```
 

--- a/packages/test-utils/src/socket.ts
+++ b/packages/test-utils/src/socket.ts
@@ -29,7 +29,7 @@ export type SocketMessage = Record<string, unknown> & { type: string }
  * ```ts
  * const ws = new WebSocket(url)
  * await waitForOpen(ws)
- * ws.send(JSON.stringify({ type: 'device:boot', ... }))
+ * ws.send(JSON.stringify({ type: 'device:boot', requestId, ... }))   // required, or the relay drops it
  * await waitForType(ws, 'device:ready')   // fine whether it has landed yet or not
  * ```
  *

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -191,7 +191,7 @@ describe('browser-inbound routing matches the protocol union', () => {
   const SIGNATURES = {
     AgentToBrowser: {
       'device:booting': 'sessionId',
-      'device:shutdown-done': 'payload sessionId',
+      'device:shutdown-done': 'payload requestId? sessionId',
       'app:install-done': 'requestId sessionId',
       'app:launch-done': 'requestId sessionId',
       'app:clear-state-done': 'requestId sessionId',
@@ -206,10 +206,10 @@ describe('browser-inbound routing matches the protocol union', () => {
     RelayOrAgentToBrowser: {
       'session:chrome': 'payload sessionId',
       'session:deviceInfo': 'payload sessionId',
-      'device:ready': 'payload sessionId?',
+      'device:ready': 'payload requestId? sessionId?',
       'app:install-error': 'message requestId sessionId',
       'app:launch-error': 'message requestId sessionId',
-      'device:boot-error': 'message sessionId',
+      'device:boot-error': 'message requestId? sessionId',
       'open-url:error': 'message requestId sessionId',
       'app:clear-state-error': 'message requestId sessionId',
       'input:error': 'message reason? sessionId',
@@ -220,8 +220,8 @@ describe('browser-inbound routing matches the protocol union', () => {
       'session:start': 'sessionId',
       'session:end': 'sessionId',
       'session:leave': 'sessionId',
-      'device:boot': 'payload sessionId',
-      'device:shutdown': 'payload sessionId',
+      'device:boot': 'payload requestId sessionId',
+      'device:shutdown': 'payload requestId? sessionId',
       'app:install': 'buildId requestId sessionId',
       'app:launch': 'buildId requestId sessionId',
       'app:clear-state': 'payload requestId sessionId',
@@ -243,7 +243,7 @@ describe('browser-inbound routing matches the protocol union', () => {
     RelayToAgent: {
       'agent:registered': 'registeredSessions',
       'stream:request-idr': 'sessionId',
-      'device:shutdown': 'payload sessionId',
+      'device:shutdown': 'payload requestId? sessionId',
       'app:install': 'payload requestId sessionId',
       'app:launch': 'payload requestId sessionId',
       'screenshot:request': 'format requestId sessionId',

--- a/scripts/__tests__/correlatedRequestsGated.test.mjs
+++ b/scripts/__tests__/correlatedRequestsGated.test.mjs
@@ -13,7 +13,7 @@ import ts from 'typescript'
 // property is **presence of a gate** — unlike the echo obligation, where the property is provenance and no
 // check can see it (see the note above `OpenUrlReplyBody`).
 //
-// The member set is **derived** from the protocol, so a seventh correlated request added later fails here
+// The member set is **derived** from the protocol, so an eighth correlated request added later fails here
 // rather than being noticed by whoever reads the comment. Two gate forms count, and both are real:
 //
 //  - `isCorrelated(msg)` inside the `case` — the inline form.
@@ -107,8 +107,10 @@ describe('every correlated browser request is gated at the relay door', () => {
 
   it('finds the correlated request set, derived rather than listed', () => {
     // If this drops to zero the derivation broke and every assertion below would vacuously pass — the
-    // failure mode a count assertion exists for.
-    expect(types.length).toBeGreaterThanOrEqual(6)
+    // failure mode a count assertion exists for. The floor is raised as pairs land, so removing a
+    // required `requestId` from a request already in the set fails here too, not only where it is used:
+    // 6 after the app commands, 7 once `device:boot` joined.
+    expect(types.length).toBeGreaterThanOrEqual(7)
   })
 
   for (const type of types) {


### PR DESCRIPTION
## Summary

The lifecycle pair joins the four already correlated by `requestId` (`screenshot`, `ui:tree`, `clipboard`, the app commands). It is the first whose correlator is **optional on every reply**, and that is the design rather than a concession: `device:ready`, `device:boot-error` and `device:shutdown-done` all have producers that answer no request at all, so absence has a real and permanent meaning — *this frame is not the answer to anything*. Not "an old agent".

`device:boot` is **required**. Nothing originates a boot but a browser, and a request passes *through* the relay, so one door gates and logs every sender at once. `device:shutdown` cannot be required: the relay sends it itself from the idle timer. Breaking-change approval for the required field was given before implementing.

## What correlation actually buys here

Narrower than the obvious claim, and review caught a draft making the obvious one. It does **not** let two concurrent boots both resolve — the agents answer a superseded boot with nothing at all (`bootSeq` returns silently at every checkpoint), so one of two overlapping boots times out either way. Both clients' `dispatch` resolves the first waiter whose predicate matches and then stops, so on `sessionId` + type alone that single reply went to the boot registered **first**, the superseded one — and the boot that actually happened was reported as a failure. The correlator sends the reply to the request it answers. Same one timeout, correct attribution.

## What the design review deleted

The plan's central premise. A first draft made `DeviceReady.sessionId` required and had the relay stamp its replay, then argued a forced choice: correlate strictly and break every agent predating the field, or keep a fallback and let a replayed ready satisfy an in-flight boot. Measured against a real `RelayServer`, that choice was manufactured by the draft itself — **the discriminator today is that the replay carries no `sessionId`**, and both boot waiters already depend on it. Requiring and stamping it is what deletes the working guard.

Dropped. `sessionId` on `device:ready` stays optional; closing #516's deferral is its own later slice, and it must carry a test pinning the *value* stamped, because there is none: with the stamp mutated to `session.deviceId` — a plausible slip on a line whose payload reads `{ deviceId: session.deviceId }` — every relay and dashboard test and the whole static suite still passed.

The review also found the producer inventory wrong: `AndroidAgent.restartVideoStream` sends `device:boot-error` for a video stream that died mid-session, with no `device:boot` behind it. So that message earns its optional correlator **on its own merits**, and `DeviceViewer` must not gate on it — it is the only surface reporting a dead stream (#426).

## Optional means tests are the entire enforcement

`<Pair>ReplyBody` cannot be built for a field an object may omit, and `scripts/__tests__/correlatedRequestsGated.test.mjs` derives its set only from *required* declarations — so it cannot see the replies, including at the position that matters most: **the relay is itself a producer of `device:boot-error`**, answering a boot it cannot hand to an agent. An uncorrelated diagnosis there is read as unsolicited and discarded, and the caller waits out its deadline instead of failing. That exact defect shipped twice from agent code (`open-url:error`, then `clipboard:error` a slice later); here it sits where no check reaches, so a relay test holds it.

`case 'device:boot': case 'device:shutdown':` was one fall-through clause and is now two — not cosmetic. A gate written into the shared body would have stopped the dashboard's four shutdown senders and the relay's own idle timer from reaching the agent, silently, in the one direction nothing replies to.

## Promoting the request side hung two suites rather than failing to compile

42 fixtures across `IOSAgent.test.ts` and `AndroidAgent.test.ts` send `device:boot` through a real `RelayServer` from inside `JSON.stringify({ … })`, where no annotation exists for a compiler to check. The three **documented** recipes those were copied from are updated too (`ios-agent/AGENTS.md`, `test-utils/src/socket.ts`, `test-utils/AGENTS.md`) — leaving them would hand the next contributor the same mystery. The dashboard has a rule against untyped injected fixtures; the agent packages have no equivalent. Worth one, out of scope here.

## Review

Design review first (two channels over the plan, since this spans several packages), then the pre-PR review — two independent channels in parallel, one with mutation authority and one strictly read-only. **8 findings, all mine, all dispositioned.** 23 author-side mutations before review; all 23 probed what the gate does *with* an id, and review found the blind spot that left — four mutations on how ids enter and leave `bootIdsRef` survived the whole suite, the worst being a `clear()` in the `device:booting` branch, which is invited by the comment above it and breaks every boot while the spinner clears and the device looks healthy.

One finding's conclusion was re-graded on verified grounds, and one of my own claims was false in a way worth naming: I wrote that promoting the field produced "zero compile errors — every sender already minted an id", which argues the compiler cannot see the request side. It can — all four boot senders go through a sink typed `BrowserToRelay` and every one would have errored; they did not only because earlier hunks of the same commit had added the ids.

Record: `.work/reviews/feat__wire-l5b-prime-lifecycle-correlation.md` (HEAD `a669e0a76d0bb94c223efa415632ae175569d50e`), including the cleared lists re-checked after the fixes and three findings skipped with reasons.

## Verification

`tsc -b` clean; `protocol` (incl. `tsconfig.assertions.json`), `dashboard`, `mcp-server`, `test-utils` typecheck clean; lint and a11y-lens clean.

static **264** · agent-core **137** · relay **601** (1 skipped) · dashboard **329** · mcp-server **76** · flow-runner **63** · ios-agent **382** · android-agent **263** · cli **246** · audiotap-helper **4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request correlation for device boot and shutdown operations across supported device workflows.
  * Boot requests now use unique request IDs to match responses to the correct operation.
  * Added protection against stale, mismatched, or replayed device-ready responses.
  * Legacy responses without correlation IDs remain supported where applicable.

* **Bug Fixes**
  * Improved handling of boot failures, shutdown completion, reconnects, and unsolicited restart errors.

* **Documentation**
  * Clarified lifecycle message correlation rules and supported fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->