### PR TITLE
feat(protocol): `error` is the session-start refusal, and it names the session it refuses

### DIFF
--- a/.changeset/error-is-addressed.md
+++ b/.changeset/error-is-addressed.md
@@ -1,0 +1,99 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': patch
+'@tapflowio/mcp-server': patch
+'@tapflowio/flow-runner': patch
+---
+
+feat(protocol): `error` is the session-start refusal, and it names the session it refuses
+
+Closes #512's first finding, and ends a contradiction that sat in two files at once. `GenericError`'s doc
+claimed *"the escape hatch for a failure the relay cannot correlate to a session"*, while
+`SessionStartFailure`'s claimed the reason has **a single producer inside `handleSessionStart`**. Both cannot
+be true.
+
+The correlation work settled it by removing the general role rather than the specific one. A request naming no
+session is dropped at the relay's door, because answering it would ship a frame whose own required `sessionId`
+`JSON.stringify` erases — and `error` has no `requestId` either, so a caller could not attribute the answer and
+would wait out the same deadline silence costs. With nothing left needing an unaddressed failure, all four
+producers answer one specific join.
+
+## What the address buys
+
+The join waiters in `mcp-server` and `flow-runner` matched `sessionId === undefined || sessionId === mine`, and
+with no such key **the left half was always true** — so any refusal resolved any pending join. Two concurrent
+`connect_device` calls and the first refusal woke the wrong one, reported as a failure that session never had,
+while the one actually refused waited out its deadline, because `dispatch` resolves only the first matching
+waiter. That is the defect; the escape was it.
+
+## `extends SessionError`, not a bolted-on field
+
+The naming check forced the decision the plan had left open. `protocolMessageNames.test.mjs` asserts that a
+session-scoped failure declares `extends SessionError`, and its predicate is exactly this change: `'error'`
+already matched `/error$/`, and it survived only because it had no `sessionId`. Adding the field flips that.
+
+Joining the family is the honest answer rather than carving an exception: the shape is the base verbatim, and
+the base's own definition — a failure a *session* is waiting on — is now exactly what `error` is. The check's
+note saying `error` *"cannot be a `SessionError`… that is the member's nature, not an exception"* described a
+nature this change replaced, so the note is corrected in place rather than worked around.
+
+## The name stays `GenericError`
+
+A first draft leaned toward `SessionStartError`, arguing that a narrowed role was the only chance to remove the
+naming exception. **Review refuted it.** The derivation rule splits the literal and PascalCases it, so `'error'`
+yields `Error` — which shadows the global, and that is the exception's whole reason. `SessionStartError` is not
+the derived name either, so it needs an exception entry just the same; `NAME_EXCEPTIONS.size` stays 6. The
+exception is removable only by renaming the **wire literal**, which this slice does not scope. Renaming would
+have touched every consumer plus `typeAssertions` and bought nothing.
+
+## Skew is logged, not hedged
+
+A client newer than its relay sees unaddressed refusals, which now match nothing — so the join runs to its
+deadline instead of reporting why it was refused. There is no version handshake anywhere in this protocol, so
+the alternative was a fallback, and a fallback here is the ambiguity this work removes. Both clients log once
+per session instead: the same shape and the same reasoning as the input-ack skew record, that logging is not
+matching. Approved as part of the breaking change, in that direction specifically.
+
+## What the design review changed
+
+Eight things, and two of them were premises the plan had asserted rather than measured.
+
+- **The scope in the program plan was wrong in three ways.** Its table called this slice *"`session:start`/`error`
+  echo (#512 finding 1 · #444's seven reply sites)"*. The seven reply sites had **already gone** — the input
+  slice's door predicate removed them, and the eleven `msg.sessionId!` left are agent→browser forwards, which is
+  #444's own body. "Echo" was rejected by the same file's decision log, which had already refused a correlator
+  on `error` on the grounds that attaching one makes it a different message. And the general role was already
+  dead in code while two comments still claimed it.
+- **Three consumers, not one.** The plan said the dashboard's filtering would newly affect
+  `DeviceViewer`, `SessionList` and `useAgentSession`. `SessionList` has no session gate at all, and **`error`
+  never arrives at `useAgentSession`** — every producer is `sendTo(ws, …)` to the socket that sent
+  `session:start`, and that hook's socket only sends `agents:list` and `device:shutdown`. So the filtering
+  affects one consumer, and it is a no-op there: no `error` the wire can deliver to that socket will be dropped.
+  A planned test for "the dashboard receives another session's error" was deleted — the wire cannot produce it.
+- **`useAgentSession`'s `error` and `session:joined` branches are unreachable**, and `inboundDisposition` named
+  it as handling both. Correcting that by *removing* the name made the table stale in the other direction, and
+  the reverse-direction check said so: `at` answers "which files compare `.type` against this", which is still
+  true. The name stays and the reachability went into the comment — with what the first attempt got wrong.
+- **Stale prose was in six places, not two.** The sharpest is `SessionList`, where three comments justify a
+  serialisation guard on `error` carrying no sessionId — and #527 has that list joining before it shuts down as
+  a client-side stand-in for a missing server check, so someone deleting the guard on the strength of the old
+  comment would unlock the wrong row's badge.
+- **`typeAssertions` needed two edits and a relocation.** One line was in the must-compile section and failed
+  under `pnpm --filter @tapflowio/protocol typecheck`, which `tsc -b` does not cover. And the `@ts-expect-error`
+  being flipped was the file's **only whole-message excess-property assertion** — flipping it would have retired
+  an assertion class as a side effect, so the guard moved to another message instead.
+- **Fixtures the compiler cannot see.** Two `mcp-server` fixtures send `error` through a fake relay typed
+  `Record<string, unknown>`; they carried neither `sessionId` nor the already-required `reason` and passed only
+  because of the escape. `flow-runner` had **no `error` fixture at all**, so removing its escape was untested in
+  both directions — three tests now cover it.
+
+## Mutations
+
+Ten, none surviving. Four on the relay's `error` exits — and the fourth, the `join()` catch, **survived at
+first**: it is reached only when `join()` throws for something the two checks above it do not cover, so no
+existing test touched it. Forced with a spy rather than left unpinned, on the rule the previous slice arrived at:
+an address no test can hold is one that will drift.
+
+Three more on the mcp client survived at first for a subtler reason — the foreign-address test does not exercise
+the `sessionId === undefined` escape, because that half only fires for a refusal carrying **no** address. The
+test that holds it is the unaddressed one, and it holds the skew log and its once-guard too.

--- a/.changeset/error-is-addressed.md
+++ b/.changeset/error-is-addressed.md
@@ -60,10 +60,10 @@ Eight things, and two of them were premises the plan had asserted rather than me
 
 - **The scope in the program plan was wrong in three ways.** Its table called this slice *"`session:start`/`error`
   echo (#512 finding 1 · #444's seven reply sites)"*. The seven reply sites had **already gone** — the input
-  slice's door predicate removed them, and the eleven `msg.sessionId!` left are agent→browser forwards, which is
-  #444's own body. "Echo" was rejected by the same file's decision log, which had already refused a correlator
-  on `error` on the grounds that attaching one makes it a different message. And the general role was already
-  dead in code while two comments still claimed it.
+  slice's door predicate removed them, so what is left is #444's own body. "Echo" was rejected by the same
+  file's decision log, which had already refused a correlator on `error` on the grounds that attaching one
+  makes it a different message. And the general role was already dead in code while two comments still claimed
+  it.
 - **Three consumers, not one.** The plan said the dashboard's filtering would newly affect
   `DeviceViewer`, `SessionList` and `useAgentSession`. `SessionList` has no session gate at all, and **`error`
   never arrives at `useAgentSession`** — every producer is `sendTo(ws, …)` to the socket that sent
@@ -74,10 +74,17 @@ Eight things, and two of them were premises the plan had asserted rather than me
   it as handling both. Correcting that by *removing* the name made the table stale in the other direction, and
   the reverse-direction check said so: `at` answers "which files compare `.type` against this", which is still
   true. The name stays and the reachability went into the comment — with what the first attempt got wrong.
-- **Stale prose was in six places, not two.** The sharpest is `SessionList`, where three comments justify a
-  serialisation guard on `error` carrying no sessionId — and #527 has that list joining before it shuts down as
-  a client-side stand-in for a missing server check, so someone deleting the guard on the strength of the old
-  comment would unlock the wrong row's badge.
+- **Stale prose was in six places, not two — and a second review found five more that the first pass had not
+  reached.** The sharpest of the first six is `SessionList`, where three comments justify a serialisation guard
+  on `error` carrying no sessionId, and #527 has that list joining before it shuts down as a client-side
+  stand-in for a missing server check, so someone deleting the guard on the strength of the old comment would
+  unlock the wrong row's badge. The sharpest of the second five is worse, because this change's own headline
+  claimed to have fixed it: the retired *"send `error` instead"* argument was still on `SessionError`, the
+  interface `GenericError` now `extends`, 140 lines above the rewritten block — so the contradiction moved
+  inside one file instead of ending, and a #444 implementer reading the base was told to do the thing this
+  slice removed, with seven line numbers that had drifted onto a `break` and three comments. Two files were
+  where the first pass looked; the six places it then found were the ones that mention `error` by name. What it
+  did not do was re-read the **paragraph above each edit**, and four of the five survivors were exactly that.
 - **`typeAssertions` needed two edits and a relocation.** One line was in the must-compile section and failed
   under `pnpm --filter @tapflowio/protocol typecheck`, which `tsc -b` does not cover. And the `@ts-expect-error`
   being flipped was the file's **only whole-message excess-property assertion** — flipping it would have retired
@@ -87,9 +94,42 @@ Eight things, and two of them were premises the plan had asserted rather than me
   because of the escape. `flow-runner` had **no `error` fixture at all**, so removing its escape was untested in
   both directions — three tests now cover it.
 
+- **The remaining `msg.sessionId!` count was wrong, and its composition was the misleading half.** A first
+  draft of this note said "the eleven left are all agent→browser forwards". There were **twelve**, and four
+  were not forwards: `stream:register`, `device:shutdown`, `forwardUnacked` and `handleAckedInput` — whose
+  assertion was **dead**, since L5c's door predicate had already narrowed that parameter to
+  `sessionId: string`. Removing it leaves eleven, of which eight are forwards and three are request-side
+  paths that deliberately carry no address gate. "All forwards" invited the conclusion that the request side
+  was settled, while `device:shutdown` sits on it with no ownership gate either (#527). The count and the
+  composition are now recorded next to the sites, with an instruction to re-derive rather than trust the
+  sentence.
+
 ## Mutations
 
-Ten, none surviving. Four on the relay's `error` exits — and the fourth, the `join()` catch, **survived at
+Ten in the author's round, none surviving — and then **four more from review, all four alive**, which is the
+number worth reporting.
+
+- **`session:joined`'s address held nothing.** Pointing it at `session.deviceId` passed relay 620, ios 382,
+  android 263 and the static suite, while **no client could join at all**: both clients match
+  `sessionId === mine` strictly and the dashboard's gate drops the rest. This slice added four assertions that
+  each *refusal* names the right session and zero that the *reply* does — and the reply is the half that was
+  already strict, so it had the largest blast radius and the least cover. The agent suites miss it because they
+  wait on the type alone.
+- **The mcp skew log's stated reason was free**, and its keying contradicted its own docstring. Adding
+  `&& this.waiters.length > 0` passed 81, so nothing held the "recorded whether or not anything is waiting"
+  claim — which exists for the refusal that arrives *after* its join gave up, the one caller who has been told
+  "timed out" with no cause. Worse, the record keyed on the literal `'a pending join'`, so it was once per
+  **process** rather than once per session: against an old relay the first refused session logged and every
+  later one was silent. Keying per session is not available — the frame carries no address and `Waiter` keeps
+  its predicate as a closure — and naming one anyway is a guess between pending joins, which is the false
+  attribution this slice removes. So it is once per **client**, which is the honest cardinality: an agent is
+  per session, a relay is per client.
+- **`flow-runner`'s once-guard was free too.** Its fixture answered a single `session:start`, so "once" and
+  "every time" were indistinguishable. The premise that flow-runner already held all three properties was
+  two-thirds true.
+- **The gate's new reach over `error` was unpinned in both directions.** Exempting `error` passed all 329.
+  Unreachable today because `useRelay` opens a socket per hook, but the unreachability expires with #527, and
+  then a foreign `session-not-found` tears down a healthy viewer. Four on the relay's `error` exits — and the fourth, the `join()` catch, **survived at
 first**: it is reached only when `join()` throws for something the two checks above it do not cover, so no
 existing test touched it. Forced with a spy rather than left unpinned, on the rule the previous slice arrived at:
 an address no test can hold is one that will drift.

--- a/.changeset/input-ack-correlation.md
+++ b/.changeset/input-ack-correlation.md
@@ -103,8 +103,11 @@ alternative, and it is what L5d is for: that union's own doc says it has a singl
 
 Narrowing `dispatchTarget` to `sessionId: string` is what found the doors — exactly four compile errors, then
 the handler signatures carried the rest. **Seven `msg.sessionId!` assertions went away** on the request side
-as a consequence, which is the payoff `SessionError`'s doc predicted. The eleven left are all agent→browser
-forwards, unchanged in count from `main`, and still #444.
+as a consequence, which is the payoff `SessionError`'s doc predicted. Twelve are left, and reviewing L5d
+corrected the sentence that stood here: they are **not** all agent→browser forwards. Eight are; `stream:register`,
+`device:shutdown` and `forwardUnacked` are request-side paths that deliberately carry no address gate, and
+`handleAckedInput`'s assertion is dead — this slice's own door predicate narrowed that parameter, so the `!`
+counted itself into #444's body while asserting nothing. Still #444, minus one line L5d removes.
 
 Three places got the predicate and then **had it removed again**, because a mutation showed there was nothing
 observable to hold it with: the unacked input clause, `device:shutdown`, and the two session commands. In each

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -123,9 +123,15 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     // narrowing rather than the widening it used to be — it was `in msg` because the local copy of
     // this union omitted the field on messages the wire always stamped it on.
     //
-    // `'sessionId' in msg` stays, because two members genuinely carry none — `agents:listed` and
-    // `error`, whose whole point is a failure the relay could not attribute. Both are the *only* two,
-    // checked against the union.
+    // `'sessionId' in msg` stays, and as of L5d **one** member genuinely carries none: `agents:listed`,
+    // which is about the relay's inventory rather than any session. `error` used to be the second — "a
+    // failure the relay could not attribute" — and is now the answer to a specific `session:start`, so it
+    // passes through the comparison instead of around it.
+    //
+    // That makes the gate reject a foreign `error`, which is a no-op rather than a change: every producer
+    // sends it with `sendTo(ws, …)` to the socket that asked, and this viewer's only `session:start` names
+    // the session it holds for the life of the socket. So there is no `error` the wire can deliver here that
+    // this line will drop — defence in depth, measured rather than assumed.
     //
     // **Why this gate is safe at all**: the relay only ever sends a session-scoped message to that
     // session's own `browserSocket`, so a mismatch means a stale socket rather than normal traffic. If

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -123,10 +123,15 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
     // narrowing rather than the widening it used to be — it was `in msg` because the local copy of
     // this union omitted the field on messages the wire always stamped it on.
     //
-    // `'sessionId' in msg` stays, and as of L5d **one** member genuinely carries none: `agents:listed`,
-    // which is about the relay's inventory rather than any session. `error` used to be the second — "a
-    // failure the relay could not attribute" — and is now the answer to a specific `session:start`, so it
-    // passes through the comparison instead of around it.
+    // `'sessionId' in msg` stays, and it is a **runtime** check rather than a type formality, so the two
+    // levels have to be read separately. In the *union*, as of L5d one member declares no `sessionId`:
+    // `agents:listed`, which is about the relay's inventory rather than any session. (`error` used to be the
+    // second — "a failure the relay could not attribute" — and is now the answer to a specific
+    // `session:start`, so it passes through the comparison instead of around it.) On the *wire* the key can
+    // also be absent from a message that declares it: the relay replays cached session state to a re-joining
+    // viewer, and `device:ready` is still sent unstamped — the paragraph below on the removed truthiness
+    // check is about exactly those frames. So "one member carries none" is a statement about the declaration,
+    // and `in msg` is what carries the replay.
     //
     // That makes the gate reject a foreign `error`, which is a no-op rather than a change: every producer
     // sends it with `sendTo(ws, …)` to the socket that asked, and this viewer's only `session:start` names

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -83,9 +83,13 @@ export function SessionList({ onSelect }: Props) {
       // the badge stayed on "Shutting down..." for good and `isShutting` hid both buttons — the row went
       // inert. Same defect `DeviceViewer` had for `Session busy`, in a second place.
       //
-      // `error` carries no sessionId — by design, since the relay sends it when it cannot correlate — so
-      // the device comes from the request this list is waiting on. One is in flight at a time (see
-      // `handleShutdown`), which is what makes that unambiguous rather than merely likely.
+      // `error` **does** carry a sessionId as of L5d — it is the answer to a specific `session:start`, not
+      // the uncorrelatable failure this comment used to describe. The device still comes from the request
+      // this list is waiting on, and one is in flight at a time (see `handleShutdown`), so the behaviour is
+      // unchanged. What changed is that the serialisation is no longer the *only* thing making it
+      // unambiguous — `pending.sessionId` could be compared against `msg.sessionId` now, which would make
+      // the guard below rest on the wire rather than on a convention. Left as it is because this slice does
+      // not touch the shutdown flow; recorded so the option is visible.
       const pending = pendingRef.current
       pendingRef.current = null
       if (pending) {
@@ -114,9 +118,13 @@ export function SessionList({ onSelect }: Props) {
     onSelect(sessionId, deviceId)
   }
 
-  // One shutdown at a time. `error` carries no sessionId, so a second request in flight would leave the
-  // handler unable to say which row a refusal belongs to — and the previous version cleared *every* row
-  // on any error, which was a guess dressed as a comment.
+  // One shutdown at a time. The original reason was that `error` carried no sessionId, so a second request
+  // in flight would leave the handler unable to say which row a refusal belongs to — and an earlier version
+  // cleared *every* row on any error, which was a guess dressed as a comment. **That reason expired in
+  // L5d**: a refusal now names its session. The guard stays because it is still the thing that keeps this
+  // list's `pendingRef` a single slot, and because #527 has this list joining before it shuts down as a
+  // client-side stand-in for a missing server check — two in flight would interleave those joins. Deleting
+  // it on the strength of the old comment would unlock the wrong row's badge.
   const handleShutdown = (deviceId: string, sessionId: string) => {
     if (pendingRef.current) return
     pendingRef.current = { deviceId, sessionId }

--- a/packages/dashboard/lib/inboundDisposition.ts
+++ b/packages/dashboard/lib/inboundDisposition.ts
@@ -51,6 +51,16 @@ export const INBOUND_DISPOSITION = {
   'device:booting': { at: 'DeviceViewer' },
   'device:ready': { at: 'DeviceViewer, SessionList' },
   'device:shutdown-done': { at: 'SessionList' },
+  // **`useAgentSession`'s branch cannot fire, and it is still named here.** L5d measured it: all four
+  // producers are `sendTo(ws, …)` to the socket that sent `session:start`, and that hook's socket only ever
+  // sends `agents:list` and `device:shutdown`. So relay failures do **not** surface in the device list, which
+  // naming three files here implies.
+  //
+  // The name stays because `at` answers "which files compare `.type` against this", and the reverse-direction
+  // check derives exactly that — dropping the name made the table stale the other way. A first attempt did
+  // drop it and that check said so. Reachability is a different question from handling, and this comment is
+  // where it belongs; the branch is a correct handler for a message that does not arrive, so whoever removes
+  // it can, and this says why.
   'error': { at: 'DeviceViewer, SessionList, useAgentSession' },
   'input:error': { at: 'DeviceViewer' },
   'keyboard:toggled': { at: 'DeviceViewer' },
@@ -58,6 +68,7 @@ export const INBOUND_DISPOSITION = {
   'open-url:error': { at: 'DeviceViewer' },
   'session:agent-away': { at: 'DeviceViewer' },
   'session:chrome': { at: 'DeviceViewer' },
+  // Same as `error` above: `useAgentSession`'s branch cannot fire, and is named for the same reason.
   'session:joined': { at: 'DeviceViewer, SessionList, useAgentSession' },
   'session:rebound': { at: 'DeviceViewer' },
   'session:terminated': { at: 'DeviceViewer' },

--- a/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.rebind.test.tsx
@@ -367,7 +367,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
     act(() => { deliver!({ type: 'session:agent-away', sessionId: 's1' }) })
 
-    act(() => { deliver!({ type: 'error', message: 'Session not found', reason: 'session-not-found' }) })
+    act(() => { deliver!({ type: 'error', sessionId: 's1', message: 'Session not found', reason: 'session-not-found' }) })
 
     expect(onSessionEnded).toHaveBeenCalledWith('agent-disconnected')
   })
@@ -383,7 +383,7 @@ describe('DeviceViewer recovers from an agent restart (#426)', () => {
     const onSessionEnded = vi.fn()
     render(<DeviceViewer sessionId="s1" deviceId="dev-1" onSessionEnded={onSessionEnded} />)
 
-    act(() => { deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' }) })
+    act(() => { deliver!({ type: 'error', sessionId: 's1', message: 'Session busy', reason: 'session-busy' }) })
 
     // Not `agent-disconnected`: the agent is fine and so is the device. That reason tells the tester to
     // re-pick the Mac, which is advice for a problem they do not have.

--- a/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
@@ -68,6 +68,42 @@ describe('DeviceViewer ignores messages addressed to another session (#445)', ()
     expect(screen.getByText(/Install failed: Build not found/)).toBeInTheDocument()
   })
 
+  it('ignores a session:start refusal belonging to a different session', () => {
+    // **L5d put `error` under this gate for the first time** — the message had no `sessionId` before, so
+    // `'sessionId' in msg` was false and every refusal reached the handler. Nothing pinned the new reach in
+    // either direction: adding `&& msg.type !== 'error'` to the gate passed all 329 tests.
+    //
+    // The consequence is not reachable today, and that is a property of the dashboard rather than of this
+    // line. `useRelay` opens a socket per hook instance, so this viewer's socket sends exactly one
+    // `session:start` — for the session it holds — and all four producers answer `sendTo(ws, …)` to that
+    // socket. So no foreign refusal can arrive here now.
+    //
+    // It is tested anyway because the unreachability **expires**, and the thing that expires it is already
+    // filed: #527 asks whether `useAgentSession` should join, and any move toward one shared socket puts
+    // another component's refusal on this handler. A `session-not-found` for someone else's session then
+    // calls `onSessionEnded('agent-disconnected')` on a healthy viewer, which tears down a working stream
+    // and sends the tester to re-pick a Mac that was fine. Pinning it now costs one test; discovering it
+    // then costs a debugging session, and the L5c rule cuts the other way here — a line a test *can* hold is
+    // one that should be held.
+    const onSessionEnded = vi.fn()
+    render(<DeviceViewer sessionId="mine" deviceId="dev-1" onSessionEnded={onSessionEnded} />)
+
+    act(() => { deliver!({ type: 'error', sessionId: 'someone-else', message: 'Session not found', reason: 'session-not-found' }) })
+
+    expect(onSessionEnded).not.toHaveBeenCalled()
+  })
+
+  it('still acts on a refusal that is its own', () => {
+    // The other direction, and the one that makes the test above mean something: a gate that dropped every
+    // `error` would also pass the assertion above, and this is #426's silent-wait defect returning.
+    const onSessionEnded = vi.fn()
+    render(<DeviceViewer sessionId="mine" deviceId="dev-1" onSessionEnded={onSessionEnded} />)
+
+    act(() => { deliver!({ type: 'error', sessionId: 'mine', message: 'Session not found', reason: 'session-not-found' }) })
+
+    expect(onSessionEnded).toHaveBeenCalledWith('agent-disconnected')
+  })
+
   it('ignores a device:ready whose session id is empty', () => {
     // The discriminating case for dropping `&& msg.sessionId` from the gate. An empty sessionId is
     // falsy, so the truthiness check let it *pass* and the message was applied to whichever viewer was

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -112,8 +112,12 @@ describe('SessionList when a shutdown is refused', () => {
   })
 
   it('refuses a second shutdown while one is still unanswered', () => {
-    // `error` carries no sessionId, so two in flight would leave the handler unable to say which row a
-    // refusal belongs to. The previous version cleared every row instead, which was a guess.
+    // Not the original reason any more. That one was "`error` carries no sessionId, so two in flight would
+    // leave the handler unable to say which row a refusal belongs to" — and it **expired in L5d**, which made
+    // the refusal name its session. The guard is what keeps `pendingRef` a single slot, which is what the
+    // handler's unconditional clear depends on, and #527 has this list joining before it shuts down as a
+    // stand-in for a missing server check, so two in flight would interleave those joins. See
+    // `SessionList.tsx`'s comment on `handleShutdown`, which carries the same correction.
     render(<SessionList onSelect={vi.fn()} />)
     act(() => { deliver!({ type: 'agents:listed', sessions: TWO_DEVICES }) })
 

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -55,7 +55,7 @@ describe('SessionList when a shutdown is refused', () => {
     expect(screen.getByText(/shutting down/i)).toBeInTheDocument()
 
     act(() => {
-      deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' })
+      deliver!({ type: 'error', sessionId: 's1', message: 'Session busy', reason: 'session-busy' })
     })
 
     // The badge is gone, so the row's buttons are back and the tester can act.
@@ -78,7 +78,7 @@ describe('SessionList when a shutdown is refused', () => {
     act(() => { screen.getByRole('button', { name: /shutdown/i }).click() })
     expect(send.mock.calls.map(([m]) => m.type)).toEqual(['agents:list', 'session:start'])
 
-    act(() => { deliver!({ type: 'error', message: 'Session busy', reason: 'session-busy' }) })
+    act(() => { deliver!({ type: 'error', sessionId: 's1', message: 'Session busy', reason: 'session-busy' }) })
 
     expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown')).toBe(false)
   })

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -128,11 +128,19 @@ describe('useAgentSession', () => {
     expect(result.current.status).toBe('Connected')
   })
 
+  // This and the `session:joined` case above call `handleMessage` directly, so they pin the handler's
+  // contract and **not** that either message reaches this hook. L5d measured that it does not: `error` and
+  // `session:joined` are both sent with `sendTo(ws, …)` to the socket that sent `session:start`, and this
+  // hook's socket only ever sends `agents:list` and `device:shutdown`. `inboundDisposition` records that.
+  //
+  // `sessionId` here is arbitrary — the handler does not read it — and required only because L5d made
+  // `error` an addressed reply. That the compiler asked for it at all is what surfaced the reachability
+  // question: a fixture had to name a session this socket never joins.
   it('clears booting flag and sets error status on error message', () => {
     const { result } = renderHook(() => useAgentSession('android'))
 
     act(() => result.current.startDevice(makeDevice()))
-    act(() => capturedOnMessage({ type: 'error', message: 'boom', reason: 'agent-resources-exhausted' }))
+    act(() => capturedOnMessage({ type: 'error', sessionId: 'avd:Pixel_7', message: 'boom', reason: 'agent-resources-exhausted' }))
 
     expect(result.current.booting).toBe(false)
     expect(result.current.status).toBe('Error: boom')

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -171,7 +171,8 @@ export class RelayClient {
         // refusal resolved any pending join. The cost is version skew — a client newer than its relay sees
         // unaddressed refusals, which match nothing, so the join burns its deadline instead of reporting why
         // it was refused. Taken deliberately: there is no version handshake in this protocol, and the
-        // alternative is a fallback, which is the ambiguity this work removes. Logged once per session.
+        // alternative is a fallback, which is the ambiguity this work removes. Logged once per **client**,
+        // not per session — a relay is per client, and the frame carries no session to key on anyway.
         (m['type'] === 'error' && m['sessionId'] === sessionId),
       5_000,
       'session join',

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -112,7 +112,18 @@ export class RelayClient {
     this.ws = null
   }
 
+  private addressSkewLogged = false
+
   private dispatch(msg: RelayMsg): void {
+    if (msg['type'] === 'error' && typeof msg['sessionId'] !== 'string' && !this.addressSkewLogged) {
+      // A relay older than L5d. The refusal matches no waiter, so the join times out with no reason — this is
+      // the only trace. One flow run holds one client, so once is once.
+      this.addressSkewLogged = true
+      console.error(
+        '[tapflow] a session:start refusal carried no sessionId — this relay predates addressed errors, so a ' +
+        'refused join times out rather than reporting why. Upgrade the relay.',
+      )
+    }
     for (let i = 0; i < this.waiters.length; i++) {
       if (this.waiters[i].predicate(msg)) {
         const [w] = this.waiters.splice(i, 1)
@@ -155,7 +166,13 @@ export class RelayClient {
     const msg = await this.waitFor(
       (m) =>
         (m['type'] === 'session:joined' && m['sessionId'] === sessionId) ||
-        (m['type'] === 'error' && (m['sessionId'] === undefined || m['sessionId'] === sessionId)),
+        // No `=== undefined` escape — see the twin in `mcp-server`. `error` carries an address as of L5d, and
+        // the escape *was* #512's first finding: with no such key the left half was always true, so any
+        // refusal resolved any pending join. The cost is version skew — a client newer than its relay sees
+        // unaddressed refusals, which match nothing, so the join burns its deadline instead of reporting why
+        // it was refused. Taken deliberately: there is no version handshake in this protocol, and the
+        // alternative is a fallback, which is the ambiguity this work removes. Logged once per session.
+        (m['type'] === 'error' && m['sessionId'] === sessionId),
       5_000,
       'session join',
     )

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -275,3 +275,71 @@ describe('RelayClient.bootDevice — an optional correlator, with a fallback', (
     await expect(client.bootDevice('s1', 'dev-1')).rejects.toThrow('emulator gone')
   })
 })
+
+
+// L5d. `error` is the answer to a `session:start` the relay refused, and it carries the session it refuses.
+// This file had **no `error` fixture at all** before, so removing the waiter's `sessionId === undefined`
+// escape was untested in both directions — the review that found that is why these exist.
+describe('RelayClient.joinSession — a refusal is addressed', () => {
+  let wss: WebSocketServer | null = null
+
+  afterEach(async () => {
+    const s = wss
+    wss = null
+    if (!s) return
+    for (const c of s.clients) c.terminate()
+    await new Promise<void>((r) => s.close(() => r()))
+  })
+
+  /** A relay that answers `session:start` with whatever the test returns. */
+  async function relay(reply: (msg: Record<string, unknown>) => Record<string, unknown>) {
+    wss = new WebSocketServer({ port: 0 })
+    wss.on('connection', (ws) => {
+      ws.on('message', (data) => {
+        const msg = JSON.parse(String(data)) as Record<string, unknown>
+        if (msg['type'] === 'session:start') ws.send(JSON.stringify(reply(msg)))
+      })
+    })
+    const port = (wss.address() as { port: number }).port
+    const client = new RelayClient(`ws://localhost:${port}`, '')
+    await client.connect()
+    return client
+  }
+
+  it('fails the join on a refusal that names its session', async () => {
+    const client = await relay((m) => ({
+      type: 'error', sessionId: m['sessionId'], message: 'Session busy', reason: 'session-busy',
+    }))
+    await expect(client.joinSession('s1')).rejects.toThrow('Session busy')
+  })
+
+  it('does not take a refusal meant for another session', async () => {
+    // The other half of #512's first finding: with the old `sessionId === undefined` escape this resolved,
+    // and the caller was told a failure that belonged to a join it had not made.
+    const client = await relay(() => ({
+      type: 'error', sessionId: 'someone-else', message: 'Session busy', reason: 'session-busy',
+    }))
+    const settled = await Promise.race([
+      client.joinSession('s1').then(() => 'resolved').catch(() => 'rejected'),
+      new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+    ])
+    expect(settled).toBe('still-waiting')
+  })
+
+  it('logs once when a refusal carries no address, and still times out', async () => {
+    // A relay older than L5d. There is no version handshake anywhere, so this frame is the only signal that
+    // the two sides disagree — and without the log the join simply times out with no stated reason, which is
+    // #512's complaint arriving through a different door.
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+    try {
+      const client = await relay(() => ({ type: 'error', message: 'Session busy', reason: 'session-busy' }))
+      const settled = await Promise.race([
+        client.joinSession('s1').then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 200)),
+      ])
+      expect(settled).toBe('still-waiting')
+    } finally { spy.mockRestore() }
+    expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
+  })
+})

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -291,13 +291,17 @@ describe('RelayClient.joinSession — a refusal is addressed', () => {
     await new Promise<void>((r) => s.close(() => r()))
   })
 
-  /** A relay that answers `session:start` with whatever the test returns. */
-  async function relay(reply: (msg: Record<string, unknown>) => Record<string, unknown>) {
+  /** A relay that answers `session:start` with whatever the test returns — one frame, or several. */
+  async function relay(
+    reply: (msg: Record<string, unknown>) => Record<string, unknown> | Record<string, unknown>[],
+  ) {
     wss = new WebSocketServer({ port: 0 })
     wss.on('connection', (ws) => {
       ws.on('message', (data) => {
         const msg = JSON.parse(String(data)) as Record<string, unknown>
-        if (msg['type'] === 'session:start') ws.send(JSON.stringify(reply(msg)))
+        if (msg['type'] !== 'session:start') return
+        const out = reply(msg)
+        for (const frame of Array.isArray(out) ? out : [out]) ws.send(JSON.stringify(frame))
       })
     })
     const port = (wss.address() as { port: number }).port
@@ -339,6 +343,27 @@ describe('RelayClient.joinSession — a refusal is addressed', () => {
         new Promise<string>((r) => setTimeout(() => r('still-waiting'), 200)),
       ])
       expect(settled).toBe('still-waiting')
+    } finally { spy.mockRestore() }
+    expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
+  })
+
+  it('logs the skew once even when the old relay refuses more than once', async () => {
+    // The once-guard above was **free**: the harness answered a single `session:start`, so "once" and "every
+    // time" produced the same one line and removing `!this.addressSkewLogged` passed all 70 tests. An old
+    // relay refuses *every* join this way, and a client driving a flow of many steps would get a line per
+    // refusal — the volume that buries the one message telling the operator what to fix. Two frames is the
+    // smallest fixture where the guard is observable.
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+    try {
+      const client = await relay(() => [
+        { type: 'error', message: 'Session busy', reason: 'session-busy' },
+        { type: 'error', message: 'Session busy', reason: 'session-busy' },
+      ])
+      await Promise.race([
+        client.joinSession('s1').catch(() => 'rejected'),
+        new Promise((r) => setTimeout(r, 200)),
+      ])
     } finally { spy.mockRestore() }
     expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
   })

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -179,6 +179,42 @@ describe('TapflowClient', () => {
       expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
     }, 15_000)
 
+    it('logs the skew for a refusal that arrives with nothing waiting for it', async () => {
+      // **The stated reason for recording this in `dispatch`**, and nothing held it: adding
+      // `&& this.waiters.length > 0` to the guard passed all 81 tests, because every other fixture has a join
+      // still pending when the refusal lands. The case that reason exists for is the opposite one — a refusal
+      // arriving *after* its join gave up, from a relay slow enough that the deadline won the race. That
+      // caller has already been told "timed out" with no cause, so this line is the only thing that can
+      // explain it, and a waiters-guard would drop precisely it.
+      const logged: string[] = []
+      const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+      try {
+        relay.send({ type: 'error', message: 'Session busy', reason: 'session-busy' })   // no join in flight
+        await new Promise((r) => setTimeout(r, 20))
+      } finally { spy.mockRestore() }
+      expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
+    })
+
+    it('names the relay and not a session it cannot know', async () => {
+      // The first draft keyed the record on the literal `'a pending join'` and rendered it into the line, so
+      // the set could only ever hold that sentinel — "once per session" in the docstring, once per *process*
+      // in fact, and against an old relay the second refused session logged nothing at all. Keying per
+      // session is not available: the frame carries no address, and `Waiter` keeps its predicate as a closure
+      // so no session id survives on the record. Naming one anyway would be a guess between the pending
+      // joins, which is the false attribution this slice exists to remove. The relay is what the operator
+      // acts on, and it is per client, so once per client is the honest cardinality.
+      const logged: string[] = []
+      const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+      try {
+        relay.send({ type: 'error', message: 'Session busy', reason: 'session-busy' })
+        await new Promise((r) => setTimeout(r, 20))
+      } finally { spy.mockRestore() }
+      const line = logged.find((l) => l.includes('predates addressed errors'))
+      expect(line).toBeDefined()
+      expect(line).toContain('Upgrade the relay')
+      expect(line).not.toContain('pending join')
+    })
+
     it('throws on session not found error', async () => {
       setTimeout(() => relay.send({ type: 'error', sessionId: 'sess-1', message: 'Session not found', reason: 'session-not-found' }), 10)
       await expect(client.connectDevice('sess-1')).rejects.toThrow('Session not found')

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -126,13 +126,61 @@ describe('TapflowClient', () => {
       expect(msg).toMatchObject({ type: 'session:start', sessionId: 'sess-1' })
     })
 
+    // These two send an **addressed** refusal, as the relay does since L5d. The fake relay's `send` takes
+    // `Record<string, unknown>`, so nothing typed them and they carried neither `sessionId` nor the required
+    // `reason` — they passed only because the waiter had a `sessionId === undefined` escape. Removing that
+    // escape is what closes #512's first finding, and it is what would have turned these two red with no
+    // compile error to point at them.
     it('throws on session busy error', async () => {
-      setTimeout(() => relay.send({ type: 'error', message: 'Session busy' }), 10)
+      setTimeout(() => relay.send({ type: 'error', sessionId: 'sess-1', message: 'Session busy', reason: 'session-busy' }), 10)
       await expect(client.connectDevice('sess-1')).rejects.toThrow('Session busy')
     })
 
+    it('does not resolve one join with another session\'s refusal', async () => {
+      // **#512 finding 1.** Before L5d `error` carried no address, so the waiter's `sessionId === undefined`
+      // half was always true and any refusal resolved any pending join. Two joins in flight and the first
+      // refusal woke the wrong one — reported as a failure that session never had — while the one that was
+      // actually refused waited out its deadline, because `dispatch` resolves only the first match.
+      const other = client.connectDevice('sess-OTHER')
+      relay.send({ type: 'error', sessionId: 'sess-1', message: 'Session busy', reason: 'session-busy' })
+
+      expect(await Promise.race([
+        other.then(() => 'resolved').catch(() => 'rejected'),
+        new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+      ])).toBe('still-waiting')
+      other.catch(() => { /* times out on its own deadline */ })
+    }, 15_000)
+
+    it('is not resolved by an unaddressed refusal, and logs the skew once', async () => {
+      // The `sessionId === undefined` escape only fires for a refusal carrying **no** address, so the
+      // foreign-address test above does not exercise it — a mutation putting the escape back left all 80
+      // tests passing. This is the case that holds it, and the same one that holds the skew log.
+      //
+      // A relay older than L5d sends unaddressed refusals. They match nothing now, so the join runs to its
+      // deadline instead of throwing `'Session busy'` — advice the caller could have acted on. Taken
+      // deliberately over a fallback, and logged once per socket because nothing else announces a relay's
+      // version and the join's own timeout says nothing about why.
+      const logged: string[] = []
+      const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => { logged.push(String(m)) })
+      try {
+        const pending = client.connectDevice('sess-1')
+        relay.send({ type: 'error', message: 'Session busy', reason: 'session-busy' })   // no sessionId
+        await new Promise((r) => setTimeout(r, 20))
+        relay.send({ type: 'error', message: 'Session busy', reason: 'session-busy' })   // and again
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(await Promise.race([
+          pending.then(() => 'resolved').catch(() => 'rejected'),
+          new Promise<string>((r) => setTimeout(() => r('still-waiting'), 150)),
+        ])).toBe('still-waiting')
+        pending.catch(() => { /* times out on its own deadline */ })
+      } finally { spy.mockRestore() }
+      // Once, not twice: an old relay refuses every join this way, and a line per refusal would bury it.
+      expect(logged.filter((l) => l.includes('predates addressed errors'))).toHaveLength(1)
+    }, 15_000)
+
     it('throws on session not found error', async () => {
-      setTimeout(() => relay.send({ type: 'error', message: 'Session not found' }), 10)
+      setTimeout(() => relay.send({ type: 'error', sessionId: 'sess-1', message: 'Session not found', reason: 'session-not-found' }), 10)
       await expect(client.connectDevice('sess-1')).rejects.toThrow('Session not found')
     })
   })

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -147,6 +147,23 @@ export class TapflowClient {
    *  second correlation strategy. */
   private skewedSessions = new Set<string>()
 
+  /** Sessions seen refused by an **unaddressed** `error`, so a relay older than L5d.
+   *
+   *  Kept apart from the ack skew set only because the two answer different questions; the reasoning is the
+   *  same one. An unaddressed refusal cannot match a join waiter, so the join burns its deadline and the
+   *  caller is told "timed out" instead of "this session is in use" — #512's complaint arriving through a
+   *  different door. Nothing announces a relay's version, so this frame is the only signal there is. */
+  private addressSkewSessions = new Set<string>()
+
+  private noteAddressSkew(sessionId: string): void {
+    if (this.addressSkewSessions.has(sessionId)) return
+    this.addressSkewSessions.add(sessionId)
+    console.error(
+      `[tapflow] a session:start refusal for ${sessionId} carried no sessionId — this relay predates addressed ` +
+      'errors, so the join will time out rather than report why it was refused. Upgrade the relay.',
+    )
+  }
+
   private noteAckSkew(sessionId: string): void {
     if (this.skewedSessions.has(sessionId)) return
     this.skewedSessions.add(sessionId)
@@ -206,6 +223,14 @@ export class TapflowClient {
     // the one that arrives *late*: it missed its window, was reported optimistically, and still proves
     // this agent acks — so the next input can be judged strictly. A ledger kept at the waiter would
     // never see it.
+    // An unaddressed refusal matches no waiter now, so without this it is dropped in silence and the join
+    // that it answers reports a timeout. Recorded here rather than at the waiter for the same reason the ack
+    // ledger is: the frame arrives whether or not anything is still waiting for it.
+    if (msg['type'] === 'error' && typeof msg['sessionId'] !== 'string') {
+      // No session to key on, so key on the one the caller asked about — there is exactly one join in flight
+      // per socket, and `waiters` is where it is.
+      this.noteAddressSkew('a pending join')
+    }
     if (msg['type'] === 'input:done') {
       const sid = msg['sessionId']
       const id = msg['requestId']
@@ -252,7 +277,19 @@ export class TapflowClient {
     const msg = await this.waitFor(
       (m) =>
         (m['type'] === 'session:joined' && m['sessionId'] === sessionId) ||
-        (m['type'] === 'error' && (m['sessionId'] === undefined || m['sessionId'] === sessionId)),
+        // **No `=== undefined` escape.** `error` carries an address as of L5d, and the escape is what #512's
+        // first finding was: with no such key the left half was always true, so *any* refusal resolved *any*
+        // pending join. Two concurrent joins and the first refusal woke the wrong one — reported as a failure
+        // the other session never had, while the one that did fail waited out its deadline, because
+        // `dispatch` resolves only the first matching waiter.
+        //
+        // The cost is version skew, and it is taken deliberately rather than hedged: a client newer than its
+        // relay sees unaddressed refusals, which now match nothing, so the join runs to its deadline instead
+        // of throwing `'Session busy'` — advice the caller could have acted on. There is no version handshake
+        // anywhere in this protocol, so the alternative was a fallback, and a fallback here is exactly the
+        // ambiguity this work removes. `noteAddressSkew` logs it instead, once per session: the same shape as
+        // the input-ack skew record, on the same reasoning that logging is not matching.
+        (m['type'] === 'error' && m['sessionId'] === sessionId),
       5_000,
     )
     if (msg['type'] === 'error') throw new Error((msg['message'] as string) ?? 'Connect failed')

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -147,20 +147,28 @@ export class TapflowClient {
    *  second correlation strategy. */
   private skewedSessions = new Set<string>()
 
-  /** Sessions seen refused by an **unaddressed** `error`, so a relay older than L5d.
+  /** Whether an **unaddressed** `error` has been seen, so a relay older than L5d. Once per client.
    *
-   *  Kept apart from the ack skew set only because the two answer different questions; the reasoning is the
-   *  same one. An unaddressed refusal cannot match a join waiter, so the join burns its deadline and the
-   *  caller is told "timed out" instead of "this session is in use" — #512's complaint arriving through a
-   *  different door. Nothing announces a relay's version, so this frame is the only signal there is. */
-  private addressSkewSessions = new Set<string>()
+   *  Same reasoning as the ack skew set above and a **different cardinality**, which is the part worth
+   *  stating: an agent is per session, so its skew is recorded per session — different devices answer from
+   *  different agents, and one old agent says nothing about the next. A relay is per *client*. This class
+   *  holds one socket to one relay for the life of the process, so "this relay predates addressed errors" is
+   *  answered once and cannot change under us.
+   *
+   *  Keying it per session was tried and is not available: the frame carries **no** session, and the only
+   *  other candidate — the join in flight — is unreadable, because `Waiter` keeps its predicate as a closure
+   *  and no session id survives on the record. Reaching for it anyway would mean naming a session on a
+   *  guess, and one refusal cannot be attributed to one of several pending joins. That guess is the defect
+   *  this whole slice removes, so the diagnostic must not reintroduce it: the line names the relay, which is
+   *  what the operator has to act on, and does not name a session it cannot know. */
+  private addressSkewLogged = false
 
-  private noteAddressSkew(sessionId: string): void {
-    if (this.addressSkewSessions.has(sessionId)) return
-    this.addressSkewSessions.add(sessionId)
+  private noteAddressSkew(): void {
+    if (this.addressSkewLogged) return
+    this.addressSkewLogged = true
     console.error(
-      `[tapflow] a session:start refusal for ${sessionId} carried no sessionId — this relay predates addressed ` +
-      'errors, so the join will time out rather than report why it was refused. Upgrade the relay.',
+      '[tapflow] a session:start refusal carried no sessionId — this relay predates addressed errors, so ' +
+      'joins will time out rather than report why they were refused. Upgrade the relay.',
     )
   }
 
@@ -225,12 +233,11 @@ export class TapflowClient {
     // never see it.
     // An unaddressed refusal matches no waiter now, so without this it is dropped in silence and the join
     // that it answers reports a timeout. Recorded here rather than at the waiter for the same reason the ack
-    // ledger is: the frame arrives whether or not anything is still waiting for it.
-    if (msg['type'] === 'error' && typeof msg['sessionId'] !== 'string') {
-      // No session to key on, so key on the one the caller asked about — there is exactly one join in flight
-      // per socket, and `waiters` is where it is.
-      this.noteAddressSkew('a pending join')
-    }
+    // ledger is: the frame arrives whether or not anything is still waiting for it — and the refusal that
+    // arrives *after* its join gave up is the one an operator most needs explained, because that caller has
+    // already been told "timed out" with no cause. A `waiters.length > 0` guard here would drop exactly that
+    // one, which is why a test holds its absence.
+    if (msg['type'] === 'error' && typeof msg['sessionId'] !== 'string') this.noteAddressSkew()
     if (msg['type'] === 'input:done') {
       const sid = msg['sessionId']
       const id = msg['requestId']
@@ -287,7 +294,7 @@ export class TapflowClient {
         // relay sees unaddressed refusals, which now match nothing, so the join runs to its deadline instead
         // of throwing `'Session busy'` — advice the caller could have acted on. There is no version handshake
         // anywhere in this protocol, so the alternative was a fallback, and a fallback here is exactly the
-        // ambiguity this work removes. `noteAddressSkew` logs it instead, once per session: the same shape as
+        // ambiguity this work removes. `noteAddressSkew` logs it instead, once per client: the same shape as
         // the input-ack skew record, on the same reasoning that logging is not matching.
         (m['type'] === 'error' && m['sessionId'] === sessionId),
       5_000,

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -64,17 +64,28 @@ conversion, so they are written down here instead:
   invisibly, because `src/__tests__` is outside that package's tsconfig.
 - **An `interface` can be reopened by a consumer.** `declare module '@tapflowio/protocol'` can add a
   field to any message, which an anonymous union member could not. Measured: a consumer can give
-  `GenericError` a `sessionId` and defeat the assertion in `typeAssertions.ts` that says it has none.
+  `session:joined` a `deviceId` and defeat the `typeAssertions.ts` assertion that says it has none —
+  the file's only whole-message excess-property check. (That example used to be `GenericError` and a
+  `sessionId`; L5d made that field **required**, so the augmentation it described is now the declaration.)
   It takes deliberate augmentation, so the risk is low — but the HOW NOT rule below ("do not widen a
   message") is now bypassable without editing this package.
 
 ### The name must be derivable from the literal
 
 `InputDone` ↔ `input:done`: PascalCase over the literal's `:` and `-` segments. Six names deliberately
-break the rule and are listed in `scripts/__tests__/protocolMessageNames.test.mjs` — `GenericError`
-(`Error` would shadow the global), and `AppInstall`/`AppLaunch` × `ToAgent`/`ToRelay`, because those two
-literals travel in both directions carrying **different shapes**: the browser sends `buildId`, the relay
-resolves it into `payload: { filePath, bundleId }`. Naming forced that split into the open.
+break the rule and are listed in `scripts/__tests__/protocolMessageNames.test.mjs` — count the list here
+against `NAME_EXCEPTIONS`, because a number that stopped matching its own enumeration is a defect this
+section has already shipped once:
+
+- `GenericError`, because `Error` would shadow the global. Renaming the interface does not remove the
+  exception — the derivation reads the **wire literal**, so only renaming `'error'` itself would, and that
+  reaches every consumer.
+- `AgentResourceReport`, because `agent:resources` derives `AgentResources`, which this package already
+  exports as the *payload* shape the message carries. Renaming the payload is a breaking change to a
+  published type that `agent-core`, `relay` and `dashboard` all re-export.
+- `AppInstall`/`AppLaunch` × `ToAgent`/`ToRelay`, because those two literals travel in both directions
+  carrying **different shapes**: the browser sends `buildId`, the relay resolves it into
+  `payload: { filePath, bundleId }`. Naming forced that split into the open.
 
 `device:shutdown` is the opposite case — identical in both directions, so it is **one** interface that
 `RelayToAgent` and `BrowserToRelay` both reference, which states that the relay forwards it untouched.
@@ -371,9 +382,13 @@ A browser receives 28 message types. They come from two producers, and the diffe
 
 ### `sessionId` stays required, even where the relay cannot prove it
 
-The relay reaches seven of its own error sites through `msg.sessionId!` — an assertion the compiler
-cannot verify — and `JSON.stringify` drops a key whose value is `undefined`. The fix is **not** to
-widen the declaration:
+The relay reaches eleven sessions through `msg.sessionId!` — an assertion the compiler cannot verify —
+and `JSON.stringify` drops a key whose value is `undefined`. **Eight are agent→browser forwards and three
+are request-side paths that deliberately have no address gate**; the seven *reply* sites this paragraph
+used to count went away with L5c's door predicates, and the number outlived them here. The composition
+matters more than the total, because "all forwards" invites the conclusion that the request side is
+settled — and `device:shutdown` is on the request side with no ownership gate either (#527). The fix is
+**not** to widen the declaration:
 
 - Every in-repo sender does supply one. `BrowserToRelay` declares `sessionId: string` on every member
   but `agents:list`, and since L4c all three senders are typed against that union, so the compiler

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -70,7 +70,7 @@ conversion, so they are written down here instead:
 
 ### The name must be derivable from the literal
 
-`InputDone` ↔ `input:done`: PascalCase over the literal's `:` and `-` segments. Five names deliberately
+`InputDone` ↔ `input:done`: PascalCase over the literal's `:` and `-` segments. Six names deliberately
 break the rule and are listed in `scripts/__tests__/protocolMessageNames.test.mjs` — `GenericError`
 (`Error` would shadow the global), and `AppInstall`/`AppLaunch` × `ToAgent`/`ToRelay`, because those two
 literals travel in both directions carrying **different shapes**: the browser sends `buildId`, the relay
@@ -275,6 +275,37 @@ whose failure half does not exist would leave it half-correlated, and the half t
 platform-asymmetric — Android's toggle has no device-side effect at all, so what its failure even means is a
 decision that slice has to make. `#517` is the prerequisite.
 
+## `error` is the session-start refusal, not an escape hatch
+
+L5d ended a contradiction that sat in this file and in `index.ts` at once for two months. `GenericError`'s doc
+claimed *"the escape hatch for a failure the relay cannot correlate to a session"*, while
+`SessionStartFailure`'s claimed the reason has **a single producer inside `handleSessionStart`**. Both cannot
+be true, and the program plan recorded that they were both in HEAD.
+
+L5c settled it by removing the general role rather than the specific one. A request naming no session is
+dropped at the relay's door (`isAddressed`), because answering it would ship a frame whose own required
+`sessionId` `JSON.stringify` erases — and `error` has no `requestId` either, so a caller could not attribute
+the answer and would wait out the same deadline silence costs. With nothing left needing an unaddressed
+failure, all four producers answer one specific join, and `error` **extends `SessionError`**: the shape is the
+base verbatim, and the base's own definition — a failure a *session* is waiting on — is now exactly what it is.
+
+**What the address buys.** The join waiters in `mcp-server` and `flow-runner` matched
+`sessionId === undefined || sessionId === mine`, and with no such key the left half was *always* true — so any
+refusal resolved any pending join. Two concurrent joins and the first refusal woke the wrong one, reported as a
+failure that session never had, while the one that was actually refused waited out its deadline, because
+`dispatch` resolves only the first matching waiter. That is #512's first finding, and the escape was it.
+
+**The name stays `GenericError` even though the role narrowed.** The derivation rule would give `Error`, which
+shadows the global, so the exception is anchored to the *literal* rather than to the role — `SessionStartError`
+would need an exception entry just the same, and removing the entry needs a new wire literal. Renaming would
+have cost every consumer plus `typeAssertions` and bought nothing.
+
+**Skew is logged, not hedged.** A client newer than its relay sees unaddressed refusals, which now match
+nothing, so the join runs to its deadline instead of reporting why. There is no version handshake anywhere in
+this protocol, so the alternative was a fallback — the ambiguity this work exists to remove. Both clients log
+once per session instead, the same shape and the same reasoning as the input-ack skew record: logging is not
+matching.
+
 ## Every direction is declared, and an agent's send is typed
 
 The six unions cover the whole wire: `BrowserToRelay`, `AgentToRelay`, `RelayToAgent`, `RelayToBrowser`,
@@ -350,9 +381,11 @@ widen the declaration:
   `flow-runner`) set it too" — true when written, and falsified by the work that typed them.)
 - `'Session not found'` answers a sessionId that did not **match** — a stale tab, a terminated
   session — not one that was absent.
-- `{ type: 'error'; message: string }` is the escape hatch for a genuinely uncorrelatable failure. So
-  the right move when there is no sessionId is to send *that*, and the required field is what forces
-  the choice.
+- `{ type: 'error' }` **is not** an escape hatch, as of L5d — it is the answer to a `session:start` the relay
+  refused, it extends `SessionError`, and it names the session it refuses. The paragraph that stood here said
+  the right move with no sessionId was to send *that*; L5c settled it the other way, by dropping a request
+  that names no session at the door. Both halves of the old advice are gone: there is no unaddressed failure
+  left to send, and nothing left that would need one.
 
 Widening would let #444 delete those `!` with no consumer forced to care, and the guarantee would go
 quietly with them. It is also close to irreversible: once optional, every consumer grows a guard.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -314,8 +314,14 @@ have cost every consumer plus `typeAssertions` and bought nothing.
 **Skew is logged, not hedged.** A client newer than its relay sees unaddressed refusals, which now match
 nothing, so the join runs to its deadline instead of reporting why. There is no version handshake anywhere in
 this protocol, so the alternative was a fallback — the ambiguity this work exists to remove. Both clients log
-once per session instead, the same shape and the same reasoning as the input-ack skew record: logging is not
-matching.
+instead, on the same reasoning as the input-ack skew record: logging is not matching.
+
+**The same reasoning, a different cardinality — once per *client*, where the ack record is once per session.**
+An agent is per session, so one old agent says nothing about the next device's; a relay is one per client for
+the life of the process. Keying this one per session is not available either: the frame carries no address,
+and naming the join in flight would mean guessing between pending ones, which is the false attribution L5d
+removes. A first draft keyed on a literal and documented itself as per-session, which made it per-*process* —
+so against an old relay the first refused session logged and every later one was silent.
 
 ## Every direction is declared, and an agent's send is typed
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -553,12 +553,34 @@ export type SessionStartFailure =
   /** The Mac is over its resource ceiling and refused to take another session. */
   | 'agent-resources-exhausted'
 
-// The escape hatch for a failure the relay cannot correlate to a session. Every typed member above
-// carries a sessionId; when there is genuinely none to carry, this is the message to send — not a
-// typed error with the key dropped by `JSON.stringify`.
-export interface GenericError {
+/**
+ * The answer to a `session:start` the relay refused. **Not a general escape hatch**, which is what this
+ * comment used to claim — and the claim could not coexist with `SessionStartFailure`'s, one screen up, that
+ * the reason has a single producer inside `handleSessionStart`. Both were in HEAD at once for two months.
+ *
+ * L5c settled it by removing the general role rather than the specific one: a request that names no session
+ * is now **dropped at the relay's door** (`isAddressed`), because answering it would ship a frame whose own
+ * required `sessionId` `JSON.stringify` erases, and `error` has no `requestId` either — so a caller could not
+ * attribute the answer and would wait out the same deadline silence costs. With nothing left needing an
+ * unaddressed failure, every producer of this message answers one specific join.
+ *
+ * **So it extends `SessionError`**, and that is the honest form rather than a field bolted on: the shape is
+ * the base verbatim, and the base's own definition — a failure a *session* is waiting on — is now exactly
+ * what this is. `protocolMessageNames.test.mjs` enforces that membership, and its note saying `error`
+ * "cannot be a `SessionError`" described a nature this change replaced.
+ *
+ * What the address buys: the join waiters in `mcp-server` and `flow-runner` matched
+ * `sessionId === undefined || sessionId === mine`, and with no such key the left half was **always true**, so
+ * any `error` resolved any pending join. Two concurrent `connect_device` calls and the first refusal woke the
+ * wrong one — reported as a failure the other session never had, while the one that did fail waited out its
+ * deadline. `dispatch` resolves only the first matching waiter, so that is one wrong answer and one timeout.
+ *
+ * The name stays `GenericError` despite the narrowed role. The derivation rule would give `Error`, which
+ * shadows the global, so the exception exists for the literal rather than the role — renaming to
+ * `SessionStartError` needs an exception entry just the same, and removing it needs a new wire literal.
+ */
+export interface GenericError extends SessionError {
   type: 'error'
-  message: string
   reason: SessionStartFailure
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -397,25 +397,35 @@ export interface DeviceReady {
 }
 
 /**
- * `sessionId` is what makes a failure findable. A dashboard viewer holds one session per socket,
- * so an uncorrelated error still lands somewhere sensible — but an MCP caller waits for the reply
- * that carries its own sessionId, and without one it waits out the deadline instead (#445).
+ * `sessionId` is what makes a failure findable. An MCP caller waits for the reply that carries its own
+ * sessionId, and without one it waits out the deadline instead (#445).
  *
  * Required here is a **specification the relay does not yet meet**, not a description of the wire.
  * Nothing validates inbound messages, so a client that sends `{"type":"input:touch:end"}` with no
- * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers `'Session not found'`
- * through `msg.sessionId!` — `JSON.stringify` then drops the key, shipping a frame whose required field
- * this declaration says is there. **Still seven sites**, re-counted after L5c restructured that file
- * (`RelayServer.ts:775,827,844,903,1181,1192,1331`) — the correlation work did not widen it and does not
- * close it, because the fix is the one below: the producer must send `error` instead, which is #444.
- * No in-repo client omits a sessionId, so the gap is reachable only from a third-party one — with one exception measured since: `sessionId: ''`
- * type-checks and `mcp-server`'s tools take `z.string()`, so an LLM can produce it.
+ * sessionId reaches `sessions.get(undefined)`, misses, and the relay answers through `msg.sessionId!` —
+ * `JSON.stringify` then drops the key, shipping a frame whose required field this declaration says is there.
+ * No in-repo client omits a sessionId, so the gap is reachable only from a third-party one — with one
+ * exception measured since: `sessionId: ''` type-checks and `mcp-server`'s tools take `z.string()`, so an LLM
+ * can produce it.
+ *
+ * **The request side is closed and the count below is not the one it used to be.** L5c's door predicates
+ * (`isCorrelated`, `isAddressed`) narrowed the handlers, which removed the seven reply sites this note used
+ * to enumerate; the line numbers it carried outlived them and pointed at unrelated code for one release. What
+ * is left is eleven `sessions.get(msg.sessionId!)` in `RelayServer.ts`, and it is **not** uniformly one kind:
+ * eight are agent→browser forwards (`session:chrome`, `session:deviceInfo`, `device:booting`,
+ * `device:boot-error`, `device:shutdown-done`, `device:ready`, `keyboard:toggled`, `clipboard:error`), and
+ * three are request-side paths that deliberately carry no address gate — `stream:register` on a stream-role
+ * socket, `device:shutdown` (whose gate a mutation showed nothing could hold, since an unaddressed shutdown
+ * is dropped by the session miss anyway), and `forwardUnacked`. Count them by reading the sites, not by
+ * trusting this sentence: a stale number here is what taught the lesson.
  *
  * Optional would describe that wire accurately and still be the wrong contract: an MCP caller that
- * receives an uncorrelatable `input:error` has nothing it can do with it — it waits out the
- * deadline either way. The producer is what has to change, and the only correct thing for it to
- * send with no sessionId is `{ type: 'error' }` below, which exists for exactly that. So this
- * required field is what makes #444 "send `error` instead" rather than "delete the `!`".
+ * receives an uncorrelatable `input:error` has nothing it can do with it — it waits out the deadline either
+ * way. The producer is what has to change, and #444 is the validator that makes it. An earlier version of
+ * this note said the producer should "send `error` instead", pointing at `GenericError` below as an escape
+ * hatch for a failure with no session. **That escape is gone**: `GenericError` requires `sessionId` since
+ * L5d, and the door predicates drop such a request rather than answering it, because a reply carrying no
+ * `requestId` cannot be attributed and costs the caller the same deadline silence would.
  */
 export interface SessionError {
   sessionId: string

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -28,8 +28,17 @@ export const unknownType: RelayOutbound = { type: 'nope', message: 'x' }
 // @ts-expect-error - `capabilities` is required on session:joined
 export const missingField: RelayOutbound = { type: 'session:joined', sessionId: 's' }
 
-// @ts-expect-error - `error` carries no sessionId
-export const extraField: RelayOutbound = { type: 'error', message: 'x', sessionId: 's' }
+// L5d made `error` an addressed `session:start` reply, so the line that used to sit here — asserting it
+// carries **no** `sessionId` — now describes the opposite of the contract. It is not simply deleted: it was
+// this file's only whole-message excess-property assertion (`unknownType` tests a bad literal, `missingField`
+// a missing required field, `legacyKeyField` an excess key nested inside `payload`), and an unused
+// `@ts-expect-error` is itself an error, so retiring it silently would drop an assertion *class* as a side
+// effect of narrowing one message. Relocated to a message that has no reason to grow a field.
+// @ts-expect-error - `session:joined` has no `deviceId`; the session already names the device
+export const extraField: RelayOutbound = { type: 'session:joined', sessionId: 's', capabilities: [], deviceId: 'd' }
+
+// And `error` now belongs to the family, which is the positive half of the same change.
+export const addressedError: RelayOutbound = { type: 'error', sessionId: 's', message: 'x', reason: 'session-busy' }
 
 // Kept on one line each: `@ts-expect-error` applies to the next line only, so a multi-line literal
 // whose error lands three lines down leaves the directive unused — which reads as a failure of the
@@ -66,7 +75,7 @@ export const relayCannotOriginateKeyboard: RelayOutbound = { type: 'keyboard:tog
 
 // A consumer reads the whole surface, whoever sent it — both of the above are valid here.
 export const inboundFromAgent: BrowserInbound = { type: 'input:done', sessionId: 's', requestId: 'rq' }
-export const inboundFromRelay: BrowserInbound = { type: 'error', message: 'x', reason: 'session-busy' }
+export const inboundFromRelay: BrowserInbound = { type: 'error', sessionId: 's', message: 'x', reason: 'session-busy' }
 
 // @ts-expect-error - sessionId is required on every one of the twelve forward-only messages
 export const forwardWithoutSession: AgentToBrowser = { type: 'app:install-done' }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -118,12 +118,19 @@ function ownershipRefusal(session: Session): string {
  *  these doors produce declares `sessionId` **required**, so answering means putting a frame on the wire
  *  whose required field `JSON.stringify` erases, which every consumer's session gate then discards.
  *
- *  **So the request is dropped, not answered**, and the note that used to sit on `SessionError` said the
- *  opposite: "the only correct thing for it to send with no sessionId is `{ type: 'error' }`". That was
- *  written before requests carried a second correlator, and its own premise refutes it now — `GenericError`
- *  has no `requestId`, so a caller that receives one cannot attribute it and waits out the same deadline it
- *  would have waited out on silence. Answering buys nothing it did not already have; not shipping a frame
- *  that violates its own declaration is the whole payoff, and dropping achieves that more cheaply.
+ *  **So the request is dropped, not answered.** `SessionError`'s doc argued the opposite until L5d — "the
+ *  only correct thing for it to send with no sessionId is `{ type: 'error' }`" — and its own premise refutes
+ *  it: `GenericError` has no `requestId`, so a caller that receives one cannot attribute it and waits out the
+ *  same deadline it would have waited out on silence. Answering buys nothing it did not already have; not
+ *  shipping a frame that violates its own declaration is the whole payoff, and dropping achieves that more
+ *  cheaply. L5d then made `error` require `sessionId`, so the escape it named no longer exists at all.
+ *
+ *  The general form of that argument — "a caller cannot attribute an unaddressed answer" — is **narrower than
+ *  it sounds**, and worth stating so nobody builds on the wide version. A dashboard viewer holds one session
+ *  per socket, so an unaddressed reply would land somewhere sensible there; `SessionList` attributes a
+ *  shutdown by single-slot convention with no correlator at all. What makes dropping right here is not that
+ *  attribution is impossible for every consumer, but that the frame would violate its own declaration and be
+ *  discarded by each consumer's session gate before any of them looked.
  *
  *  Widening `SessionStartFailure` to carry an "unaddressed" reason was the alternative, and it is what L5d
  *  is for: that union's own doc says it has a single producer in `handleSessionStart`, and adding a member
@@ -1323,7 +1330,9 @@ export class RelayServer {
    *  session that has never acked as **success** (#457) — so a silent drop here would report an input that
    *  never left the relay as landed, which is worse than the misrouting it replaced. */
   private handleAckedInput(ws: WebSocket, msg: RelayMessage & { requestId: string; sessionId: string }): void {
-    const session = this.sessions.get(msg.sessionId!)
+    // No `!`: the door predicate narrowed the parameter, so the assertion here was dead and counted itself
+    // into #444's remaining body as if it were a real gap.
+    const session = this.sessions.get(msg.sessionId)
 
     if (session && !this.ownsSession(ws, session)) {
       // `not-session-owner` rather than `channel-unavailable`, on that set's own rule — a reason exists per

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1170,10 +1170,16 @@ export class RelayServer {
     logger.info(`agent connected: ${msg.agentName ?? msg.agentId ?? 'unknown'} (${msg.platform ?? 'unknown'}) — ${registeredSessions.length} device(s)`)
   }
 
+  /** The only producer of `error` — all four exits below, and nothing else in the repo sends that message.
+   *
+   *  That is what makes the address possible rather than aspirational: `msg.sessionId` is narrowed to a
+   *  non-empty `string` by the door (`isAddressed`), so every refusal can name the join it refuses. Before
+   *  L5d they carried none, and the clients' join waiters matched `sessionId === undefined || sessionId ===
+   *  mine` — with no such key the left half was always true, so any refusal resolved any pending join. */
   private handleSessionStart(ws: WebSocket, msg: RelayMessage & { sessionId: string }): void {
     const session = this.sessions.get(msg.sessionId)
     if (!session) {
-      this.sendTo(ws, { type: 'error', message: 'Session not found', reason: 'session-not-found' })
+      this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session not found', reason: 'session-not-found' })
       return
     }
     // Occupancy first, because it is the more specific answer and both can be true at once. A tester
@@ -1184,7 +1190,7 @@ export class RelayServer {
     // `!== ws` because a socket re-joining the session it already holds is not contending with anyone:
     // `SessionList` sends `session:start` before a shutdown, so pressing shutdown twice hit this.
     if (session.browserSocket && session.browserSocket !== ws && session.browserSocket.readyState === WebSocket.OPEN) {
-      this.sendTo(ws, { type: 'error', message: 'Session busy', reason: 'session-busy' })
+      this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session busy', reason: 'session-busy' })
       return
     }
     // Read before the resource gate, and answered before it too. The gate would otherwise read the
@@ -1195,7 +1201,7 @@ export class RelayServer {
     if (resources) {
       const memPercent = (resources.memUsedMB / resources.memTotalMB) * 100
       if (resources.cpuPercent > RESOURCE_THRESHOLD || memPercent > RESOURCE_THRESHOLD) {
-        this.sendTo(ws, { type: 'error', message: 'Agent resources exhausted', reason: 'agent-resources-exhausted' })
+        this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Agent resources exhausted', reason: 'agent-resources-exhausted' })
         return
       }
     }
@@ -1208,7 +1214,7 @@ export class RelayServer {
       // `catch {}` also discarded the error entirely: nothing reached the route-level handler, because
       // this swallowed it first.
       logger.error(`session:start could not join ${msg.sessionId}:`, e)
-      this.sendTo(ws, { type: 'error', message: 'Session not found', reason: 'session-not-found' })
+      this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session not found', reason: 'session-not-found' })
       return
     }
     // Include the agent's capabilities so the viewer knows up front what is implemented on

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -181,6 +181,40 @@ describe('RelayServer', () => {
     browser.close()
   })
 
+  it('addresses the refusal from the unanticipated join failure too', async () => {
+    // The fourth `error` exit, and the only one no other test reaches: `join()` throws for not-found and busy
+    // as well, and both are answered above it, so getting here means a condition the handler did not foresee.
+    // Its own comment says so, and that is why it exists — an earlier version was a bare `catch {}` that
+    // swallowed the cause entirely.
+    //
+    // Forced with a spy rather than left unpinned. A mutation confirmed the gap: replacing this exit's address
+    // with a literal passed all 619 relay tests, and an address no test can hold is one that will drift.
+    const devices = [{ id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' }]
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({ type: 'agent:register', devices }))
+    const { registeredSessions } = await waitForMessage(agent)
+    const sessionId = registeredSessions![0].sessionId
+
+    const sessions = (server as unknown as { sessions: { join(id: string, ws: WebSocket): void } }).sessions
+    const join = vi.spyOn(sessions, 'join').mockImplementation(() => { throw new Error('unforeseen') })
+    try {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const msg = await waitForMessage(browser)
+
+      expect(msg.type).toBe('error')
+      expect(msg.sessionId).toBe(sessionId)
+      // `session-not-found` rather than `session-busy`, because busy was already answered above — putting a
+      // specific claim on an unknown cause is what `reason` exists to stop.
+      expect(msg.reason).toBe('session-not-found')
+      browser.close()
+    } finally { join.mockRestore() }
+
+    agent.close()
+  })
+
   it('returns error when joining a non-existent session', async () => {
     const browser = new WebSocket(`ws://localhost:${port}`)
     await waitForOpen(browser)
@@ -188,6 +222,10 @@ describe('RelayServer', () => {
     const msg = await waitForMessage(browser)
     expect(msg.type).toBe('error')
     expect(msg.message).toBe('Session not found')
+    // The refusal names the id it could not find — the session does not exist, but the *request* does, and it
+    // is the request the caller's waiter is keyed on.
+    expect(msg.sessionId).toBe('bad-id')
+    expect(msg.reason).toBe('session-not-found')
     browser.close()
   })
 
@@ -210,6 +248,13 @@ describe('RelayServer', () => {
     const msg = await waitForMessage(browser2)
     expect(msg.type).toBe('error')
     expect(msg.message).toBe('Session busy')
+    // L5d. Every refusal names the join it refuses, and each of the four exits needs its own assertion:
+    // asserting one leaves the other three free to carry a literal, and the two `'Session not found'` exits
+    // are especially easy to mistake for one. Before this, `error` carried no address at all and the clients'
+    // join waiters had a `sessionId === undefined` escape that let any refusal resolve any pending join —
+    // #512's first finding.
+    expect(msg.sessionId).toBe(sessionId)
+    expect(msg.reason).toBe('session-busy')
 
     agent.close()
     browser1.close()
@@ -1245,6 +1290,7 @@ describe('RelayServer', () => {
       const msg = await waitForMessage(browser)
       expect(msg.type).toBe('error')
       expect(msg.message).toBe('Agent resources exhausted')
+      expect(msg.sessionId).toBe(sessionId)
 
       agent.close()
       browser.close()
@@ -1261,6 +1307,7 @@ describe('RelayServer', () => {
       const msg = await waitForMessage(browser)
       expect(msg.type).toBe('error')
       expect(msg.message).toBe('Agent resources exhausted')
+      expect(msg.sessionId).toBe(sessionId)
 
       agent.close()
       browser.close()

--- a/packages/relay/src/__tests__/RelayServer.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.test.ts
@@ -176,6 +176,14 @@ describe('RelayServer', () => {
     browser.send(JSON.stringify({ type: 'session:start', sessionId }))
     const msg = await waitForMessage(browser)
     expect(msg.type).toBe('session:joined')
+    // **The address on the success half, and nothing held it.** L5d added four assertions that each
+    // *refusal* names the right session and none that the reply does — and the reply is the one both
+    // clients already matched strictly (`sessionId === mine`), so it had the largest blast radius and the
+    // least coverage. Measured: pointing it at `session.deviceId` instead passed relay 620, ios 382,
+    // android 263 and the static suite, while **no client could join at all** — viewer spinning forever,
+    // `connect_device` and `joinSession` burning their deadlines. The agent suites miss it because they
+    // wait on the type alone; `waitForMessage` here returns the frame, so the id is readable.
+    expect(msg.sessionId).toBe(sessionId)
 
     agent.close()
     browser.close()

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -257,7 +257,7 @@ describe('browser-inbound routing matches the protocol union', () => {
       'session:terminated': 'reason sessionId',
       'session:agent-away': 'sessionId',
       'session:rebound': 'capabilities sessionId',
-      error: 'message reason',
+      error: 'message reason sessionId',
     },
   }
 

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -138,15 +138,19 @@ describe('protocol message interfaces', () => {
     for (const [name, { literal, extends: base, body }] of messages) {
       const isFailure = /error$/.test(literal) && !REQUEST_SCOPED.has(literal)
       const hasSession = /^ {2}sessionId[?]?:/m.test(body) || base === 'SessionError'
-      // `error` is the escape hatch for a failure that cannot be attributed to a session, so it has no
-      // `sessionId` and cannot be a `SessionError`. That is the member's nature, not an exception.
+      // `error` used to be excluded here, on the grounds that it was the escape hatch for a failure that
+      // could not be attributed to a session — "the member's nature, not an exception". L5d replaced that
+      // nature: a request naming no session is dropped at the relay's door, so every producer of `error`
+      // answers one specific join, and it joins the family like every other session-scoped failure. The
+      // predicate needed no change; what changed is that `error` now satisfies it.
       if (!isFailure || !hasSession) continue
       if (base !== 'SessionError') offenders.push(`${name} ('${literal}')`)
     }
     expect(offenders).toEqual([])
-    expect([...messages].filter(([, m]) => m.extends === 'SessionError')).toHaveLength(8)
-    // The failures that deliberately do not inherit, each for its own reason.
-    expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: null })
+    expect([...messages].filter(([, m]) => m.extends === 'SessionError')).toHaveLength(9)
+    // `error` is the ninth, as of L5d. Pinned by name rather than only by the count, because the count alone
+    // would be satisfied by any new member and this is the one whose membership was argued.
+    expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: 'SessionError' })
     expect(REQUEST_SCOPED.size).toBe(2)
     for (const literal of REQUEST_SCOPED) {
       const entry = [...messages].find(([, m]) => m.literal === literal)


### PR DESCRIPTION
Closes #512's first finding. **Breaking**: `GenericError` gains a required `sessionId` and now `extends SessionError`.

`GenericError`'s doc claimed *"the escape hatch for a failure the relay cannot correlate to a session"*, while `SessionStartFailure`'s claimed the reason has **a single producer inside `handleSessionStart`**. Both could not be true. L5c settled it by removing the general role rather than the specific one — a request naming no session is dropped at the relay's door — so with nothing left needing an unaddressed failure, all four producers answer one specific join.

## What the address buys

The join waiters in `mcp-server` and `flow-runner` matched `sessionId === undefined || sessionId === mine`, and with no such key **the left half was always true**, so any refusal resolved any pending join. Two concurrent `connect_device` calls and the first refusal woke the wrong one — reported as a failure that session never had — while the one actually refused waited out its deadline, because `dispatch` resolves only the first matching waiter.

`extends SessionError` rather than a bolted-on field, because the naming check forced the decision: `protocolMessageNames.test.mjs` asserts that a session-scoped failure declares it, `'error'` already matched `/error$/`, and it survived only because it had no `sessionId`. The name stays `GenericError` — the derivation reads the **wire literal**, and `'error'` yields `Error`, which shadows the global.

A client newer than its relay sees unaddressed refusals, which now match nothing. There is no version handshake anywhere in this protocol, so the alternative was a fallback — and a fallback here is the ambiguity this work removes. Both clients log the skew instead.

## Adversarial review

Two independent channels against `4d4fe138b21aab3b5b53919dfcb0bac3e0c431f7` — mutation gaps, and contract/prose truth (read-only). Record: `.work/reviews/feat__wire-l5d-error-is-addressed.md`, refreshed against `0d2b12c96f0b8c826a3f384d4886ff5cbdccf394`.

**Eight findings, all eight defects in this branch.** Channel 1 executed four mutations and all four survived, returning an explicitly empty cleared list. Channel 2 refuted the first commit's own headline. Nothing was skipped; the second commit is the disposition.

- **`session:joined`'s address held nothing.** Pointing it at `session.deviceId` passed relay 620, ios 382, android 263 and static 275 while **no client could join at all** — both clients match `sessionId === mine` strictly and the dashboard drops the rest. This slice asserted four times that a *refusal* names the right session and zero times that the *reply* does; the reply is the half that was already strict, so it had the largest blast radius and the least cover. The agent suites miss it because they wait on the type alone.
- **The mcp skew log was once per process, not once per session.** It keyed on the literal `'a pending join'`, so against an old relay the first refused session logged and every later one timed out with no trace — and the comment described code that cannot exist, since `Waiter` keeps its predicate as a closure and no session id survives on the record. It is once per **client** now, which is the honest cardinality: an agent is per session, a relay is per client. Keying per session would mean guessing between pending joins, which is the false attribution this slice removes.
- **Two once-guards and one gate reach were free.** Guarding the mcp log on a live waiter passed 81, dropping flow-runner's guard passed 70, and exempting `error` from the dashboard's session gate passed 329. The last is unreachable today because `useRelay` opens a socket per hook — and #527 expires that, so it is pinned in both directions rather than argued.
- **Five stale-prose survivors, four of them the paragraph directly above an edit.** The worst is `SessionError`'s doc, which still carried the retired *"send `error` instead"* argument 140 lines above the rewritten block, in the interface `GenericError` now extends — so the contradiction moved inside one file rather than ending, and a #444 implementer reading the base was told to do the thing this slice removed, with seven line numbers that had drifted onto a `break` and three comments.
- **The remaining `msg.sessionId!` count was wrong and its composition was the misleading half.** Twelve, not eleven, and four were not agent→browser forwards. `handleAckedInput`'s was **dead** — L5c's door predicate had already narrowed that parameter — so it is removed, leaving eleven: eight forwards and three request-side paths with no address gate by design. "All forwards" invited the conclusion that the request side was settled, while `device:shutdown` sits on it with no ownership gate either (#527).

The same false count was in **#528's unreleased changeset**, so it is corrected there too — before it reaches a CHANGELOG.

Six re-verification mutations, none surviving.

## Verification

static 275 · relay 620 (+1 skipped) · dashboard 331 · mcp-server 83 · flow-runner 71 · agent-core 137 · cli 246 · ios-agent 382 · android-agent 263 · audiotap-helper 4. `tsc -b`, `@tapflowio/protocol typecheck` (which covers `tsconfig.assertions.json`, and `tsc -b` does not), and `--noEmit` for `mcp-server` and `dashboard` all clean. Lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DSPRdkt9SEVgPDjhS4PsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session-start refusals now identify the affected session, preventing attribution to the wrong active session.
  * Concurrent joins handle unrelated refusals safely without resolving another session’s request.
  * Legacy unaddressed refusals now time out safely and generate a single diagnostic.
  * Improved handling for session-not-found, busy, and resource-exhaustion scenarios.

* **Documentation**
  * Clarified session-scoped error handling and correlation rules in protocol guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->