### PR TITLE
feat(protocol): correlate input acks, and gate every session command on ownership

### DIFF
--- a/.changeset/input-ack-correlation.md
+++ b/.changeset/input-ack-correlation.md
@@ -1,0 +1,147 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': patch
+'@tapflowio/ios-agent': patch
+'@tapflowio/android-agent': patch
+'@tapflowio/mcp-server': patch
+'@tapflowio/flow-runner': patch
+---
+
+feat(protocol): correlate input acks, and refuse an input from a socket that does not hold the session
+
+Closes #499. Five requests carry a required `requestId` — the four terminal frames (`input:touch:end`,
+`input:pinch:end`, `input:key`, `input:button`) and `input:type` — and so do the four replies. The four pairs
+already correlated arrive at the speed a person clicks a button; a swipe is dozens of frames, which is why an
+ack that missed its own deadline being consumed by the **next** input's waiter was never a corner case.
+
+**Opening and move frames carry none, and neither does `input:rotate`.** Nothing acks them, so an id there
+would name a waiter that does not exist.
+
+## Required on both sides, and the compiler holds more here than anywhere else in this work
+
+No producer of these replies sends one unsolicited — `ackInput` fires on terminal outcomes only,
+`ackNoSession` answers a terminal input for a session the agent lost, and the relay answers one it cannot
+dispatch. Six producers of `input:error`, every one behind a request. So both sides are required, unlike the
+lifecycle pair (#521) whose replies have genuinely unsolicited producers.
+
+That matters concretely: the relay's own `input:error` goes through `sendTo(msg: RelayOutbound)` and the
+agents' through `sendMsg(msg: AgentControlOutbound)`, so omitting the echo is a **compile error** rather than
+something only a test could catch. That is the position #521 could not reach, and it is exactly where the same
+defect had already shipped twice.
+
+`input:type-error` moved from `AgentToBrowser` to `RelayOrAgentToBrowser`, because the relay produces it now —
+the compiler refused the send until the union said so, which is the rule `relay/AGENTS.md` states.
+
+## The eleven input cases became two clauses
+
+Written into the shared body, the correlator gate would have dropped every opening and move frame with it: no
+swipe, no pinch, no rotation, and nothing said. `correlatedRequestsGated` resolves fall-through by sharing the
+next non-empty body, so it would have read one gate as covering all eleven — the trap `#521`'s own comment
+documents, walked into one slice later. `TERMINAL_INPUT_TYPES` is deleted: the clause labels are the
+definition now, and a second source of truth for "which inputs are answered" is what this work removes.
+
+## The sender must hold the session — on every branch, not just input
+
+Folded in rather than deferred, because it changes this layer's own reasoning: with the check, a foreign
+`input:error` cannot reach the dashboard, so the rule "the dashboard does not correlate" gets a durable reason
+instead of one a later slice deletes.
+
+Review then found that **input was one branch of ten.** The relay acted on every browser→agent command on the
+strength of the session existing — `clipboard:write` pasting attacker text into the victim's device,
+`clipboard:read` pressing copy or cut on it with the payload landing on *that* tester's host OS clipboard,
+`session:end` deleting their session. `clipboard:data` has asked the mirror-image question since the bridge
+was written, with the reason beside it; the browser direction had none anywhere. And the hole was already
+documented in-repo: `SessionList.tsx` sends `session:start` before a shutdown purely to work around it, and
+its comment says so.
+
+So the check now covers the five acked inputs, `device:boot`, `open-url`, `app:install`, `app:launch`,
+`app:clear-state`, `clipboard:read`, `clipboard:write`, `session:leave` and `session:end`. Nothing in-repo
+relied on the old behaviour — every sender joins first, and the dashboard's app, deeplink and clipboard
+senders all live under the component that joins.
+
+`dispatchTarget` decides it once: session exists, this socket holds it, agent connected. That collapsed three
+conditions spread across seven `case` bodies as two each — with ownership in none of them — so the cases got
+**shorter**. The app-command handlers check ownership directly instead, after the session lookup and before
+the build lookup: the resolver also decides agent liveness, and using it there would move `agent offline`
+ahead of `Build not found`, changing which of two simultaneous problems the caller is told about.
+
+A refusal is **answered where a waiter exists** and dropped where none does. Answering is the load-bearing
+half: a session that has never acked reports silence as *success*, so dropping would report a command that
+never left the relay as having landed. `session:leave` and `session:end` have no reply, so they are dropped —
+the same asymmetry as the input frames nothing acks.
+
+`not-session-owner` is its own reason on this set's rule — one reason per thing a consumer must do
+differently — and it is the only member that can promise nothing reached the device, so the first whose advice
+says "retry after joining" without a hedge (#491). Two prose strings behind it (`ownershipRefusal`), because
+telling a caller the session is in use when it is idle steers it off a device it could have had.
+
+**`device:shutdown` is the one command left out**, and the blocker is the dashboard rather than the relay:
+three of its four senders come from `useAgentSession`, whose socket never joins, so the gate would break going
+back and the unmount teardown. The question is whether that hook should join — #527.
+
+One diagnosis improved for free: `open-url` answered `'agent offline'` for a session the relay does not have,
+which is the wrong-diagnosis class #492 fixed for `device:boot` and `input:error` and had left here. The
+shared resolver corrected it, and the test that pinned the old prose says so.
+
+## The ledger records a *correlated* ack
+
+`ackedSessions` gates whether silence is fatal, and it now records `input:done` only when it carries a
+correlator. `strict` licenses one inference — *silence here is an anomaly, not an agent that does not ack* —
+and for an agent that never carries a correlator, silence at the waiter is **structural**: its acks can never
+match. Recording it would make every input after the first report a failure the agent had no way to avoid.
+
+Not a provenance question, which is what a first draft claimed: an id-less `input:done` is still the agent's
+word. What it lacks is attribution, and attribution is the waiter's question. Nor is the condition "an id
+*this client* issued" — that needs a set of issued ids outliving their waiters, and since the late ack is
+precisely the one worth recording, the set would never shrink in a long-lived stdio process.
+
+The cost lands on agents predating the correlator, and it is not a revert of #457: `mcp-server/AGENTS.md`
+already documented that an agent whose acks never arrive keeps the optimistic path. This widens that
+exemption from "predating the ack protocol" to "predating the correlator". Because there is **no version
+handshake anywhere** in this system, an id-less ack is the only skew signal that exists — so it goes in a
+second set carrying no strictness, logged once per session. Dropped silently, the session would return to
+optimistic reporting, which from an operator's seat is indistinguishable from #457.
+
+## Not closed: #517
+
+`input:keyboard:toggle` stays out, and not for the reason a first draft gave. It **has** a reply on iOS
+(`keyboard:toggled`) with a consumer that sets session state; what is missing is the **failure half** — the
+`.catch` only logs, so the pending flag never clears and the button latches off. Correlating a pair whose
+failure half does not exist leaves it half-correlated, and the missing half is platform-asymmetric, since
+Android's toggle has no device-side effect at all. #517 is the prerequisite.
+
+## What the mutation round found
+
+**26 mutations, none surviving** — reached in three rounds, and what each round found is the story.
+
+Round one: nine mutations, **five alive** on a green suite. The correlator gate deleted (600 relay tests
+passed), the ownership check deleted (600 passed), both agents' `input:done` echo replaced with a literal,
+`ackNoSession`'s echo likewise, and a `sessionId` fallback added back to the waiter (77 passed). Every one was
+a test the plan had specified and this work had not written — the same blind spot as #521, where fixing the
+fixtures felt like finishing.
+
+Round two, after six new tests: the two review channels found **four more**, and the sharpest was not a gap in
+coverage but a new failure mode. `flow-runner`'s `tap`, `swipe` and `pressKey` await nothing, so setting their
+minted id to `''` left all 63 tests passing while every frame was dropped at the relay's door — a flow whose
+taps never left the relay reports **PASS**. The old code could not fail that way, because there was no id to
+get wrong. Also unpinned: the `input:error` half of both agents' `ackInput` (worse than a hang — an unmatched
+reply resolves *optimistically*, so a stated device failure reaches the caller as success), `input:type`'s
+correlation on all four producers and both consumers, and an **unheld** session accepting input from anyone.
+
+Round three: two of the tests written in round two were themselves Potemkin. Both staged a stale reply and
+then asserted the request count — 1 either way, so they passed with the correlator check deleted. Making the
+stale reply an *error* is what made which reply resolved the call observable. Asserting a property needs the
+mutation that removes it to fail, and counting requests was not that.
+
+Six more mutations cover the widened gate, including one that collapses the two ownership prose strings into
+one (nine tests) and one that drops `Session not found` from the resolver (four).
+
+Two things caught by tooling rather than by me. `pnpm exec tsc -b` does not cover
+`protocol/tsconfig.assertions.json`, so four errors there passed straight through my checks until the
+pre-commit hook refused the commit. And lint reported `TERMINAL_INPUT_TYPES` dead the moment the clause split
+removed its last use.
+
+Promoting the request side hung both agent suites rather than failing to compile: 64 fixtures across
+`IOSAgent.test.ts` and `AndroidAgent.test.ts` send these inputs from inside `JSON.stringify({ … })`, where no
+annotation exists for a compiler to check. Third slice in a row on that surface — worth a rule for the agent
+packages, as the dashboard has, and out of scope here.

--- a/.changeset/input-ack-correlation.md
+++ b/.changeset/input-ack-correlation.md
@@ -83,6 +83,35 @@ One diagnosis improved for free: `open-url` answered `'agent offline'` for a ses
 which is the wrong-diagnosis class #492 fixed for `device:boot` and `input:error` and had left here. The
 shared resolver corrected it, and the test that pinned the old prose says so.
 
+## A second door predicate: the request must name a session
+
+CodeRabbit found that `isCorrelated` validated `requestId` only, so a command with no `sessionId` — or an
+empty one, which type-checks and which `mcp-server`'s bare `z.string()` tool schemas let a model produce —
+reached the reply builders and shipped a frame whose **required** `sessionId` `JSON.stringify` erases. Every
+consumer's session gate then discards it, so the caller waits out its deadline with the diagnosis in hand and
+no way to attribute it. `isAddressed` closes it at the same doors, with the same policy: not forwarded, not
+answered, logged.
+
+**Dropped rather than answered, and the note this contradicts is in this repo.** `SessionError`'s doc said
+"the only correct thing for it to send with no sessionId is `{ type: 'error' }`". That was written before
+requests carried a second correlator, and its own premise refutes it now: `GenericError` has no `requestId`,
+so a caller that receives one cannot attribute it and waits out the same deadline it would have waited out on
+silence. Answering was never the payoff — not shipping a frame that violates its own declaration is, and
+dropping achieves that more cheaply. Widening `SessionStartFailure` to carry an "unaddressed" reason was the
+alternative, and it is what L5d is for: that union's own doc says it has a single producer in
+`handleSessionStart`, so adding a member would make that false while pre-deciding what `error` is.
+
+Narrowing `dispatchTarget` to `sessionId: string` is what found the doors — exactly four compile errors, then
+the handler signatures carried the rest. **Seven `msg.sessionId!` assertions went away** on the request side
+as a consequence, which is the payoff `SessionError`'s doc predicted. The eleven left are all agent→browser
+forwards, unchanged in count from `main`, and still #444.
+
+Three places got the predicate and then **had it removed again**, because a mutation showed there was nothing
+observable to hold it with: the unacked input clause, `device:shutdown`, and the two session commands. In each
+the frame is dropped by the session miss anyway, so the gate bought only its log — one line per
+`input:touch:move` in the first case, which is the ~60/s the ownership warn had already been removed from that
+same method for. A line no test can hold is a line that will drift, and the reason is recorded at each site.
+
 ## The ledger records a *correlated* ack
 
 `ackedSessions` gates whether silence is fatal, and it now records `input:done` only when it carries a

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -953,7 +953,22 @@ export class AndroidAgent implements DeviceAgent {
   // it awaited the dispatch. Reading it here would be too late: a reboot that started under that
   // await would already have been counted, and caching `booted` across it poisons every later input
   // on the session, since they all skip the verify.
-  private async ackInput(state: DeviceState, outcome: InputOutcome, seq: number): Promise<void> {
+  /** The correlator on an input an ack answers, or `null` if the frame cannot be attributed.
+   *
+   *  A local capture rather than a guard at the top of the dispatcher: a guard there would not narrow
+   *  `msg.requestId` inside the case, so the shortest way to satisfy the reply's required field would be
+   *  `msg.requestId!` — the assertion removed from `open-url` and then from clipboard. Inbound is
+   *  unvalidated (#444) and `mcp-server`'s tool schemas are bare `z.string()`, so `''` is reachable. */
+  private correlatorOf(msg: { type: string; requestId?: string }): string | null {
+    if (typeof msg.requestId === 'string' && msg.requestId !== '') return msg.requestId
+    logger.warn(`${msg.type} without a usable requestId — dropped, its ack could not be attributed`)
+    return null
+  }
+
+  // `requestId` joins `seq` as a caller-captured parameter, for the same reason stated above it: state
+  // moves under the awaited dispatch, and a correlator read from shared state would answer one input with
+  // another's id — #499 rebuilt inside the agent.
+  private async ackInput(state: DeviceState, outcome: InputOutcome, seq: number, requestId: string): Promise<void> {
     // Only worth verifying the device when we believe we dispatched: every other outcome already
     // knows why it failed, and asking adb would add a round trip to say the same thing.
     const resolved: InputOutcome = outcome !== 'delivered'
@@ -962,20 +977,20 @@ export class AndroidAgent implements DeviceAgent {
     if (resolved === 'delivered' && seq === state.bootSeq) state.booted = true // cache the verify
     this.sendMsg(
       resolved === 'delivered'
-        ? { type: 'input:done', sessionId: state.sessionId }
-        : { type: 'input:error', sessionId: state.sessionId, message: outcomeMessage(resolved), reason: wireReason(resolved) })
+        ? { type: 'input:done', sessionId: state.sessionId, requestId }
+        : { type: 'input:error', sessionId: state.sessionId, requestId, message: outcomeMessage(resolved), reason: wireReason(resolved) })
   }
 
   // A terminal input naming a session this agent holds no state for. `deviceStates` is never
   // deleted, so this is an unregistered sessionId rather than an evicted one — and the relay only
   // answers on an agent's behalf when the agent is *offline*, so nothing else would answer at all
   // and the caller would wait out its own timeout.
-  private ackNoSession(sessionId: string): void {
+  private ackNoSession(sessionId: string, requestId: string): void {
     // The `if (!sessionId) return` this used to open with is gone: the dispatcher now declares
     // `sessionId: string`, so there is no undefined to guard against and the guard would have been a
     // silent drop with nothing left that could reach it.
     this.sendMsg({
-      type: 'input:error', sessionId, message: outcomeMessage('no-session'), reason: wireReason('no-session'),
+      type: 'input:error', sessionId, requestId, message: outcomeMessage('no-session'), reason: wireReason('no-session'),
     })
   }
 
@@ -1110,8 +1125,10 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:touch:end': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         const pc = this.pointerControl(state)
         const helper = state.touchHelper
         const seq = state.bootSeq
@@ -1120,7 +1137,7 @@ export class AndroidAgent implements DeviceAgent {
           pc ? await this.dispatchTo(pc, () => pc.touchUp(0, state.lastTouchPx.x, state.lastTouchPx.y))
             : helper ? await helper.touchEnd()
             : 'channel-down',
-          seq,
+          seq, requestId,
         ))().catch((e) => logger.error('input:touch:end ack failed:', e))
         break
       }
@@ -1153,8 +1170,10 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:end': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         const pc = this.pointerControl(state)
         const helper = state.touchHelper
         const seq = state.bootSeq
@@ -1162,7 +1181,7 @@ export class AndroidAgent implements DeviceAgent {
           pc ? await this.dispatchTo(pc, () => pc.pinchEnd())
             : helper ? helper.pinchEnd()   // 'unsupported' — the adb path has no pinch at all
             : 'channel-down',
-          seq,
+          seq, requestId,
         ))().catch((e) => logger.error('input:pinch:end ack failed:', e))
         break
       }
@@ -1181,8 +1200,10 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:button': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         // Buttons go through the adb helper on BOTH backends — this is the path that actually runs
         // a command in production, so its outcome is the one that matters most here.
         // Destructuring inside the async body: doing it out here would throw synchronously on a
@@ -1191,9 +1212,9 @@ export class AndroidAgent implements DeviceAgent {
         void (async () => {
           const { name } = (msg.payload ?? {}) as { name?: string }
           const helper = state.touchHelper
-          if (name === undefined) return this.ackInput(state, 'malformed', seq)
-          if (!helper) return this.ackInput(state, 'channel-down', seq)
-          return this.ackInput(state, await helper.pressButton(name), seq)
+          if (name === undefined) return this.ackInput(state, 'malformed', seq, requestId)
+          if (!helper) return this.ackInput(state, 'channel-down', seq, requestId)
+          return this.ackInput(state, await helper.pressButton(name), seq, requestId)
         })().catch((e) => logger.error('input:button ack failed:', e))
         break
       }
@@ -1241,12 +1262,14 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'input:type': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
         const { text } = (msg.payload ?? {}) as { text?: string }
         if (!serial) {
-          this.sendMsg({ type: 'input:type-error', sessionId, message: 'No booted device' })
+          this.sendMsg({ type: 'input:type-error', sessionId, requestId, message: 'No booted device' })
           break
         }
         // Empty text is a successful no-op, not a failure: the caller asked for nothing and nothing
@@ -1256,26 +1279,28 @@ export class AndroidAgent implements DeviceAgent {
         // Ack on completion so a following input step (e.g. pressKey Enter) is
         // only sent after the text has actually landed.
         Promise.resolve(text ? this.adb.inputText(serial, text) : undefined)
-          .then(() => this.sendMsg({ type: 'input:type-done', sessionId }))
+          .then(() => this.sendMsg({ type: 'input:type-done', sessionId, requestId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
             logger.error('input:type failed:', e)
-            this.sendMsg({ type: 'input:type-error', sessionId, message })
+            this.sendMsg({ type: 'input:type-error', sessionId, requestId, message })
           })
         break
       }
       case 'input:key': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         const seq = state.bootSeq
         void (async () => {
           const serial = this.adb.getSerial(state.deviceId)
-          if (!serial) return this.ackInput(state, 'channel-down', seq)
+          if (!serial) return this.ackInput(state, 'channel-down', seq, requestId)
           // `modifiers` is optional in the contract and iOS already defaults it; match that here so
           // both agents read the same message the same way.
           const { code, modifiers } = (msg.payload ?? {}) as { code?: string; modifiers?: number }
-          if (code === undefined) return this.ackInput(state, 'malformed', seq)
-          return this.ackInput(state, await this.handleKeyInput(serial, code, modifiers ?? 0), seq)
+          if (code === undefined) return this.ackInput(state, 'malformed', seq, requestId)
+          return this.ackInput(state, await this.handleKeyInput(serial, code, modifiers ?? 0), seq, requestId)
         })().catch((e) => logger.error('input:key ack failed:', e))
         break
       }

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -864,7 +864,7 @@ describe('AndroidAgent', () => {
       it('touch:end lifts at the last touched px', () => {
         const control = getState().scrcpySession!.control
         inject({ type: 'input:touch:start', payload: { x: 0.1, y: 0.2 } })
-        inject({ type: 'input:touch:end' })
+        inject({ type: 'input:touch:end', requestId: 'rq-lift' })
         // last px from start: 0.1*1080 = 108, 0.2*2400 = 480
         expect(control.touchUp).toHaveBeenCalledWith(0, 108, 480)
       })
@@ -873,8 +873,14 @@ describe('AndroidAgent', () => {
       it('acks input:done on touch:end for a booted session', async () => {
         const done = waitForType(browser, 'input:done')
         browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-        browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-        expect((await done).sessionId).toBe(agent.sessionId)
+        browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in1', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+        const ack = await done
+        expect(ack.sessionId).toBe(agent.sessionId)
+        // L5c. The terminal frame's id, not any id: replacing the echo with a literal left all 263 tests
+        // passing in the mutation round. `requestId` rides beside `seq` as a caller-captured argument for
+        // the same reason — a gesture is dozens of frames and two can overlap, so a correlator read from
+        // shared state would answer one input with another's id, which is #499 rebuilt inside the agent.
+        expect(ack.requestId).toBe('rq-in1')
       })
     })
 
@@ -890,7 +896,7 @@ describe('AndroidAgent', () => {
         const control = getState().scrcpySession!.control
         inject({ type: 'input:pinch:move', payload: { f0: { x: 0.5, y: 0.5 }, f1: { x: 0.5, y: 0.5 } } })
         expect(control.pinchMove).toHaveBeenCalledWith(540, 1200, 540, 1200)
-        inject({ type: 'input:pinch:end' })
+        inject({ type: 'input:pinch:end', requestId: 'rq-pinch' })
         expect(control.pinchEnd).toHaveBeenCalledOnce()
       })
     })
@@ -920,7 +926,7 @@ describe('AndroidAgent', () => {
         let resolveInput!: () => void
         const spy = vi.spyOn(adb, 'inputText').mockReturnValue(new Promise<void>((r) => { resolveInput = r }))
         const ack = waitForType(browser, 'input:type-done')
-        inject({ type: 'input:type', payload: { text: 'hello' } })
+        inject({ type: 'input:type', requestId: 'rq-in2', payload: { text: 'hello' } })
         await vi.waitFor(() => expect(spy).toHaveBeenCalledWith('emulator-5554', 'hello'), { timeout: 500 })
         // ack must NOT have fired while inputText is still pending
         let acked = false
@@ -937,23 +943,28 @@ describe('AndroidAgent', () => {
       it('acks input:type-done for empty text without touching adb', async () => {
         const inputText = vi.spyOn(adb, 'inputText')
         const ack = waitForType(browser, 'input:type-done')
-        inject({ type: 'input:type', payload: { text: '' } })
-        await ack
+        inject({ type: 'input:type', requestId: 'rq-in3', payload: { text: '' } })
+        // The correlator on the success half. All three `input:type-*` producers here took a literal in the
+        // mutation round without a single test noticing — and the two client tests that echo it echo it
+        // *correctly*, so a predicate that stopped checking would have matched either way.
+        expect((await ack).requestId).toBe('rq-in3')
         expect(inputText).not.toHaveBeenCalled()
       })
 
       it('acks input:type-error when the text is rejected', async () => {
         vi.spyOn(adb, 'inputText').mockRejectedValue(new Error('ASCII only'))
         const ack = waitForType(browser, 'input:type-error')
-        inject({ type: 'input:type', payload: { text: '안녕' } })
-        expect((await ack).message).toBe('ASCII only')
+        inject({ type: 'input:type', requestId: 'rq-in4', payload: { text: '안녕' } })
+        const err = await ack
+        expect(err.message).toBe('ASCII only')
+        expect(err.requestId).toBe('rq-in4')
       })
     })
 
     describe('input — button', () => {
       it('forwards a named button press to the touch helper', () => {
         const helper = getState().touchHelper!
-        inject({ type: 'input:button', payload: { name: 'home' } })
+        inject({ type: 'input:button', requestId: 'rq-in5', payload: { name: 'home' } })
         expect(helper.pressButton).toHaveBeenCalledWith('home')
       })
     })
@@ -961,25 +972,25 @@ describe('AndroidAgent', () => {
     describe('input — keyboard', () => {
       it('sends a keyevent for a special key (Enter → 66)', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
-        inject({ type: 'input:key', payload: { code: 'Enter', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in6', payload: { code: 'Enter', modifiers: 0 } })
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', '66')
       })
 
       it('types a lowercase character for a letter key with no shift', () => {
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in7', payload: { code: 'KeyA', modifiers: 0 } })
         expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', 'a')
       })
 
       it('types an uppercase character when shift modifier is set', () => {
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0x02 } })
+        inject({ type: 'input:key', requestId: 'rq-in8', payload: { code: 'KeyA', modifiers: 0x02 } })
         expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', 'A')
       })
 
       it('maps a shifted digit to its symbol (Digit1 + shift → !)', () => {
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'Digit1', modifiers: 0x02 } })
+        inject({ type: 'input:key', requestId: 'rq-in9', payload: { code: 'Digit1', modifiers: 0x02 } })
         expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', '!')
       })
 
@@ -988,7 +999,7 @@ describe('AndroidAgent', () => {
       it('maps Cmd+C (meta) to KEYCODE_COPY, not a typed "c"', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyC', modifiers: 0x08 } })
+        inject({ type: 'input:key', requestId: 'rq-in10', payload: { code: 'KeyC', modifiers: 0x08 } })
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_COPY')
         expect(inputSpy).not.toHaveBeenCalled()
       })
@@ -996,8 +1007,8 @@ describe('AndroidAgent', () => {
       it('maps Cmd+V to KEYCODE_PASTE and Ctrl+X to KEYCODE_CUT', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyV', modifiers: 0x08 } })
-        inject({ type: 'input:key', payload: { code: 'KeyX', modifiers: 0x01 } })
+        inject({ type: 'input:key', requestId: 'rq-in11', payload: { code: 'KeyV', modifiers: 0x08 } })
+        inject({ type: 'input:key', requestId: 'rq-in12', payload: { code: 'KeyX', modifiers: 0x01 } })
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_PASTE')
         expect(keyEvSpy).toHaveBeenCalledWith('emulator-5554', 'KEYCODE_CUT')
         expect(inputSpy).not.toHaveBeenCalled()
@@ -1006,14 +1017,14 @@ describe('AndroidAgent', () => {
       it('does not type the raw letter for a non-clipboard chord (Cmd+A)', () => {
         const keyEvSpy = vi.spyOn(adb, 'sendKeyEvent')
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0x08 } })
+        inject({ type: 'input:key', requestId: 'rq-in13', payload: { code: 'KeyA', modifiers: 0x08 } })
         expect(inputSpy).not.toHaveBeenCalled()
         expect(keyEvSpy).not.toHaveBeenCalled()
       })
 
       it('still types a plain letter with no chord modifier (regression)', () => {
         const inputSpy = vi.spyOn(adb, 'sendInput')
-        inject({ type: 'input:key', payload: { code: 'KeyC', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in14', payload: { code: 'KeyC', modifiers: 0 } })
         expect(inputSpy).toHaveBeenCalledWith('emulator-5554', 'text', 'c')
       })
 
@@ -1055,13 +1066,15 @@ describe('AndroidAgent', () => {
           const sent = vi.spyOn(internals(agent).ws!, 'send')
           internals(agent).deviceStates.clear()
 
-          internals(agent).handleRelayMessage({ type, sessionId, payload })
+          internals(agent).handleRelayMessage({ type, sessionId, requestId: 'rq-gone', payload })
 
           const acks = sent.mock.calls
-            .map(([raw]) => JSON.parse(raw as string) as { type: string; message?: string })
+            .map(([raw]) => JSON.parse(raw as string) as { type: string; requestId?: string; message?: string })
             .filter((m) => m.type === 'input:error')
           expect(acks).toHaveLength(1)
           expect(acks[0].message).toContain('no active session')
+          // `ackNoSession` has no `state` to hang a correlator on, so it must arrive as an argument.
+          expect(acks[0].requestId).toBe('rq-gone')
         })
       }
     })
@@ -1075,9 +1088,13 @@ describe('AndroidAgent', () => {
 
         const errored = waitForType(browser, 'input:error')
         inject({ type: 'input:touch:start', payload: { x: 0.5, y: 0.5 } })
-        inject({ type: 'input:touch:end', payload: { x: 0.5, y: 0.5 } })
+        inject({ type: 'input:touch:end', requestId: 'rq-in15', payload: { x: 0.5, y: 0.5 } })
 
-        expect((await errored)['message']).toBe('input channel not ready')
+        const e = await errored
+        expect(e['message']).toBe('input channel not ready')
+        // The error half of `ackInput`. See the iOS twin: an unmatched `input:error` is resolved
+        // optimistically by `awaitInputAck`, so a stated device failure reaches the caller as success.
+        expect(e['requestId']).toBe('rq-in15')
         expect(control.touchUp).not.toHaveBeenCalled()
       })
 
@@ -1093,7 +1110,7 @@ describe('AndroidAgent', () => {
 
         const errored = waitForType(browser, 'input:error')
         inject({ type: 'input:touch:start', payload: { x: 0.5, y: 0.5 } })
-        inject({ type: 'input:touch:end', payload: { x: 0.5, y: 0.5 } })
+        inject({ type: 'input:touch:end', requestId: 'rq-in16', payload: { x: 0.5, y: 0.5 } })
 
         expect((await errored)['message']).toBe('the device rejected the input')
       })
@@ -1105,7 +1122,7 @@ describe('AndroidAgent', () => {
         helper.pressButton.mockResolvedValue('failed')
 
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:button', payload: { name: 'back' } })
+        inject({ type: 'input:button', requestId: 'rq-in17', payload: { name: 'back' } })
 
         expect((await errored)['message']).toBe('the device rejected the input')
       })
@@ -1115,7 +1132,7 @@ describe('AndroidAgent', () => {
         helper.pressButton.mockResolvedValue('unsupported')
 
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:button', payload: { name: 'not_a_button' } })
+        inject({ type: 'input:button', requestId: 'rq-in18', payload: { name: 'not_a_button' } })
 
         expect((await errored)['message']).toContain('not supported')
       })
@@ -1128,7 +1145,7 @@ describe('AndroidAgent', () => {
         state.grpcClient = null
 
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:pinch:end', payload: { f0: { x: 0.5, y: 0.5 }, f1: { x: 0.5, y: 0.5 } } })
+        inject({ type: 'input:pinch:end', requestId: 'rq-in19', payload: { f0: { x: 0.5, y: 0.5 }, f1: { x: 0.5, y: 0.5 } } })
 
         expect((await errored)['message']).toContain('not supported')
       })
@@ -1140,7 +1157,7 @@ describe('AndroidAgent', () => {
         state.touchHelper = null
 
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:touch:end', payload: { x: 0.5, y: 0.5 } })
+        inject({ type: 'input:touch:end', requestId: 'rq-in20', payload: { x: 0.5, y: 0.5 } })
 
         expect((await errored)['message']).toBe('input channel not ready')
       })
@@ -1151,7 +1168,7 @@ describe('AndroidAgent', () => {
       for (const type of ['input:button', 'input:key']) {
         it(`answers malformed — not channel-down — for a ${type} with no payload`, async () => {
           const errored = waitForType(browser, 'input:error')
-          internals(agent).handleRelayMessage({ type, sessionId: agent.sessionId })
+          internals(agent).handleRelayMessage({ type, sessionId: agent.sessionId, requestId: 'rq-malformed' })
           expect((await errored)['message']).toContain('missing what it needs')
         })
       }
@@ -1169,7 +1186,7 @@ describe('AndroidAgent', () => {
 
         const done = waitForType(browser, 'input:done')
         inject({ type: 'input:touch:start', payload: { x: 0.5, y: 0.5 } })
-        inject({ type: 'input:touch:end', payload: { x: 0.5, y: 0.5 } })
+        inject({ type: 'input:touch:end', requestId: 'rq-in21', payload: { x: 0.5, y: 0.5 } })
         state.bootSeq += 1 // a reboot begins while the dispatch is still in flight
         release('delivered')
         await done
@@ -1188,7 +1205,7 @@ describe('AndroidAgent', () => {
         for (const attempt of [1, 2]) {
           const errored = waitForType(browser, 'input:error')
           inject({ type: 'input:touch:start', payload: { x: 0.5, y: 0.5 } })
-          inject({ type: 'input:touch:end', payload: { x: 0.5, y: 0.5 } })
+          inject({ type: 'input:touch:end', requestId: 'rq-in22', payload: { x: 0.5, y: 0.5 } })
           expect((await errored)['message'], `attempt ${attempt}`).toBe('device not booted')
         }
         // Re-verified rather than trusting a cache that the first attempt must not have written.
@@ -1202,7 +1219,7 @@ describe('AndroidAgent', () => {
       it('answers unsupported for a chord it deliberately does not send', async () => {
         const sendKeyEvent = vi.spyOn(adb, 'sendKeyEvent')
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0x08 } }) // Cmd+A
+        inject({ type: 'input:key', requestId: 'rq-in23', payload: { code: 'KeyA', modifiers: 0x08 } }) // Cmd+A
         expect((await errored)['message']).toContain('not supported')
         expect(sendKeyEvent).not.toHaveBeenCalled()
       })
@@ -1210,27 +1227,27 @@ describe('AndroidAgent', () => {
       it('answers unsupported for a code that is only a prototype member', async () => {
         const sendKeyEvent = vi.spyOn(adb, 'sendKeyEvent')
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:key', payload: { code: 'constructor', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in24', payload: { code: 'constructor', modifiers: 0 } })
         expect((await errored)['message']).toContain('not supported')
         expect(sendKeyEvent).not.toHaveBeenCalled()
       })
 
       it('answers unsupported for a code with no character mapping', async () => {
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:key', payload: { code: 'CapsLock', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in25', payload: { code: 'CapsLock', modifiers: 0 } })
         expect((await errored)['message']).toContain('not supported')
       })
 
       it('answers failed when the key dispatch rejects', async () => {
         vi.spyOn(adb, 'sendInput').mockRejectedValue(new Error('offline'))
         const errored = waitForType(browser, 'input:error')
-        inject({ type: 'input:key', payload: { code: 'KeyA', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in26', payload: { code: 'KeyA', modifiers: 0 } })
         expect((await errored)['message']).toBe('the device rejected the input')
       })
 
       it('still answers input:done for a key it does send', async () => {
         const done = waitForType(browser, 'input:done')
-        inject({ type: 'input:key', payload: { code: 'Enter', modifiers: 0 } })
+        inject({ type: 'input:key', requestId: 'rq-in27', payload: { code: 'Enter', modifiers: 0 } })
         await done
       })
     })

--- a/packages/dashboard/components/device/AndroidViewer.tsx
+++ b/packages/dashboard/components/device/AndroidViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BrowserToRelay } from '@tapflowio/protocol'
+import { newRequestId } from '@/lib/requestId';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useClientRecording } from '@/hooks/useClientRecording';
 import { ArrowLeft, Home, LayoutGrid, Loader2, Play, Power, Volume1, Volume2 } from 'lucide-react';
@@ -228,7 +229,7 @@ export function AndroidViewer({
   }, [])
 
   const sendChord = useCallback((code: 'KeyC' | 'KeyV' | 'KeyX', modifiers: number) => {
-    send({ type: 'input:key', sessionId, payload: { code, modifiers } })
+    send({ type: 'input:key', sessionId, requestId: newRequestId(), payload: { code, modifiers } })
   }, [send, sessionId])
   useClipboardBridge({
     sessionId, send, active: keyboardActive, supported: clipboardSupported,
@@ -257,11 +258,11 @@ export function AndroidViewer({
       if (clipboardSupported && isBridgedChord(e)) return
       e.preventDefault()
       const modifiers = (e.shiftKey ? 0x02 : 0) | (e.ctrlKey ? 0x01 : 0) | (e.metaKey ? 0x08 : 0)
-      send({ type: 'input:key', sessionId, payload: { code: e.code, modifiers } })
+      send({ type: 'input:key', sessionId, requestId: newRequestId(), payload: { code: e.code, modifiers } })
     }
     const endPinch = () => {
       if (isPinchMode.current) {
-        isPinchMode.current = false; setPinchActive(false); send({ type: 'input:pinch:end', sessionId })
+        isPinchMode.current = false; setPinchActive(false); send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() })
       }
       isOptionHeld.current = false; setPinchHint(null)
     }
@@ -388,7 +389,7 @@ export function AndroidViewer({
   const handlePointerUp = useCallback(() => {
     if (isPinchMode.current) {
       isPinchMode.current = false; setPinchActive(false); setPinchHint(null)
-      send({ type: 'input:pinch:end', sessionId }); return
+      send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() }); return
     }
     touchStartPos.current = null
     cursorStateRef.current = 'release'; releaseAnimRef.current = { startTime: performance.now() }
@@ -398,17 +399,17 @@ export function AndroidViewer({
       _lc.style.background = 'transparent'; _lc.style.border = '1.5px solid rgba(255,255,255,0.6)'
       _lc.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.3)'
     }
-    send({ type: 'input:touch:end', sessionId })
+    send({ type: 'input:touch:end', sessionId, requestId: newRequestId() })
   }, [send, sessionId])
 
   const handlePointerCancel = useCallback(() => {
     if (isPinchMode.current) {
       isPinchMode.current = false; setPinchActive(false); setPinchHint(null)
-      send({ type: 'input:pinch:end', sessionId }); return
+      send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() }); return
     }
     touchStartPos.current = null
     cursorStateRef.current = 'release'; releaseAnimRef.current = { startTime: performance.now() }
-    send({ type: 'input:touch:end', sessionId })
+    send({ type: 'input:touch:end', sessionId, requestId: newRequestId() })
   }, [send, sessionId])
 
   const handlePointerLeave = useCallback(() => {
@@ -470,7 +471,7 @@ export function AndroidViewer({
           <TooltipTrigger asChild>
             <Button variant="ghost" size="icon" className="h-8 w-8"
               aria-label={btn.accessibilityTitle}
-              onClick={() => send({ type: 'input:button', sessionId, payload: { name: btn.name } })}
+              onClick={() => send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: btn.name } })}
             >
               {btn.name === 'back' ? <ArrowLeft className="h-4 w-4" />
                 : btn.name === 'recent_apps' ? <LayoutGrid className="h-4 w-4" />

--- a/packages/dashboard/components/device/IOSViewer.tsx
+++ b/packages/dashboard/components/device/IOSViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BrowserToRelay } from '@tapflowio/protocol'
+import { newRequestId } from '@/lib/requestId';
 import { useCallback, useEffect, useRef, useState, Fragment } from 'react';
 import { useClientRecording } from '@/hooks/useClientRecording';
 import { Home, Keyboard, Loader2, Play } from 'lucide-react';
@@ -294,7 +295,7 @@ export function IOSViewer({
   }, [])
 
   const sendChord = useCallback((code: 'KeyC' | 'KeyV' | 'KeyX', modifiers: number) => {
-    send({ type: 'input:key', sessionId, payload: { code, modifiers } })
+    send({ type: 'input:key', sessionId, requestId: newRequestId(), payload: { code, modifiers } })
   }, [send, sessionId])
   useClipboardBridge({
     sessionId, send, active: keyboardActive, supported: clipboardSupported,
@@ -313,7 +314,7 @@ export function IOSViewer({
           if (!e.shiftKey && e.code === 'KeyS') { e.preventDefault(); handleScreenshot(); return }
           if (e.shiftKey && e.code === 'KeyY') { e.preventDefault(); handleRecordToggle(); return }
           if (e.shiftKey && e.code === 'KeyO') { e.preventDefault(); handleRotate(); return }
-          if (e.shiftKey && e.code === 'KeyU') { e.preventDefault(); send({ type: 'input:button', sessionId, payload: { name: 'home' } }); return }
+          if (e.shiftKey && e.code === 'KeyU') { e.preventDefault(); send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: 'home' } }); return }
           if (e.shiftKey && e.code === 'KeyK') { e.preventDefault(); if (!swKeyboardPending) onKbdToggle(); return }
         }
       }
@@ -325,10 +326,10 @@ export function IOSViewer({
       if (clipboardSupported && isBridgedChord(e)) return
       e.preventDefault()
       const modifiers = (e.shiftKey ? 0x02 : 0) | (e.ctrlKey ? 0x01 : 0) | (e.metaKey ? 0x08 : 0)
-      send({ type: 'input:key', sessionId, payload: { code: e.code, modifiers } })
+      send({ type: 'input:key', sessionId, requestId: newRequestId(), payload: { code: e.code, modifiers } })
     }
     const endPinch = () => {
-      if (isPinchMode.current) { isPinchMode.current = false; setPinchActive(false); send({ type: 'input:pinch:end', sessionId }) }
+      if (isPinchMode.current) { isPinchMode.current = false; setPinchActive(false); send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() }) }
       isOptionHeld.current = false; setPinchHint(null)
     }
     const onKeyUp = (e: KeyboardEvent) => { if (e.code === 'AltLeft' || e.code === 'AltRight') endPinch() }
@@ -418,7 +419,7 @@ export function IOSViewer({
     if (btn) {
       pressedButton.current = btn; setFlashedButton(btn)
       ;(e.target as Element).setPointerCapture(e.pointerId)
-      send({ type: 'input:button', sessionId, payload: { name: btn, phase: 'down' } })
+      send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: btn, phase: 'down' } })
       return
     }
     const pos = toNormScreen(e); if (!pos) return
@@ -484,11 +485,11 @@ export function IOSViewer({
 
   const handlePointerUp = useCallback(() => {
     if (isPinchMode.current) {
-      isPinchMode.current = false; setPinchActive(false); setPinchHint(null); send({ type: 'input:pinch:end', sessionId }); return
+      isPinchMode.current = false; setPinchActive(false); setPinchHint(null); send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() }); return
     }
     touchStartPos.current = null
     if (pressedButton.current) {
-      send({ type: 'input:button', sessionId, payload: { name: pressedButton.current, phase: 'up' } })
+      send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: pressedButton.current, phase: 'up' } })
       pressedButton.current = null; setTimeout(() => setFlashedButton(null), 100); return
     }
     cursorStateRef.current = 'release'; releaseAnimRef.current = { startTime: performance.now() }
@@ -498,21 +499,21 @@ export function IOSViewer({
       _lc.style.background = 'transparent'; _lc.style.border = '1.5px solid rgba(255,255,255,0.6)'
       _lc.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.3)'
     }
-    send({ type: 'input:touch:end', sessionId })
+    send({ type: 'input:touch:end', sessionId, requestId: newRequestId() })
   }, [send, sessionId])
 
   const handlePointerCancel = useCallback(() => {
     if (isPinchMode.current) {
-      isPinchMode.current = false; setPinchActive(false); setPinchHint(null); send({ type: 'input:pinch:end', sessionId }); return
+      isPinchMode.current = false; setPinchActive(false); setPinchHint(null); send({ type: 'input:pinch:end', sessionId, requestId: newRequestId() }); return
     }
     touchStartPos.current = null
     if (pressedButton.current) {
       // Release the held button, else the HID button stays down on the device.
-      send({ type: 'input:button', sessionId, payload: { name: pressedButton.current, phase: 'up' } })
+      send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: pressedButton.current, phase: 'up' } })
       pressedButton.current = null; setFlashedButton(null); return
     }
     cursorStateRef.current = 'release'; releaseAnimRef.current = { startTime: performance.now() }
-    send({ type: 'input:touch:end', sessionId })
+    send({ type: 'input:touch:end', sessionId, requestId: newRequestId() })
   }, [send, sessionId])
 
   const handlePointerLeave = useCallback(() => {
@@ -538,7 +539,7 @@ export function IOSViewer({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="ghost" size="icon" className="h-8 w-8"
-            onClick={() => send({ type: 'input:button', sessionId, payload: { name: 'home' } })}
+            onClick={() => send({ type: 'input:button', sessionId, requestId: newRequestId(), payload: { name: 'home' } })}
           >
             <Home className="h-4 w-4" />
           </Button>

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -76,15 +76,19 @@ export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | nul
   // is bounded and ends up visible.
   'no-gesture': null,
   // **Reachable, and a first draft had this as `null` on the grounds that it was not.** The claim was that
-  // this viewer only ever sends input for the session it joined, so the relay would never address it here.
-  // That holds for the join path and not for the session's lifetime: `session:leave` is forwarded on the
-  // strength of the session existing, with no check that the sender owns it, and it nulls `browserSocket`.
-  // So another client can strip ownership out from under a mounted viewer, and from that moment this
-  // tester's own taps are refused. Silent there is the #426 symptom exactly — a picture that keeps updating
-  // while input stops working, with nothing said.
+  // this viewer only ever sends input for the session it joined, so the relay could never address it here.
+  // That is true of the join and false of the reconnect: `DeviceViewer` re-sends `session:start` from an
+  // effect on every `connected` edge, while the pointer handlers in the platform viewers are not gated on
+  // `joined` at all — so a tap between the socket coming back and the re-join being answered is refused,
+  // and a Wi-Fi blip or a laptop waking is all it takes.
   //
-  // The action names re-entering the session rather than the device, because nothing about the device is
-  // wrong: the frame was refused at the relay's door and never reached it.
+  // (An earlier version of this note blamed an unguarded `session:leave` stripping ownership from a mounted
+  // viewer. That was true when written and stopped being true inside the same change, which widened the
+  // ownership check to `session:leave` among others. The reachable path is the ordinary one above.)
+  //
+  // Silent here is the #426 symptom exactly — a picture that keeps updating while input stops working, with
+  // nothing said. The action names re-entering the session rather than the device, because nothing about the
+  // device is wrong: the frame was refused at the relay's door and never reached it.
   'not-session-owner': {
     title: 'This session is no longer yours',
     action: 'Go back and open the device again — another tester may have taken it. Nothing you just did reached the device.',

--- a/packages/dashboard/lib/inputErrorNotice.ts
+++ b/packages/dashboard/lib/inputErrorNotice.ts
@@ -75,6 +75,20 @@ export const INPUT_ERROR_NOTICE: Record<InputErrorReason, InputErrorNotice | nul
   // frame — but that case exhausts the respawn budget and surfaces as `channel-unavailable`, so it
   // is bounded and ends up visible.
   'no-gesture': null,
+  // **Reachable, and a first draft had this as `null` on the grounds that it was not.** The claim was that
+  // this viewer only ever sends input for the session it joined, so the relay would never address it here.
+  // That holds for the join path and not for the session's lifetime: `session:leave` is forwarded on the
+  // strength of the session existing, with no check that the sender owns it, and it nulls `browserSocket`.
+  // So another client can strip ownership out from under a mounted viewer, and from that moment this
+  // tester's own taps are refused. Silent there is the #426 symptom exactly — a picture that keeps updating
+  // while input stops working, with nothing said.
+  //
+  // The action names re-entering the session rather than the device, because nothing about the device is
+  // wrong: the frame was refused at the relay's door and never reached it.
+  'not-session-owner': {
+    title: 'This session is no longer yours',
+    action: 'Go back and open the device again — another tester may have taken it. Nothing you just did reached the device.',
+  },
 }
 
 /**

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -183,7 +183,7 @@ describe('DeviceViewer — input:error (#485)', () => {
   it('ignores an input:error for another session', () => {
     mounted()
     act(() => {
-      deliver!({ type: 'input:error', sessionId: 'other', message: 'x', reason: 'channel-unavailable' })
+      deliver!({ type: 'input:error', sessionId: 'other', requestId: 'rq-other', message: 'x', reason: 'channel-unavailable' })
     })
     expect(toastError).not.toHaveBeenCalled()
   })
@@ -207,7 +207,7 @@ describe('DeviceViewer — input:error (#485)', () => {
   it('does nothing on input:done', () => {
     mounted()
     inputError('channel-unavailable')
-    act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
+    act(() => { deliver!({ type: 'input:done', sessionId: 's1', requestId: 'rq-done' }) })
     quiet()
     expect(toastError).toHaveBeenCalledTimes(1)
   })
@@ -219,7 +219,7 @@ describe('DeviceViewer — input:error (#485)', () => {
   it('lets a success between two failures change nothing', () => {
     mounted()
     inputError('channel-unavailable')
-    act(() => { deliver!({ type: 'input:done', sessionId: 's1' }) })
+    act(() => { deliver!({ type: 'input:done', sessionId: 's1', requestId: 'rq-done' }) })
     inputError('channel-unavailable')
     expect(toastError).toHaveBeenCalledTimes(2)
     quiet()

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -210,10 +210,17 @@ export class RelayClient {
     if (msg['type'] === 'app:clear-state-error') throw new PlatformError((msg['message'] as string) ?? 'clear state failed')
   }
 
+  // `tap`, `swipe` and `pressKey` mint a correlator that nothing here reads — they are fire-and-forget,
+  // unlike `typeText` below. The id is not optional slack: the terminal frame declares it required, because
+  // the relay gates on it and every ack echoes it. Minting it at the sender is also what a waiter added
+  // later would need already on the wire; a flow that cannot see a failed tap is a separate gap.
+  //
+  // The **opening and move frames carry none**, and that is the contract rather than an omission: nothing
+  // acks them, so an id there would name a waiter that does not exist.
   tap(sessionId: string, x: number, y: number): void {
     const payload = { x, y }
     this.send({ type: 'input:touch:start', sessionId, payload })
-    this.send({ type: 'input:touch:end', sessionId, payload })
+    this.send({ type: 'input:touch:end', sessionId, requestId: randomUUID(), payload })
   }
 
   async swipe(sessionId: string, from: [number, number], to: [number, number], durationMs: number): Promise<void> {
@@ -230,13 +237,15 @@ export class RelayClient {
       })
     }
     await delay(interval)
-    this.send({ type: 'input:touch:end', sessionId, payload: { x: to[0], y: to[1] } })
+    this.send({ type: 'input:touch:end', sessionId, requestId: randomUUID(), payload: { x: to[0], y: to[1] } })
   }
 
   async typeText(sessionId: string, text: string): Promise<void> {
-    this.send({ type: 'input:type', sessionId, payload: { text } })
+    const requestId = randomUUID()
+    this.send({ type: 'input:type', sessionId, requestId, payload: { text } })
     const msg = await this.waitFor(
-      (m) => (m['type'] === 'input:type-done' || m['type'] === 'input:type-error') && m['sessionId'] === sessionId,
+      (m) => (m['type'] === 'input:type-done' || m['type'] === 'input:type-error')
+        && m['sessionId'] === sessionId && m['requestId'] === requestId,
       15_000,
       'type text',
     )
@@ -244,7 +253,7 @@ export class RelayClient {
   }
 
   pressKey(sessionId: string, code: string): void {
-    this.send({ type: 'input:key', sessionId, payload: { code, modifiers: 0 } })
+    this.send({ type: 'input:key', sessionId, requestId: randomUUID(), payload: { code, modifiers: 0 } })
   }
 
   async openUrl(sessionId: string, url: string): Promise<void> {

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -70,6 +70,115 @@ describe('RelayClient.queryUITree — transient vs permanent classification', ()
 //
 // Nothing else covers it: the correlator is optional, so `<Pair>ReplyBody` cannot exist for it and
 // `correlatedRequestsGated` derives only required declarations.
+// L5c. `tap`, `swipe` and `pressKey` await nothing, so the correlator they mint is the only thing standing
+// between a flow and a silent no-op: the relay drops an acked input whose id is absent or `''`, without
+// answering, and these three senders would never know. Review measured it — setting all three to `''` left
+// all 63 tests passing, and a flow whose every tap, swipe and key press never left the relay reports **PASS**.
+// The old code could not fail this way, because there was no id to get wrong.
+//
+// Read off the wire rather than asserted at the call site: what matters is what the relay would receive.
+describe('RelayClient — the fire-and-forget input senders mint a usable correlator', () => {
+  let wss: WebSocketServer | null = null
+
+  afterEach(async () => {
+    const s = wss
+    wss = null
+    if (!s) return
+    for (const c of s.clients) c.terminate()
+    await new Promise<void>((r) => s.close(() => r()))
+  })
+
+  async function capture() {
+    const received: Record<string, unknown>[] = []
+    wss = new WebSocketServer({ port: 0 })
+    wss.on('connection', (ws) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        received.push(msg)
+        if (msg['type'] === 'session:start') {
+          ws.send(JSON.stringify({ type: 'session:joined', sessionId: msg['sessionId'], capabilities: [] }))
+        }
+      })
+    })
+    const port = (wss.address() as { port: number }).port
+    const client = new RelayClient(`ws://localhost:${port}`, '')
+    await client.connect()
+    await client.joinSession('s1')
+    return { client, received }
+  }
+
+  const usable = (m: Record<string, unknown> | undefined, what: string) => {
+    expect(m, `no ${what} was sent`).toBeDefined()
+    expect(typeof m!['requestId']).toBe('string')
+    expect(m!['requestId']).not.toBe('')
+  }
+
+  it('tap sends a terminal frame with a usable id, and an opening frame with none', async () => {
+    const { client, received } = await capture()
+    client.tap('s1', 0.5, 0.5)
+    await vi.waitFor(() => expect(received.some((m) => m['type'] === 'input:touch:end')).toBe(true))
+
+    usable(received.find((m) => m['type'] === 'input:touch:end'), 'input:touch:end')
+    // And the opening frame carries none — nothing acks it, so an id there would name a waiter that does
+    // not exist. Pinned so a later edit cannot quietly add one.
+    expect(received.find((m) => m['type'] === 'input:touch:start')).not.toHaveProperty('requestId')
+  })
+
+  it('swipe sends a terminal frame with a usable id, and its moves with none', async () => {
+    const { client, received } = await capture()
+    await client.swipe('s1', [0.1, 0.1], [0.9, 0.9], 40)
+    // `swipe` resolves once it has *sent* the terminal frame; the server receiving it is a separate turn.
+    await vi.waitFor(() => expect(received.some((m) => m['type'] === 'input:touch:end')).toBe(true))
+
+    usable(received.find((m) => m['type'] === 'input:touch:end'), 'input:touch:end')
+    const moves = received.filter((m) => m['type'] === 'input:touch:move')
+    expect(moves.length).toBeGreaterThan(0)
+    for (const m of moves) expect(m).not.toHaveProperty('requestId')
+  })
+
+  it('pressKey sends a usable id', async () => {
+    const { client, received } = await capture()
+    client.pressKey('s1', 'Enter')
+    await vi.waitFor(() => expect(received.some((m) => m['type'] === 'input:key')).toBe(true))
+
+    usable(received.find((m) => m['type'] === 'input:key'), 'input:key')
+  })
+
+  it('typeText correlates, so its waiter cannot take the previous typing\'s reply', async () => {
+    // The one input sender here with a waiter. Dropping `requestId` from its predicate leaves #499 alive for
+    // `input:type` specifically: a late `input:type-done` from the previous call lands in this one's waiter.
+    const received: Record<string, unknown>[] = []
+    wss = new WebSocketServer({ port: 0 })
+    wss.on('connection', (ws) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        received.push(msg)
+        if (msg['type'] === 'session:start') {
+          ws.send(JSON.stringify({ type: 'session:joined', sessionId: msg['sessionId'], capabilities: [] }))
+        }
+        if (msg['type'] === 'input:type') {
+          // The stale reply is an **error** so that resolving on it is observable. A first version sent two
+          // successes, which passed with the correlator check deleted — the mutation that removes the
+          // property has to fail the test, and two indistinguishable successes cannot do that.
+          ws.send(JSON.stringify({
+            type: 'input:type-error', sessionId: 's1', requestId: 'stale', message: 'a previous call',
+          }))
+          setTimeout(() => ws.send(JSON.stringify({
+            type: 'input:type-done', sessionId: 's1', requestId: msg['requestId'],
+          })), 20)
+        }
+      })
+    })
+    const port = (wss.address() as { port: number }).port
+    const client = new RelayClient(`ws://localhost:${port}`, '')
+    await client.connect()
+    await client.joinSession('s1')
+
+    await expect(client.typeText('s1', 'hi')).resolves.toBeUndefined()
+    usable(received.find((m) => m['type'] === 'input:type'), 'input:type')
+  })
+})
+
 describe('RelayClient.bootDevice — an optional correlator, with a fallback', () => {
   let wss: WebSocketServer | null = null
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -29,6 +29,9 @@ const INPUT_ERROR_MESSAGES: Record<InputErrorReason, string> = {
   unsupported: 'this input is not supported on the active connection to the device',
   malformed: 'this input does not fit what the device is doing',
   'no-gesture': 'no gesture is in progress to complete — start a new one',
+  // The relay is the only producer of this one — an agent has no way to know which socket asked. Present
+  // because the map is exhaustive, which is what makes a new reason a decision rather than an omission.
+  'not-session-owner': 'this input was addressed to a session the sender does not hold',
 }
 
 // Cross-platform button name → iOS device-chrome button name. Chrome uses
@@ -733,12 +736,28 @@ export class IOSAgent implements DeviceAgent {
   // device can now sit behind two sessions, which leaves the second unseeded. Answering costs four
   // lines; staying silent costs a terminal input swallowed and the caller's own fallback reporting
   // success. Android already answers, and `channel-unavailable` is what it maps this to.
-  private ackNoSession(sessionId: string): void {
+  /** The correlator on an input an ack answers, or `null` if the frame cannot be attributed.
+   *
+   *  A local capture rather than a guard at the top of the dispatcher, and that is the point: a guard there
+   *  would not narrow `msg.requestId` inside the case, so the shortest way to satisfy the reply's required
+   *  field would be `msg.requestId!` — the assertion removed from `open-url` and then from clipboard. This
+   *  hands back a `string` the case can close over.
+   *
+   *  It is unvalidated JSON, so the check is real work rather than ceremony: the declaration is required and
+   *  every in-repo sender is typed against it, but nothing validates inbound (#444), and `mcp-server`'s tool
+   *  schemas are bare `z.string()` so a model can produce `''`. */
+  private correlatorOf(msg: { type: string; requestId?: string }): string | null {
+    if (typeof msg.requestId === 'string' && msg.requestId !== '') return msg.requestId
+    logger.warn(`${msg.type} without a usable requestId — dropped, its ack could not be attributed`)
+    return null
+  }
+
+  private ackNoSession(sessionId: string, requestId: string): void {
     // The `if (!sessionId) return` this used to open with is gone: the dispatcher now declares
     // `sessionId: string`, so there is no undefined to guard against and the guard would have been a
     // silent drop with nothing left that could reach it.
     this.sendMsg({
-      type: 'input:error', sessionId,
+      type: 'input:error', sessionId, requestId,
       message: INPUT_ERROR_MESSAGES['channel-unavailable'],
       reason: 'channel-unavailable' satisfies InputErrorReason,
     })
@@ -779,15 +798,19 @@ export class IOSAgent implements DeviceAgent {
   // HID is fire-and-forget). Otherwise `input:error` carries a machine-readable `reason` so a caller
   // can tell "retry in a moment" from "reconnect" from "never retry"; `message` stays human prose.
   // Off the sync inject path, so start/end pairing is unaffected.
-  private async ackInput(state: DeviceState, outcome: 'delivered' | InputErrorReason): Promise<void> {
+  //
+  // `requestId` is a parameter, never read from shared state: a gesture is dozens of frames and two can
+  // overlap, so a correlator hoisted out of per-request scope would answer one input with another's id —
+  // which is #499 rebuilt inside the agent. Same reason `seq` is passed in on the Android side.
+  private async ackInput(state: DeviceState, outcome: 'delivered' | InputErrorReason, requestId: string): Promise<void> {
     const reason: InputErrorReason | null = outcome !== 'delivered'
       ? outcome
       : (state.booted || (await this.isBooted(state.deviceId))) ? null : 'not-booted'
     if (reason === null) state.booted = true // cache the post-reconnect verify so later inputs skip simctl
     this.sendMsg(
       reason === null
-        ? { type: 'input:done', sessionId: state.sessionId }
-        : { type: 'input:error', sessionId: state.sessionId, message: INPUT_ERROR_MESSAGES[reason], reason })
+        ? { type: 'input:done', sessionId: state.sessionId, requestId }
+        : { type: 'input:error', sessionId: state.sessionId, requestId, message: INPUT_ERROR_MESSAGES[reason], reason })
   }
 
   private async isBooted(deviceId: string): Promise<boolean> {
@@ -883,13 +906,15 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:touch:end': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         // The helper's answer, not its existence: a helper whose process has died reports every
         // write as dropped, and that is what the caller needs to hear (#482).
         const helper = state.touchHelper
         // terminal of a tap/swipe → ack the gesture
-        void this.ackInput(state, helper?.touchEnd() ? 'delivered' : this.refusalReason(helper, 'continuation'))
+        void this.ackInput(state, helper?.touchEnd() ? 'delivered' : this.refusalReason(helper, 'continuation'), requestId)
         break
       }
       case 'input:pinch:start': {
@@ -908,10 +933,12 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:pinch:end': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         const pinchHelper = state.touchHelper
-        void this.ackInput(state, pinchHelper?.pinchEnd() ? 'delivered' : this.refusalReason(pinchHelper, 'continuation'))
+        void this.ackInput(state, pinchHelper?.pinchEnd() ? 'delivered' : this.refusalReason(pinchHelper, 'continuation'), requestId)
         break
       }
       case 'input:rotate': {
@@ -947,12 +974,14 @@ export class IOSAgent implements DeviceAgent {
         break
       }
       case 'input:type': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         if (state) this.ensureTouchHelper(state)
         const { text } = (msg.payload ?? {}) as { text?: string }
         if (!state?.touchHelper) {
-          this.sendMsg({ type: 'input:type-error', sessionId, message: 'No booted device' })
+          this.sendMsg({ type: 'input:type-error', sessionId, requestId, message: 'No booted device' })
           break
         }
         // simctl pbcopy → Cmd+V paste. Works for arbitrary Unicode (unlike a
@@ -981,17 +1010,19 @@ export class IOSAgent implements DeviceAgent {
         // Shares the clipboard queue: this writes the pasteboard, so running it alongside a
         // clipboard:read would overwrite that read's sentinel and be returned as "copied".
         this.clipboardQueue(state.deviceId, doType)
-          .then(() => this.sendMsg({ type: 'input:type-done', sessionId }))
+          .then(() => this.sendMsg({ type: 'input:type-done', sessionId, requestId }))
           .catch((e: unknown) => {
             const message = e instanceof Error ? e.message : String(e)
             logger.error('input:type (pbcopy+paste) failed:', e)
-            this.sendMsg({ type: 'input:type-error', sessionId, message })
+            this.sendMsg({ type: 'input:type-error', sessionId, requestId, message })
           })
         break
       }
       case 'input:key': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         this.ensureTouchHelper(state)
         const { code, modifiers } = msg.payload as { code: string; modifiers?: number }
         const usage = KEY_CODE_MAP[code]
@@ -999,7 +1030,7 @@ export class IOSAgent implements DeviceAgent {
           // Prose preserved (it names the code), reason added: `unsupported` tells a caller never to
           // retry, which the message alone could not.
           this.sendMsg({
-            type: 'input:error', sessionId: msg.sessionId,
+            type: 'input:error', sessionId: msg.sessionId, requestId,
             message: `unknown key code: ${code}`, reason: 'unsupported' satisfies InputErrorReason,
           })
           break
@@ -1016,17 +1047,19 @@ export class IOSAgent implements DeviceAgent {
             .catch((e: unknown) => { logger.error('hideSoftwareKeyboard (on key) failed:', e) })
             .then(() => {
               const h = state.touchHelper
-              return this.ackInput(state, h?.sendKey(usage, modifiers ?? 0) ? 'delivered' : this.refusalReason(h, 'standalone'))
+              return this.ackInput(state, h?.sendKey(usage, modifiers ?? 0) ? 'delivered' : this.refusalReason(h, 'standalone'), requestId)
             })
         } else {
           const h = state.touchHelper
-          void this.ackInput(state, h?.sendKey(usage, modifiers ?? 0) ? 'delivered' : this.refusalReason(h, 'standalone'))
+          void this.ackInput(state, h?.sendKey(usage, modifiers ?? 0) ? 'delivered' : this.refusalReason(h, 'standalone'), requestId)
         }
         break
       }
       case 'input:button': {
+        const requestId = this.correlatorOf(msg)
+        if (requestId === null) break
         const state = this.deviceStates.get(msg.sessionId)
-        if (!state) { this.ackNoSession(msg.sessionId); break }
+        if (!state) { this.ackNoSession(msg.sessionId, requestId); break }
         this.ensureTouchHelper(state)
         const { name, phase } = msg.payload as { name: string; phase?: 'down' | 'up' }
         // Map the cross-platform button vocabulary (used by MCP) onto this
@@ -1059,7 +1092,7 @@ export class IOSAgent implements DeviceAgent {
             else outcome = wrote(btnHelper?.pressButton(btn.usagePage, btn.usage) ?? false)
           }
         }
-        void this.ackInput(state, outcome)
+        void this.ackInput(state, outcome, requestId)
         break
       }
       case 'open-url': {

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -388,8 +388,8 @@ describe('IOSAgent', () => {
       const sent = vi.spyOn(ws, 'send')
 
       for (const frame of [
-        { type: 'input:touch:end', payload: { x: 0.4, y: 0.6 } },
-        { type: 'input:touch:end', sessionId: 42, payload: { x: 0.4, y: 0.6 } },
+        { type: 'input:touch:end', requestId: 'rq-in1', payload: { x: 0.4, y: 0.6 } },
+        { type: 'input:touch:end', requestId: 'rq-in2', sessionId: 42, payload: { x: 0.4, y: 0.6 } },
       ]) ws.emit('message', Buffer.from(JSON.stringify(frame)))
 
       const answers = () => sent.mock.calls
@@ -399,7 +399,7 @@ describe('IOSAgent', () => {
 
       // A well-formed frame on the same path is still dispatched, so the guard is not rejecting everything.
       ws.emit('message', Buffer.from(JSON.stringify(
-        { type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.4, y: 0.6 } },
+        { type: 'input:touch:end', requestId: 'rq-in3', sessionId: agent.sessionId, payload: { x: 0.4, y: 0.6 } },
       )))
       await vi.waitFor(() => expect(answers()).toHaveLength(1), { timeout: 500 })
 
@@ -426,7 +426,7 @@ describe('IOSAgent', () => {
       const { browser, agent } = await joinBootlessSession()
 
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in4', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
 
       await vi.waitFor(() => {
         expect(MockTouchHelper.mock.results).toHaveLength(1)
@@ -455,8 +455,14 @@ describe('IOSAgent', () => {
 
       const done = waitForType(browser, 'input:done')
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-      expect((await done).sessionId).toBe(agent.sessionId)
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in5', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      const ack = await done
+      expect(ack.sessionId).toBe(agent.sessionId)
+      // L5c. The ack must carry **the terminal frame's** id, and nothing else here would say so: replacing
+      // the echo with a literal left all 382 tests passing in the mutation round. `#499` is what an
+      // unattributed ack costs — a late one is consumed by the next input's waiter, which then reports the
+      // previous input's outcome, including reporting an unanswered input as landed.
+      expect(ack.requestId).toBe('rq-in5')
 
       agent.disconnect()
       browser.close()
@@ -483,10 +489,16 @@ describe('IOSAgent', () => {
 
       const errored = waitForType(browser, 'input:error')
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in6', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
       const e = await errored
       expect(e.sessionId).toBe(agent.sessionId)
       expect(e.message).toBe('device not booted')
+      // The **error** half of `ackInput`, and it needs its own assertion: the `input:done` line above is
+      // pinned one test up, and a literal on this line survived the whole suite in review. Worse than a
+      // hang, too — `awaitInputAck` drops an unmatched reply into its catch, and on a session that is not
+      // yet strict that path resolves *optimistically*. So a device failure the agent stated plainly would
+      // be reported to the caller as success: #457 restored for exactly the frames that carry the failure.
+      expect(e.requestId).toBe('rq-in6')
 
       agent.disconnect()
       browser.close()
@@ -515,13 +527,13 @@ describe('IOSAgent', () => {
       type Internals = {
         ws: WebSocket
         deviceStates: Map<string, unknown>
-        handleRelayMessage(msg: { type: string; sessionId?: string; payload?: unknown }): void
+        handleRelayMessage(msg: { type: string; sessionId?: string; requestId?: string; payload?: unknown }): void
       }
       const internals = (a: IOSAgent): Internals => a as unknown as Internals
 
       function inputErrors(spy: ReturnType<typeof vi.spyOn>) {
         return spy.mock.calls
-          .map(([raw]) => JSON.parse(raw as string) as { type: string; sessionId?: string; message?: string; reason?: string })
+          .map(([raw]) => JSON.parse(raw as string) as { type: string; sessionId?: string; requestId?: string; message?: string; reason?: string })
           .filter((m) => m.type === 'input:error')
       }
 
@@ -539,12 +551,15 @@ describe('IOSAgent', () => {
           const sent = vi.spyOn(internals(agent).ws, 'send')
           internals(agent).deviceStates.clear()
 
-          internals(agent).handleRelayMessage({ type, sessionId: sessionId!, payload })
+          internals(agent).handleRelayMessage({ type, sessionId: sessionId!, requestId: 'rq-gone', payload })
 
           const acks = inputErrors(sent)
           expect(acks).toHaveLength(1)
           expect(acks[0]!.sessionId).toBe(sessionId)
           expect(acks[0]!.reason).toBe('channel-unavailable')
+          // `ackNoSession` is the one reply path with no `state` to hang anything on, so the correlator has
+          // to arrive as an argument. A literal there survived the whole suite in the mutation round.
+          expect(acks[0]!.requestId).toBe('rq-gone')
 
           agent.disconnect()
           browser.close()
@@ -596,7 +611,7 @@ describe('IOSAgent', () => {
       th.ownsGesture.mockReturnValue(false)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in7', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
 
       expect((await errored)['reason']).toBe('no-gesture')
 
@@ -618,7 +633,7 @@ describe('IOSAgent', () => {
       th.ownsGesture.mockReturnValue(false) // nothing was owned: the open was refused
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in8', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
 
       const msg = await errored
       expect(msg['reason']).toBe('no-gesture')
@@ -634,7 +649,7 @@ describe('IOSAgent', () => {
       startingHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in9', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
 
       expect((await errored)['reason']).toBe('channel-starting')
 
@@ -647,7 +662,7 @@ describe('IOSAgent', () => {
       killHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in10', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
 
       const msg = await errored
       // No channel at all outranks "no gesture": re-opening one could not help.
@@ -662,7 +677,7 @@ describe('IOSAgent', () => {
       const { browser, agent } = await bootedSession()
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyNope', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in11', sessionId: agent.sessionId, payload: { code: 'KeyNope', modifiers: 0 } }))
 
       const msg = await errored
       expect(msg['reason']).toBe('unsupported')
@@ -678,7 +693,7 @@ describe('IOSAgent', () => {
 
       const errored = waitForType(browser, 'input:error')
       browser.send(JSON.stringify({ type: 'input:touch:start', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in12', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
 
       // The device is still booted — this is the input channel failing, not the device.
       expect((await errored).message).toBe('input channel not ready')
@@ -694,7 +709,7 @@ describe('IOSAgent', () => {
       const errored = waitForType(browser, 'input:error')
       const f0 = { x: 0.2, y: 0.2 }, f1 = { x: 0.8, y: 0.8 }
       browser.send(JSON.stringify({ type: 'input:pinch:start', sessionId: agent.sessionId, payload: { f0, f1 } }))
-      browser.send(JSON.stringify({ type: 'input:pinch:end', sessionId: agent.sessionId, payload: { f0, f1 } }))
+      browser.send(JSON.stringify({ type: 'input:pinch:end', requestId: 'rq-in13', sessionId: agent.sessionId, payload: { f0, f1 } }))
       expect((await errored).message).toBe('input channel not ready')
 
       agent.disconnect()
@@ -705,7 +720,7 @@ describe('IOSAgent', () => {
       const { browser, agent, th } = await bootedSession()
       killHelper(th)
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in14', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
       await errored
 
       // TouchHelper respawns itself, so the session heals in place — the same object starts
@@ -714,7 +729,7 @@ describe('IOSAgent', () => {
       th.isReady.mockReturnValue(true)
 
       const done = waitForType(browser, 'input:done')
-      browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
+      browser.send(JSON.stringify({ type: 'input:touch:end', requestId: 'rq-in15', sessionId: agent.sessionId, payload: { x: 0.5, y: 0.5 } }))
       expect((await done).sessionId).toBe(agent.sessionId)
 
       agent.disconnect()
@@ -726,7 +741,7 @@ describe('IOSAgent', () => {
       killHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload: { name: 'home' } }))
+      browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in16', sessionId: agent.sessionId, payload: { name: 'home' } }))
       expect((await errored).message).toBe('input channel not ready')
 
       agent.disconnect()
@@ -750,7 +765,7 @@ describe('IOSAgent', () => {
         const { browser, agent, th } = await bootedSession()
 
         const done = waitForType(browser, 'input:done')
-        browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload }))
+        browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in17', sessionId: agent.sessionId, payload }))
         expect((await done).sessionId).toBe(agent.sessionId)
         expect(th.pressLegacyButton).not.toHaveBeenCalled()
         expect(th.pressButtonDown).not.toHaveBeenCalled()
@@ -764,7 +779,7 @@ describe('IOSAgent', () => {
         killHelper(th)
 
         const errored = waitForType(browser, 'input:error')
-        browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload }))
+        browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in18', sessionId: agent.sessionId, payload }))
         expect((await errored).message).toBe('input channel not ready')
 
         agent.disconnect()
@@ -777,7 +792,7 @@ describe('IOSAgent', () => {
       killHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in19', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       expect((await errored).message).toBe('input channel not ready')
 
       agent.disconnect()
@@ -795,7 +810,7 @@ describe('IOSAgent', () => {
       startingHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in20', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
 
       const msg = await errored
       expect(msg['reason']).toBe('channel-starting')
@@ -814,7 +829,7 @@ describe('IOSAgent', () => {
       killHelper(th)
 
       const errored = waitForType(browser, 'input:error')
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in21', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       expect((await errored).message).toBe('input channel not ready')
       expect(simctl.hideSoftwareKeyboard).toHaveBeenCalledWith('dev-1')
 
@@ -925,8 +940,13 @@ describe('IOSAgent', () => {
       killHelper(th)
 
       const errored = waitForType(browser, 'input:type-error')
-      browser.send(JSON.stringify({ type: 'input:type', sessionId: agent.sessionId, payload: { text: 'hello' } }))
-      expect((await errored).message).toContain('no input channel')
+      browser.send(JSON.stringify({ type: 'input:type', requestId: 'rq-in22', sessionId: agent.sessionId, payload: { text: 'hello' } }))
+      const e = await errored
+      expect(e.message).toContain('no input channel')
+      // All three `input:type-*` producers here took a literal in the mutation round with nothing failing.
+      // The client tests that echo it echo it correctly, so a predicate that stopped checking matched either
+      // way — which is what makes an assertion at the producer the only real one.
+      expect(e.requestId).toBe('rq-in22')
 
       agent.disconnect()
       browser.close()
@@ -974,12 +994,14 @@ describe('IOSAgent', () => {
       // register the ack listener before sending — the done can arrive before
       // the assertions below finish awaiting
       const done = waitForType(browser, 'input:type-done')
-      browser.send(JSON.stringify({ type: 'input:type', sessionId: agent.sessionId, payload: { text: '안녕 hi' } }))
+      browser.send(JSON.stringify({ type: 'input:type', requestId: 'rq-in23', sessionId: agent.sessionId, payload: { text: '안녕 hi' } }))
       // the ack must arrive AFTER the work completed — so once done lands, the
       // pasteboard write and Cmd+V (KeyV 0x19, MetaLeft 0x08) are already done.
       // (a synchronous check here, not waitFor, so moving .then(done) ahead of
       // the paste would fail this test — the ordering is what's under guard)
-      expect((await done).sessionId).toBe(agent.sessionId)
+      const ack = await done
+      expect(ack.sessionId).toBe(agent.sessionId)
+      expect(ack.requestId).toBe('rq-in23')
       expect(simctl.setPasteboard).toHaveBeenCalledWith('dev-1', '안녕 hi')
       expect(thInstance.sendKey).toHaveBeenCalledWith(0x19, 0x08)
 
@@ -1004,7 +1026,7 @@ describe('IOSAgent', () => {
       await waitForType(browser, 'keyboard:toggled')
 
       const typed = waitForType(browser, 'input:type-done')
-      browser.send(JSON.stringify({ type: 'input:type', sessionId: agent.sessionId, payload: { text: 'hi' } }))
+      browser.send(JSON.stringify({ type: 'input:type', requestId: 'rq-in24', sessionId: agent.sessionId, payload: { text: 'hi' } }))
       await typed
       // hidden before the Cmd+V chord (mirrors the input:key guard)
       expect(simctl.hideSoftwareKeyboard).toHaveBeenCalledWith('dev-1')
@@ -1039,7 +1061,7 @@ describe('IOSAgent', () => {
 
     it('input:pinch:end calls touchHelper.pinchEnd', async () => {
       const { browser, agent, thInstance } = await setupPinchSession()
-      browser.send(JSON.stringify({ type: 'input:pinch:end', sessionId: agent.sessionId }))
+      browser.send(JSON.stringify({ type: 'input:pinch:end', requestId: 'rq-in25', sessionId: agent.sessionId }))
       await vi.waitFor(() => expect(thInstance.pinchEnd).toHaveBeenCalled(), { timeout: 500 })
       agent.disconnect()
       browser.close()
@@ -1048,7 +1070,7 @@ describe('IOSAgent', () => {
     // home has no HID down/up split — a down+up pair from the dashboard must not fire it twice.
     it('input:button home (no phase) presses the legacy button once', async () => {
       const { browser, agent, thInstance } = await setupPinchSession()
-      browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload: { name: 'home' } }))
+      browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in26', sessionId: agent.sessionId, payload: { name: 'home' } }))
       await vi.waitFor(() => expect(thInstance.pressLegacyButton).toHaveBeenCalledWith(0), { timeout: 500 })
       expect(thInstance.pressLegacyButton).toHaveBeenCalledTimes(1)
       agent.disconnect()
@@ -1057,8 +1079,8 @@ describe('IOSAgent', () => {
 
     it('input:button home fires only on the up phase, not on down', async () => {
       const { browser, agent, thInstance } = await setupPinchSession()
-      browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload: { name: 'home', phase: 'down' } }))
-      browser.send(JSON.stringify({ type: 'input:button', sessionId: agent.sessionId, payload: { name: 'home', phase: 'up' } }))
+      browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in27', sessionId: agent.sessionId, payload: { name: 'home', phase: 'down' } }))
+      browser.send(JSON.stringify({ type: 'input:button', requestId: 'rq-in28', sessionId: agent.sessionId, payload: { name: 'home', phase: 'up' } }))
       await vi.waitFor(() => expect(thInstance.pressLegacyButton).toHaveBeenCalledWith(0), { timeout: 500 })
       expect(thInstance.pressLegacyButton).toHaveBeenCalledTimes(1)
       agent.disconnect()
@@ -1899,7 +1921,7 @@ describe('IOSAgent', () => {
 
     it('input:key Backspace calls touchHelper.sendKey with HID usage 0x2A', async () => {
       const { browser, agent, thInstance } = await setupSession()
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'Backspace', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in29', sessionId: agent.sessionId, payload: { code: 'Backspace', modifiers: 0 } }))
       await vi.waitFor(() => expect(thInstance.sendKey).toHaveBeenCalledWith(HID_BACKSPACE, 0), { timeout: 500 })
       agent.disconnect()
       browser.close()
@@ -1907,7 +1929,7 @@ describe('IOSAgent', () => {
 
     it('input:key KeyA calls touchHelper.sendKey with HID usage 0x04', async () => {
       const { browser, agent, thInstance } = await setupSession()
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in30', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       await vi.waitFor(() => expect(thInstance.sendKey).toHaveBeenCalledWith(HID_KEY_A, 0), { timeout: 500 })
       agent.disconnect()
       browser.close()
@@ -1915,7 +1937,7 @@ describe('IOSAgent', () => {
 
     it('input:key with Shift modifier forwards modifier bits', async () => {
       const { browser, agent, thInstance } = await setupSession()
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0x02 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in31', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0x02 } }))
       await vi.waitFor(() => expect(thInstance.sendKey).toHaveBeenCalledWith(HID_KEY_A, 0x02), { timeout: 500 })
       agent.disconnect()
       browser.close()
@@ -1925,8 +1947,8 @@ describe('IOSAgent', () => {
       const { browser, agent, thInstance } = await setupSession()
       // Send unknown key first, then a known key as a sentinel.
       // WebSocket messages are ordered — when KeyA is processed, UnknownKey was already processed.
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'UnknownKey', modifiers: 0 } }))
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in32', sessionId: agent.sessionId, payload: { code: 'UnknownKey', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in33', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       await vi.waitFor(() => expect(thInstance.sendKey).toHaveBeenCalledTimes(1), { timeout: 500 })
       expect(thInstance.sendKey).toHaveBeenCalledWith(HID_KEY_A, 0)
       agent.disconnect()
@@ -2008,7 +2030,7 @@ describe('IOSAgent', () => {
       browser.send(JSON.stringify({ type: 'input:keyboard:toggle', sessionId: agent.sessionId }))
       await waitForType(browser, 'keyboard:toggled')
       // hardware key press → hide must be called before sendKey
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in34', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       await vi.waitFor(() => expect(sim.hideSoftwareKeyboard).toHaveBeenCalledWith('dev-1'), { timeout: 500 })
       await vi.waitFor(() => {
         expect(MockTouchHelper.mock.results[0].value.sendKey).toHaveBeenCalledWith(HID_KEY_A, 0)
@@ -2023,7 +2045,7 @@ describe('IOSAgent', () => {
     it('input:key 수신 시 SW 꺼져 있으면 hideSoftwareKeyboard를 호출하지 않는다', async () => {
       const sim = mockSimctl(true)
       const { browser, agent } = await setupSession(sim)
-      browser.send(JSON.stringify({ type: 'input:key', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
+      browser.send(JSON.stringify({ type: 'input:key', requestId: 'rq-in35', sessionId: agent.sessionId, payload: { code: 'KeyA', modifiers: 0 } }))
       await vi.waitFor(() => {
         const thInstance = MockTouchHelper.mock.results[0].value
         return expect(thInstance.sendKey).toHaveBeenCalledWith(HID_KEY_A, 0)

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -49,8 +49,20 @@ landed to a model that then moved on (#457). Three things about the fix are easy
   relay may have forwarded it. A close says nothing about whether the agent acks — only that we stopped
   being able to hear it — so it is unconfirmed regardless of the ledger.
 - **Whether silence is fatal is decided by what the session has already done**, not by a negotiated
-  flag: `ackedSessions` records any session that has answered an input with `input:done`, and only
-  those are judged strictly. **`input:done` and not `input:error`**, because the relay originates
+  flag: `ackedSessions` records a session that has answered an input with `input:done` **carrying a
+  correlator**, and only those are judged strictly. L5c added that qualifier and it is the whole content of
+  the rule: `strict` licenses exactly one inference — *silence here is an anomaly, not an agent that does not
+  ack* — and for an agent that never carries a correlator, silence at the waiter is **structural**, since its
+  acks can never match. Recording it would make every input after the first report a failure the agent never
+  had a chance to avoid.
+  It is not a provenance question. An id-less `input:done` is still the agent's word, because nothing else
+  produces that message; what it lacks is *attribution*, and attribution is the waiter's question rather than
+  this ledger's. Nor is the condition "an id **this client** issued" — recognising that after the fact needs a
+  set of issued ids outliving their waiters, and the late ack is precisely the one worth recording, so the set
+  would never shrink in a long-lived stdio process. A correlated ack for someone else's input still
+  demonstrates that this agent echoes correlators, which is what the ledger is for.
+
+  **`input:done` and not `input:error`**, because the relay originates
   `input:error` to this same socket for a terminal input it cannot dispatch — counting those would let
   one agent-offline blip mark a session as acking when its agent may never have answered anything, and
   then report every later input as unconfirmed on evidence the agent did not produce. Nothing in the
@@ -72,11 +84,19 @@ landed to a model that then moved on (#457). Three things about the fix are easy
   decision, and `REASON_ADVICE` is what it decides on — including the warning that `no-gesture` may
   already have applied part of the input.
 
-**A known gap this does not close**: an ack carries no correlation id, so the waiter matches any ack for
-the session. An ack that arrives after its own input timed out is consumed by the *next* input's waiter,
-which then reports the previous input's outcome — including reporting an unanswered input as landed. That
-needs a field on the wire and is tracked in #499; it is stated here rather than papered over, because it
-is the one way the gate above can still be defeated.
+**That gap is closed (#499).** The ack used to carry no correlation id, so the waiter matched any ack for the
+session and one that arrived after its own input had timed out was consumed by the *next* input's waiter —
+which then reported the previous input's outcome, including reporting an unanswered input as landed. It was
+the one way the gate above could still be defeated. `awaitInputAck` now matches on `requestId`, **with no
+fallback for an absent one**: accepting an id-less ack would keep exactly the behaviour that defect was.
+
+The cost lands on agents predating the correlator, and it is bounded by the ledger above rather than by a
+version check — there is no protocol or agent version handshake anywhere in this system. Their acks never
+match, so those sessions never become strict and keep the optimistic path: the residual exemption this file
+already described, now widened from "agents predating the ack protocol" to "agents predating the correlator".
+An id-less ack is therefore the only skew signal that exists, so it is recorded in `skewedSessions` — which
+carries no strictness — and logged once per session. Dropping it silently would return the session to
+optimistic reporting, which from an operator's seat is indistinguishable from the defect #457 fixed.
 
 ## HOW NOT
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -25,11 +25,14 @@ function createMockRelay(): {
       try { msg = JSON.parse(data.toString()) as Record<string, unknown> } catch { return }
       received.push(msg)
       if (inputAck !== 'none' && TERMINAL.has(msg['type'] as string)) {
+        // Echoes `requestId`, because an agent must (L5c). Read back off the request rather than invented:
+        // a made-up id would only prove the waiter rejects made-up ids, which is a different claim.
+        const requestId = msg['requestId']
         ws.send(JSON.stringify(inputAck === 'error'
-          ? { type: 'input:error', sessionId: msg['sessionId'], message: 'device not booted' }
+          ? { type: 'input:error', sessionId: msg['sessionId'], requestId, message: 'device not booted' }
           : inputAck === 'error-with-reason'
-          ? { type: 'input:error', sessionId: msg['sessionId'], message: 'the input channel is still starting — retry in a moment', reason: 'channel-starting' }
-          : { type: 'input:done', sessionId: msg['sessionId'] }))
+          ? { type: 'input:error', sessionId: msg['sessionId'], requestId, message: 'the input channel is still starting — retry in a moment', reason: 'channel-starting' }
+          : { type: 'input:done', sessionId: msg['sessionId'], requestId }))
       }
     })
   })
@@ -297,11 +300,62 @@ describe('TapflowClient', () => {
     it('learns from an ack that arrives after its window expired', async () => {
       relay.setInputAck('none')
       await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined() // optimistic, nothing acked
-      relay.send({ type: 'input:done', sessionId: 'sess-1' })           // the late ack, no waiter armed
+      // The late ack carries the id the first tap minted. Read back, not invented: the ledger records a
+      // **correlated** done and only that, so an invented id would test the opposite of this test's subject.
+      const sent = relay.sentMessages().filter((m) => m['type'] === 'input:touch:end').at(-1)
+      relay.send({ type: 'input:done', sessionId: 'sess-1', requestId: sent!['requestId'] })
       await new Promise((r) => setTimeout(r, 20))
       await expect(client.tap('sess-1', 3, 4)).rejects.toThrow(/could not confirm/i)
       // Two serial 2s windows plus a handshake; vitest's unconfigured default is 5s, which this would
       // otherwise sit at 80% of and flake on a loaded runner.
+    }, 15_000)
+
+    it('is not satisfied by an ack carrying no correlator', async () => {
+      // **The no-fallback rule, and nothing else held it**: adding `m['requestId'] === undefined ||` to the
+      // waiter left all 77 tests passing in the mutation round. A fallback here would keep #499 exactly as
+      // it is — an ack that missed its own deadline still matching the next input's waiter — which is the
+      // one thing this layer exists to remove. The lifecycle pair (#521) has a fallback because its replies
+      // have producers that answer no request; every producer of `input:done` answers a terminal input.
+      const ws = relay.lastClient()
+      relay.setInputAck('none')
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] !== 'input:touch:end') return
+        ws.send(JSON.stringify({ type: 'input:done', sessionId: msg['sessionId'] })) // no requestId
+      })
+      // Resolves optimistically rather than on that ack — the session has never produced a matchable one,
+      // so `strict` is false. What this pins is that the ack did not *satisfy the waiter*: with a fallback
+      // it would, and the assertion below is what tells the two apart.
+      await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
+
+      // Now make the session strict with a correlated ack, then send an uncorrelated one for the next tap.
+      relay.setInputAck('done')
+      await client.tap('sess-1', 3, 4)
+      relay.setInputAck('none')
+      await expect(client.tap('sess-1', 5, 6)).rejects.toThrow(/could not confirm/i)
+    }, 15_000)
+
+    it('does not learn from an uncorrelated late ack, and says why once', async () => {
+      // An agent predating the correlator. Its acks can never match a waiter, so silence on this session is
+      // **structural** rather than anomalous — recording it would make every later input report a failure
+      // the agent never had a chance to avoid. The skew is logged instead, because nothing else in this
+      // system announces an agent's version and dropping the signal silently returns the session to
+      // optimistic reporting, which reads exactly like the defect #457 fixed.
+      const logged: string[] = []
+      const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+      try {
+        relay.setInputAck('none')
+        await expect(client.tap('sess-1', 1, 2)).resolves.toBeUndefined()
+        relay.send({ type: 'input:done', sessionId: 'sess-1' })   // no requestId: an old agent
+        await new Promise((r) => setTimeout(r, 20))
+        // Still optimistic, because the ledger did not record an ack it cannot match.
+        await expect(client.tap('sess-1', 3, 4)).resolves.toBeUndefined()
+        relay.send({ type: 'input:done', sessionId: 'sess-1' })
+        await new Promise((r) => setTimeout(r, 20))
+      } finally { spy.mockRestore() }
+      // Once per session, not once per ack: an old agent answers every input this way, and a line per tap
+      // would bury the one thing the operator needs to read.
+      expect(logged.filter((l) => l.includes('predates input correlation'))).toHaveLength(1)
     }, 15_000)
 
     // A per-session ledger, not a per-client one: one session's agent acking says nothing about
@@ -342,14 +396,43 @@ describe('TapflowClient', () => {
   })
 
   describe('typeText', () => {
+    // Answered off the request rather than on a timer, because the reply must now carry the id the client
+    // minted and that id is only knowable once the request has arrived.
+    const answerType = (reply: (m: Record<string, unknown>) => Record<string, unknown>) => {
+      const ws = relay.lastClient()
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] === 'input:type') ws.send(JSON.stringify(reply(msg)))
+      })
+    }
+
     it('sends input:type and resolves on input:type-done', async () => {
-      setTimeout(() => relay.send({ type: 'input:type-done', sessionId: 'sess-1' }), 10)
+      answerType((m) => ({ type: 'input:type-done', sessionId: 'sess-1', requestId: m['requestId'] }))
       await expect(client.typeText('sess-1', 'hello')).resolves.toBeUndefined()
       expect(await waitForMessage(relay, 'input:type')).toMatchObject({ type: 'input:type', sessionId: 'sess-1', payload: { text: 'hello' } })
     })
 
+    it('does not take the previous typing\'s reply', async () => {
+      // Both tests here answer with the id the client minted, so dropping `requestId` from the predicate
+      // matched either way — the echo made the assertion vacuous, which review measured. A **stale** reply
+      // is what tells the two apart, and it is #499's shape for `input:type` specifically: a late
+      // `input:type-done` from the previous call landing in this one's waiter.
+      // The stale reply is an **error** and the real one a success, so which of the two resolved the call is
+      // observable. A first version sent two successes and asserted the request count — 1 either way, so it
+      // passed with the correlator check deleted. Asserting a property needs the mutation that removes it to
+      // fail, and counting requests was not that.
+      answerType((m) => {
+        const ws = relay.lastClient()
+        setTimeout(() => ws.send(JSON.stringify({
+          type: 'input:type-done', sessionId: 'sess-1', requestId: m['requestId'],
+        })), 20)
+        return { type: 'input:type-error', sessionId: 'sess-1', requestId: 'a-previous-call', message: 'stale' }
+      })
+      await expect(client.typeText('sess-1', 'hello')).resolves.toBeUndefined()
+    }, 20_000)
+
     it('throws on input:type-error', async () => {
-      setTimeout(() => relay.send({ type: 'input:type-error', sessionId: 'sess-1', message: 'No booted device' }), 10)
+      answerType((m) => ({ type: 'input:type-error', sessionId: 'sess-1', requestId: m['requestId'], message: 'No booted device' }))
       await expect(client.typeText('sess-1', 'x')).rejects.toThrow('No booted device')
     })
   })

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -102,6 +102,10 @@ export const REASON_ADVICE: Record<InputErrorReason, string> = {
   unsupported: 'This input is not supported on the active connection to the device. Do not retry it.',
   malformed: 'The message did not carry what the input needs. This is a bug in tapflow rather than something to retry.',
   'no-gesture': 'The gesture this input was completing is gone. Part of it may already have been applied to the device, so repeating it may duplicate what landed.',
+  // The only entry in this table that can promise nothing landed, and the promise is what makes it
+  // actionable: the relay refused the frame at its door, before any agent saw it. Every other reason
+  // leaves partial delivery open, which is why none of them says "retry" without a hedge.
+  'not-session-owner': 'You do not hold this session, so the input was refused and nothing reached the device. Call connect_device for it first, then send the input again — the accompanying message says whether the session is idle or held by someone else. If the join is refused it is in use; pick another device.',
 }
 
 export function reasonAdvice(reason: string | undefined): string {
@@ -117,8 +121,41 @@ export function reasonAdvice(reason: string | undefined): string {
 export class TapflowClient {
   private ws: WebSocket | null = null
   private waiters: Waiter[] = []
-  /** Sessions that have answered at least one input. See `awaitInputAck`. */
+  /** Sessions that have answered at least one input **in a form this client's waiter can match**.
+   *
+   *  A correlated `input:done` only, and the qualifier is the whole content of the rule. `strict` licenses
+   *  exactly one inference — *silence here is an anomaly, not an agent that does not ack* — and for an agent
+   *  that never carries a correlator, silence at the waiter is **structural**: its acks can never match, so
+   *  the inference is false for it and this set must not record it. It is not a provenance question; an
+   *  id-less `input:done` is still the agent's word, since nothing else produces that message. What it
+   *  lacks is attribution, and attribution is the waiter's question rather than this one's.
+   *
+   *  Deliberately **not** "an id this client issued". Recognising that after the fact needs a set of issued
+   *  ids outliving their waiters — the late ack is precisely the one worth recording (see `dispatch`) and
+   *  nothing ever says an id will not be answered, so the set would never shrink in a long-lived stdio
+   *  process. And it would answer the wrong question: a correlated ack for someone else's input still
+   *  demonstrates that this agent echoes correlators, which is what this set is for. */
   private ackedSessions = new Set<string>()
+
+  /** Sessions seen answering with an **uncorrelated** ack, so an agent older than the correlator.
+   *
+   *  Kept apart from `ackedSessions` because it must carry no strictness: judging this session strictly is
+   *  the thing the rule above rules out. It exists because there is **no protocol or agent version
+   *  handshake anywhere** in this system — an id-less ack is the only skew signal there is, and dropping it
+   *  silently returns the session to optimistic reporting, which from an operator's seat is
+   *  indistinguishable from the defect #457 fixed. Logging is not matching, so this does not reintroduce a
+   *  second correlation strategy. */
+  private skewedSessions = new Set<string>()
+
+  private noteAckSkew(sessionId: string): void {
+    if (this.skewedSessions.has(sessionId)) return
+    this.skewedSessions.add(sessionId)
+    console.error(
+      `[tapflow] input:done for ${sessionId} carried no requestId — this agent predates input correlation, ` +
+      'so an unanswered input on this session is reported optimistically rather than as a failure. ' +
+      'Upgrade the agent to get truthful input acks.',
+    )
+  }
 
   constructor(
     private readonly relayUrl: string,
@@ -171,7 +208,10 @@ export class TapflowClient {
     // never see it.
     if (msg['type'] === 'input:done') {
       const sid = msg['sessionId']
-      if (typeof sid === 'string') this.ackedSessions.add(sid)
+      const id = msg['requestId']
+      if (typeof sid !== 'string') { /* nothing to key on */ }
+      else if (typeof id === 'string' && id !== '') this.ackedSessions.add(sid)
+      else this.noteAckSkew(sid)
     }
     for (let i = 0; i < this.waiters.length; i++) {
       if (this.waiters[i].predicate(msg)) {
@@ -290,14 +330,19 @@ export class TapflowClient {
    * input's waiter, which then reports the previous input's outcome. Recorded as a known gap rather than
    * papered over — see the issue linked from `AGENTS.md`.
    */
-  private async awaitInputAck(sessionId: string): Promise<void> {
+  private async awaitInputAck(sessionId: string, requestId: string): Promise<void> {
     const strict = this.ackedSessions.has(sessionId)
     let msg: RelayMsg
     try {
       msg = await this.waitFor(
+        // **No fallback for an absent id.** #499 is what `sessionId` + type alone cost: an ack that missed
+        // its own deadline was consumed by the next input's waiter, which then reported the previous input's
+        // outcome — including reporting an unanswered input as landed. Accepting an id-less ack here would
+        // keep exactly that. An old agent's acks therefore never match, and the ledger above is what makes
+        // that degrade to the optimistic path instead of to a false failure.
         (m) =>
           (m['type'] === 'input:done' || m['type'] === 'input:error') &&
-          m['sessionId'] === sessionId,
+          m['sessionId'] === sessionId && m['requestId'] === requestId,
         2_000,
       )
     } catch (e) {
@@ -332,8 +377,9 @@ export class TapflowClient {
   async tap(sessionId: string, x: number, y: number): Promise<void> {
     const payload = { x, y }
     this.send({ type: 'input:touch:start', sessionId, payload })
-    this.send({ type: 'input:touch:end', sessionId, payload })
-    await this.awaitInputAck(sessionId)
+    const requestId = randomUUID()
+    this.send({ type: 'input:touch:end', sessionId, requestId, payload })
+    await this.awaitInputAck(sessionId, requestId)
   }
 
   async swipe(
@@ -363,22 +409,32 @@ export class TapflowClient {
       })
     }
     await delay(interval)
-    this.send({ type: 'input:touch:end', sessionId, payload: { x: endX, y: endY } })
-    await this.awaitInputAck(sessionId)
+    const requestId = randomUUID()
+    this.send({ type: 'input:touch:end', sessionId, requestId, payload: { x: endX, y: endY } })
+    await this.awaitInputAck(sessionId, requestId)
   }
 
   // Awaits the agent's ack so a following input (e.g. pressKey Enter) is sent
   // only after the text has landed — the paste/adb write runs async agent-side.
   async typeText(sessionId: string, text: string): Promise<void> {
-    this.send({ type: 'input:type', sessionId, payload: { text } })
+    const requestId = randomUUID()
+    this.send({ type: 'input:type', sessionId, requestId, payload: { text } })
     const msg = await this.waitFor(
       (m) =>
         (m['type'] === 'input:type-done' || m['type'] === 'input:type-error') &&
-        m['sessionId'] === sessionId,
+        m['sessionId'] === sessionId && m['requestId'] === requestId,
       15_000,
     )
     if (msg['type'] === 'input:type-error') {
-      throw new Error((msg['message'] as string) ?? 'Type text failed')
+      // The reason is read here for the same purpose as on `input:error`: the prose is the producer's and
+      // says what happened, the reason is the contract and says what to do. Agents send none — their
+      // failures are a rejected `adb` or pasteboard write — so this stays prose-only for them. The relay
+      // sets it, and without reading it here `not-session-owner` was unreachable for one of the five
+      // requests it can refuse: the only reason that promises nothing reached the device, delivered as a
+      // string the caller would have had to branch on (#492).
+      const reason = msg['reason'] as string | undefined
+      const prose = (msg['message'] as string) ?? 'Type text failed'
+      throw new Error(reason ? `${prose} (${reason}) — ${reasonAdvice(reason)}` : prose)
     }
   }
 
@@ -386,16 +442,18 @@ export class TapflowClient {
   // 'Return' is accepted as an alias — neither platform maps it, 'Enter' is the code.
   async pressKey(sessionId: string, key: string): Promise<void> {
     const code = key === 'Return' ? 'Enter' : key
-    this.send({ type: 'input:key', sessionId, payload: { code, modifiers: 0 } })
-    await this.awaitInputAck(sessionId)
+    const requestId = randomUUID()
+    this.send({ type: 'input:key', sessionId, requestId, payload: { code, modifiers: 0 } })
+    await this.awaitInputAck(sessionId, requestId)
   }
 
   // Agents consume { name, phase? } on input:button; a phase-less message is a
   // single press on both platforms (iOS 'home' is legacy-pressed once, chrome
   // buttons and Android BUTTON_KEY_MAP names resolve by name).
   async pressButton(sessionId: string, button: string): Promise<void> {
-    this.send({ type: 'input:button', sessionId, payload: { name: button } })
-    await this.awaitInputAck(sessionId)
+    const requestId = randomUUID()
+    this.send({ type: 'input:button', sessionId, requestId, payload: { name: button } })
+    await this.awaitInputAck(sessionId, requestId)
   }
 
   async openUrl(sessionId: string, url: string): Promise<void> {

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -91,7 +91,7 @@ Correlated by `requestId` today: `screenshot`, `ui:tree`, `clipboard`, the app c
 「Lifecycle correlation」), and **the inputs an ack answers** (see 「Input correlation」). What is left correlates
 by `sessionId` + message type, and the reason a pair is *not* in the set is always one of the two below.
 
-#499 was the last of the defects that came from having no correlator, and it was the sharpest: the four pairs
+`#499` was the last of the defects that came from having no correlator, and it was the sharpest: the four pairs
 above arrive at the speed a person clicks a button, while a swipe is dozens of frames, so an ack that missed
 its own deadline being consumed by the **next** input's waiter was not a corner case.
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -86,11 +86,14 @@ assertion green.
 
 ## Request/response correlation — `requestId`, required on both sides
 
-Four pairs correlate by `requestId` today: `screenshot`, `ui:tree`, `clipboard`, and the app commands
-(`open-url`, `app:install`, `app:launch`, `app:clear-state`). The rest still correlate by `sessionId` +
-message type, which is the root of #499 and of #512's first finding — a reply for one request satisfying
-another's waiter. Each remaining pair is scheduled; the reason a pair is *not* in the set is always one of
-the two below.
+Correlated by `requestId` today: `screenshot`, `ui:tree`, `clipboard`, the app commands (`open-url`,
+`app:install`, `app:launch`, `app:clear-state`), the device lifecycle (`device:boot`, `device:shutdown` — see
+「Lifecycle correlation」), and **the inputs an ack answers** (see 「Input correlation」). What is left correlates
+by `sessionId` + message type, and the reason a pair is *not* in the set is always one of the two below.
+
+#499 was the last of the defects that came from having no correlator, and it was the sharpest: the four pairs
+above arrive at the speed a person clicks a button, while a swipe is dozens of frames, so an ack that missed
+its own deadline being consumed by the **next** input's waiter was not a corner case.
 
 **Required on the reply, not optional.** The tempting asymmetry is to leave the reply optional so an agent
 predating the field does not falsify the declaration. It was measured and rejected:
@@ -188,6 +191,89 @@ rebind on `device:ready`, and a replayed ready currently consumes one and fires 
 relay, so one door gates and logs every sender at once. A reply does not — the relay forwards it with
 `JSON.stringify` without inspecting it — so "log the uncorrelatable frame" has to be written once per consuming
 client, and one of those clients must not drop at all.
+
+## Input correlation — the pair where the request is not one message
+
+Five requests carry a required `requestId`: the four terminal frames (`input:touch:end`, `input:pinch:end`,
+`input:key`, `input:button`) and `input:type`. The four replies do too — `input:done`, `input:error`,
+`input:type-done`, `input:type-error`.
+
+**Opening and move frames carry none, and neither does `input:rotate`.** Nothing acks them
+(`ios-agent/AGENTS.md`: *"Opening frames stay silent: they carry no ack obligation"*), so an id there would
+name a waiter that does not exist. `input:keyboard:toggle` is out for a different reason — see below.
+
+**Required on both sides, unlike the lifecycle pair**, and the discriminator is the one this file already
+uses: no producer of these four replies sends one unsolicited. `ackInput` on both agents fires on terminal
+outcomes only; `ackNoSession` answers a terminal input for a session the agent lost; the relay answers a
+terminal input it cannot dispatch. Six producers of `input:error`, every one of them behind a request.
+
+**So the compiler holds more here than anywhere else in this work.** The relay's own `input:error` goes
+through `sendTo(socket, msg: RelayOutbound)` and the agents' through `sendMsg(msg: AgentControlOutbound)`, so
+with the reply required, omitting the echo is a **compile error** — not something only a test could see. That
+is the position the lifecycle pair could not reach, and it is where the same defect had already shipped twice.
+
+**`input:type-error` moved from `AgentToBrowser` to `RelayOrAgentToBrowser`.** The relay refuses an
+`input:type` whose session the sender does not hold, and it has to refuse in *that* shape: the waiters in
+`mcp-server` and `flow-runner` key on the `input:type-*` pair and ignore an `input:error` entirely. Answering
+one would be the deadline-burning non-answer this reply replaced — which is also why widening the terminal
+set was never the fix for it.
+
+### The correlator is a parameter, never shared state
+
+A gesture is dozens of frames and two can overlap, so `ackInput` and `ackNoSession` take the id as an
+argument, beside `seq` and for the same reason: state moves under the awaited dispatch. A correlator read
+from `DeviceState` would answer one input with another's id — #499 rebuilt inside the agent, where no test
+downstream could see it.
+
+`correlatorOf` on each agent is a **local capture**, not a guard at the top of the dispatcher. A guard there
+does not narrow `msg.requestId` inside the case, so the shortest way to satisfy the reply's required field
+would be `msg.requestId!` — the assertion removed from `open-url` and then from clipboard.
+
+### The eleven input cases became two clauses
+
+`input:*` shared one `case` body. Only five of them are answered, so a gate written into a shared body would
+have dropped every opening and move frame with it: no swipe, no pinch, no rotation, and nothing said.
+`correlatedRequestsGated` resolves fall-through by sharing the next non-empty body, so it would have read one
+gate as covering all eleven. The split is what makes the gate unable to reach them, and
+`TERMINAL_INPUT_TYPES` was deleted because the clause labels are now the definition — a second source of
+truth for "which inputs are answered" is the thing this package exists to remove.
+
+### The sender must hold the session, and a refusal is answered where a waiter exists
+
+Not an input-only rule, though it was found there. The relay resolved the session and forwarded **every**
+browser→agent command without asking whether the socket asking was the one the session is bound to —
+`clipboard:data` asks the mirror-image question one branch up, with the reason beside it, and the browser
+direction had no equivalent anywhere. So any authenticated client that knew a session id could drive a device
+another tester was looking at, and the reply routed to that session's browser rather than to whoever asked.
+
+Every branch that can take the check now has it: the five acked inputs, `device:boot`, `open-url`,
+`app:install`, `app:launch`, `app:clear-state`, `clipboard:read`, `clipboard:write`, `session:leave`,
+`session:end`. **`device:shutdown` is the exception**, and the blocker is in the dashboard rather than the
+relay — three of its four senders never join the session. #527.
+
+A refusal is **answered where a waiter exists** and dropped where none does. Answering matters more than it
+looks: `awaitInputAck` reports silence from a session that has never acked as *success*, so a silent refusal
+would report a command that never left the relay as landed — worse than the misrouting it replaced. The two
+session commands have no reply at all, so they are dropped; the same asymmetry as the input frames nothing
+acks, which is why the clause split matters twice.
+
+One diagnosis improved for free. `open-url` answered `'agent offline'` for a session the relay does not have
+— the wrong-diagnosis class #492 fixed for `device:boot` and `input:error`, still present here — and routing
+it through the shared resolver corrected it.
+
+`not-session-owner` is its own reason rather than folded into `channel-unavailable`, on this set's own rule —
+a reason exists per thing a consumer must do differently. And it is the **only** member that can promise
+nothing reached the device, because the refusal happens at the door; every other one leaves partial delivery
+open, which is why none of them says "retry" without a hedge (#491).
+
+### What this does not close
+
+`input:keyboard:toggle` is **not** in the set, and the reason is not that it has no reply — it has one on
+iOS, `keyboard:toggled`, with a consumer that sets session state. Its **failure half** is missing: the
+`.catch` only logs, so the pending flag never clears and the button latches off (#517). Correlating a pair
+whose failure half does not exist would leave it half-correlated, and the half that is missing is
+platform-asymmetric — Android's toggle has no device-side effect at all, so what its failure even means is a
+decision that slice has to make. `#517` is the prerequisite.
 
 ## Every direction is declared, and an agent's send is typed
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -404,9 +404,11 @@ export interface DeviceReady {
  * Required here is a **specification the relay does not yet meet**, not a description of the wire.
  * Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
  * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
- * through `msg.sessionId!` — `JSON.stringify` then drops the key. Seven sites do this
- * (`RelayServer.ts:721,743,752,786,803,1129,1158`). No in-repo client omits a sessionId, so the
- * gap is reachable only from a third-party one — with one exception measured since: `sessionId: ''`
+ * through `msg.sessionId!` — `JSON.stringify` then drops the key, shipping a frame whose required field
+ * this declaration says is there. **Still seven sites**, re-counted after L5c restructured that file
+ * (`RelayServer.ts:775,827,844,903,1181,1192,1331`) — the correlation work did not widen it and does not
+ * close it, because the fix is the one below: the producer must send `error` instead, which is #444.
+ * No in-repo client omits a sessionId, so the gap is reachable only from a third-party one — with one exception measured since: `sessionId: ''`
  * type-checks and `mcp-server`'s tools take `z.string()`, so an LLM can produce it.
  *
  * Optional would describe that wire accurately and still be the wrong contract: an MCP caller that

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -308,6 +308,22 @@ export type InputErrorReason =
    * giving up. Distinct from `channel-starting` for the same reason — waiting does not help.
    */
   | 'no-gesture'
+  /**
+   * The sender does not hold the session it addressed. The relay forwards a browser-role input after
+   * resolving the session and, until this existed, without checking that the socket asking is the one the
+   * session is bound to — so any authenticated client could drive a device another tester was looking at,
+   * and the agent's ack went to the session holder rather than to whoever asked.
+   *
+   * **Not folded into `channel-unavailable`**, on that set's own rule — a reason exists per thing a consumer
+   * must do differently. `channel-unavailable` means reconnect or re-join *this* session; this means the
+   * caller never held it, so the move is to join first, and it may find someone else holding it.
+   *
+   * And it is the **only** reason that guarantees nothing reached the device. Every other one leaves partial
+   * delivery open — `no-gesture` most sharply, which is why nothing retries on it (#491). Here the frame was
+   * refused at the relay's door, so a retry after joining is safe, and that makes this the first member
+   * whose advice can say so.
+   */
+  | 'not-session-owner'
 
 // ── relay → browser ──────────────────────────────────────────────────────────
 //
@@ -436,6 +452,9 @@ export interface AppClearStateError extends SessionError {
 
 export interface InputError extends SessionError {
   type: 'input:error'
+  /** Required — see `InputDone`. The relay produces this message too, so omission is a compile error there
+   *  rather than something only a test could hold. */
+  requestId: string
   reason?: InputErrorReason
 }
 
@@ -463,6 +482,11 @@ export type RelayOrAgentToBrowser =
   | OpenUrlError
   | AppClearStateError
   | InputError
+  // Moved out of `AgentToBrowser` in L5c: the relay originates this one now. An `input:type` whose session
+  // the sender does not hold is refused here, and it has to be refused in *this* shape — the waiters in
+  // `mcp-server` and `flow-runner` key on the `input:type-*` pair and ignore an `input:error` entirely,
+  // which is why widening `TERMINAL_INPUT_TYPES` was never the fix for it.
+  | InputTypeError
   | ClipboardError
 
 export interface AgentsListed {
@@ -586,15 +610,35 @@ export interface OpenUrlDone {
 export interface InputDone {
   type: 'input:done'
   sessionId: string
+  /**
+   * Required, and this is the pair where an absent correlator costs the most. The four already correlated
+   * arrive at the speed a person clicks a button; a swipe is dozens of frames, so a late ack landing in the
+   * next input's waiter is not a corner case — it is #499.
+   *
+   * There is no unsolicited producer to make this optional (the discriminator this repo uses): `ackInput`
+   * on both agents is the only sender, and it fires on terminal outcomes only. Contrast the lifecycle pair,
+   * where an Android stream dying mid-session produces a `device:boot-error` answering nothing.
+   */
+  requestId: string
 }
 
 export interface InputTypeDone {
   type: 'input:type-done'
   sessionId: string
+  requestId: string
 }
 
 export interface InputTypeError extends SessionError {
   type: 'input:type-error'
+  requestId: string
+  /**
+   * Optional because the agents' own failures carry none — they answer with prose from a rejected `adb` or
+   * pasteboard write. The **relay** sets it, and without this field one of the five requests it can refuse
+   * had no machine-readable answer at all: `not-session-owner`'s whole value is the promise that nothing
+   * reached the device, and a consumer that can only read `message` cannot act on it. Branching on prose is
+   * the thing #492 legislated against.
+   */
+  reason?: InputErrorReason
 }
 
 // iOS only — Android's `input:keyboard:toggle` is a client-side forwarding flag with no device
@@ -651,7 +695,6 @@ export type AgentToBrowser =
   | OpenUrlDone
   | InputDone
   | InputTypeDone
-  | InputTypeError
   | KeyboardToggled
   | ClipboardData
   | ClipboardWriteDone
@@ -845,6 +888,16 @@ export type AgentControlOutbound = AgentToRelay | AgentToBrowser
 export interface InputKey {
   type: 'input:key'
   sessionId: string
+  /**
+   * Required. A terminal input is the only kind that gets an ack, and #499 is what an unattributed one
+   * costs: an ack that arrives after its own deadline is consumed by the **next** input's waiter, which
+   * then reports the previous input's outcome — including reporting an unanswered input as landed.
+   *
+   * Opening and move frames deliberately do **not** carry this. They get no reply
+   * (`ios-agent/AGENTS.md`: "Opening frames stay silent: they carry no ack obligation"), so an id there
+   * would be minted for a waiter that does not exist. Nor does `input:rotate`, for the same reason.
+   */
+  requestId: string
   payload: { code: string; modifiers?: number }
 }
 
@@ -1000,6 +1053,7 @@ export interface InputTouchMove {
 export interface InputTouchEnd {
   type: 'input:touch:end'
   sessionId: string
+  requestId: string
   payload?: Point
 }
 
@@ -1018,17 +1072,20 @@ export interface InputPinchMove {
 export interface InputPinchEnd {
   type: 'input:pinch:end'
   sessionId: string
+  requestId: string
 }
 
 export interface InputType {
   type: 'input:type'
   sessionId: string
+  requestId: string
   payload: { text: string }
 }
 
 export interface InputButton {
   type: 'input:button'
   sessionId: string
+  requestId: string
   payload: { name: string; phase?: 'down' | 'up' }
 }
 

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -46,7 +46,7 @@ export const legacyKeyField: BrowserToRelay = { type: 'input:key', sessionId: 's
 
 export const validOutbound: RelayOutbound = { type: 'stream:request-idr', sessionId: 's' }
 export const validInbound: BrowserToRelay = {
-  type: 'input:key', sessionId: 's', payload: { code: 'KeyA', modifiers: 2 },
+  type: 'input:key', sessionId: 's', requestId: 'rq', payload: { code: 'KeyA', modifiers: 2 },
 }
 export const validClipboard: BrowserToRelay = {
   type: 'clipboard:write', sessionId: 's', requestId: 'r', payload: { text: 'x', pasteAfter: true },
@@ -65,7 +65,7 @@ export const relayCannotOriginateForward: RelayOutbound = { type: 'input:done', 
 export const relayCannotOriginateKeyboard: RelayOutbound = { type: 'keyboard:toggled', sessionId: 's', payload: { visible: true } }
 
 // A consumer reads the whole surface, whoever sent it — both of the above are valid here.
-export const inboundFromAgent: BrowserInbound = { type: 'input:done', sessionId: 's' }
+export const inboundFromAgent: BrowserInbound = { type: 'input:done', sessionId: 's', requestId: 'rq' }
 export const inboundFromRelay: BrowserInbound = { type: 'error', message: 'x', reason: 'session-busy' }
 
 // @ts-expect-error - sessionId is required on every one of the twelve forward-only messages
@@ -86,8 +86,8 @@ export const streamIsNotBrowserInbound: BrowserInbound = { type: 'stream:registe
 // The field is optional on purpose: an agent that predates it omits it, and a consumer must read
 // absence as "unknown" rather than "fine". Making it required is the breaking step.
 
-export const errorWithoutReason: RelayOutbound = { type: 'input:error', sessionId: 's', message: 'agent offline' }
-export const errorWithReason: RelayOutbound = { type: 'input:error', sessionId: 's', message: 'agent offline', reason: 'channel-unavailable' }
+export const errorWithoutReason: RelayOutbound = { type: 'input:error', sessionId: 's', requestId: 'rq', message: 'agent offline' }
+export const errorWithReason: RelayOutbound = { type: 'input:error', sessionId: 's', requestId: 'rq', message: 'agent offline', reason: 'channel-unavailable' }
 
 // @ts-expect-error - the reason set is closed; a free string would let each agent invent its own
 export const errorWithFreeReason: RelayOutbound = { type: 'input:error', sessionId: 's', message: 'x', reason: 'something-else' }

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -38,15 +38,12 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 - Control message protocol: `input:touch:*`, `input:pinch:*`, `input:button`, `input:key`, `input:type`, `input:rotate`, `input:keyboard:toggle`, `device:boot`, `device:shutdown`, `session:start`, `session:end`, `clipboard:read`, `clipboard:write`.
 - **The message shapes live in [`@tapflowio/protocol`](../protocol/AGENTS.md), not here.** Every message the relay *originates* goes through `sendTo(socket, msg: RelayOutbound)`, so adding one means adding it to that union first — the compiler will not let you do it in the other order. Messages the relay only *forwards* keep their inbound type and are re-serialised unchanged.
 - **Clipboard bridge** (`clipboard:*`): browser→agent `clipboard:read` (`payload.press`: `'copy' | 'cut'` presses that chord on the device first) and `clipboard:write` (`payload.text`, `payload.pasteAfter`); agent→browser `clipboard:data` / `clipboard:write-done` / `clipboard:error`, correlated by `requestId`. Unlike the other agent→browser replies these are **bound to the session's own `agentSocket`** — their payload lands on the viewer's host OS clipboard, so a second agent must not be able to address someone else's session. An undeliverable request answers `clipboard:error` immediately rather than letting the caller's deadline expire. Agents advertise `capabilities: ['clipboard']` in `agent:register`; the relay echoes them on `session:joined` so a viewer can tell a capable agent from one that predates the feature instead of inferring it from silence.
-- **A terminal input the relay cannot dispatch is answered here, with a reason.** `input:touch:end` /
-  `input:pinch:end` / `input:key` / `input:button` (`TERMINAL_INPUT_TYPES`) get an `input:error` when
-  the session's agent socket is not open, so an MCP or browser caller fails now instead of waiting out
-  its own timeout — which its fallback would report as success. Everything outside that set gets
-  nothing, and the set is not "the ones that matter": moves and starts have no waiter, but `input:type`
-  does (`input:type-done` / `input:type-error`, awaited in `mcp-server` and `flow-runner`) and receives
-  no answer here, so a type on an offline agent still burns its full deadline. Adding it to this set
-  would not fix that — those waiters key on the `input:type-*` pair and would ignore an `input:error`
-  — so the honest fix is a separate reply, which is why the set was left as it is rather than widened.
+- **An input the relay cannot dispatch is answered here, with a reason.** The four terminal frames get an
+  `input:error` and `input:type` gets an `input:type-error`, so an MCP or browser caller fails now instead of
+  waiting out its own timeout — which its fallback would report as success. `input:type` used to receive
+  nothing and burn its full deadline; widening the terminal set would not have fixed it, because its waiters
+  key on the `input:type-*` pair and ignore an `input:error`, and L5c did what the note here called the
+  honest fix — a reply in the shape those waiters read.
   Two situations reach that reply and only one is the agent's fault, so they carry **different prose
   and the same reason**: a held session with a closed socket is `agent offline`, while no session at
   all is `Session not found` — evicted after the reconnect grace, or never valid, and the agent may be
@@ -54,6 +51,36 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   `channel-unavailable` for both because the set is derived from what a consumer must *do* differently
   and both want a reconnect or a re-join; the machine field was right for both while the prose was
   wrong for one, which is the concrete case for reading `reason` rather than `message` (#492).
+  **Everything else gets nothing, and that is the contract**: opening and move frames, `input:rotate` and
+  `input:keyboard:toggle` have no waiter, so a reply would be one nobody is listening for.
+  The eleven `input:*` cases are **two clauses**, split by whether an ack answers them, and the split is
+  load-bearing rather than tidy — the correlator gate belongs on the answered five, and written into the
+  shared body it would have dropped every opening and move frame with it.
+- **A browser-role command is acted on only from the socket the session is bound to.** The mirror of the
+  clipboard rule above, and it was missing until L5c on **every** branch: the relay resolved the session and
+  forwarded without asking who was asking, so any authenticated client that knew a session id could drive a
+  device another tester was looking at — `clipboard:write` pasting its text into that device,
+  `clipboard:read` pressing copy or cut on it with the payload landing on *that* tester's host OS clipboard,
+  `session:end` deleting their session. The reply then routed to the session's own browser, never to the
+  injector.
+  `dispatchTarget` decides it once for all of them — session exists, **this socket holds it**, agent
+  connected — and each case wraps the prose it returns in the reply type its own waiter reads. The two
+  ownership strings are one reason with different prose (`ownershipRefusal`), the treatment #492 settled:
+  telling a caller the session is in use when it is idle steers it off a device it could have had.
+  **A refusal is answered where a waiter exists and dropped where none does.** `input:*`, `device:boot`,
+  `open-url`, `app:*` and `clipboard:*` are answered — `awaitInputAck` reports silence from a session that
+  has never acked as *success*, so a silent refusal would report a command that never left the relay as
+  having landed. `session:leave` and `session:end` are dropped, because neither has a reply and inventing
+  one would grow the wire for a message no consumer reads.
+  **`device:shutdown` is the one exception, and the blocker is not here** — three of the dashboard's four
+  senders come from `useAgentSession`, whose socket never joins, so the gate would break going back and the
+  unmount teardown. `SessionList` joins before shutting down and documents why, so the dashboard already
+  carries two conventions for this message. Tracked in #527; the question there is whether
+  `useAgentSession` should join, not whether the relay should check.
+  The app-command handlers check ownership **after** the session lookup and **before** the build lookup,
+  deliberately not through `dispatchTarget`: that resolver also decides agent liveness, and using it there
+  would move `agent offline` ahead of `Build not found`, changing which of two simultaneous problems the
+  caller is told about.
 - JWTs are issued based on team invite links.
 - Serves the `public/` directory as HTTP static files (dashboard build output).
 - The relay does not buffer stream data — it forwards immediately on arrival.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -6,8 +6,9 @@ import path from 'path'
 import { randomUUID } from 'crypto'
 import { WebSocketServer, WebSocket } from 'ws'
 import { SessionManager } from './SessionManager.js'
+import type { Session } from './SessionManager.js'
 import type { DeviceDetails, RelayMessage, UIElement } from './types.js'
-import type { ChromePayload, RelayOutbound } from '@tapflowio/protocol'
+import type { ChromePayload, InputErrorReason, RelayOutbound } from '@tapflowio/protocol'
 import { Router, json } from './router.js'
 import { requireViewAuth, requireAuth, getAuth, verifyPat } from './middleware/auth.js'
 import { classifyConnection } from './lib/connectionAuth.js'
@@ -91,8 +92,6 @@ const RESOURCE_THRESHOLD = Number.isFinite(_parsedThreshold) ? _parsedThreshold 
 // Terminal input messages the MCP client awaits an ack for — if the agent is offline
 // the relay replies input:error so the client fails truthfully (non-terminal moves/starts
 // expect no ack and are dropped silently).
-const TERMINAL_INPUT_TYPES = new Set<string>(['input:touch:end', 'input:pinch:end', 'input:key', 'input:button'])
-
 /** A request that carries a usable correlator.
  *
  *  A predicate rather than a bare `typeof` at each site, for two measured reasons. A bare check in the
@@ -105,6 +104,13 @@ const TERMINAL_INPUT_TYPES = new Set<string>(['input:touch:end', 'input:pinch:en
  *
  *  Empty string counts as absent: it type-checks against a required `string`, nothing validates inbound
  *  JSON (#444), and `mcp-server`'s tool schemas are bare `z.string()`. */
+/** Why a session is not this socket's to command. One reason, two prose strings — the treatment `#492`
+ *  settled for `agent offline` / `Session not found`: telling a caller the session is in use when it is
+ *  idle steers it off a device it could have had. Shared so the two never drift. */
+function ownershipRefusal(session: Session): string {
+  return session.browserSocket ? 'session held by another client' : 'session not joined'
+}
+
 function isCorrelated(msg: RelayMessage): msg is RelayMessage & { requestId: string } {
   if (typeof msg.requestId === 'string' && msg.requestId !== '') return true
   // Logged, because the three places this can be dropped are all silent otherwise: the relay `break`s, the
@@ -604,8 +610,20 @@ export class RelayServer {
 
       // ── Session / Stream lifecycle ─────────────────────────────────────────
       case 'session:start':    this.handleSessionStart(ws, msg); break
+      // ── the two session commands, gated but not answered ───────────────────────────────────────
+      //
+      // Both destroy state a viewer depends on, and until L5c both acted on the strength of the session
+      // existing. `session:leave` is the sharper of the two: it nulls `browserSocket`, so an unguarded one
+      // strips ownership out from under a mounted viewer — and then that tester's own input is refused,
+      // which is why `not-session-owner` needed real copy in the dashboard rather than the `null` a first
+      // draft gave it.
+      //
+      // **Dropped rather than refused, and that is the contract**: neither has a reply, so there is no
+      // waiter to tell. The same asymmetry as the input frames nothing acks. Inventing a
+      // `session:leave-error` would grow the wire for a message no consumer reads — and `session:end` has
+      // no in-repo sender at all, so it would be a reply to nobody.
       case 'session:end': {
-        if (msg.sessionId) {
+        if (msg.sessionId && this.ownsSession(ws, this.sessions.get(msg.sessionId))) {
           this.sessions.remove(msg.sessionId)
           this.dropHandlers.delete(msg.sessionId)
           this.audioDropHandlers.delete(msg.sessionId)
@@ -615,7 +633,7 @@ export class RelayServer {
         break
       }
       case 'session:leave': {
-        if (msg.sessionId) {
+        if (msg.sessionId && this.ownsSession(ws, this.sessions.get(msg.sessionId))) {
           this.sessions.clearBrowser(msg.sessionId)
           this.dropHandlers.delete(msg.sessionId)
           this.audioDropHandlers.delete(msg.sessionId)
@@ -740,25 +758,23 @@ export class RelayServer {
         // here (forward it, or answer it with a `device:boot-error`), and gating only one of them leaves
         // the guarantee resting on whichever branch was not gated.
         if (!isCorrelated(msg)) break
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState !== WebSocket.OPEN) {
-          // A boot the agent never receives leaves the viewer on "Waiting for first frame…" with
-          // nothing said. `device:shutdown` gets no such reply: nothing waits on it, and inventing
-          // a `device:shutdown-error` would grow the contract for a message no one reads.
-          //
-          // The two are worth telling apart: `bootDevice` is the first call an MCP caller makes, so
-          // reporting a stale session id as a dead Mac sends the reader after the wrong problem.
-          //
-          // **The relay is a producer of this reply, so it echoes the correlator itself.** An MCP
-          // caller that receives this diagnosis uncorrelated reads it as unsolicited and waits out
-          // its deadline — the diagnosis arrives and is discarded. That defect shipped twice from
-          // agent code (`open-url:error`, then `clipboard:error`); here the producer is the relay,
-          // where `correlatedRequestsGated` cannot see it because the field is optional.
+        // A boot the agent never receives leaves the viewer on "Waiting for first frame…" with nothing
+        // said, and the reasons it might not arrive are worth telling apart: `bootDevice` is the first
+        // call an MCP caller makes, so reporting a stale session id as a dead Mac sends the reader after
+        // the wrong problem. `dispatchTarget` decides which of the four it is.
+        //
+        // **The relay is a producer of this reply, so it echoes the correlator itself.** An MCP caller
+        // that receives this diagnosis uncorrelated reads it as unsolicited and waits out its deadline —
+        // the diagnosis arrives and is discarded. That defect shipped twice from agent code
+        // (`open-url:error`, then `clipboard:error`); here the producer is the relay, where
+        // `correlatedRequestsGated` cannot see it because the field is optional.
+        const boot = this.dispatchTarget(ws, msg.sessionId)
+        if (!boot.ok) {
           this.sendTo(ws, {
             type: 'device:boot-error',
             sessionId: msg.sessionId!,
             requestId: msg.requestId,
-            message: session ? 'agent offline' : 'Session not found',
+            message: boot.message,
           })
           break
         }
@@ -767,7 +783,7 @@ export class RelayServer {
         if (msg.payload && typeof msg.payload === 'object') {
           (msg.payload as Record<string, unknown>).external = this.wsExternal.get(ws) ?? false
         }
-        session.agentSocket.send(JSON.stringify(msg))
+        boot.session.agentSocket.send(JSON.stringify(msg))
         break
       }
       case 'device:shutdown': {
@@ -802,15 +818,15 @@ export class RelayServer {
         // `requestId: msg.requestId!`, which is not the `sessionId!` below it in kind, because that
         // one feeds a *read* whose miss still produces a visible error.
         if (!isCorrelated(msg)) break
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify(msg))
+        const target = this.dispatchTarget(ws, msg.sessionId)
+        if (target.ok) {
+          target.session.agentSocket.send(JSON.stringify(msg))
         } else {
           this.sendTo(ws, {
             type: 'open-url:error',
             sessionId: msg.sessionId!,
             requestId: msg.requestId,
-            message: 'agent offline',
+            message: target.message,
           })
         }
         break
@@ -819,54 +835,46 @@ export class RelayServer {
         // Verbatim forward like `open-url`, so the correlator rides for free; the door check and the echo
         // are the same two lines.
         if (!isCorrelated(msg)) break
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify(msg))
+        const target = this.dispatchTarget(ws, msg.sessionId)
+        if (target.ok) {
+          target.session.agentSocket.send(JSON.stringify(msg))
         } else {
           this.sendTo(ws, {
             type: 'app:clear-state-error',
             sessionId: msg.sessionId!,
             requestId: msg.requestId,
-            message: 'agent offline',
+            message: target.message,
           })
         }
         break
       }
+      // ── input, split by whether an ack answers it ──────────────────────────────────────────────
+      //
+      // These eleven shared one clause until L5c, and the sharing was the trap. Only five of them are
+      // answered — the four terminal frames plus `input:type` — so only those five carry a
+      // required `requestId`, and a gate written into a shared body would have dropped every opening
+      // and move frame with it: no swipe, no pinch, no rotation, and nothing said. Splitting the clause
+      // is what makes the gate unable to reach them. `correlatedRequestsGated` resolves fall-through by
+      // sharing the next non-empty body, so it would have read one gate as covering all eleven.
       case 'input:touch:start':
       case 'input:touch:move':
-      case 'input:touch:end':
       case 'input:pinch:start':
       case 'input:pinch:move':
-      case 'input:pinch:end':
-      case 'input:key':
-      case 'input:type':
-      case 'input:button':
       case 'input:rotate':
       case 'input:keyboard:toggle': {
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify(msg))
-        } else if (TERMINAL_INPUT_TYPES.has(msg.type) && ws.readyState === WebSocket.OPEN) {
-          // A terminal input that cannot be dispatched. Reply to the sender (the MCP/browser socket)
-          // so it fails truthfully instead of falling through to its optimistic 2s timeout.
-          //
-          // Two situations reach here and only one of them is the agent's fault: the session may be
-          // held with a socket that is no longer open, or there may be no such session — evicted
-          // after the reconnect grace expired, or never valid. In the second the agent can be
-          // perfectly healthy, so `agent offline` is a wrong diagnosis, and it is the same pair
-          // `device:boot` already tells apart above for the same reason. Same two strings as there.
-          //
-          // The reason is `channel-unavailable` either way, and that is the point rather than an
-          // approximation: the set is derived from what a consumer must do differently, and both of
-          // these want a reconnect or a re-join. The machine field is right for both and the prose
-          // was wrong for one, which is why the prose is what changed.
-          this.sendTo(ws, {
-            type: 'input:error',
-            sessionId: msg.sessionId!,
-            message: session ? 'agent offline' : 'Session not found',
-            reason: 'channel-unavailable',
-          })
-        }
+        // No ack, so no correlator to check and nothing to answer. An unowned frame is dropped rather
+        // than refused for the same reason: there is no waiter to tell.
+        this.forwardUnacked(ws, msg)
+        break
+      }
+      case 'input:touch:end':
+      case 'input:pinch:end':
+      case 'input:key':
+      case 'input:button':
+      case 'input:type': {
+        // One policy at the door, as for the app commands: an uncorrelatable request is not forwarded and
+        // not answered, because every reply it could produce declares `requestId` required.
+        if (isCorrelated(msg)) this.handleAckedInput(ws, msg)
         break
       }
       // Kept out of the input:* chain above: these need their own error type, and the caller
@@ -882,12 +890,17 @@ export class RelayServer {
         // `if (!msg.requestId) return` — so "agent offline" became the caller waiting out its budget.
         // Removed once already in `e98abd4`, for `open-url`, and still here.
         if (!isCorrelated(msg)) break
-        const session = this.sessions.get(msg.sessionId!)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify(msg))
+        // Ownership matters most here of all of them: a `clipboard:write` from a socket that does not hold
+        // the session pastes its text into someone else's device, and a `clipboard:read` presses the copy
+        // or cut chord on it — and the reply routes to the session's own browser, so the payload lands on
+        // **that** tester's host OS clipboard. The agent-side mirror of this check has been here since the
+        // bridge was written, with the reason beside it; the browser side had none.
+        const clip = this.dispatchTarget(ws, msg.sessionId)
+        if (clip.ok) {
+          clip.session.agentSocket.send(JSON.stringify(msg))
         } else if (ws.readyState === WebSocket.OPEN) {
           this.sendTo(ws, {
-            type: 'clipboard:error', sessionId: msg.sessionId!, requestId: msg.requestId, message: 'agent offline',
+            type: 'clipboard:error', sessionId: msg.sessionId!, requestId: msg.requestId, message: clip.message,
           })
         }
         break
@@ -1205,6 +1218,122 @@ export class RelayServer {
     }
   }
 
+  /** Where a browser-role command can be dispatched, or what its sender needs to be told instead.
+   *
+   *  Three refusals used to be spread across seven `case` bodies as two conditions each, and the ownership
+   *  one was in none of them. Collapsed here so the set is decided once: a command reaches an agent only if
+   *  the session exists, **this socket holds it**, and the agent is connected. Anything else has prose the
+   *  caller can act on, and each case wraps that prose in the reply type its own waiter reads.
+   *
+   *  The two ownership strings are one reason with different prose, the treatment `#492` settled: telling a
+   *  caller the session is in use when it is idle steers it off a device it could have had.
+   */
+  private dispatchTarget(
+    ws: WebSocket,
+    sessionId: string | undefined,
+  ): { ok: true; session: Session } | { ok: false; message: string } {
+    const session = this.sessions.get(sessionId!)
+    if (!session) return { ok: false, message: 'Session not found' }
+    if (!this.ownsSession(ws, session)) return { ok: false, message: ownershipRefusal(session) }
+    if (session.agentSocket.readyState !== WebSocket.OPEN) return { ok: false, message: 'agent offline' }
+    return { ok: true, session }
+  }
+
+  /** Is `ws` the socket this session is bound to?
+   *
+   *  Until L5c the input path resolved the session and forwarded without asking. `clipboard:data` asks the
+   *  mirror-image question one branch up (`session?.agentSocket !== ws`) with the reason written beside it —
+   *  a second agent on the same relay must not address someone else's session — and the browser direction
+   *  had no equivalent. So any authenticated client that knew a session id could drive a device another
+   *  tester was looking at, and the agent's ack went to the session holder rather than to whoever asked.
+   *
+   *  An **unheld** session (no `browserSocket`, or one that has gone) is also not owned by the sender. That
+   *  is deliberate rather than incidental: it makes an input arriving inside the reconnect grace fail fast
+   *  instead of being applied to a device with nobody watching the result. */
+  private ownsSession(ws: WebSocket, session: Session | undefined): boolean {
+    return session?.browserSocket === ws
+  }
+
+  /** Input that no ack answers: opening and move frames, rotation, the keyboard-forwarding toggle.
+   *
+   *  Dropped rather than refused when unowned, and that asymmetry with `handleAckedInput` is the whole
+   *  reason these have their own clause: refusing means answering, and there is no waiter here to answer.
+   *  `clipboard:data`'s silent `break` is the precedent that fits — a frame nobody is waiting on. */
+  private forwardUnacked(ws: WebSocket, msg: RelayMessage): void {
+    const session = this.sessions.get(msg.sessionId!)
+    if (session && !this.ownsSession(ws, session)) {
+      // **Deliberately silent.** A first draft logged here, which is one line per `input:touch:move` — the
+      // dashboard sends those per `pointermove`, so ~60/s for as long as a finger is down, unbounded and
+      // outside `logger`. It says nothing new either: a gesture's terminal frame goes through
+      // `handleAckedInput`, which answers, so a non-owner attempting real input is already visible there.
+      return
+    }
+    if (session?.agentSocket.readyState === WebSocket.OPEN) {
+      session.agentSocket.send(JSON.stringify(msg))
+    }
+  }
+
+  /** The five inputs an ack answers, so the five that carry a required correlator.
+   *
+   *  Every exit answers the sender. That is the rule this method exists to hold: a request with a waiter on
+   *  a 2s deadline must not be dropped silently, because the caller's fallback reports silence from a
+   *  session that has never acked as **success** (#457) — so a silent drop here would report an input that
+   *  never left the relay as landed, which is worse than the misrouting it replaced. */
+  private handleAckedInput(ws: WebSocket, msg: RelayMessage & { requestId: string }): void {
+    const session = this.sessions.get(msg.sessionId!)
+
+    if (session && !this.ownsSession(ws, session)) {
+      // `not-session-owner` rather than `channel-unavailable`, on that set's own rule — a reason exists per
+      // thing a consumer must do differently. That one means reconnect or re-join *this* session; this one
+      // means the caller does not hold it, so the move is to join first. It is also the only reason that can
+      // promise nothing reached the device, because the refusal happens here, before any agent saw the frame.
+      //
+      // **Two situations, one reason, different prose** — the treatment `#492` settled for the pair below.
+      // Someone else holding the session and nobody holding it want the same *action* (join, and if that is
+      // refused pick another device), so splitting the reason would grow the vocabulary for nothing. But one
+      // string cannot be true of both: telling a caller the session is in use when it is idle steers it off
+      // a device it could have had.
+      this.refuseInput(ws, msg, ownershipRefusal(session), 'not-session-owner')
+      return
+    }
+
+    if (session?.agentSocket.readyState === WebSocket.OPEN) {
+      session.agentSocket.send(JSON.stringify(msg))
+      return
+    }
+
+    // A request that cannot be dispatched. Two situations reach here and only one is the agent's fault:
+    // the session may be held with a socket that is no longer open, or there may be no such session —
+    // evicted after the reconnect grace, or never valid. In the second the agent can be perfectly healthy,
+    // so `agent offline` is a wrong diagnosis, and it is the same pair `device:boot` tells apart above for
+    // the same reason. Same two strings as there.
+    //
+    // The reason is `channel-unavailable` either way, and that is the point rather than an approximation:
+    // the set is derived from what a consumer must do differently, and both of these want a reconnect or a
+    // re-join. The machine field was right for both while the prose was wrong for one (#492).
+    this.refuseInput(ws, msg, session ? 'agent offline' : 'Session not found', 'channel-unavailable')
+  }
+
+  /** Answers the sender in the shape its waiter is keyed on.
+   *
+   *  `input:type` needs `input:type-error`, not `input:error` — its waiters in `mcp-server` and
+   *  `flow-runner` match on the `input:type-*` pair and ignore an `input:error` entirely. That is why
+   *  adding `input:type` to the terminal set was never the fix for it, and answering it properly here is
+   *  closes the gap `relay/AGENTS.md` recorded: before L5c an `input:type` on an offline agent got nothing
+   *  and burned its caller's full deadline. */
+  private refuseInput(
+    ws: WebSocket,
+    msg: RelayMessage & { requestId: string },
+    message: string,
+    reason: InputErrorReason,
+  ): void {
+    if (ws.readyState !== WebSocket.OPEN) return
+    const { sessionId, requestId } = { sessionId: msg.sessionId!, requestId: msg.requestId }
+    this.sendTo(ws, msg.type === 'input:type'
+      ? { type: 'input:type-error', sessionId, requestId, message, reason }
+      : { type: 'input:error', sessionId, requestId, message, reason })
+  }
+
   /** Relay looks up file_path from DB and enriches it for the agent.
    *
    *  Every exit carries the request's `sessionId`, including the failures. A dashboard viewer holds
@@ -1223,6 +1352,12 @@ export class RelayServer {
 
     const session = this.sessions.get(sessionId)
     if (!session) return fail('Session not found')
+    // Ownership only, and **not** `dispatchTarget`: that resolver also decides agent liveness, and using it
+    // here would move the `agent offline` check ahead of the build lookup below — changing which of two
+    // simultaneous problems the caller is told about. Until L5c this branch asked whether the session
+    // existed and not who was asking, so a socket that never joined could install a build onto a device
+    // someone else was testing, with the reply going to that session's browser rather than to it.
+    if (!this.ownsSession(ws, session)) return fail(ownershipRefusal(session))
 
     // `JSON.parse` does not honour `RelayMessage`, so buildId is whatever the sender put there.
     // better-sqlite3 binds a missing value as NULL but *throws* on an object or array — and that
@@ -1263,6 +1398,12 @@ export class RelayServer {
 
     const session = this.sessions.get(sessionId)
     if (!session) return fail('Session not found')
+    // Ownership only, and **not** `dispatchTarget`: that resolver also decides agent liveness, and using it
+    // here would move the `agent offline` check ahead of the build lookup below — changing which of two
+    // simultaneous problems the caller is told about. Until L5c this branch asked whether the session
+    // existed and not who was asking, so a socket that never joined could install a build onto a device
+    // someone else was testing, with the reply going to that session's browser rather than to it.
+    if (!this.ownsSession(ws, session)) return fail(ownershipRefusal(session))
 
     // See handleBrowserAppInstall — an object here throws inside the driver and the exception is
     // swallowed upstream.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -111,6 +111,29 @@ function ownershipRefusal(session: Session): string {
   return session.browserSocket ? 'session held by another client' : 'session not joined'
 }
 
+/** A request that names a session, with the same policy as `isCorrelated` and for the same reason.
+ *
+ *  Nothing validates inbound JSON (#444), so a third-party client — or an LLM driving `mcp-server`, whose
+ *  tool schemas are bare `z.string()` — can send a command with no `sessionId` or an empty one. Every reply
+ *  these doors produce declares `sessionId` **required**, so answering means putting a frame on the wire
+ *  whose required field `JSON.stringify` erases, which every consumer's session gate then discards.
+ *
+ *  **So the request is dropped, not answered**, and the note that used to sit on `SessionError` said the
+ *  opposite: "the only correct thing for it to send with no sessionId is `{ type: 'error' }`". That was
+ *  written before requests carried a second correlator, and its own premise refutes it now — `GenericError`
+ *  has no `requestId`, so a caller that receives one cannot attribute it and waits out the same deadline it
+ *  would have waited out on silence. Answering buys nothing it did not already have; not shipping a frame
+ *  that violates its own declaration is the whole payoff, and dropping achieves that more cheaply.
+ *
+ *  Widening `SessionStartFailure` to carry an "unaddressed" reason was the alternative, and it is what L5d
+ *  is for: that union's own doc says it has a single producer in `handleSessionStart`, and adding a member
+ *  here would make that false while pre-deciding what `error` is. */
+function isAddressed(msg: RelayMessage): msg is RelayMessage & { sessionId: string } {
+  if (typeof msg.sessionId === 'string' && msg.sessionId !== '') return true
+  console.warn(`[tapflow] ${msg.type} without a usable sessionId — dropped, no reply could be addressed`)
+  return false
+}
+
 function isCorrelated(msg: RelayMessage): msg is RelayMessage & { requestId: string } {
   if (typeof msg.requestId === 'string' && msg.requestId !== '') return true
   // Logged, because the three places this can be dropped are all silent otherwise: the relay `break`s, the
@@ -609,7 +632,7 @@ export class RelayServer {
       }
 
       // ── Session / Stream lifecycle ─────────────────────────────────────────
-      case 'session:start':    this.handleSessionStart(ws, msg); break
+      case 'session:start':    if (isAddressed(msg)) this.handleSessionStart(ws, msg); break
       // ── the two session commands, gated but not answered ───────────────────────────────────────
       //
       // Both destroy state a viewer depends on, and until L5c both acted on the strength of the session
@@ -617,6 +640,10 @@ export class RelayServer {
       // strips ownership out from under a mounted viewer — and then that tester's own input is refused,
       // which is why `not-session-owner` needed real copy in the dashboard rather than the `null` a first
       // draft gave it.
+      //
+      // `msg.sessionId &&` rather than `isAddressed`: a falsy check already rejects both an absent id and an
+      // empty one, and the miss below rejects a non-string, so the predicate would add only its log here —
+      // and a mutation confirmed there is nothing observable to hold it with.
       //
       // **Dropped rather than refused, and that is the contract**: neither has a reply, so there is no
       // waiter to tell. The same asymmetry as the input frames nothing acks. Inventing a
@@ -757,7 +784,7 @@ export class RelayServer {
         // `open-url` next door. Both things the relay could do with an id-less boot are downstream of
         // here (forward it, or answer it with a `device:boot-error`), and gating only one of them leaves
         // the guarantee resting on whichever branch was not gated.
-        if (!isCorrelated(msg)) break
+        if (!isCorrelated(msg) || !isAddressed(msg)) break
         // A boot the agent never receives leaves the viewer on "Waiting for first frame…" with nothing
         // said, and the reasons it might not arrive are worth telling apart: `bootDevice` is the first
         // call an MCP caller makes, so reporting a stale session id as a dead Mac sends the reader after
@@ -772,7 +799,7 @@ export class RelayServer {
         if (!boot.ok) {
           this.sendTo(ws, {
             type: 'device:boot-error',
-            sessionId: msg.sessionId!,
+            sessionId: msg.sessionId,
             requestId: msg.requestId,
             message: boot.message,
           })
@@ -787,8 +814,12 @@ export class RelayServer {
         break
       }
       case 'device:shutdown': {
-        // Deliberately ungated: the relay sends this itself from the idle timer, with no browser and
-        // no id behind it, so a correlator cannot be required and an absent one is not an error.
+        // Deliberately **un**correlated: the relay sends this itself from the idle timer, with no browser and
+        // no id behind it, so a correlator cannot be required and an absent one is not an error. Addressing
+        // is different, and it gets **no gate either** — for the reason the unacked input clause does not:
+        // an unaddressed shutdown resolves no session and is dropped by the miss, so a gate would buy only
+        // its log, and a line no test can hold is a line that will drift. A mutation confirmed there is
+        // nothing observable to hold. Ownership is #527.
         const session = this.sessions.get(msg.sessionId!)
         if (session?.agentSocket.readyState === WebSocket.OPEN) {
           session.agentSocket.send(JSON.stringify(msg))
@@ -797,8 +828,8 @@ export class RelayServer {
       }
       // Door checks, one policy per request: an uncorrelatable request is not forwarded, not rebuilt and
       // not answered, because every reply these produce declares `requestId` as required.
-      case 'app:install': if (isCorrelated(msg)) this.handleBrowserAppInstall(ws, msg); break
-      case 'app:launch':  if (isCorrelated(msg)) this.handleBrowserAppLaunch(ws, msg); break
+      case 'app:install': if (isCorrelated(msg) && isAddressed(msg)) this.handleBrowserAppInstall(ws, msg); break
+      case 'app:launch':  if (isCorrelated(msg) && isAddressed(msg)) this.handleBrowserAppLaunch(ws, msg); break
       case 'open-url': {
         // **At the door, before either branch.** A correlator is required on this request, and the
         // relay has two things it could do with one that lacks it — forward it, or answer it — so
@@ -817,14 +848,14 @@ export class RelayServer {
         // becomes a caller waiting out its full deadline. That was the first draft's other half:
         // `requestId: msg.requestId!`, which is not the `sessionId!` below it in kind, because that
         // one feeds a *read* whose miss still produces a visible error.
-        if (!isCorrelated(msg)) break
+        if (!isCorrelated(msg) || !isAddressed(msg)) break
         const target = this.dispatchTarget(ws, msg.sessionId)
         if (target.ok) {
           target.session.agentSocket.send(JSON.stringify(msg))
         } else {
           this.sendTo(ws, {
             type: 'open-url:error',
-            sessionId: msg.sessionId!,
+            sessionId: msg.sessionId,
             requestId: msg.requestId,
             message: target.message,
           })
@@ -834,14 +865,14 @@ export class RelayServer {
       case 'app:clear-state': {
         // Verbatim forward like `open-url`, so the correlator rides for free; the door check and the echo
         // are the same two lines.
-        if (!isCorrelated(msg)) break
+        if (!isCorrelated(msg) || !isAddressed(msg)) break
         const target = this.dispatchTarget(ws, msg.sessionId)
         if (target.ok) {
           target.session.agentSocket.send(JSON.stringify(msg))
         } else {
           this.sendTo(ws, {
             type: 'app:clear-state-error',
-            sessionId: msg.sessionId!,
+            sessionId: msg.sessionId,
             requestId: msg.requestId,
             message: target.message,
           })
@@ -864,6 +895,12 @@ export class RelayServer {
       case 'input:keyboard:toggle': {
         // No ack, so no correlator to check and nothing to answer. An unowned frame is dropped rather
         // than refused for the same reason: there is no waiter to tell.
+        //
+        // **And no `isAddressed` gate**, unlike the answered five. An unaddressed frame resolves no session
+        // and is dropped by the miss either way, so the gate would buy only its log — one line per
+        // `input:touch:move`, which is the ~60/s the ownership warn was removed from this same method for.
+        // A mutation confirmed it: adding the gate here changes nothing a test can observe, and a line no
+        // test can hold is a line that will drift.
         this.forwardUnacked(ws, msg)
         break
       }
@@ -874,7 +911,7 @@ export class RelayServer {
       case 'input:type': {
         // One policy at the door, as for the app commands: an uncorrelatable request is not forwarded and
         // not answered, because every reply it could produce declares `requestId` required.
-        if (isCorrelated(msg)) this.handleAckedInput(ws, msg)
+        if (isCorrelated(msg) && isAddressed(msg)) this.handleAckedInput(ws, msg)
         break
       }
       // Kept out of the input:* chain above: these need their own error type, and the caller
@@ -889,7 +926,7 @@ export class RelayServer {
         // `clipboard:error` whose required correlator is missing, which `useClipboardBridge` discards on
         // `if (!msg.requestId) return` — so "agent offline" became the caller waiting out its budget.
         // Removed once already in `e98abd4`, for `open-url`, and still here.
-        if (!isCorrelated(msg)) break
+        if (!isCorrelated(msg) || !isAddressed(msg)) break
         // Ownership matters most here of all of them: a `clipboard:write` from a socket that does not hold
         // the session pastes its text into someone else's device, and a `clipboard:read` presses the copy
         // or cut chord on it — and the reply routes to the session's own browser, so the payload lands on
@@ -900,7 +937,7 @@ export class RelayServer {
           clip.session.agentSocket.send(JSON.stringify(msg))
         } else if (ws.readyState === WebSocket.OPEN) {
           this.sendTo(ws, {
-            type: 'clipboard:error', sessionId: msg.sessionId!, requestId: msg.requestId, message: clip.message,
+            type: 'clipboard:error', sessionId: msg.sessionId, requestId: msg.requestId, message: clip.message,
           })
         }
         break
@@ -1133,8 +1170,8 @@ export class RelayServer {
     logger.info(`agent connected: ${msg.agentName ?? msg.agentId ?? 'unknown'} (${msg.platform ?? 'unknown'}) — ${registeredSessions.length} device(s)`)
   }
 
-  private handleSessionStart(ws: WebSocket, msg: RelayMessage): void {
-    const session = this.sessions.get(msg.sessionId!)
+  private handleSessionStart(ws: WebSocket, msg: RelayMessage & { sessionId: string }): void {
+    const session = this.sessions.get(msg.sessionId)
     if (!session) {
       this.sendTo(ws, { type: 'error', message: 'Session not found', reason: 'session-not-found' })
       return
@@ -1163,7 +1200,7 @@ export class RelayServer {
       }
     }
     try {
-      this.sessions.join(msg.sessionId!, ws)
+      this.sessions.join(msg.sessionId, ws)
     } catch (e) {
       // `join()` throws for not-found as well as busy, and the check above already answered busy — so
       // reaching here means something this handler did not anticipate. Reporting it as `session-busy`
@@ -1178,7 +1215,7 @@ export class RelayServer {
     // the other end — an agent that predates a feature omits it, and the dashboard degrades
     // deliberately instead of inferring anything from a timeout.
     this.sendTo(ws, {
-      type: 'session:joined', sessionId: msg.sessionId!, capabilities: session.agentCapabilities ?? [],
+      type: 'session:joined', sessionId: msg.sessionId, capabilities: session.agentCapabilities ?? [],
     })
     if (agentAway) {
       // Joining into a held session. Refusing instead would be worse than it sounds: the viewer
@@ -1189,7 +1226,7 @@ export class RelayServer {
       //
       // Everything below describes the agent that went away, so it stops here. The viewer will get
       // it all again from the boot it sends on `session:rebound`.
-      this.sendTo(ws, { type: 'session:agent-away', sessionId: msg.sessionId! })
+      this.sendTo(ws, { type: 'session:agent-away', sessionId: msg.sessionId })
       return
     }
     // These three replay a session's cached state to a re-joining viewer. They carry `sessionId`
@@ -1230,9 +1267,9 @@ export class RelayServer {
    */
   private dispatchTarget(
     ws: WebSocket,
-    sessionId: string | undefined,
+    sessionId: string,
   ): { ok: true; session: Session } | { ok: false; message: string } {
-    const session = this.sessions.get(sessionId!)
+    const session = this.sessions.get(sessionId)
     if (!session) return { ok: false, message: 'Session not found' }
     if (!this.ownsSession(ws, session)) return { ok: false, message: ownershipRefusal(session) }
     if (session.agentSocket.readyState !== WebSocket.OPEN) return { ok: false, message: 'agent offline' }
@@ -1279,7 +1316,7 @@ export class RelayServer {
    *  a 2s deadline must not be dropped silently, because the caller's fallback reports silence from a
    *  session that has never acked as **success** (#457) — so a silent drop here would report an input that
    *  never left the relay as landed, which is worse than the misrouting it replaced. */
-  private handleAckedInput(ws: WebSocket, msg: RelayMessage & { requestId: string }): void {
+  private handleAckedInput(ws: WebSocket, msg: RelayMessage & { requestId: string; sessionId: string }): void {
     const session = this.sessions.get(msg.sessionId!)
 
     if (session && !this.ownsSession(ws, session)) {
@@ -1323,12 +1360,12 @@ export class RelayServer {
    *  and burned its caller's full deadline. */
   private refuseInput(
     ws: WebSocket,
-    msg: RelayMessage & { requestId: string },
+    msg: RelayMessage & { requestId: string; sessionId: string },
     message: string,
     reason: InputErrorReason,
   ): void {
     if (ws.readyState !== WebSocket.OPEN) return
-    const { sessionId, requestId } = { sessionId: msg.sessionId!, requestId: msg.requestId }
+    const { sessionId, requestId } = { sessionId: msg.sessionId, requestId: msg.requestId }
     this.sendTo(ws, msg.type === 'input:type'
       ? { type: 'input:type-error', sessionId, requestId, message, reason }
       : { type: 'input:error', sessionId, requestId, message, reason })
@@ -1341,8 +1378,8 @@ export class RelayServer {
    *  caller waits for the reply matching its own sessionId, so anything else is indistinguishable
    *  from silence and it waits out the deadline (#445). `Session not found` is app-specific for the
    *  same reason: a generic `error` cannot be correlated by construction. */
-  private handleBrowserAppInstall(ws: WebSocket, msg: RelayMessage & { requestId: string }): void {
-    const sessionId = msg.sessionId!
+  private handleBrowserAppInstall(ws: WebSocket, msg: RelayMessage & { requestId: string; sessionId: string }): void {
+    const sessionId = msg.sessionId
     const { requestId } = msg
     // Closing over the narrowed correlator covers all four failure exits at once. It does **not** cover a
     // fifth: a throw out of `getDb().prepare(…).get(…)` — SQLITE_BUSY, a closed db, I/O — unwinds to the
@@ -1387,8 +1424,8 @@ export class RelayServer {
   }
 
   /** Relay looks up bundle_id from DB. Same correlation rules as `handleBrowserAppInstall`. */
-  private handleBrowserAppLaunch(ws: WebSocket, msg: RelayMessage & { requestId: string }): void {
-    const sessionId = msg.sessionId!
+  private handleBrowserAppLaunch(ws: WebSocket, msg: RelayMessage & { requestId: string; sessionId: string }): void {
+    const sessionId = msg.sessionId
     const { requestId } = msg
     // Closing over the narrowed correlator covers all four failure exits at once. It does **not** cover a
     // fifth: a throw out of `getDb().prepare(…).get(…)` — SQLITE_BUSY, a closed db, I/O — unwinds to the

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -1137,7 +1137,11 @@ describe('RelayServer', () => {
     browser.send(JSON.stringify({ type: 'open-url', sessionId: 'nonexistent-session', requestId: 'req-nos', payload: { url: 'myapp://home' } }))
     const received = await msgPromise
     expect(received.type).toBe('open-url:error')
-    expect(received.message).toBe('agent offline')
+    // **Was `'agent offline'`, and that was the wrong diagnosis** — the same one #492 fixed for
+    // `device:boot` and `input:error`: the relay has no session for this id, which says nothing about any
+    // agent's health, and telling an MCP caller its Mac is down sends the reader after the wrong problem.
+    // `open-url` still had it, and routing this branch through `dispatchTarget` corrected it for free.
+    expect(received.message).toBe('Session not found')
     expect(received.requestId).toBe('req-nos')
 
     browser.close()

--- a/packages/relay/src/__tests__/clearState.test.ts
+++ b/packages/relay/src/__tests__/clearState.test.ts
@@ -76,7 +76,7 @@ describe('app:clear-state relay routing', () => {
     agent.close()
     await agentClosed
 
-    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, requestId: 'rq-cs1', payload: { x: 0.5, y: 0.5 } }))
     const err = await waitForType(browser, 'input:error')
     expect(err.sessionId).toBe(sessionId)
     expect(err.message).toBe('agent offline')
@@ -139,7 +139,7 @@ describe('app:clear-state relay routing', () => {
       }
     })
 
-    browser.send(JSON.stringify({ type: 'input:type', sessionId, payload: { text: 'hi' } }))
+    browser.send(JSON.stringify({ type: 'input:type', sessionId, requestId: 'rq-cs2', payload: { text: 'hi' } }))
     const done = await waitForType(browser, 'input:type-done')
     expect(done.sessionId).toBe(sessionId)
 

--- a/packages/relay/src/__tests__/inputErrorReason.test.ts
+++ b/packages/relay/src/__tests__/inputErrorReason.test.ts
@@ -297,6 +297,60 @@ describe('input:error from the relay carries a reason (#492)', () => {
     agent.close(); browser.close(); other.close()
   })
 
+  // ── the second door predicate: a request must name a session (CodeRabbit on #528) ──────────────
+  //
+  // `isCorrelated` validated `requestId` only, so a command with no `sessionId` — or an empty one, which
+  // type-checks and which `mcp-server`'s bare `z.string()` tool schemas let a model produce — reached the
+  // reply builders and shipped a frame whose **required** `sessionId` `JSON.stringify` erases. Every
+  // consumer's session gate then discards it, so the caller waits out its deadline with the diagnosis in
+  // hand and no way to attribute it.
+  //
+  // Dropped rather than answered, the same policy as an uncorrelatable request, and for a reason the note on
+  // `SessionError` used to contradict: `GenericError` carries no `requestId`, so answering an unaddressed
+  // request is *also* unattributable — it buys the caller nothing that silence did not, while widening what
+  // `error` means. See `isAddressed`.
+  for (const bad of [undefined, ''] as Array<string | undefined>) {
+    const label = bad === undefined ? 'absent' : 'the empty string'
+    it(`drops a request whose sessionId is ${label}, and answers nothing`, async () => {
+      const { agent, browser, sessionId } = await live()
+      void sessionId
+
+      for (const type of ['input:touch:end', 'device:boot', 'open-url', 'app:clear-state', 'clipboard:read', 'app:install', 'app:launch']) {
+        browser.send(JSON.stringify({
+          type, requestId: `rq-${type}`, ...(bad === undefined ? {} : { sessionId: bad }),
+          buildId: 1,
+          payload: { x: 0.5, y: 0.5, deviceId: 'dev-1', url: 'x://y', bundleId: 'com.example', press: 'copy' },
+        }))
+      }
+      await barrier(browser)
+      await barrier(agent)
+
+      // Nothing forwarded, and nothing answered — an answer would be the frame that violates its own
+      // declaration, which is what this predicate exists to stop.
+      for (const type of ['input:touch:end', 'device:boot', 'open-url', 'app:clear-state', 'clipboard:read', 'app:install', 'app:launch']) {
+        expect(await waitForTypeOrNull(agent, type, 0), `${type} was forwarded`).toBeNull()
+      }
+      for (const reply of ['input:error', 'device:boot-error', 'open-url:error', 'app:clear-state-error', 'clipboard:error', 'app:install-error', 'app:launch-error']) {
+        expect(await waitForTypeOrNull(browser, reply, 0), `${reply} was sent`).toBeNull()
+      }
+
+      agent.close(); browser.close()
+    })
+  }
+
+  it('drops an unaddressed session:start rather than answering session:joined without an id', async () => {
+    // The door that made the defect visible: `session:joined` declares `sessionId` required, and this branch
+    // built it from `msg.sessionId!`.
+    const browser = await outsider()
+    browser.send(JSON.stringify({ type: 'session:start' }))
+    await barrier(browser)
+
+    expect(await waitForTypeOrNull(browser, 'session:joined', 0)).toBeNull()
+    expect(await waitForTypeOrNull(browser, 'error', 0)).toBeNull()
+
+    browser.close()
+  })
+
   // ── the same gate on every other browser→agent command (L5c, widened) ─────────────────────────
   //
   // Input was one branch of ten. Review found the rest still forwarding on the strength of the session

--- a/packages/relay/src/__tests__/inputErrorReason.test.ts
+++ b/packages/relay/src/__tests__/inputErrorReason.test.ts
@@ -6,7 +6,7 @@ import { WebSocket } from 'ws'
 import { RelayServer } from '../RelayServer'
 import { initDb, closeDb } from '../db'
 import type { RelayMessage } from '../types'
-import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 
 // #492. The relay answers a terminal input it cannot dispatch, and it was the last producer of
 // `input:error` sending no `reason` — while being the one that knows the answer with the most
@@ -78,7 +78,7 @@ describe('input:error from the relay carries a reason (#492)', () => {
     it(`answers ${type} with reason channel-unavailable when the agent's socket is gone`, async () => {
       const { browser, sessionId } = await agentGone()
 
-      browser.send(JSON.stringify({ type, sessionId, payload }))
+      browser.send(JSON.stringify({ type, sessionId, requestId: 'rq-terminal', payload }))
       // By type, not "the next message": losing the agent also produces a `session:agent-away`, and
       // whichever lands first is not this test's subject. (Not `session:terminated` — that waits for
       // the 15s grace to expire, long after this test is over.)
@@ -99,7 +99,7 @@ describe('input:error from the relay carries a reason (#492)', () => {
     await waitForOpen(browser)
 
     browser.send(JSON.stringify({
-      type: 'input:touch:end', sessionId: 'no-such-session', payload: { x: 0.5, y: 0.5 },
+      type: 'input:touch:end', sessionId: 'no-such-session', requestId: 'rq-unknown', payload: { x: 0.5, y: 0.5 },
     }))
     const err = await waitForType(browser, 'input:error')
     expect(err.sessionId).toBe('no-such-session')
@@ -116,10 +116,10 @@ describe('input:error from the relay carries a reason (#492)', () => {
   it('uses one reason for both branches while the wording differs', async () => {
     const { browser, sessionId } = await agentGone()
 
-    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, requestId: 'rq-held', payload: { x: 0.5, y: 0.5 } }))
     const held = await waitForType(browser, 'input:error')
 
-    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: 'nope', payload: { x: 0.5, y: 0.5 } }))
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId: 'nope', requestId: 'rq-nope', payload: { x: 0.5, y: 0.5 } }))
     const unknown = await waitForType(browser, 'input:error')
 
     // Named, not merely equal: two absent reasons are also equal, and that is the state this whole
@@ -131,21 +131,300 @@ describe('input:error from the relay carries a reason (#492)', () => {
     browser.close()
   })
 
-  // This change adds a field to an existing reply; it does not widen what gets answered. Every input
-  // type outside `TERMINAL_INPUT_TYPES` is listed, because the two ways of widening it are both
-  // harmful and neither is caught by testing one representative: adding `input:touch:start` would
-  // answer twice per tap, and adding `input:type` would answer a message whose waiters key on
-  // `input:type-done` / `input:type-error` (`mcp-server`, `flow-runner`) — they would ignore it and
-  // wait out the full deadline anyway, which is the failure this reply exists to prevent.
+  // ── the door, and who is allowed through it (L5c) ─────────────────────────────────────────────
+  //
+  // These were the mutation-round survivors: with the correlator gate deleted and again with the ownership
+  // check deleted, all 600 relay tests passed. Nothing here had ever sent an id-less acked input, and
+  // nothing had ever sent input from a socket that did not hold the session — so the two guards that make
+  // this layer mean anything were held by their own absence of counterexamples.
+
+  /** Opens a second browser socket that has **not** joined `sessionId`. */
+  async function outsider() {
+    const ws = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(ws)
+    return ws
+  }
+
+  /** A joined browser, a live agent, and the session they share. */
+  async function live() {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register',
+      devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
+    }))
+    const reg = await waitForType<RelayMessage>(agent, 'agent:registered')
+    const sessionId = reg.registeredSessions![0]!.sessionId
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return { agent, browser, sessionId }
+  }
+
+  for (const bad of [undefined, ''] as Array<string | undefined>) {
+    it(`drops an acked input whose correlator is ${bad === undefined ? 'absent' : 'the empty string'}`, async () => {
+      // Both halves of the shared predicate. A gate written as `!== undefined` lets `''` through, and
+      // `mcp-server`'s tool schemas are bare `z.string()` so a model can produce it.
+      const { agent, browser, sessionId } = await live()
+
+      browser.send(JSON.stringify({
+        type: 'input:touch:end', sessionId, ...(bad === undefined ? {} : { requestId: bad }),
+        payload: { x: 0.5, y: 0.5 },
+      }))
+      await barrier(browser)
+      await barrier(agent)
+
+      // Not forwarded, and not answered either: answering would ship a reply whose required correlator
+      // `JSON.stringify` erases, which every correlating consumer then discards.
+      expect(await waitForTypeOrNull(agent, 'input:touch:end', 0)).toBeNull()
+      expect(await waitForTypeOrNull(browser, 'input:error', 0)).toBeNull()
+
+      agent.close(); browser.close()
+    })
+  }
+
+  it('forwards an acked input from the socket that holds the session', async () => {
+    // The control for the two below: the ownership check must not refuse the normal path.
+    const { agent, browser, sessionId } = await live()
+
+    const fwd = waitForType<RelayMessage>(agent, 'input:touch:end')
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-own', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await fwd).requestId).toBe('rq-own')
+
+    agent.close(); browser.close()
+  })
+
+  it('refuses an acked input from a socket that does not hold the session', async () => {
+    // `session:start` is exclusive, so a second socket cannot *join* — but until L5c it could still drive
+    // the device, because the input branch resolved the session and forwarded without asking who was
+    // asking. `clipboard:data` asks the mirror question one branch up. The agent's ack went to the session
+    // holder, never to the injector, so the tester watching the screen saw input they did not send.
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-inject', payload: { x: 0.5, y: 0.5 },
+    }))
+    const err = await waitForType<RelayMessage>(other, 'input:error')
+
+    expect(err.reason).toBe('not-session-owner')
+    expect(err.requestId).toBe('rq-inject')
+    // **Answered, not dropped**, and that is the point rather than a nicety: `awaitInputAck` reports
+    // silence from a session that has never acked as *success*, so a silent refusal would report an input
+    // that never left the relay as landed — worse than the misrouting it replaced.
+    await barrier(other)
+    await barrier(agent)
+    expect(await waitForTypeOrNull(agent, 'input:touch:end', 0)).toBeNull()
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('refuses input for a session nobody holds, and says which of the two it is', async () => {
+    // `ownsSession` is `browserSocket === ws`, so an **unheld** session is refused too — and every other
+    // outsider case here runs against a held one, so relaxing the check to `session?.browserSocket &&`
+    // survived all 607 tests in review. That relaxation is a "nobody is holding it, so anybody may drive
+    // it" policy for precisely the window the check exists to close, and `session:leave` is forwarded with
+    // no ownership check of its own, so an outsider can *create* the unheld state and then use it.
+    //
+    // One reason, two prose strings — the treatment #492 settled for `agent offline` / `Session not found`.
+    // Telling a caller the session is in use when it is idle steers it off a device it could have had.
+    const { agent, browser, sessionId } = await live()
+    browser.send(JSON.stringify({ type: 'session:leave', sessionId }))
+    await barrier(browser)
+
+    const other = await outsider()
+    other.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-unheld', payload: { x: 0.5, y: 0.5 },
+    }))
+    const err = await waitForType<RelayMessage>(other, 'input:error')
+
+    expect(err.reason).toBe('not-session-owner')
+    expect(err.message).toBe('session not joined')
+    await barrier(agent)
+    expect(await waitForTypeOrNull(agent, 'input:touch:end', 0)).toBeNull()
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('names the held case differently from the unheld one', async () => {
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({
+      type: 'input:key', sessionId, requestId: 'rq-held-prose', payload: { code: 'KeyA' },
+    }))
+    const err = await waitForType<RelayMessage>(other, 'input:error')
+
+    expect(err.reason).toBe('not-session-owner')
+    expect(err.message).toBe('session held by another client')
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('refuses an outsider input:type in the shape its waiters read', async () => {
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({ type: 'input:type', sessionId, requestId: 'rq-t', payload: { text: 'hi' } }))
+    const err = await waitForType<RelayMessage>(other, 'input:type-error')
+
+    expect(err.requestId).toBe('rq-t')
+    // The reason rides this shape too. Without it, `not-session-owner` was unreachable for one of the five
+    // requests the relay can refuse — the only reason that promises nothing reached the device, delivered as
+    // a string the caller would have to branch on (#492). `InputTypeError` gained `reason?` for this.
+    expect(err.reason).toBe('not-session-owner')
+    expect(await waitForTypeOrNull(other, 'input:error', 100)).toBeNull()
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('drops an outsider frame that no ack answers, without inventing a reply', async () => {
+    // The asymmetry the split clause exists for: refusing means answering, and a move frame has no waiter
+    // to answer. `clipboard:data`'s silent break is the precedent that fits here and not above.
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({ type: 'input:touch:move', sessionId, payload: { x: 0.5, y: 0.5 } }))
+    await barrier(other)
+    await barrier(agent)
+
+    expect(await waitForTypeOrNull(agent, 'input:touch:move', 0)).toBeNull()
+    expect(await waitForTypeOrNull(other, 'input:error', 0)).toBeNull()
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  // ── the same gate on every other browser→agent command (L5c, widened) ─────────────────────────
+  //
+  // Input was one branch of ten. Review found the rest still forwarding on the strength of the session
+  // existing — `clipboard:write` pastes attacker text into the victim's device and `clipboard:read` with
+  // `press: 'cut'` presses cut on it, with the reply landing on **that** tester's host OS clipboard;
+  // `session:end` deletes their session. Each is refused in the shape its own waiter reads, and the two
+  // session commands are dropped because neither has one.
+  //
+  // Table-driven so a command added later is a visible omission rather than an invisible one.
+  const gated: Array<[string, Record<string, unknown>, string]> = [
+    ['device:boot', { payload: { deviceId: 'dev-1' } }, 'device:boot-error'],
+    ['open-url', { payload: { url: 'x://y' } }, 'open-url:error'],
+    ['app:clear-state', { payload: { bundleId: 'com.example' } }, 'app:clear-state-error'],
+    ['clipboard:read', { payload: { press: 'copy' } }, 'clipboard:error'],
+    ['clipboard:write', { payload: { text: 'stolen', pasteAfter: true } }, 'clipboard:error'],
+  ]
+
+  for (const [type, extra, errType] of gated) {
+    it(`refuses ${type} from a socket that does not hold the session`, async () => {
+      const { agent, browser, sessionId } = await live()
+      const other = await outsider()
+
+      other.send(JSON.stringify({ type, sessionId, requestId: `rq-${type}`, ...extra }))
+      const err = await waitForType<RelayMessage>(other, errType)
+
+      expect(err.message).toBe('session held by another client')
+      // The correlator rides the refusal, or the caller cannot attribute it and waits out its deadline —
+      // the defect this file's sibling tests record as having shipped twice.
+      expect(err.requestId).toBe(`rq-${type}`)
+
+      await barrier(other)
+      await barrier(agent)
+      expect(await waitForTypeOrNull(agent, type, 0)).toBeNull()
+
+      agent.close(); browser.close(); other.close()
+    })
+  }
+
+  it('refuses app:install from a non-owner before it reads the build', async () => {
+    // Ownership is checked ahead of the build lookup but **after** the session lookup, deliberately: the
+    // resolver used by the cases above also decides agent liveness, and using it here would move
+    // `agent offline` ahead of `Build not found`, changing which of two simultaneous problems is reported.
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({ type: 'app:install', sessionId, requestId: 'rq-inst', buildId: 999999 }))
+    const err = await waitForType<RelayMessage>(other, 'app:install-error')
+
+    // Not `Build not found`, which is what an owner would get for this buildId.
+    expect(err.message).toBe('session held by another client')
+    expect(err.requestId).toBe('rq-inst')
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('ignores session:leave and session:end from a non-owner, and answers nothing', async () => {
+    // Dropped rather than refused: neither has a reply, so there is no waiter to tell — the same asymmetry
+    // as the input frames nothing acks. `session:leave` is the sharper of the two, because it nulls
+    // `browserSocket`: an unguarded one strips ownership from a mounted viewer, and that viewer's own input
+    // is then refused. That is why `not-session-owner` needed real copy in the dashboard.
+    const { agent, browser, sessionId } = await live()
+    const other = await outsider()
+
+    other.send(JSON.stringify({ type: 'session:leave', sessionId }))
+    other.send(JSON.stringify({ type: 'session:end', sessionId }))
+    await barrier(other)
+
+    // Nothing answered, and the session still works for the socket that holds it.
+    expect(await waitForTypeOrNull<RelayMessage>(other, 'error', 0)).toBeNull()
+    const fwd = waitForType<RelayMessage>(agent, 'input:touch:end')
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-survived', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await fwd).requestId).toBe('rq-survived')
+
+    agent.close(); browser.close(); other.close()
+  })
+
+  it('lets the holder leave its own session', async () => {
+    // The control: the gate must not break the ordinary path, and `session:leave` has no reply to confirm
+    // with — so this reads the effect instead. After leaving, the holder no longer owns it, so its next
+    // input is refused, which is the observable consequence of the leave having worked.
+    const { agent, browser, sessionId } = await live()
+
+    browser.send(JSON.stringify({ type: 'session:leave', sessionId }))
+    await barrier(browser)
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-after-leave', payload: { x: 0.5, y: 0.5 },
+    }))
+    const err = await waitForType<RelayMessage>(browser, 'input:error')
+    expect(err.message).toBe('session not joined')
+
+    agent.close(); browser.close()
+  })
+
+  // Every input type that is still answered by nothing. Listed rather than sampled, because the ways of
+  // widening the set are harmful in different ways and testing one representative catches neither:
+  // answering `input:touch:start` would answer twice per tap, and answering any of these at all would put
+  // a reply on a frame with no waiter.
+  //
+  // **`input:type` left this list in L5c.** The comment that used to stand here said adding it to
+  // `TERMINAL_INPUT_TYPES` would be useless, because its waiters key on the `input:type-*` pair and would
+  // ignore an `input:error` and burn the full deadline anyway — and it named the honest fix, a reply in the
+  // shape those waiters read. That is what landed, so the case below asserts it rather than its absence.
   const nonTerminals: Array<[string, Record<string, unknown>]> = [
     ['input:touch:start', { x: 0.5, y: 0.5 }],
     ['input:touch:move', { x: 0.5, y: 0.5 }],
     ['input:pinch:start', { f0: { x: 0.4, y: 0.4 }, f1: { x: 0.6, y: 0.6 } }],
     ['input:pinch:move', { f0: { x: 0.4, y: 0.4 }, f1: { x: 0.6, y: 0.6 } }],
-    ['input:type', { text: 'hello' }],
     ['input:rotate', { orientation: 'landscapeLeft' }],
     ['input:keyboard:toggle', {}],
   ]
+
+  it('answers input:type in the shape its waiters read, not with input:error', async () => {
+    const { browser, sessionId } = await agentGone()
+
+    browser.send(JSON.stringify({ type: 'input:type', sessionId, requestId: 'rq-type', payload: { text: 'hi' } }))
+    const err = await waitForType(browser, 'input:type-error')
+
+    expect(err.sessionId).toBe(sessionId)
+    expect(err.requestId).toBe('rq-type')
+    expect(err.message).toBe('agent offline')
+    // And **not** an `input:error`: that is the frame its waiters ignore, so sending one would be the
+    // deadline-burning non-answer this reply replaced.
+    expect(await waitForTypeOrNull(browser, 'input:error', 100)).toBeNull()
+
+    browser.close()
+  })
 
   for (const [type, payload] of nonTerminals) {
     it(`still answers nothing for ${type}`, async () => {

--- a/packages/relay/src/__tests__/sessionRebind.test.ts
+++ b/packages/relay/src/__tests__/sessionRebind.test.ts
@@ -344,7 +344,7 @@ describe('a session survives its agent restarting (#426)', () => {
     await waitForType(browser, 'session:rebound')
 
     browser.send(JSON.stringify({ type: 'input:touch:start', sessionId, payload: { x: 1, y: 1 } }))
-    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, payload: { x: 1, y: 1 } }))
+    browser.send(JSON.stringify({ type: 'input:touch:end', sessionId, requestId: 'rq-rebind', payload: { x: 1, y: 1 } }))
 
     await expect(waitForType(second.agent, 'input:touch:start')).resolves.toBeTruthy()
     await expect(waitForType(second.agent, 'input:touch:end')).resolves.toBeTruthy()

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -163,7 +163,7 @@ describe('browser-inbound routing matches the protocol union', () => {
 
   it('RelayOrAgentToBrowser is shared by both directions rather than copied', () => {
     const shared = unionMembers(protocolSrc, 'RelayOrAgentToBrowser')
-    expect(shared.size).toBe(10)
+    expect(shared.size).toBe(11)
     for (const name of ['RelayToBrowser', 'AgentToBrowser']) {
       expect(protocolSrc).toContain(`export type ${name} =\n  | RelayOrAgentToBrowser`)
     }
@@ -196,9 +196,8 @@ describe('browser-inbound routing matches the protocol union', () => {
       'app:launch-done': 'requestId sessionId',
       'app:clear-state-done': 'requestId sessionId',
       'open-url:done': 'requestId sessionId',
-      'input:done': 'sessionId',
-      'input:type-done': 'sessionId',
-      'input:type-error': 'message sessionId',
+      'input:done': 'requestId sessionId',
+      'input:type-done': 'requestId sessionId',
       'keyboard:toggled': 'payload sessionId',
       'clipboard:data': 'payload requestId sessionId',
       'clipboard:write-done': 'requestId sessionId',
@@ -212,7 +211,10 @@ describe('browser-inbound routing matches the protocol union', () => {
       'device:boot-error': 'message requestId? sessionId',
       'open-url:error': 'message requestId sessionId',
       'app:clear-state-error': 'message requestId sessionId',
-      'input:error': 'message reason? sessionId',
+      'input:error': 'message reason? requestId sessionId',
+      // Moved here from AgentToBrowser in L5c: the relay refuses an `input:type` whose session the sender
+      // does not hold, and the waiters key on this pair rather than on `input:error`.
+      'input:type-error': 'message reason? requestId sessionId',
       'clipboard:error': 'message payload? requestId sessionId',
     },
     BrowserToRelay: {
@@ -228,13 +230,13 @@ describe('browser-inbound routing matches the protocol union', () => {
       'open-url': 'payload requestId sessionId',
       'input:touch:start': 'payload sessionId',
       'input:touch:move': 'payload sessionId',
-      'input:touch:end': 'payload? sessionId',
+      'input:touch:end': 'payload? requestId sessionId',
       'input:pinch:start': 'payload sessionId',
       'input:pinch:move': 'payload sessionId',
-      'input:pinch:end': 'sessionId',
-      'input:key': 'payload sessionId',
-      'input:type': 'payload sessionId',
-      'input:button': 'payload sessionId',
+      'input:pinch:end': 'requestId sessionId',
+      'input:key': 'payload requestId sessionId',
+      'input:type': 'payload requestId sessionId',
+      'input:button': 'payload requestId sessionId',
       'input:rotate': 'sessionId',
       'input:keyboard:toggle': 'sessionId',
       'clipboard:read': 'payload? requestId sessionId',

--- a/scripts/__tests__/inputErrorReason.test.mjs
+++ b/scripts/__tests__/inputErrorReason.test.mjs
@@ -34,7 +34,10 @@ describe('input:error reason — one contract, two producers', () => {
     // A bare length check passed on any non-empty union, including a truncated parse — this file's
     // parser terminates on a blank line, so a reformat could have silently shortened the set.
     expect(declaredReasons()).toEqual(
-      ['channel-starting', 'channel-unavailable', 'dispatch-failed', 'malformed', 'no-gesture', 'not-booted', 'unsupported'],
+      ['channel-starting', 'channel-unavailable', 'dispatch-failed', 'malformed', 'no-gesture', 'not-booted',
+       // L5c. The relay is its only producer — an agent cannot know which socket asked — and it is the one
+       // member whose advice can promise nothing reached the device, because the refusal happens at the door.
+       'not-session-owner', 'unsupported'],
     )
   })
 


### PR DESCRIPTION
Closes #499.

## The pair where the request is not one message

Five requests carry a required `requestId` — `input:touch:end`, `input:pinch:end`, `input:key`, `input:button`, `input:type` — and so do the four replies. The pairs already correlated arrive at the speed a person clicks a button; a swipe is dozens of frames, which is why an ack that missed its own deadline landing in the **next** input's waiter was never a corner case.

**Opening and move frames carry none, and neither does `input:rotate`.** Nothing acks them, so an id there would name a waiter that does not exist.

Required on both sides, unlike the lifecycle pair (#521), because no producer of these replies is unsolicited — six producers of `input:error`, every one behind a request. That is what lets the **compiler** hold the echo here: the relay sends through `sendTo(msg: RelayOutbound)` and the agents through `sendMsg(msg: AgentControlOutbound)`, so omitting it is a compile error rather than something only a test sees. #521 could not reach that position, and it is exactly where the same defect had already shipped twice.

`input:type-error` moved from `AgentToBrowser` to `RelayOrAgentToBrowser` because the relay produces it now — the compiler refused the send until the union said so. That also closed a gap `relay/AGENTS.md` had recorded: an `input:type` on an offline agent used to get nothing and burn the caller's full deadline, and widening the terminal set was never the fix, because its waiters key on the `input:type-*` pair.

The eleven `input:*` cases became **two clauses**. Written into the shared body the gate would have dropped every opening and move frame with it — the trap #521's own comment documents, walked into one slice later, and `correlatedRequestsGated` resolves fall-through by sharing the next body, so it would have passed. `TERMINAL_INPUT_TYPES` is deleted: the clause labels are the definition now.

## Ownership — this PR's second subject

It started as an input-only check, folded in because it changes the layer's own reasoning: with it, a foreign `input:error` cannot reach the dashboard, so "the dashboard does not correlate" gets a durable reason instead of one a later slice deletes.

**Review then found input was one branch of ten.** The relay acted on every browser→agent command on the strength of the session existing: `clipboard:write` pastes attacker text into the victim's device, `clipboard:read` with `press: 'cut'` presses cut on it and the reply lands on *that* tester's host OS clipboard, `session:end` deletes their session. `clipboard:data` has asked the mirror-image question since the bridge was written; the browser direction had none anywhere. And it was already documented in-repo — `SessionList.tsx` sends `session:start` before a shutdown purely to work around it.

Measured per branch, the nine split three ways: **7 take the same gate with nothing breaking** (every sender joins first, and the dashboard's app, deeplink and clipboard senders all live under the component that joins), **2 more take it with a silent drop** because they have no reply, and **1 cannot**.

`dispatchTarget` decides it once — session exists, this socket holds it, agent connected — collapsing three conditions that were spread across seven `case` bodies as two each, with ownership in none of them. The cases got **shorter**. The app-command handlers check ownership directly instead, after the session lookup and before the build lookup, because the resolver also decides agent liveness and using it there would change which of two simultaneous problems the caller is told about.

A refusal is **answered where a waiter exists and dropped where none does**. Answering is the load-bearing half: `awaitInputAck` reports silence from a session that has never acked as *success*, so a silent refusal would report a command that never left the relay as having landed.

**`device:shutdown` is the one left out**, and the blocker is the dashboard rather than the relay — three of its four senders come from `useAgentSession`, whose socket never joins, while `SessionList` joins first and documents why. So the dashboard already carries two conventions for that message. Filed as **#527**; the question there is whether the hook should join.

One diagnosis improved for free: `open-url` answered `'agent offline'` for a session the relay does not have — the wrong-diagnosis class #492 fixed for `device:boot` and `input:error` and had left here.

## The ledger records a *correlated* ack

`ackedSessions` gates whether silence is fatal, and it now records `input:done` only when it carries a correlator. `strict` licenses one inference — *silence here is an anomaly, not an agent that does not ack* — and for an agent that never carries a correlator, silence at the waiter is **structural**, so that inference is false for it.

Not a provenance question, which is what a first draft claimed: an id-less `input:done` is still the agent's word; what it lacks is attribution, and attribution is the waiter's question. Nor is the condition "an id *this client* issued" — that needs a set of issued ids outliving their waiters, and the late ack is precisely the one worth recording, so the set would never shrink.

The cost lands on agents predating the correlator and is **not** a revert of #457: `mcp-server/AGENTS.md` already documented that an agent whose acks never arrive keeps the optimistic path. Because there is no version handshake anywhere in this system, an id-less ack is the only skew signal that exists — so it goes in a second set carrying no strictness, logged once per session.

## Not closed: #517

`input:keyboard:toggle` stays out, and not for the reason a first draft gave. It **has** a reply on iOS (`keyboard:toggled`) with a consumer that sets session state; what is missing is the **failure half**, and that half is platform-asymmetric. Getting this wrong the first time was the same mistake as #521's — grepping a message name instead of reading what its `case` sends.

## Review

Design review first (two channels over the plan, zero commands, 8 and 10 minutes) — it found six things wrong with the first draft, including that inventory error twice. Then the pre-PR review, **split by subject** because the PR does two things: one channel on mutation coverage, one read-only on the access change.

**8 findings, all mine, all dispositioned.** **26 mutations, none surviving**, reached in three rounds:

- Round one: 9 mutations, **five alive** on a green suite — every one a test the plan had specified and this work had not written.
- Round two: the reviews found four more. The sharpest was not a coverage gap but a new failure mode — `flow-runner`'s fire-and-forget senders await nothing, so an empty minted id left 63 tests passing while every frame was dropped at the door and **the flow reported PASS**.
- Round three: **two of the tests written in round two were themselves Potemkin.** Both staged a stale reply and then asserted the request count, which is 1 either way, so they passed with the correlator check deleted. Making the stale reply an *error* is what made the outcome observable.

Two things caught by tooling rather than by me: `pnpm exec tsc -b` does not cover `protocol/tsconfig.assertions.json`, so four errors passed straight through my checks until the pre-commit hook refused the commit; and lint reported `TERMINAL_INPUT_TYPES` dead the moment the clause split removed its last use.

Record: `.work/reviews/feat__wire-l5c-input-ack-correlation.md`, including two process failures of mine — I edited the checkout while a mutation channel was running on it, and its restore-to-HEAD discarded six of my fixes. That is the previous slice's lesson with the branch swapped for a file, so the rule is now the stronger one: while a mutation channel runs, this checkout is read-only to me.

Also: promoting the request side hung both agent suites rather than failing to compile — 64 fixtures send these inputs from inside `JSON.stringify({ … })`, where no annotation exists for a compiler to check. Third slice in a row on that surface; the measurement is on #422.

## Verification

`tsc -b` clean; `protocol` (incl. assertions), `dashboard`, `mcp-server`, `test-utils` typecheck clean; lint clean apart from two pre-existing warnings; a11y-lens no findings.

static **275** · agent-core **137** · relay **617** (1 skipped) · dashboard **329** · mcp-server **79** · flow-runner **67** · ios-agent **382** · android-agent **263** · cli **246** · audiotap-helper **4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added request correlation for terminal input actions and acknowledgements.
  - Added session ownership validation for device commands.
  - Added clear errors when commands target unavailable or non-owned sessions.
  - Added guidance to reopen a device when session ownership changes.
  - Improved text, key, touch, pinch, button, and clipboard command handling.
- **Bug Fixes**
  - Prevented stale or unrelated acknowledgements from completing the wrong request.
  - Improved handling of missing sessions, disconnected devices, malformed inputs, and unsupported actions.
  - Preserved compatibility with older agents through optimistic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->