### PR TITLE
test(scripts): guard dashboard chunk size regression

### DIFF
--- a/scripts/__tests__/dashboardFirstLoadBudget.test.mjs
+++ b/scripts/__tests__/dashboardFirstLoadBudget.test.mjs
@@ -5,7 +5,7 @@
 // index.html, and budget the precompressed Brotli bytes that the relay serves.
 import { beforeAll, describe, expect, it } from 'vitest'
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync, statSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
 import { dirname, relative, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -13,6 +13,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const DASHBOARD_DIST = resolve(ROOT, 'packages', 'dashboard', 'dist')
 const INDEX_HTML = resolve(DASHBOARD_DIST, 'index.html')
 const FIRST_LOAD_BROTLI_BUDGET = 155_000
+const MAX_RAW_JS_CHUNK_SIZE = 500_000
 
 function buildDashboardDist() {
   const env = { ...process.env, NODE_ENV: 'production' }
@@ -80,6 +81,22 @@ function firstLoadBrotliReport() {
   return { total, details: lines.join('\n') }
 }
 
+function oversizedJavascriptChunks() {
+  const assetsDir = resolve(DASHBOARD_DIST, 'assets')
+  if (!existsSync(assetsDir)) {
+    throw new Error('packages/dashboard/dist/assets is missing after dashboard build')
+  }
+
+  return readdirSync(assetsDir)
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => {
+      const asset = resolve(assetsDir, name)
+      return { name, size: statSync(asset).size }
+    })
+    .filter(({ size }) => size > MAX_RAW_JS_CHUNK_SIZE)
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
 describe('dashboard first-load JavaScript budget', () => {
   beforeAll(() => {
     buildDashboardDist()
@@ -91,5 +108,14 @@ describe('dashboard first-load JavaScript budget', () => {
       total,
       `First-load Brotli JS is ${total} B, budget is ${FIRST_LOAD_BROTLI_BUDGET} B.\n\nAssets:\n${details}`,
     ).toBeLessThanOrEqual(FIRST_LOAD_BROTLI_BUDGET)
+  })
+
+  it('keeps emitted JavaScript chunks below the Vite large-chunk threshold', () => {
+    const oversized = oversizedJavascriptChunks()
+    const details = oversized.map(({ name, size }) => `- ${name}: ${size} B`).join('\n')
+    expect(
+      oversized,
+      `JavaScript chunks exceed ${MAX_RAW_JS_CHUNK_SIZE} B raw:\n${details}`,
+    ).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary

Closes #524

Extends the dashboard build regression guard added in #520 with a second, independent assertion for emitted JavaScript chunk size.

The existing check protects first-load Brotli bytes, but removing `manualChunks` lowers that metric while restoring the 541.99 kB application chunk and Vite warning. This adds a raw-size guard so the two failure modes are covered separately.

## What changed

- scan emitted `packages/dashboard/dist/assets/*.js` files dynamically
- fail if any JavaScript chunk exceeds 500,000 B raw
- include the offending chunk name and byte size in the failure message
- keep the existing 155,000 B first-load Brotli budget unchanged

## Validation

Healthy configuration:

- first-load Brotli: 147,129 B / 155,000 B
- largest JS chunk: 285,077 B / 500,000 B
- targeted guard: 2 tests passed

Negative checks:

- removing `manualChunks`
  - first-load Brotli guard still passes
  - raw chunk guard fails at 541,990 B as expected

- restoring the rejected eager UI/forms split
  - existing first-load Brotli guard fails at 159,602 B as expected
  - confirms the two guards protect different regressions

Full validation:

- `pnpm exec vitest run --config scripts/vitest.config.mjs dashboardFirstLoadBudget`
- `pnpm test` — 180 files passed / 1 skipped; 2370 tests passed / 1 skipped
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

The existing unrelated lint warnings remain unchanged.

## Scope

Only:

- `scripts/__tests__/dashboardFirstLoadBudget.test.mjs`

No production configuration or dependency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure dashboard JavaScript assets stay within a 500,000-byte size limit.
  * Added checks that the dashboard assets directory exists and reports details for oversized chunks.
  * Preserved the existing Brotli-compressed first-load budget validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->