### PR TITLE
fix(scripts): enumerate the tree from disk, not from git ls-files

### DIFF
--- a/scripts/__tests__/agentSendTyped.test.mjs
+++ b/scripts/__tests__/agentSendTyped.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { execFileSync } from 'node:child_process'
+import { sources } from './sourceFiles.mjs'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -75,8 +75,7 @@ describe('agent sends go through the typed helpers', () => {
     ])
     const offenders = []
     for (const pkg of ['packages/ios-agent/src', 'packages/android-agent/src', 'packages/agent-core/src']) {
-      const files = execFileSync('git', ['ls-files', pkg], { cwd: root, encoding: 'utf8' })
-        .split('\n').filter((f) => f.endsWith('.ts') && !f.includes('__tests__'))
+      const files = sources(pkg).filter((f) => f.endsWith('.ts'))
       for (const f of files) {
         if (Object.values(AGENTS).includes(f) || ALLOWED.has(f)) continue
         const body = stripComments(readFileSync(join(root, f), 'utf8'))

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { execFileSync } from 'node:child_process'
+import { sources } from './sourceFiles.mjs'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -284,9 +284,7 @@ describe('browser-inbound routing matches the protocol union', () => {
     const wire = new Set([...protocolSrc.matchAll(/\{\s*type: '([^']+)'/g)].map((m) => m[1]))
     const found = []
     for (const pkg of ['packages/dashboard', 'packages/mcp-server/src', 'packages/flow-runner/src']) {
-      const files = execFileSync('git', ['ls-files', pkg], { cwd: root, encoding: 'utf8' })
-        .split('\n')
-        .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('__tests__'))
+      const files = sources(pkg)
       for (const f of files) {
         const src = readFileSync(join(root, f), 'utf8').replace(/^\s*\/\/.*$/gm, '')
         for (const m of src.matchAll(/export type (\w+)\s*=\s*((?:\s*\|?\s*\{[^{}]*\}\s*)+)/g)) {

--- a/scripts/__tests__/checksWalkDisk.test.mjs
+++ b/scripts/__tests__/checksWalkDisk.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, mkdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { sources, SKIP_DIRS } from './sourceFiles.mjs'
 
 // #522. Three static checks asked git which files exist. `git ls-files` reports **tracked** files only, and a
@@ -10,46 +10,110 @@ import { sources, SKIP_DIRS } from './sourceFiles.mjs'
 // `packages/ios-agent/src` left all 6 of its tests passing while untracked, and failed the moment `git add -N`
 // made it visible.
 //
-// Fixing the three instances is worth less than this file, because the pattern is what recurs: `git ls-files`
-// is the obvious way to enumerate a package, it reads as more authoritative than a directory walk, and the
-// resulting hole is invisible — the check goes green.
+// Fixing the three instances is worth less than this file, because the pattern is what recurs: asking git is
+// the obvious way to enumerate a package, it reads as more authoritative than a directory walk, and the hole
+// it opens is invisible — the check goes green.
 //
 // The cost was never a bypass, and saying so plainly matters for judging this: pre-commit runs lint and
 // typecheck rather than vitest, and by push time the file is tracked, so CI catches it. What was lost is the
 // local signal — green on the machine that introduced the offender, red in CI, and nothing in the failure to
 // say the two runs disagreed about which files existed.
+//
+// **The first version of this guard was defeated four ways in review**, and each defeat shaped an assertion
+// below rather than being patched where it landed:
+//
+//  1. It scanned only `*.test.mjs` at the top of `scripts/__tests__`. Moving the git call into a sibling
+//     helper module put it out of reach — and this change *created* that idiom by adding `sourceFiles.mjs`,
+//     so the next person writes `trackedFiles.mjs`. One new file plus one changed import reopened the hole
+//     with all three tests green.
+//  2. Its regex required a quote on each side of the literal, so `` execSync(`git ls-files ${pkg}`) `` and
+//     `'git ls-files ' + pkg` walked past it, as did `git ls-tree -r HEAD --name-only`, which lists tracked
+//     files without containing the string at all.
+//  3. `readdirSync` does not recurse, while vitest's include is `scripts/__tests__/**/*.test.mjs`. A check in
+//     a subdirectory was run by vitest and unknown to the guard.
+//  4. (Not a defeat of this file, but found with it.) The extraction had quietly dropped `.d.ts` from the
+//     walk — see `sourceFiles.mjs`.
 
 const root = join(import.meta.dirname, '../..')
-const SELF = 'checksWalkDisk.test.mjs'
+const scriptsDir = join(root, 'scripts')
+const SELF = relative(root, import.meta.filename)
+
+/** Comments stripped, so prose *about* this rule — which every file involved contains — cannot trip it. */
+const code = (path) =>
+  readFileSync(path, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+/** Every `.mjs` under `scripts/`, recursively: checks, helpers a check imports, and checks in subdirectories.
+ *  Walked rather than listed by git, for the reason this whole file is about — a guard against a listing that
+ *  cannot see new files, built on that listing, is blind to the new file, which is the case it exists for.
+ *
+ *  **Not `SKIP_DIRS`**, which is for walks over *sources* and therefore skips `__tests__` — where every check
+ *  lives. Reusing it here reduced this walk to the 7 top-level scripts and was caught only by the floor
+ *  assertion below, which is the case that assertion exists for. */
+const NOT_MODULES = new Set(['node_modules', 'dist', 'coverage'])
+function scriptModules(dir = scriptsDir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (!NOT_MODULES.has(e.name) && !e.name.startsWith('.')) scriptModules(join(dir, e.name), out)
+    } else if (e.name.endsWith('.mjs')) {
+      out.push(join(dir, e.name))
+    }
+  }
+  return out
+}
 
 describe('static checks enumerate the tree from disk, not from git', () => {
-  it('no check derives a file list from git', () => {
-    // Deliberately a property of the *checks*, not of one call site: the three that had this were found by
-    // reading them, and the fourth will be written by someone who has not read this file.
+  const modules = scriptModules().filter((p) => relative(root, p) !== SELF)
+
+  it('no script module asks git which files exist', () => {
+    // `ls-tree` as well as `ls-files`: both report tracked paths only, and the second is the natural
+    // substitute once the first is forbidden. Unanchored, so a template literal or a concatenated command
+    // matches — the spelling that defeated the first version of this assertion.
     //
-    // Enumerated with `readdirSync`, not `git ls-files`. A guard against a listing that cannot see new files,
-    // built on that same listing, would be blind to the new check — which is the case it exists for.
-    const checks = readdirSync(import.meta.dirname)
-      .filter((f) => f.endsWith('.test.mjs') && f !== SELF)
-    expect(checks.length).toBeGreaterThan(10) // derivation broke ⇒ everything below passes vacuously
+    // What this does not catch is deliberate obfuscation (`'ls' + '-files'`), and it is not trying to. The
+    // failure mode being guarded is someone reaching for the obvious tool, not someone hiding it. The import
+    // assertion below is the structural half that does not depend on spelling at all.
+    expect(modules.length).toBeGreaterThan(15) // derivation broke ⇒ everything below passes vacuously
 
-    const offenders = checks.filter((f) =>
-      /['"]ls-files['"]/.test(readFileSync(join(import.meta.dirname, f), 'utf8')))
-
+    const offenders = modules.filter((p) => /\bls-(files|tree)\b/.test(code(p))).map((p) => relative(root, p))
     expect(
       offenders,
-      `these checks enumerate files with 'git ls-files', which cannot see an untracked offender — ` +
+      `these modules ask git which files exist, which cannot see an untracked offender — ` +
       `import { sources } from './sourceFiles.mjs' instead (#522)`,
     ).toEqual([])
   })
 
+  it('every module that enumerates files gets the walk from sourceFiles.mjs', () => {
+    // The structural half, and the one that catches the defeat the spelling check was designed around: the
+    // review reopened the hole by adding `trackedFiles.mjs` exporting its own `sources()` and changing one
+    // import line. The call site read identically, so nothing about the call could tell the difference.
+    const wrong = []
+    for (const p of modules) {
+      const src = code(p)
+      if (!/\bsources\s*\(/.test(src)) continue
+      if (relative(root, p) === 'scripts/__tests__/sourceFiles.mjs') continue // it *is* the walk
+      if (!/from\s+'\.\/sourceFiles\.mjs'/.test(src)) wrong.push(relative(root, p))
+    }
+    expect(
+      wrong,
+      `these modules call sources() but do not import it from './sourceFiles.mjs' — a second walk is how ` +
+      `the git listing comes back under a name this check does not know (#522)`,
+    ).toEqual([])
+  })
+
   it('the walk sees a file git has never heard of', () => {
-    // The assertion above is about spelling. This one is about behaviour, and the pair is what makes the rule
-    // real: alone, the first would still pass if `sources` were rewritten to shell out to git.
-    const dir = mkdtempSync(join(root, 'packages', '.walkprobe-'))
+    // The assertions above are about how the checks are written. This one is about what the walk does, and the
+    // pair is what makes the rule real: alone, the others would still pass if `sources` itself were rewritten
+    // to shell out.
+    //
+    // The probe lives under `scripts/`, deliberately not under `packages/`. Nothing walks `scripts/` for
+    // sources, whereas three checks walk `packages/` — and vitest runs files in parallel, so a probe there
+    // shares a namespace with a tree another worker is enumerating. A leaked directory would then be reported
+    // as a real path by `clientOutboundTyped`, and a removal mid-walk would break it with an ENOENT that has
+    // nothing to do with its subject.
+    const dir = mkdtempSync(join(scriptsDir, '__tests__', '.walkprobe-'))
     try {
       writeFileSync(join(dir, 'brandNew.ts'), 'export const x = 1\n')
-      const rel = dir.slice(root.length + 1)
+      const rel = relative(root, dir)
 
       expect(sources(rel)).toContain(join(rel, 'brandNew.ts'))
       // And git genuinely cannot see it, so the two disagree — which is the whole finding.
@@ -59,14 +123,17 @@ describe('static checks enumerate the tree from disk, not from git', () => {
     }
   })
 
-  it('skips the directories a source check never wants, tests included', () => {
+  it('skips the directories a source check never wants, and keeps .d.ts', () => {
     // `__tests__` is in the skip set because all three callers filtered it by hand. Dropping it widens every
-    // one of them — measured: three tests fail, two of them the consumer checks themselves reporting their own
-    // fixtures as offenders. So the set is load-bearing and the failure is loud, which is why this case asserts
-    // the membership as well as the behaviour: a caller that needs tests should walk them deliberately rather
-    // than by editing this set. `dist` likewise — a built copy of an offender would be reported at a path
+    // one of them — measured: three tests fail, two of them the consumer checks reporting their own fixtures
+    // as offenders. So the set is load-bearing and the failure is loud, which is why membership is asserted
+    // here as well as behaviour. `dist` likewise: a built copy of an offender would be reported at a path
     // nobody can fix.
-    const dir = mkdtempSync(join(root, 'packages', '.walkprobe-'))
+    //
+    // `.d.ts` is asserted **present**, which is the inverse of what this case first claimed. Excluding them
+    // narrowed `browserInboundRouting`, whose subject is exactly what a declaration file holds — see
+    // `sourceFiles.mjs`.
+    const dir = mkdtempSync(join(scriptsDir, '__tests__', '.walkprobe-'))
     try {
       for (const d of ['__tests__', 'dist', 'node_modules']) {
         mkdirSync(join(dir, d))
@@ -75,8 +142,8 @@ describe('static checks enumerate the tree from disk, not from git', () => {
       writeFileSync(join(dir, 'visible.ts'), 'export const z = 1\n')
       writeFileSync(join(dir, 'types.d.ts'), 'export declare const w: number\n')
 
-      const rel = dir.slice(root.length + 1)
-      expect(sources(rel)).toEqual([join(rel, 'visible.ts')])
+      const rel = relative(root, dir)
+      expect(sources(rel).sort()).toEqual([join(rel, 'types.d.ts'), join(rel, 'visible.ts')])
       expect(SKIP_DIRS.has('__tests__')).toBe(true)
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/scripts/__tests__/checksWalkDisk.test.mjs
+++ b/scripts/__tests__/checksWalkDisk.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { sources, SKIP_DIRS } from './sourceFiles.mjs'
+
+// #522. Three static checks asked git which files exist. `git ls-files` reports **tracked** files only, and a
+// file that was just created is exactly the state a new violation is in — so each of those checks was blind to
+// the one file it existed to look at. Measured on `agentSendTyped`: an offender planted in
+// `packages/ios-agent/src` left all 6 of its tests passing while untracked, and failed the moment `git add -N`
+// made it visible.
+//
+// Fixing the three instances is worth less than this file, because the pattern is what recurs: `git ls-files`
+// is the obvious way to enumerate a package, it reads as more authoritative than a directory walk, and the
+// resulting hole is invisible — the check goes green.
+//
+// The cost was never a bypass, and saying so plainly matters for judging this: pre-commit runs lint and
+// typecheck rather than vitest, and by push time the file is tracked, so CI catches it. What was lost is the
+// local signal — green on the machine that introduced the offender, red in CI, and nothing in the failure to
+// say the two runs disagreed about which files existed.
+
+const root = join(import.meta.dirname, '../..')
+const SELF = 'checksWalkDisk.test.mjs'
+
+describe('static checks enumerate the tree from disk, not from git', () => {
+  it('no check derives a file list from git', () => {
+    // Deliberately a property of the *checks*, not of one call site: the three that had this were found by
+    // reading them, and the fourth will be written by someone who has not read this file.
+    //
+    // Enumerated with `readdirSync`, not `git ls-files`. A guard against a listing that cannot see new files,
+    // built on that same listing, would be blind to the new check — which is the case it exists for.
+    const checks = readdirSync(import.meta.dirname)
+      .filter((f) => f.endsWith('.test.mjs') && f !== SELF)
+    expect(checks.length).toBeGreaterThan(10) // derivation broke ⇒ everything below passes vacuously
+
+    const offenders = checks.filter((f) =>
+      /['"]ls-files['"]/.test(readFileSync(join(import.meta.dirname, f), 'utf8')))
+
+    expect(
+      offenders,
+      `these checks enumerate files with 'git ls-files', which cannot see an untracked offender — ` +
+      `import { sources } from './sourceFiles.mjs' instead (#522)`,
+    ).toEqual([])
+  })
+
+  it('the walk sees a file git has never heard of', () => {
+    // The assertion above is about spelling. This one is about behaviour, and the pair is what makes the rule
+    // real: alone, the first would still pass if `sources` were rewritten to shell out to git.
+    const dir = mkdtempSync(join(root, 'packages', '.walkprobe-'))
+    try {
+      writeFileSync(join(dir, 'brandNew.ts'), 'export const x = 1\n')
+      const rel = dir.slice(root.length + 1)
+
+      expect(sources(rel)).toContain(join(rel, 'brandNew.ts'))
+      // And git genuinely cannot see it, so the two disagree — which is the whole finding.
+      expect(execFileSync('git', ['ls-files', rel], { cwd: root, encoding: 'utf8' }).trim()).toBe('')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips the directories a source check never wants, tests included', () => {
+    // `__tests__` is in the skip set because all three callers filtered it by hand. Dropping it widens every
+    // one of them — measured: three tests fail, two of them the consumer checks themselves reporting their own
+    // fixtures as offenders. So the set is load-bearing and the failure is loud, which is why this case asserts
+    // the membership as well as the behaviour: a caller that needs tests should walk them deliberately rather
+    // than by editing this set. `dist` likewise — a built copy of an offender would be reported at a path
+    // nobody can fix.
+    const dir = mkdtempSync(join(root, 'packages', '.walkprobe-'))
+    try {
+      for (const d of ['__tests__', 'dist', 'node_modules']) {
+        mkdirSync(join(dir, d))
+        writeFileSync(join(dir, d, 'hidden.ts'), 'export const y = 1\n')
+      }
+      writeFileSync(join(dir, 'visible.ts'), 'export const z = 1\n')
+      writeFileSync(join(dir, 'types.d.ts'), 'export declare const w: number\n')
+
+      const rel = dir.slice(root.length + 1)
+      expect(sources(rel)).toEqual([join(rel, 'visible.ts')])
+      expect(SKIP_DIRS.has('__tests__')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/__tests__/clientOutboundTyped.test.mjs
+++ b/scripts/__tests__/clientOutboundTyped.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
+import { sources } from './sourceFiles.mjs'
 import { join } from 'node:path'
 import ts from 'typescript'
 
@@ -47,22 +48,6 @@ const FILES = {
   'mcp-server': 'packages/mcp-server/src/client.ts',
   'flow-runner': 'packages/flow-runner/src/RelayClient.ts',
   dashboard: 'packages/dashboard/hooks/useRelay.ts',
-}
-
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'coverage', '__tests__', '.turbo'])
-
-/** Every source file under `packages/`, walked from disk rather than `git ls-files`. Measured: a new sender file
- *  that serializes escapes the completeness check below while it is untracked, and "I just added it" is exactly
- *  when it is untracked. `agentSendTyped.test.mjs` has the same hole for the same reason. */
-function sources(dir, out = []) {
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    if (e.isDirectory()) {
-      if (!SKIP_DIRS.has(e.name)) sources(join(dir, e.name), out)
-    } else if (/\.(ts|tsx)$/.test(e.name) && !e.name.endsWith('.d.ts')) {
-      out.push(join(dir, e.name).slice(root.length + 1))
-    }
-  }
-  return out
 }
 
 const isFn = (n) =>

--- a/scripts/__tests__/sourceFiles.mjs
+++ b/scripts/__tests__/sourceFiles.mjs
@@ -1,0 +1,43 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Shared by every static check that asks "which files are in this part of the tree".
+//
+// **Walked from disk, never `git ls-files`.** That listing reports tracked files only, and a file that was
+// just created is exactly the state a new violation is in — so a completeness check built on it reports
+// nothing about the one file it exists to look at. Measured on `agentSendTyped`: a module calling
+// `ws.send(JSON.stringify(…))` planted in `packages/ios-agent/src` left all 6 tests passing while it was
+// untracked, and failed the moment `git add -N` made it visible.
+//
+// The cost was never a bypass — pre-commit runs lint and typecheck rather than vitest, and by push time the
+// file is tracked, so CI catches it. What it cost was the **local signal**: green on the machine that
+// introduced the offender, red in CI, and nothing in the failure to say the two runs disagreed about which
+// files existed. `clientOutboundTyped` was moved off `git` for this reason and its comment named the two
+// checks still on it; this module is that fix generalised, and `checksWalkDisk.test.mjs` is what stops a
+// fourth check reintroducing the pattern. See #522.
+
+/** Directories a source-completeness check never wants. `__tests__` is here because every current caller
+ *  filtered it out by hand, and a caller that wants tests should walk them deliberately. Load-bearing rather
+ *  than tidy: removing it makes both consumer checks report their own fixtures as offenders. */
+export const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'coverage', '__tests__', '.turbo'])
+
+const repoRoot = join(import.meta.dirname, '../..')
+
+/**
+ * Every `.ts`/`.tsx` source file under `dir`, as **repo-root-relative** paths — the same shape
+ * `git ls-files` produced, so call sites keep their existing filters and comparisons.
+ *
+ * `dir` may be absolute or repo-root-relative. `.d.ts` files are excluded: they declare rather than
+ * implement, so they cannot contain the call sites these checks look for.
+ */
+export function sources(dir, out = []) {
+  const abs = dir.startsWith(repoRoot) ? dir : join(repoRoot, dir)
+  for (const e of readdirSync(abs, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (!SKIP_DIRS.has(e.name)) sources(join(abs, e.name), out)
+    } else if (/\.(ts|tsx)$/.test(e.name) && !e.name.endsWith('.d.ts')) {
+      out.push(join(abs, e.name).slice(repoRoot.length + 1))
+    }
+  }
+  return out
+}

--- a/scripts/__tests__/sourceFiles.mjs
+++ b/scripts/__tests__/sourceFiles.mjs
@@ -27,15 +27,22 @@ const repoRoot = join(import.meta.dirname, '../..')
  * Every `.ts`/`.tsx` source file under `dir`, as **repo-root-relative** paths — the same shape
  * `git ls-files` produced, so call sites keep their existing filters and comparisons.
  *
- * `dir` may be absolute or repo-root-relative. `.d.ts` files are excluded: they declare rather than
- * implement, so they cannot contain the call sites these checks look for.
+ * `dir` may be absolute or repo-root-relative.
+ *
+ * **`.d.ts` files are included**, because excluding them narrowed a check that needs them. A first version
+ * dropped them on the reasoning that a declaration file cannot contain a call site — true for
+ * `agentSendTyped`, false for `browserInboundRouting`, whose subject is `export type X = { type: '…' } | …`
+ * and which walks `packages/dashboard`, where two tracked `.d.ts` files live. Measured: a planted union in a
+ * `.d.ts` was reported before the extraction and silently not after, and renaming it to `.ts` brought the
+ * detection back — so the extension, not the content, decided it. The three call sites' original filters
+ * (`endsWith('.ts')` and `/\.(ts|tsx)$/`) both admitted `.d.ts`, and this helper reproduces that exactly.
  */
 export function sources(dir, out = []) {
   const abs = dir.startsWith(repoRoot) ? dir : join(repoRoot, dir)
   for (const e of readdirSync(abs, { withFileTypes: true })) {
     if (e.isDirectory()) {
       if (!SKIP_DIRS.has(e.name)) sources(join(abs, e.name), out)
-    } else if (/\.(ts|tsx)$/.test(e.name) && !e.name.endsWith('.d.ts')) {
+    } else if (/\.(ts|tsx)$/.test(e.name)) {
       out.push(join(abs, e.name).slice(repoRoot.length + 1))
     }
   }


### PR DESCRIPTION
Closes #522.

## The hole

Three static checks under `scripts/__tests__/` built their file lists with `execFileSync('git', ['ls-files', pkg])`. `git ls-files` reports **tracked** files only — so a file that was just created, which is the state a new violation is always in, was not in the list, and the check that exists to catch it reported nothing.

Measured on `agentSendTyped`: a module calling `ws.send(JSON.stringify(…))` planted in `packages/ios-agent/src` left all 6 of its tests passing while untracked, and failed the moment `git add -N` made it visible. After this change the same untracked file fails immediately.

**Not a bypass, and the distinction decides how much this is worth.** `lefthook.yml` runs lint, typecheck and a11y-lens on pre-commit rather than vitest — but by push time the file is tracked, so CI's `test` job catches it. What was lost is the **local signal**: green on the machine that introduced the offender, red in CI, and nothing in the failure to say the two runs disagreed about which files existed.

`clientOutboundTyped` was already walking the filesystem for exactly this reason, and its comment named the two checks still on git. That walk is now `sourceFiles.mjs`, shared by all three.

## The guard is the part worth more than the three edits

The pattern is what recurs: asking git is the obvious way to enumerate a package, it reads as more authoritative than a directory walk, and the hole it opens is invisible because the check goes green. So `checksWalkDisk.test.mjs` asserts the property rather than the three instances.

**Review defeated the first version of it four ways, each green on the full suite with the hole reopened.** Every fix is an assertion, not a patch where the defeat landed:

1. **A sibling helper put the git call out of reach.** The scan looked only at `*.test.mjs` at the top of `scripts/__tests__` — and this change had *invented* the helper idiom by adding `sourceFiles.mjs`, so `trackedFiles.mjs` plus one changed import line reopened everything. Fixed two ways: the scan is now every `.mjs` under `scripts/`, recursively, and a second assertion is structural rather than textual — any module calling `sources()` must import it from `./sourceFiles.mjs`, which is the exact line that defeat changed.
2. **The regex required a quote on each side of the literal**, so `` `git ls-files ${pkg}` `` and `'git ls-files ' + pkg` walked past it, as did `git ls-tree -r HEAD --name-only`, which lists tracked paths without containing the forbidden string at all. Now `/\bls-(files|tree)\b/`, unanchored, over comment-stripped source — needed because every file involved discusses the rule in prose. It does **not** try to catch obfuscation (`'ls' + '-files'`), and says so: the structural assertion above is the half that does not depend on spelling.
3. **`readdirSync` does not recurse** while vitest's include does, so a check under `scripts/__tests__/wire/` was run by vitest and unknown to the guard — with the `> 10` floor still satisfied by the 19 top-level files, so nothing reported the gap.
4. **The extraction had quietly dropped `.d.ts`** — a coverage regression, not a tidy-up. All three original filters admitted declaration files, and `browserInboundRouting`'s subject is `export type X = { type: '…' } | …`, which is exactly what a `.d.ts` holds, in a tree with two tracked ones. Measured pre/post on the same planted file: reported before, silent after, and renaming it `.ts` restored detection — so the extension decided it. The first commit's reasoning ("declare rather than implement, so they cannot contain the call sites") was true for `agentSendTyped` and false for the check that needed them.

Also from the review: the probe directories were created under `packages/`, sharing a namespace with the tree three checks walk while vitest runs files in parallel — a leak would be reported as a real path and a removal mid-walk would break an unrelated check with an ENOENT. They live under `scripts/__tests__/` now; nothing walks it.

And one my own anti-vacuity floor caught: reusing `SKIP_DIRS` for the module scan reduced it to the 7 top-level scripts, because that set is for walks over *sources* and skips `__tests__` — where every check lives.

## Verification

All four defeats re-run against this branch: each fails. The original hole still fails immediately.

`tsc -b` clean; `protocol`, `dashboard`, `mcp-server`, `test-utils` typecheck clean; lint clean apart from two pre-existing warnings, neither on this diff. Static suite **267**. No probe directories left behind. No changeset — `pnpm changeset:check` reports no published source changed.

Review record: `.work/reviews/fix__static-checks-walk-disk.md`. It also records a process failure of mine worth reading: I switched the shared checkout's branch while the review was running on it, and the reviewer only survived by noticing via `git reflog` and building its own worktree.

## Ordering

Touches `browserInboundRouting.test.mjs`, as #521 does, but in a different function — a rebase should be clean either way. Merging #521 first is the simpler order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify source checks scan files directly from disk, including newly created untracked files.
  - Confirmed generated, dependency, test, and tooling directories are excluded while declaration files remain included.
  - Updated existing validation tests to use consistent source discovery.
- **Refactor**
  - Centralized recursive TypeScript source-file discovery for more reliable and consistent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->