### PR TITLE
fix(ios-agent): wait for the simulator to finish booting before device:ready

### DIFF
--- a/.changeset/ios-boot-readiness.md
+++ b/.changeset/ios-boot-readiness.md
@@ -20,14 +20,22 @@ policy. A human is slower than the gap and rarely notices; `mcp-server` installs
 the session's udid removed one of its two causes and left this one, because the two were indistinguishable at
 the time.
 
-**Three readings get three answers.** `unknown` is a device in motion — `toDeviceStatus` collapses `Booting`
-into it — so it gets the whole deadline. `shutdown`, or gone from the list, is what a device looks like when
-nothing is bringing it up, so it gets a 3s grace and no more: the handler skips `boot` entirely when the device
-was already `booted` when it read the list, and a shutdown landing in that window leaves nobody booting
-anything. A **failed** reading is not a reading at all — this spawns `xcrun simctl list` up to 180 times where
-the old code spawned it once, each an independent chance to kill a healthy boot during the interval when
-CoreSimulator is busiest, so failures are retried and the last one is reported with the deadline. Android's poll
-has always swallowed them.
+**Every status other than `booted` counts as still coming up, `shutdown` included.** `toDeviceStatus` collapses
+`Booting` into `unknown`, and the wait only ever runs after a `boot` was accepted, so a `shutdown` reading is
+the transition not yet observed rather than a failure.
+
+Keeping that sentence true costs one line elsewhere: **the boot is now issued on every path, including the one
+where the device list already said `booted`.** That skip came with the original on-demand boot feature as an
+obvious economy and had no recorded reason; once a wait existed it became the only route into it with nothing
+bringing the device up, so a tester who quit the simulator inside one `xcrun` round trip paid the full
+deadline. `SimctlWrapper.boot` swallows `Unable to boot device in current state: Booted`, so the economy was
+one no-op subprocess. A short grace on `shutdown` inside the poll was tried first and reverted: that reading is
+not distinguishable from a slow machine's healthy boot, so the clock would have failed real boots.
+
+A **failed** reading is not a reading at all — this spawns `xcrun simctl list` up to 180 times where the old
+code spawned it once, each an independent chance to kill a healthy boot during the interval when CoreSimulator
+is busiest, so failures are retried and the last one is reported with the deadline. Android's poll has always
+swallowed them.
 
 The wait also takes an `isStale` signal, checked every iteration. `handleDeviceBoot` is fire-and-forget and its
 `bootSeq` check runs only once the wait returns, so a shutdown arriving mid-wait would otherwise leave a poll

--- a/.changeset/ios-boot-readiness.md
+++ b/.changeset/ios-boot-readiness.md
@@ -1,0 +1,37 @@
+---
+'@tapflowio/ios-agent': patch
+---
+
+fix(ios-agent): wait for the simulator to finish booting before announcing device:ready
+
+`simctl boot` returns when CoreSimulator has *accepted* the boot, not when the device reaches `Booted`, and
+nothing waited for the difference. Measured on an iPhone 17 Pro / iOS 26.5: `xcrun simctl bootstatus` reported
+`Finished` **7.6 seconds** after `boot` had already returned. `device:ready` went out inside that window, so it
+announced something that was not yet true.
+
+`SimctlWrapper.waitUntilBooted` polls the device list until the device reports `booted` and returns what it
+read; `handleDeviceBoot` awaits it before `sendChromeData`, and a boot that never finishes ends as
+`device:boot-error` at a 90s deadline rather than as a ready device that is not up.
+
+Android has waited since the beginning (`EmulatorLauncher.waitForBoot` — `adb wait-for-device` plus a
+`sys.boot_completed` poll, awaited on both boot paths), so this closes an asymmetry rather than adding a
+policy. A human is slower than the gap and rarely notices; `mcp-server` installs and taps the moment it sees
+`device:ready`, and #440's "app install intermittently fails with *No devices are booted*" was this — targeting
+the session's udid removed one of its two causes and left this one, because the two were indistinguishable at
+the time.
+
+**Every status other than `booted` counts as still coming up, `shutdown` included.** `toDeviceStatus` collapses
+`Booting` into `unknown`, and the wait only ever runs after `boot` was accepted, so a `shutdown` reading here is
+the transition not having been observed yet. Failing on it would race a boot that was about to succeed. That
+also keeps `DeviceStatus` alone: widening it to carry `booting` would change a union `agent-core` publishes and
+the dashboard consumes, and the poll's exit condition never needed the distinction.
+
+The status sent with the chrome data stops being hardcoded. It was `status: 'booted'` written over a value that
+had just been fetched and discarded — a lie in the source that no consumer read, since `sendChromeData` uses
+only `name`, `osVersion` and `typeId`. The behaviour is unchanged; what changes is that the value is now the one
+that was observed.
+
+The seq re-check after the wait is load-bearing, not defensive: this is another multi-second `await`, and
+`sendChromeData` starts a helper process on the far side of it. A shutdown or a newer boot arriving in that gap
+would otherwise install a self-reviving helper for the device it is taking down — the same shape #484 had to
+add a check for after exactly this kind of gap.

--- a/.changeset/ios-boot-readiness.md
+++ b/.changeset/ios-boot-readiness.md
@@ -20,16 +20,33 @@ policy. A human is slower than the gap and rarely notices; `mcp-server` installs
 the session's udid removed one of its two causes and left this one, because the two were indistinguishable at
 the time.
 
-**Every status other than `booted` counts as still coming up, `shutdown` included.** `toDeviceStatus` collapses
-`Booting` into `unknown`, and the wait only ever runs after `boot` was accepted, so a `shutdown` reading here is
-the transition not having been observed yet. Failing on it would race a boot that was about to succeed. That
-also keeps `DeviceStatus` alone: widening it to carry `booting` would change a union `agent-core` publishes and
-the dashboard consumes, and the poll's exit condition never needed the distinction.
+**Three readings get three answers.** `unknown` is a device in motion — `toDeviceStatus` collapses `Booting`
+into it — so it gets the whole deadline. `shutdown`, or gone from the list, is what a device looks like when
+nothing is bringing it up, so it gets a 3s grace and no more: the handler skips `boot` entirely when the device
+was already `booted` when it read the list, and a shutdown landing in that window leaves nobody booting
+anything. A **failed** reading is not a reading at all — this spawns `xcrun simctl list` up to 180 times where
+the old code spawned it once, each an independent chance to kill a healthy boot during the interval when
+CoreSimulator is busiest, so failures are retried and the last one is reported with the deadline. Android's poll
+has always swallowed them.
+
+The wait also takes an `isStale` signal, checked every iteration. `handleDeviceBoot` is fire-and-forget and its
+`bootSeq` check runs only once the wait returns, so a shutdown arriving mid-wait would otherwise leave a poll
+spawning a process twice a second, for the rest of the deadline, against a device that is now deliberately off
+and will never converge.
+
+`DeviceStatus` is left alone throughout: widening it to carry `booting` would change a union `agent-core`
+publishes and the dashboard consumes, and the poll's exit condition never needed the distinction.
 
 The status sent with the chrome data stops being hardcoded. It was `status: 'booted'` written over a value that
-had just been fetched and discarded — a lie in the source that no consumer read, since `sendChromeData` uses
-only `name`, `osVersion` and `typeId`. The behaviour is unchanged; what changes is that the value is now the one
-that was observed.
+had just been fetched and discarded — a lie in the source that changes nothing observable, because
+`sendChromeData` reads `id`, `name`, `osVersion` and `typeId` and never `status`. What changes is that the value
+is now the one that was observed.
+
+**Known gap, not addressed here:** `mcp-server`'s `boot_device` waiter has a 30s deadline
+(`client.ts`), which now sits *inside* the agent's 90s one. A cold or full-erase boot past 30s
+reports a bare timeout to the LLM rather than the reason the agent is about to send. Before this change that
+ceiling was unreachable, because the agent answered as soon as the boot was accepted — with the answer that
+`No devices are booted` came from. Raising it belongs with the `mcp-server` client rather than here.
 
 The seq re-check after the wait is load-bearing, not defensive: this is another multi-second `await`, and
 `sendChromeData` starts a helper process on the far side of it. A shutdown or a newer boot arriving in that gap

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -20,6 +20,14 @@ status: living
 - Wrap all xcrun/simctl calls in dedicated functions so they can be swapped with mocks in tests.
 - Capture frames via SimulatorKit IOSurface and stream H.264 (default) or JPEG frames as WebSocket binary messages (≤30 fps).
 - `connect` only registers devices with the relay — it never boots one. Booting is on-demand via `device:boot` (dashboard / MCP). The `deviceFilter` option (CLI `--device`) narrows which devices are exposed to the relay (parity with android-agent), not a boot target.
+- **`device:ready` means the device is up, not that the boot was accepted.** `simctl boot` returns on
+  *initiation* and the device reaches `Booted` seconds later — measured 7.6s on an iPhone 17 Pro / iOS 26.5 —
+  so `handleDeviceBoot` awaits `SimctlWrapper.waitUntilBooted` before it sends anything (#486). Android has
+  always waited (`EmulatorLauncher.waitForBoot`), and a caller that acts on `ready` immediately is the one that
+  notices: #440's *No devices are booted* was this half of the race. Every status other than `booted` counts as
+  still coming up, **`shutdown` included** — `toDeviceStatus` collapses `Booting` into `unknown`, and the wait
+  only ever runs after `boot` was accepted, so a `shutdown` reading is the transition not yet observed rather
+  than a failure. A boot that never finishes ends at a 90s deadline as `device:boot-error`.
 
 ### Input acks carry a reason
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -24,10 +24,25 @@ status: living
   *initiation* and the device reaches `Booted` seconds later — measured 7.6s on an iPhone 17 Pro / iOS 26.5 —
   so `handleDeviceBoot` awaits `SimctlWrapper.waitUntilBooted` before it sends anything (#486). Android has
   always waited (`EmulatorLauncher.waitForBoot`), and a caller that acts on `ready` immediately is the one that
-  notices: #440's *No devices are booted* was this half of the race. Every status other than `booted` counts as
-  still coming up, **`shutdown` included** — `toDeviceStatus` collapses `Booting` into `unknown`, and the wait
-  only ever runs after `boot` was accepted, so a `shutdown` reading is the transition not yet observed rather
-  than a failure. A boot that never finishes ends at a 90s deadline as `device:boot-error`.
+  notices: #440's *No devices are booted* was this half of the race. A boot that never finishes ends at a 90s
+  deadline as `device:boot-error`. Three details of the poll are load-bearing and each closed a hole the first
+  draft shipped:
+  - **`unknown` gets the whole deadline; `shutdown` and "gone from the list" get 3 seconds.** They are not the
+    same reading. `toDeviceStatus` collapses `Booting` into `unknown`, so that is the ordinary one during a
+    boot — but the handler **skips `boot` entirely** when the device was already `booted` when it read the
+    list, and a shutdown landing in that window leaves nobody booting anything. The grace covers CoreSimulator
+    still reporting the pre-boot state; past it, the first reading already had the answer.
+  - **A failed reading is not a reading.** This spawns `xcrun simctl list` up to 180 times where the old code
+    spawned it once, each one a chance to kill a healthy boot while CoreSimulator is busiest. Failures are
+    swallowed and retried, and the last is reported with the deadline. Android has always done this; the claim
+    of parity with `waitForBoot` was false until it did.
+  - **`isStale` cancels the poll from inside.** The handler is fire-and-forget and its `bootSeq` check runs
+    only once the wait *returns*, so a shutdown mid-wait would otherwise leave a process spawning twice a
+    second against a device that is deliberately off. The check after the wait stays as well — it covers the
+    microtask-thin case where the wait has resolved and the seq moves before the handler resumes.
+  - **A caller with a shorter deadline still cannot hear the reason.** `mcp-server`'s `boot_device` waits 30s,
+    inside the agent's 90s, so a cold boot past 30s reports a bare timeout to the LLM. That ceiling was
+    unreachable before, because the agent answered on boot acceptance.
 
 ### Input acks carry a reason
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -462,7 +462,9 @@ await vi.waitFor(() => expect(MockTouchHelper.mock.results.length).toBeGreaterTh
 const touchHelper = MockTouchHelper.mock.results[0].value
 ```
 
-`mockSimctl(true)` (booted=true) → skips `device:booting` and delivers `device:ready` immediately.
+`mockSimctl(true)` (booted=true) reaches `device:ready` fastest, but it takes the same path as any other
+boot — `device:booting` goes out before the handler's `try` on every call, and since #486 `simctl boot` is
+issued for a device the list called `booted` too. Nothing short-circuits on the device already being up.
 
 **`device:ready` is not a sync point.** It is sent as soon as the stream is handed off, before the helpers a test is usually about to read are observable — so `waitForType(browser, 'device:ready')` returning does not mean `MockCapture` or `MockTouchHelper` has been constructed. Always `vi.waitFor` on the mock you are about to read, never on the message alone.
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -25,24 +25,30 @@ status: living
   so `handleDeviceBoot` awaits `SimctlWrapper.waitUntilBooted` before it sends anything (#486). Android has
   always waited (`EmulatorLauncher.waitForBoot`), and a caller that acts on `ready` immediately is the one that
   notices: #440's *No devices are booted* was this half of the race. A boot that never finishes ends at a 90s
-  deadline as `device:boot-error`. Three details of the poll are load-bearing and each closed a hole the first
-  draft shipped:
-  - **`unknown` gets the whole deadline; `shutdown` and "gone from the list" get 3 seconds.** They are not the
-    same reading. `toDeviceStatus` collapses `Booting` into `unknown`, so that is the ordinary one during a
-    boot — but the handler **skips `boot` entirely** when the device was already `booted` when it read the
-    list, and a shutdown landing in that window leaves nobody booting anything. The grace covers CoreSimulator
-    still reporting the pre-boot state; past it, the first reading already had the answer.
+  deadline as `device:boot-error`. Four details are load-bearing, and three of them are holes the first draft
+  of that wait shipped:
+  - **Every status other than `booted` counts as still coming up, `shutdown` included.** `toDeviceStatus`
+    collapses `Booting` into `unknown`, and the wait only ever runs after a `boot` was accepted, so a
+    `shutdown` reading is the transition not yet observed. A draft gave it a 3s grace and failed early on it;
+    that was reverted, because the reading is indistinguishable from a slow machine's healthy boot.
+  - **The boot is issued on every path, including when the list already said `booted`** — which is what makes
+    the sentence above true. The original on-demand boot skipped it there as an obvious economy; that skip
+    became the one route into the wait with *nothing bringing the device up*, so a tester who quit the
+    simulator inside one `xcrun` round trip paid the whole deadline. `SimctlWrapper.boot` swallows
+    `Unable to boot device in current state: Booted`, so the skip bought one no-op subprocess.
   - **A failed reading is not a reading.** This spawns `xcrun simctl list` up to 180 times where the old code
     spawned it once, each one a chance to kill a healthy boot while CoreSimulator is busiest. Failures are
-    swallowed and retried, and the last is reported with the deadline. Android has always done this; the claim
-    of parity with `waitForBoot` was false until it did.
+    swallowed and retried, and the last is reported with the deadline — but only if it is genuinely the last,
+    which is why the success path clears it. Android has always swallowed them; the claim of parity with
+    `waitForBoot` was false until this did too.
   - **`isStale` cancels the poll from inside.** The handler is fire-and-forget and its `bootSeq` check runs
     only once the wait *returns*, so a shutdown mid-wait would otherwise leave a process spawning twice a
     second against a device that is deliberately off. The check after the wait stays as well — it covers the
     microtask-thin case where the wait has resolved and the seq moves before the handler resumes.
-  - **A caller with a shorter deadline still cannot hear the reason.** `mcp-server`'s `boot_device` waits 30s,
-    inside the agent's 90s, so a cold boot past 30s reports a bare timeout to the LLM. That ceiling was
-    unreachable before, because the agent answered on boot acceptance.
+
+  Still open, and **not** fixed by the above: `mcp-server`'s `boot_device` waits 30s, *inside* the agent's 90s,
+  so a cold boot past 30s reports a bare timeout to the LLM rather than the reason the agent is about to send.
+  That ceiling was unreachable while the agent answered on boot acceptance.
 
 ### Input acks carry a reason
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -610,7 +610,14 @@ export class IOSAgent implements DeviceAgent {
           throw err
         }
         await this.simctl.boot(deviceId)
-      } else if (target.status !== 'booted') {
+      } else {
+        // Unconditionally, including when the list above said `booted`. That reading is already
+        // stale by the time we act on it — a tester can ⌘Q the simulator, or run `simctl shutdown`,
+        // in the width of one `xcrun` round trip — and skipping the boot on it is the only way to
+        // reach the wait below with *nothing bringing the device up*, which then costs the full
+        // deadline to discover. `SimctlWrapper.boot` swallows `Unable to boot device in current
+        // state: Booted`, so re-issuing it for a device that really is up costs one no-op
+        // subprocess and makes "the wait only ever runs after a boot was accepted" true.
         await this.bootWithZombieRecovery(deviceId)
       }
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -622,7 +622,11 @@ export class IOSAgent implements DeviceAgent {
       // `device:ready` went out a few lines later. A human is slower than the gap and rarely
       // notices; `mcp-server` installs and taps the moment it sees ready, which is what #440's
       // "No devices are booted" was.
-      const bootedDevice = await this.simctl.waitUntilBooted(deviceId)
+      // `isStale` rather than a check on the far side alone: this handler is fire-and-forget, so a
+      // shutdown arriving mid-wait bumps `bootSeq` and leaves the poll spawning `xcrun simctl list`
+      // twice a second against a device that is now deliberately off — for the rest of the deadline,
+      // with nothing left that wants the answer.
+      const bootedDevice = await this.simctl.waitUntilBooted(deviceId, { isStale: () => seq !== state.bootSeq })
       // Another await — a multi-second one — and `sendChromeData` below starts a helper process. A
       // shutdown or a newer boot arriving in this gap would otherwise get a helper installed for the
       // device it is taking down — and one that revives itself, so the stale reference outlives the

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -63,7 +63,7 @@ import {
   sendAudioYieldingToVideo,
 } from '@tapflowio/agent-core/utils'
 import type { AudioFrame } from '@tapflowio/agent-core'
-import { SimctlWrapper, isDeviceMissingError, ClipboardTooLargeError } from './SimctlWrapper.js'
+import { SimctlWrapper, isDeviceMissingError, ClipboardTooLargeError, firstLine } from './SimctlWrapper.js'
 import {
   MAX_CLIPBOARD_BYTES, clipboardByteLength,
   CLIPBOARD_SENTINEL_PREFIX as SENTINEL_PREFIX, isClipboardSentinel as isSentinel,
@@ -663,8 +663,12 @@ export class IOSAgent implements DeviceAgent {
 
     } catch (e) {
       if (seq !== state.bootSeq) return
-      const message = e instanceof Error ? e.message : String(e)
-      this.sendMsg({ type: 'device:boot-error', sessionId, requestId, message })
+      // `firstLine`, not `e.message`: this reaches a toast, and node's first line is
+      // `Command failed: xcrun simctl boot <UDID>`, which says nothing and echoes the udid. That
+      // matters more now that the boot is issued unconditionally — a device caught mid `Shutting
+      // Down` refuses the boot, and refusing is correct (swallowing it would put us back to waiting
+      // on a device nobody is bringing up), so the refusal is what the tester reads.
+      this.sendMsg({ type: 'device:boot-error', sessionId, requestId, message: firstLine(e) })
     }
   }
 

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -616,17 +616,19 @@ export class IOSAgent implements DeviceAgent {
 
       if (seq !== state.bootSeq) return
 
-      const refreshed = await this.simctl.listDevices()
-      // Another await, and `sendChromeData` below starts a helper process. A shutdown or a newer
-      // boot arriving in this gap would otherwise get a helper installed for the device it is
-      // taking down — and one that revives itself, so the stale reference outlives the boot that
-      // returns just below.
+      // `simctl boot` returns on initiation, so everything below used to run while the device was
+      // still coming up — measured 7.6s early (#486). The status sent with the chrome data was
+      // hardcoded `'booted'` over a value that had just been fetched and discarded, and
+      // `device:ready` went out a few lines later. A human is slower than the gap and rarely
+      // notices; `mcp-server` installs and taps the moment it sees ready, which is what #440's
+      // "No devices are booted" was.
+      const bootedDevice = await this.simctl.waitUntilBooted(deviceId)
+      // Another await — a multi-second one — and `sendChromeData` below starts a helper process. A
+      // shutdown or a newer boot arriving in this gap would otherwise get a helper installed for the
+      // device it is taking down — and one that revives itself, so the stale reference outlives the
+      // boot that returns just below.
       if (seq !== state.bootSeq) return
-      const refreshedDevice = refreshed.find((d) => d.id === deviceId) ?? target
-      this.sendChromeData(state, {
-        ...refreshedDevice,
-        status: 'booted',
-      } as Device)
+      this.sendChromeData(state, bootedDevice)
 
       const streamWs = await this.openStreamWs(state)
       if (seq !== state.bootSeq) {

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -135,31 +135,82 @@ export class SimctlWrapper {
   // Android has waited since the beginning (`EmulatorLauncher.waitForBoot`); this is the counterpart.
   private static readonly BOOT_READY_TIMEOUT_MS = 90_000
   private static readonly BOOT_POLL_INTERVAL_MS = 500
+  private static readonly BOOT_SETTLED_GRACE_MS = 3_000
 
   /**
    * Polls the device list until `deviceId` reports `booted`, and returns it — so the caller sends
    * on the value it read rather than asserting one.
    *
-   * Every status other than `booted` counts as "still coming up", **`shutdown` included**. That is
-   * not laxness: `toDeviceStatus` collapses `Booting` into `unknown`, and this only ever runs after
-   * `boot` has been accepted, so a `shutdown` reading here is the transition not having been
-   * observed yet. Failing on it would race a boot that was about to succeed. The deadline is what
-   * ends a boot that genuinely never happens.
+   * Three readings, three answers, because they are not the same claim:
+   *
+   * - **`unknown`** is a device in motion. `toDeviceStatus` collapses `Booting` into it, so this is
+   *   the ordinary reading during a boot and it gets the whole `timeoutMs`.
+   * - **`shutdown`, or gone from the list**, is what a device looks like when *nothing* is bringing
+   *   it up, so it gets `settledGraceMs` and no more. The grace exists because CoreSimulator can
+   *   still report the pre-boot state for a moment after `boot` returns — but the caller does not
+   *   always reach here via `boot` at all: `handleDeviceBoot` skips it when the device was already
+   *   `booted` when the handler read the list, and a shutdown landing in that window leaves nobody
+   *   booting anything. Spending the full deadline there waits 90s for an answer the first reading
+   *   already had.
+   * - **A failed reading is not a reading.** `listDevices` spawns `xcrun simctl list`, and this now
+   *   does it up to `timeoutMs / pollIntervalMs` times where the old code did it once — every one
+   *   of those an independent chance to kill a healthy boot, during the interval when
+   *   CoreSimulator is busiest. Failures are swallowed and retried, and the last one is reported
+   *   with the deadline so the cause is not lost. Android's poll has always done this
+   *   (`EmulatorLauncher.waitForBoot`); the first draft of this method did not, which made the
+   *   "counterpart" claim false in the one way that matters.
+   *
+   * `isStale` is checked every iteration. This loop outlives the boot that started it — the handler
+   * is fire-and-forget, and its `bootSeq` check runs only once the wait *returns* — so a shutdown
+   * arriving mid-wait would otherwise leave a poll spawning a process twice a second for the rest
+   * of the deadline, against a device that is now deliberately off and therefore never converges.
    */
   async waitUntilBooted(
     deviceId: string,
-    timeoutMs = SimctlWrapper.BOOT_READY_TIMEOUT_MS,
-    pollIntervalMs = SimctlWrapper.BOOT_POLL_INTERVAL_MS,
+    opts: {
+      timeoutMs?: number
+      pollIntervalMs?: number
+      settledGraceMs?: number
+      isStale?: () => boolean
+    } = {},
   ): Promise<Device> {
+    const {
+      timeoutMs = SimctlWrapper.BOOT_READY_TIMEOUT_MS,
+      pollIntervalMs = SimctlWrapper.BOOT_POLL_INTERVAL_MS,
+      settledGraceMs = SimctlWrapper.BOOT_SETTLED_GRACE_MS,
+      isStale,
+    } = opts
     const deadline = Date.now() + timeoutMs
+    let settledSince: number | null = null
+    let lastError: unknown = null
+
     for (;;) {
-      const device = (await this.listDevices()).find((d) => d.id === deviceId)
+      if (isStale?.()) throw new PlatformError(`Boot of ${deviceId} was superseded while waiting for it to come up`)
+
+      let device: Device | undefined
+      try {
+        device = (await this.listDevices()).find((d) => d.id === deviceId)
+        lastError = null
+      } catch (err) {
+        lastError = err
+      }
       if (device?.status === 'booted') return device
-      // Checked after the read, not before it, so a zero timeout still gets one look — a device that
-      // is already up must not need a second poll interval to be reported as up.
-      if (Date.now() >= deadline) {
-        const seen = device?.status ?? 'no longer listed'
-        throw new PlatformError(`Device ${deviceId} did not finish booting within ${timeoutMs}ms (last seen: ${seen})`)
+
+      const settled = lastError === null && (device === undefined || device.status === 'shutdown')
+      settledSince = settled ? settledSince ?? Date.now() : null
+
+      // Both checks sit after the read, not before it, so a zero timeout still gets one look — a
+      // device that is already up must not need a poll interval to be reported as up.
+      const now = Date.now()
+      if (settledSince !== null && now - settledSince >= settledGraceMs) {
+        const seen = device === undefined ? 'it is no longer listed' : 'it reports shutdown'
+        throw new PlatformError(`Device ${deviceId} is not coming up — ${seen}, ${settledGraceMs}ms after the boot began`)
+      }
+      if (now >= deadline) {
+        const seen = lastError !== null
+          ? `last poll failed: ${firstLine(lastError)}`
+          : `last seen: ${device?.status ?? 'no longer listed'}`
+        throw new PlatformError(`Device ${deviceId} did not finish booting within ${timeoutMs}ms (${seen})`)
       }
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
     }

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -94,8 +94,15 @@ export class SimctlWrapper {
 
   constructor(private readonly runner: SimctlRunner = defaultRunner) {}
 
-  async listDevices(): Promise<Device[]> {
-    const output = await this.runner.exec('list', 'devices', '--json')
+  /**
+   * `timeoutMs` bounds the underlying `xcrun simctl list`. Left off everywhere except the boot poll:
+   * a blanket timeout would fail a legitimately slow call, which is the reason `SimctlExecOpts.timeoutMs`
+   * is per-call in the first place.
+   */
+  async listDevices(timeoutMs?: number): Promise<Device[]> {
+    const output = timeoutMs === undefined
+      ? await this.runner.exec('list', 'devices', '--json')
+      : await this.runner.execWithOpts({ timeoutMs }, 'list', 'devices', '--json')
     const parsed: SimctlListOutput = JSON.parse(output)
     const devices: Device[] = []
 
@@ -135,6 +142,12 @@ export class SimctlWrapper {
   // Android has waited since the beginning (`EmulatorLauncher.waitForBoot`); this is the counterpart.
   private static readonly BOOT_READY_TIMEOUT_MS = 90_000
   private static readonly BOOT_POLL_INTERVAL_MS = 500
+  // Bounds one reading, not the wait. `listDevices` is otherwise untimed, so a wedged
+  // CoreSimulatorService makes the deadline below unreachable — the loop would sit inside a single
+  // `xcrun` forever and never look at the clock again. A fixed ceiling rather than "whatever is left of
+  // the deadline": the latter lets the last reading swallow the remaining 89 seconds with no retry, and
+  // a healthy `simctl list` answers in well under a second, so 5s is already several times slack.
+  private static readonly BOOT_POLL_READ_TIMEOUT_MS = 5_000
 
   /**
    * Polls the device list until `deviceId` reports `booted`, and returns it — so the caller sends
@@ -156,6 +169,11 @@ export class SimctlWrapper {
    * is not lost. Android's poll has always done this (`EmulatorLauncher.waitForBoot`); the first
    * draft of this method did not, which made the "counterpart" claim false in the one way that
    * matters.
+   *
+   * **And a reading has to end.** Each one is bounded by `BOOT_POLL_READ_TIMEOUT_MS`, because
+   * `listDevices` is otherwise untimed: a wedged CoreSimulatorService would park the loop inside one
+   * `xcrun` and the deadline below would never be consulted again. Bounding the reading is what makes
+   * the deadline a deadline; swallowing the failure is what stops it ending the boot.
    *
    * `isStale` is checked every iteration. This loop outlives the boot that started it — the handler
    * is fire-and-forget, and its `bootSeq` check runs only once the wait *returns* — so a shutdown
@@ -183,7 +201,7 @@ export class SimctlWrapper {
 
       let device: Device | undefined
       try {
-        device = (await this.listDevices()).find((d) => d.id === deviceId)
+        device = (await this.listDevices(SimctlWrapper.BOOT_POLL_READ_TIMEOUT_MS)).find((d) => d.id === deviceId)
         // Cleared on every success, so the deadline blames a failed poll only when the *last* one
         // failed. Leaving it set would report a recovered-from error as the reason for the timeout.
         lastError = null

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -135,30 +135,27 @@ export class SimctlWrapper {
   // Android has waited since the beginning (`EmulatorLauncher.waitForBoot`); this is the counterpart.
   private static readonly BOOT_READY_TIMEOUT_MS = 90_000
   private static readonly BOOT_POLL_INTERVAL_MS = 500
-  private static readonly BOOT_SETTLED_GRACE_MS = 3_000
 
   /**
    * Polls the device list until `deviceId` reports `booted`, and returns it — so the caller sends
    * on the value it read rather than asserting one.
    *
-   * Three readings, three answers, because they are not the same claim:
+   * **Every status other than `booted` counts as still coming up, `shutdown` included.**
+   * `toDeviceStatus` collapses `Booting` into `unknown`, and this only ever runs after a `boot` was
+   * accepted — `handleDeviceBoot` issues one on every path, deliberately including the one where
+   * the list already said `booted`, precisely so this sentence stays true. So a `shutdown` reading
+   * here is the transition not yet observed, and failing on it would race a boot that was about to
+   * succeed. A draft gave `shutdown` a 3s grace instead; it was removed, because the reading it
+   * would end early is indistinguishable from a slow machine's, the 3s answered no measurement, and
+   * the case it was for is better removed than timed.
    *
-   * - **`unknown`** is a device in motion. `toDeviceStatus` collapses `Booting` into it, so this is
-   *   the ordinary reading during a boot and it gets the whole `timeoutMs`.
-   * - **`shutdown`, or gone from the list**, is what a device looks like when *nothing* is bringing
-   *   it up, so it gets `settledGraceMs` and no more. The grace exists because CoreSimulator can
-   *   still report the pre-boot state for a moment after `boot` returns — but the caller does not
-   *   always reach here via `boot` at all: `handleDeviceBoot` skips it when the device was already
-   *   `booted` when the handler read the list, and a shutdown landing in that window leaves nobody
-   *   booting anything. Spending the full deadline there waits 90s for an answer the first reading
-   *   already had.
-   * - **A failed reading is not a reading.** `listDevices` spawns `xcrun simctl list`, and this now
-   *   does it up to `timeoutMs / pollIntervalMs` times where the old code did it once — every one
-   *   of those an independent chance to kill a healthy boot, during the interval when
-   *   CoreSimulator is busiest. Failures are swallowed and retried, and the last one is reported
-   *   with the deadline so the cause is not lost. Android's poll has always done this
-   *   (`EmulatorLauncher.waitForBoot`); the first draft of this method did not, which made the
-   *   "counterpart" claim false in the one way that matters.
+   * **A failed reading is not a reading.** `listDevices` spawns `xcrun simctl list`, and this does
+   * it up to `timeoutMs / pollIntervalMs` times where the old code did it once — every one an
+   * independent chance to kill a healthy boot, during the interval when CoreSimulator is busiest.
+   * Failures are swallowed and retried, and the last one is reported with the deadline so the cause
+   * is not lost. Android's poll has always done this (`EmulatorLauncher.waitForBoot`); the first
+   * draft of this method did not, which made the "counterpart" claim false in the one way that
+   * matters.
    *
    * `isStale` is checked every iteration. This loop outlives the boot that started it — the handler
    * is fire-and-forget, and its `bootSeq` check runs only once the wait *returns* — so a shutdown
@@ -170,18 +167,15 @@ export class SimctlWrapper {
     opts: {
       timeoutMs?: number
       pollIntervalMs?: number
-      settledGraceMs?: number
       isStale?: () => boolean
     } = {},
   ): Promise<Device> {
     const {
       timeoutMs = SimctlWrapper.BOOT_READY_TIMEOUT_MS,
       pollIntervalMs = SimctlWrapper.BOOT_POLL_INTERVAL_MS,
-      settledGraceMs = SimctlWrapper.BOOT_SETTLED_GRACE_MS,
       isStale,
     } = opts
     const deadline = Date.now() + timeoutMs
-    let settledSince: number | null = null
     let lastError: unknown = null
 
     for (;;) {
@@ -190,23 +184,17 @@ export class SimctlWrapper {
       let device: Device | undefined
       try {
         device = (await this.listDevices()).find((d) => d.id === deviceId)
+        // Cleared on every success, so the deadline blames a failed poll only when the *last* one
+        // failed. Leaving it set would report a recovered-from error as the reason for the timeout.
         lastError = null
       } catch (err) {
         lastError = err
       }
       if (device?.status === 'booted') return device
 
-      const settled = lastError === null && (device === undefined || device.status === 'shutdown')
-      settledSince = settled ? settledSince ?? Date.now() : null
-
-      // Both checks sit after the read, not before it, so a zero timeout still gets one look — a
-      // device that is already up must not need a poll interval to be reported as up.
-      const now = Date.now()
-      if (settledSince !== null && now - settledSince >= settledGraceMs) {
-        const seen = device === undefined ? 'it is no longer listed' : 'it reports shutdown'
-        throw new PlatformError(`Device ${deviceId} is not coming up — ${seen}, ${settledGraceMs}ms after the boot began`)
-      }
-      if (now >= deadline) {
+      // Checked after the read, not before it, so a zero timeout still gets one look — a device that
+      // is already up must not need a poll interval to be reported as up.
+      if (Date.now() >= deadline) {
         const seen = lastError !== null
           ? `last poll failed: ${firstLine(lastError)}`
           : `last seen: ${device?.status ?? 'no longer listed'}`

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -41,7 +41,7 @@ const CLIPBOARD_CMD_TIMEOUT_MS = 5_000
 // which says nothing and echoes the device UDID, so prefer any other line. When there is none
 // (e.g. the timeout path, where stderr is empty) fall back to a plain description rather than
 // the argv line this exists to drop.
-function firstLine(e: unknown): string {
+export function firstLine(e: unknown): string {
   const msg = e instanceof Error ? e.message : String(e)
   const lines = msg.split('\n').map((l) => l.trim()).filter(Boolean)
   return lines.find((l) => !l.startsWith('Command failed:')) ?? 'the simulator did not respond'

--- a/packages/ios-agent/src/SimctlWrapper.ts
+++ b/packages/ios-agent/src/SimctlWrapper.ts
@@ -128,6 +128,43 @@ export class SimctlWrapper {
     }
   }
 
+  // `boot` returns when CoreSimulator has *accepted* the boot, and the device reaches `Booted`
+  // seconds later — measured at 7.6s on an iPhone 17 Pro / iOS 26.5 (#486). A caller that announces
+  // readiness on `boot` resolving is announcing something that is not yet true, which is what
+  // `app install intermittently fails with "No devices are booted"` (#440) was left standing on.
+  // Android has waited since the beginning (`EmulatorLauncher.waitForBoot`); this is the counterpart.
+  private static readonly BOOT_READY_TIMEOUT_MS = 90_000
+  private static readonly BOOT_POLL_INTERVAL_MS = 500
+
+  /**
+   * Polls the device list until `deviceId` reports `booted`, and returns it — so the caller sends
+   * on the value it read rather than asserting one.
+   *
+   * Every status other than `booted` counts as "still coming up", **`shutdown` included**. That is
+   * not laxness: `toDeviceStatus` collapses `Booting` into `unknown`, and this only ever runs after
+   * `boot` has been accepted, so a `shutdown` reading here is the transition not having been
+   * observed yet. Failing on it would race a boot that was about to succeed. The deadline is what
+   * ends a boot that genuinely never happens.
+   */
+  async waitUntilBooted(
+    deviceId: string,
+    timeoutMs = SimctlWrapper.BOOT_READY_TIMEOUT_MS,
+    pollIntervalMs = SimctlWrapper.BOOT_POLL_INTERVAL_MS,
+  ): Promise<Device> {
+    const deadline = Date.now() + timeoutMs
+    for (;;) {
+      const device = (await this.listDevices()).find((d) => d.id === deviceId)
+      if (device?.status === 'booted') return device
+      // Checked after the read, not before it, so a zero timeout still gets one look — a device that
+      // is already up must not need a second poll interval to be reported as up.
+      if (Date.now() >= deadline) {
+        const seen = device?.status ?? 'no longer listed'
+        throw new PlatformError(`Device ${deviceId} did not finish booting within ${timeoutMs}ms (last seen: ${seen})`)
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+    }
+  }
+
   async shutdown(deviceId: string): Promise<void> {
     try {
       await this.runner.exec('shutdown', deviceId)

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -152,7 +152,7 @@ function mockSimctl(booted: boolean | 'unknown' = false): SimctlWrapper {
   const status = booted === 'unknown' ? 'unknown' : booted ? 'booted' : 'shutdown'
   pasteboard = ''
   pasteboardApplyDelayMs = 0
-  return {
+  const sw = {
     listDevices: vi.fn().mockResolvedValue([
       { id: 'dev-1', name: 'iPhone 15', platform: 'ios', status, osVersion: 'iOS 18.3' },
     ]),
@@ -178,6 +178,18 @@ function mockSimctl(booted: boolean | 'unknown' = false): SimctlWrapper {
     getPasteboard: vi.fn(async () => pasteboard),
     stopKeyboardDaemon: vi.fn(),
   } as unknown as SimctlWrapper
+  // `handleDeviceBoot` awaits this before it announces readiness (#486). The real one polls
+  // `listDevices` until the device reports `booted`, so the double reads the same list — a test that
+  // rewrites it (`mockSimctlTwoDevices`, and the per-test overrides) then gets the device the agent
+  // actually asked for rather than a fixture pinned here. It answers `booted` because that is the
+  // only status the poll returns on; the polling itself is covered in `SimctlWrapper.test.ts`, which
+  // drives a real Booting→Booted transition through the runner.
+  sw.waitUntilBooted = vi.fn(async (deviceId: string) => {
+    const device = (await sw.listDevices()).find((d) => d.id === deviceId)
+    if (!device) throw new PlatformError(`Device ${deviceId} did not finish booting`)
+    return { ...device, status: 'booted' as const }
+  })
+  return sw
 }
 
 describe('IOSAgent', () => {
@@ -1107,6 +1119,80 @@ describe('IOSAgent', () => {
       const ready = await readyPromise
       expect((ready.payload as { deviceId: string }).deviceId).toBe('dev-1')
       expect(simctl.boot).toHaveBeenCalledWith('dev-1')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('holds device:ready until the simulator has finished booting (#486)', async () => {
+      // `simctl boot` returns when the boot has been *initiated* — measured 7.6s short of Booted on an
+      // iPhone 17 Pro / iOS 26.5. Announcing readiness there tells `mcp-server` to install and tap a
+      // device that is not up, which is the half of #440 ("No devices are booted") that targeting the
+      // session udid did not remove. Android has waited since the beginning.
+      //
+      // The wait is held open and `session:deviceInfo` is what is asserted absent, not `device:ready`.
+      // Two earlier drafts of this test passed under the mutation that drops the `await`:
+      //   - a 30ms mock + `events.push('ready')` after `await waitForType` stamps the *read* rather
+      //     than the arrival, and the stream handoff between the two outlasts 30ms;
+      //   - releasing the wait as soon as it had been called still ran ahead of the mutated path,
+      //     because `openStreamWs` sits between the mutation site and `device:ready`.
+      // `sendChromeData` is the first thing after the wait and it sends `session:deviceInfo`
+      // synchronously, so with the await gone it arrives with nothing in front of it to hide behind.
+      const simctl = mockSimctl(false)
+      let releaseWait = (): void => {}
+      ;(simctl.waitUntilBooted as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise((resolve) => {
+          releaseWait = () =>
+            resolve({ id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted', osVersion: 'iOS 18.3' })
+        }),
+      )
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-486', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:booting')
+      await vi.waitFor(() => expect(simctl.waitUntilBooted).toHaveBeenCalledWith('dev-1'), { timeout: 2000 })
+
+      expect(await waitForTypeOrNull(browser, 'session:deviceInfo', 300)).toBeNull()
+
+      const ready = waitForType(browser, 'device:ready')
+      releaseWait()
+      await ready
+      expect(await waitForTypeOrNull(browser, 'session:deviceInfo', 0)).not.toBeNull()
+      // The wait runs after the boot, not instead of it.
+      const bootOrder = (simctl.boot as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!
+      const waitOrder = (simctl.waitUntilBooted as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!
+      expect(bootOrder).toBeLessThan(waitOrder)
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('reports a boot that never finishes as device:boot-error (#486)', async () => {
+      // What the deadline answers with. `device:ready` is the alternative — ready-anyway with a
+      // warning — and it would put the caller back where it started, acting on a device that is not up.
+      const simctl = mockSimctl(false)
+      ;(simctl.waitUntilBooted as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new PlatformError('Device dev-1 did not finish booting within 90000ms (last seen: unknown)'),
+      )
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      const errored = waitForType(browser, 'device:boot-error')
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-486b', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      const e = await errored
+      expect(e.message).toContain('did not finish booting')
+      expect(e.requestId).toBe('rq-486b')
 
       agent.disconnect()
       browser.close()

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -1223,6 +1223,32 @@ describe('IOSAgent', () => {
       browser.close()
     })
 
+    it('keeps the argv line out of a boot failure toast', async () => {
+      // `Shutting Down` is the state a device caught mid-quit is in, and `simctl boot` refuses it.
+      // Refusing is right — swallowing it would put the wait back to polling a device nobody is
+      // bringing up — so this refusal is what the tester reads, and node's own first line is
+      // `Command failed: xcrun simctl boot <UDID>`, which says nothing and echoes the udid.
+      const simctl = mockSimctl(false)
+      ;(simctl.boot as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Command failed: xcrun simctl boot 1A2B-3C4D\nUnable to boot device in current state: Shutting Down'),
+      )
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      const errored = waitForType(browser, 'device:boot-error')
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-486f', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      const e = await errored
+      expect(e.message).toBe('Unable to boot device in current state: Shutting Down')
+
+      agent.disconnect()
+      browser.close()
+    })
+
     it('installs no helper when a shutdown lands while the boot is waiting (#486)', async () => {
       // The `bootSeq` re-check on the far side of the wait, which nothing reached before. The
       // existing reconnect test bumps the seq while `simctl.boot` is in flight, so it returns at the

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -1858,7 +1858,19 @@ describe('IOSAgent', () => {
       browser.close()
     })
 
-    it('skips boot call for already-booted device', async () => {
+    it('re-issues the boot even for a device the list reported as booted (#486)', async () => {
+      // This used to assert the opposite — the boot was skipped when the list said `booted`. That
+      // skip arrived with the original on-demand boot feature (`42a5ea6`) as an obvious economy,
+      // with no recorded reason, and it became load-bearing in the wrong direction once
+      // `waitUntilBooted` existed: it was the only path reaching the wait with **nothing bringing
+      // the device up**, so a tester who ⌘Q'd the simulator in the width of one `xcrun` round trip
+      // got a 90s deadline instead of a boot.
+      //
+      // A short grace on `shutdown` inside the poll was tried first and rejected in review: that
+      // reading is not distinguishable from a slow machine's healthy boot, so the clock would fail
+      // real boots to shorten a case that can simply be removed. `SimctlWrapper.boot` swallows
+      // `Unable to boot device in current state: Booted`, so the cost for a device that really is
+      // up is one no-op subprocess.
       const simctl = mockSimctl(true)
       const agent = new IOSAgent({ intervalMs: 50 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
@@ -1871,7 +1883,9 @@ describe('IOSAgent', () => {
       const readyPromise = waitForType(browser, 'device:ready')
       browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-fix-19', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await readyPromise
-      expect(simctl.boot).not.toHaveBeenCalled()
+      expect(simctl.boot).toHaveBeenCalledWith('dev-1')
+      // Not the erase path — that one has its own boot call and a very different meaning.
+      expect(simctl.erase).not.toHaveBeenCalled()
 
       agent.disconnect()
       browser.close()

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -180,11 +180,20 @@ function mockSimctl(booted: boolean | 'unknown' = false): SimctlWrapper {
   } as unknown as SimctlWrapper
   // `handleDeviceBoot` awaits this before it announces readiness (#486). The real one polls
   // `listDevices` until the device reports `booted`, so the double reads the same list — a test that
-  // rewrites it (`mockSimctlTwoDevices`, and the per-test overrides) then gets the device the agent
-  // actually asked for rather than a fixture pinned here. It answers `booted` because that is the
-  // only status the poll returns on; the polling itself is covered in `SimctlWrapper.test.ts`, which
-  // drives a real Booting→Booted transition through the runner.
-  sw.waitUntilBooted = vi.fn(async (deviceId: string) => {
+  // rewrites it (`mockSimctlTwoDevices`, and the per-test `mockResolvedValue` overrides) then gets
+  // the device the agent actually asked for rather than a fixture pinned here. It answers `booted`
+  // because that is the only status the poll returns on; the polling itself, its deadline, its grace
+  // for a settled device and its `isStale` signal are all covered in `SimctlWrapper.test.ts`, which
+  // drives real transitions through the runner.
+  //
+  // **`opts.isStale` is deliberately ignored here.** This double does not poll, so there is nothing
+  // to cancel — and the agent-side claim worth testing is the other guard: the `bootSeq` re-check on
+  // the far side of the wait, which only runs once the wait returns.
+  //
+  // One caller does not get the shared list: `{ ...mockSimctl(false), listDevices: … }` spreads the
+  // object, and the copy's `waitUntilBooted` still closes over the original `sw`. That test does not
+  // boot, and the failure mode if one did would be a loud `device:boot-error`, not a silent pass.
+  sw.waitUntilBooted = vi.fn(async (deviceId: string, _opts?: { isStale?: () => boolean }) => {
     const device = (await sw.listDevices()).find((d) => d.id === deviceId)
     if (!device) throw new PlatformError(`Device ${deviceId} did not finish booting`)
     return { ...device, status: 'booted' as const }
@@ -930,10 +939,16 @@ describe('IOSAgent', () => {
       }
       expect(joined).not.toBeNull()
 
-      // The abandoned boot returns at the seq check *before* its second `listDevices`, so that
-      // call not happening is the assertion — no sleep, and it fails if the bump is removed
-      // (the boot then runs on to `listDevices` and builds the helper). `setImmediate` drains the
-      // microtask queue, which is all the guarded path needs to reach its early return.
+      // The abandoned boot returns at the seq check that follows `simctl.boot`, before it reaches
+      // `waitUntilBooted` — so no further `listDevices` happening is the assertion. No sleep, and it
+      // fails if the bump is removed (the boot then runs on and builds the helper). `setImmediate`
+      // drains the microtask queue, which is all the guarded path needs to reach its early return.
+      //
+      // The extra reading it would make is now the double's, not the handler's: `mockSimctl`'s
+      // `waitUntilBooted` reads the shared list to answer with the right device. That keeps this
+      // assertion working, but the `MockTouchHelper` check below is the one that does not depend on
+      // how the double is written. The later seq check — the one on the far side of the wait — is a
+      // different guard with its own test in `device:boot handler`.
       const listCallsBeforeRelease = (simctl.listDevices as ReturnType<typeof vi.fn>).mock.calls.length
       releaseBoot()
       await new Promise((r) => setImmediate(r))
@@ -1101,6 +1116,8 @@ describe('IOSAgent', () => {
   })
 
   describe('device:boot handler', () => {
+    beforeEach(() => { MockTouchHelper.mockClear() })
+
     it('sends device:booting then device:ready for a shutdown device', async () => {
       const simctl = mockSimctl(false)
       const agent = new IOSAgent({ intervalMs: 50 }, simctl)
@@ -1156,9 +1173,17 @@ describe('IOSAgent', () => {
 
       browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-486', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
       await waitForType(browser, 'device:booting')
-      await vi.waitFor(() => expect(simctl.waitUntilBooted).toHaveBeenCalledWith('dev-1'), { timeout: 2000 })
+      await vi.waitFor(() => expect(simctl.waitUntilBooted).toHaveBeenCalledWith('dev-1', expect.anything()), { timeout: 2000 })
 
       expect(await waitForTypeOrNull(browser, 'session:deviceInfo', 300)).toBeNull()
+      // `device:ready` too, and not only `session:deviceInfo`. The recording is already running, so
+      // this reads whatever arrived during the 300ms above rather than waiting again — and without
+      // it, moving the `sendMsg({ type: 'device:ready' })` above the wait while leaving
+      // `sendChromeData` below it passes this test, which is #486 itself restored.
+      expect(await waitForTypeOrNull(browser, 'device:ready', 0)).toBeNull()
+      // In-process and hop-free: `sendChromeData` constructs the helper synchronously, before either
+      // message goes out, so this holds even if a socket were slower than the deadline above.
+      expect(MockTouchHelper.mock.results).toHaveLength(0)
 
       const ready = waitForType(browser, 'device:ready')
       releaseWait()
@@ -1193,6 +1218,53 @@ describe('IOSAgent', () => {
       const e = await errored
       expect(e.message).toContain('did not finish booting')
       expect(e.requestId).toBe('rq-486b')
+
+      agent.disconnect()
+      browser.close()
+    })
+
+    it('installs no helper when a shutdown lands while the boot is waiting (#486)', async () => {
+      // The `bootSeq` re-check on the far side of the wait, which nothing reached before. The
+      // existing reconnect test bumps the seq while `simctl.boot` is in flight, so it returns at the
+      // check *before* this one — its own comment says so — and deleting the check after the wait
+      // left all 388 tests green. The gap it guards used to be sub-second and is now the boot itself
+      // (measured 7.6s), so it is the wider of the two.
+      //
+      // `isStale` covers the same window from inside the poll, but only while the poll is running.
+      // This is the microtask-thin case it cannot see: the wait has already resolved and the seq
+      // moves before the handler resumes.
+      const simctl = mockSimctl(false)
+      let releaseWait = (): void => {}
+      ;(simctl.waitUntilBooted as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise((resolve) => {
+          releaseWait = () =>
+            resolve({ id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted', osVersion: 'iOS 18.3' })
+        }),
+      )
+      const agent = new IOSAgent({ intervalMs: 50 }, simctl)
+      await agent.connect(`ws://localhost:${port}`)
+
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      await waitForType(browser, 'session:joined')
+
+      browser.send(JSON.stringify({ type: 'device:boot', requestId: 'rq-486c', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:booting')
+      await vi.waitFor(() => expect(simctl.waitUntilBooted).toHaveBeenCalled(), { timeout: 2000 })
+      expect(MockTouchHelper.mock.results).toHaveLength(0)
+
+      // `device:shutdown` bumps `bootSeq` on its first line. Its reply is the barrier: the agent has
+      // finished with the shutdown before the wait is released, so this is an answer rather than a
+      // guess about timing.
+      browser.send(JSON.stringify({ type: 'device:shutdown', requestId: 'rq-486d', sessionId: agent.sessionId, payload: { deviceId: 'dev-1' } }))
+      await waitForType(browser, 'device:shutdown-done')
+
+      releaseWait()
+      await new Promise((r) => setImmediate(r))
+
+      expect(MockTouchHelper.mock.results).toHaveLength(0)
+      expect(await waitForTypeOrNull(browser, 'device:ready', 0)).toBeNull()
 
       agent.disconnect()
       browser.close()

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -119,17 +119,27 @@ describe('SimctlWrapper', () => {
           ],
         },
       })
+      // Both entry points walk the same script. The poll reads through `execWithOpts` because it bounds
+      // each reading, and a double that only scripted `exec` would answer it with `''` — `JSON.parse('')`
+      // throwing on every poll, which the retry branch would then swallow into a deadline. Loud, but for
+      // the wrong reason, and it would hide whatever the test was actually about.
+      const next = (...args: string[]) => {
+        if (args[0] !== 'list') return ''
+        const step = script[Math.min(i++, script.length - 1)]
+        if (step === 'throw') throw new Error('Command failed: xcrun simctl list devices --json\nservice invalidated')
+        return listing(step)
+      }
       return {
-        exec: vi.fn(async (...args: string[]) => {
-          if (args[0] !== 'list') return ''
-          const step = script[Math.min(i++, script.length - 1)]
-          if (step === 'throw') throw new Error('Command failed: xcrun simctl list devices --json\nservice invalidated')
-          return listing(step)
-        }),
+        exec: vi.fn(async (...args: string[]) => next(...args)),
         execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
-        execWithOpts: vi.fn().mockResolvedValue(''),
+        execWithOpts: vi.fn(async (_opts: SimctlExecOpts, ...args: string[]) => next(...args)),
       }
     }
+
+    /** Readings taken, whichever entry point took them. */
+    const reads = (runner: SimctlRunner) =>
+      (runner.exec as ReturnType<typeof vi.fn>).mock.calls.filter((c) => c[0] === 'list').length +
+      (runner.execWithOpts as ReturnType<typeof vi.fn>).mock.calls.filter((c) => c[1] === 'list').length
 
     it('polls until the device reaches Booted and returns the whole record it read', async () => {
       // `Shutdown` first on purpose: `simctl boot` has already returned by the time this runs, and the
@@ -145,7 +155,7 @@ describe('SimctlWrapper', () => {
         typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
         osVersion: 'iOS 17.0',
       })
-      expect(runner.exec).toHaveBeenCalledTimes(3)
+      expect(reads(runner)).toBe(3)
     })
 
     it('reads once when the device is already up, even at a zero deadline', async () => {
@@ -154,7 +164,19 @@ describe('SimctlWrapper', () => {
       const runner = transitioningRunner(['Booted'])
       const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 0, pollIntervalMs: 0 })
       expect(device.status).toBe('booted')
-      expect(runner.exec).toHaveBeenCalledTimes(1)
+      expect(reads(runner)).toBe(1)
+    })
+
+    it('bounds each reading, so a wedged simctl cannot outlive the deadline', async () => {
+      // `listDevices` is untimed everywhere else on purpose — a blanket timeout would fail a
+      // legitimately slow call — but the poll is the one caller whose whole contract is a deadline, and a
+      // wedged CoreSimulatorService would park it inside one `xcrun` where the clock is never consulted
+      // again. Bounding the reading is what makes the deadline a deadline; swallowing the failure (the
+      // test below) is what stops it ending a healthy boot.
+      const runner = transitioningRunner(['Booted'])
+      await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 0, pollIntervalMs: 0 })
+      expect(runner.execWithOpts).toHaveBeenCalledWith({ timeoutMs: 5_000 }, 'list', 'devices', '--json')
+      expect(runner.exec).not.toHaveBeenCalledWith('list', 'devices', '--json')
     })
 
     it('sleeps between polls, at the default interval', async () => {
@@ -168,7 +190,7 @@ describe('SimctlWrapper', () => {
       await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 1_200 }))
         .rejects.toThrow(/did not finish booting within 1200ms/)
       expect(Date.now() - started).toBeGreaterThanOrEqual(1_000)
-      expect((runner.exec as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(4)
+      expect(reads(runner)).toBeLessThanOrEqual(4)
     })
 
     it('gives up at the deadline and names the last status it saw', async () => {
@@ -185,7 +207,7 @@ describe('SimctlWrapper', () => {
       const recovered = transitioningRunner(['throw', 'throw', 'Booted'])
       const device = await new SimctlWrapper(recovered).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0 })
       expect(device.status).toBe('booted')
-      expect(recovered.exec).toHaveBeenCalledTimes(3)
+      expect(reads(recovered)).toBe(3)
 
       const persistent = transitioningRunner(['throw'])
       await expect(new SimctlWrapper(persistent).waitUntilBooted('device-1', { timeoutMs: 20, pollIntervalMs: 5 }))
@@ -220,7 +242,7 @@ describe('SimctlWrapper', () => {
       const runner = transitioningRunner(['Shutdown', 'Shutdown', 'Shutdown', 'Booting', 'Booted'])
       const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0 })
       expect(device.status).toBe('booted')
-      expect(runner.exec).toHaveBeenCalledTimes(5)
+      expect(reads(runner)).toBe(5)
     })
 
     it('abandons the poll as soon as the boot is superseded', async () => {
@@ -237,9 +259,9 @@ describe('SimctlWrapper', () => {
       await new Promise((r) => setTimeout(r, 30))
       stale = true
       await expect(wait).rejects.toThrow(/was superseded while waiting/)
-      const callsAtRejection = (runner.exec as ReturnType<typeof vi.fn>).mock.calls.length
+      const callsAtRejection = reads(runner)
       await new Promise((r) => setTimeout(r, 40))
-      expect(runner.exec).toHaveBeenCalledTimes(callsAtRejection)
+      expect(reads(runner)).toBe(callsAtRejection)
     })
   })
 

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -192,29 +192,35 @@ describe('SimctlWrapper', () => {
         .rejects.toThrow(/last poll failed: service invalidated/)
     })
 
-    it('stops early when the device is settled rather than coming up', async () => {
-      // `shutdown` and "gone from the list" mean nothing is bringing this device up, and
-      // `handleDeviceBoot` reaches here without calling `boot` when the device was already `booted`
-      // when it read the list — so a shutdown landing in that window leaves nobody booting anything.
-      // The grace covers CoreSimulator still reporting the pre-boot state; past it, waiting out the
-      // full deadline would spend 90s on an answer the first reading already had.
-      const off = transitioningRunner(['Shutdown'])
-      const started = Date.now()
-      await expect(new SimctlWrapper(off).waitUntilBooted('device-1', { timeoutMs: 60_000, pollIntervalMs: 5, settledGraceMs: 30 }))
-        .rejects.toThrow(/is not coming up — it reports shutdown, 30ms after the boot began/)
-      expect(Date.now() - started).toBeLessThan(1_000)
-
-      const gone = transitioningRunner(['Booted'])
-      await expect(new SimctlWrapper(gone).waitUntilBooted('device-404', { timeoutMs: 60_000, pollIntervalMs: 5, settledGraceMs: 0 }))
-        .rejects.toThrow(/is not coming up — it is no longer listed/)
+    it('reports a device that is not in the list at all', async () => {
+      // Reached both by a deleted device and by one `listDevices` filtered out for
+      // `isAvailable: false`. Neither self-heals, and neither gets its own early exit — for the same
+      // reason `shutdown` does not, and it costs the deadline to say so.
+      const runner = transitioningRunner(['Booted'])
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-404', { timeoutMs: 0, pollIntervalMs: 0 }))
+        .rejects.toThrow(/last seen: no longer listed/)
     })
 
-    it('does not let a settled reading end a boot that then comes up', async () => {
-      // The grace is a window, not a verdict on the first reading. `boot` returning before
-      // CoreSimulator has left `Shutdown` is the ordinary case this exists for.
-      const runner = transitioningRunner(['Shutdown', 'Shutdown', 'Booting', 'Booted'])
-      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0, settledGraceMs: 5_000 })
+    it('does not blame a recovered-from failure for the timeout', async () => {
+      // The `lastError = null` on the success path. Without it a single failed poll makes every
+      // later deadline report `last poll failed: …` — naming an error the wait recovered from, for a
+      // device that was answering perfectly well and simply never finished booting. Deleting that
+      // line passes every other test here, because none of them follow a `throw` with a
+      // non-`Booted` reading.
+      const runner = transitioningRunner(['throw', 'Booting'])
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 30, pollIntervalMs: 5 }))
+        .rejects.toThrow(/did not finish booting within 30ms \(last seen: unknown\)/)
+    })
+
+    it('keeps waiting on shutdown, which is a transition it has not observed yet', async () => {
+      // `boot` returning before CoreSimulator has left `Shutdown` is ordinary, and the handler
+      // issues a boot on every path that reaches here — so this reading is never "nobody is booting
+      // it". A draft gave `shutdown` a 3s grace and failed early on it; a slow machine's healthy
+      // boot is not distinguishable from a dead one by that clock, so the deadline owns it instead.
+      const runner = transitioningRunner(['Shutdown', 'Shutdown', 'Shutdown', 'Booting', 'Booted'])
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0 })
       expect(device.status).toBe('booted')
+      expect(runner.exec).toHaveBeenCalledTimes(5)
     })
 
     it('abandons the poll as soon as the boot is superseded', async () => {

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -96,33 +96,55 @@ describe('SimctlWrapper', () => {
   })
 
   describe('waitUntilBooted', () => {
-    // One `list` reading per call, walking the states in order and holding on the last — the shape a
+    // One `list` reading per call, walking the script in order and holding on the last — the shape a
     // real boot has. `mockRunner` answers every `list` identically, which cannot express a transition.
-    function transitioningRunner(states: string[]): SimctlRunner {
+    // A step of `throw` is a failed reading, which is a different thing from a reading of a failure.
+    //
+    // `deviceTypeIdentifier` is in the fixture because it is the field a re-assembled return value
+    // loses most quietly: `sendChromeData` falls back to `chromeLoader.load(device.name)` when
+    // `typeId` is missing, which is the name-based lookup this package's AGENTS.md marks ❌, and the
+    // only symptom is that every boot loses its device chrome.
+    function transitioningRunner(script: Array<string | 'throw'>): SimctlRunner {
       let i = 0
       const listing = (state: string) => JSON.stringify({
         devices: {
           'com.apple.CoreSimulator.SimRuntime.iOS-17-0': [
-            { udid: 'device-1', name: 'iPhone 15', state, isAvailable: true },
+            {
+              udid: 'device-1',
+              name: 'iPhone 15',
+              state,
+              isAvailable: true,
+              deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+            },
           ],
         },
       })
       return {
-        exec: vi.fn(async (...args: string[]) =>
-          args[0] === 'list' ? listing(states[Math.min(i++, states.length - 1)]) : ''),
+        exec: vi.fn(async (...args: string[]) => {
+          if (args[0] !== 'list') return ''
+          const step = script[Math.min(i++, script.length - 1)]
+          if (step === 'throw') throw new Error('Command failed: xcrun simctl list devices --json\nservice invalidated')
+          return listing(step)
+        }),
         execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
         execWithOpts: vi.fn().mockResolvedValue(''),
       }
     }
 
-    it('polls until the device reaches Booted and returns what it read', async () => {
+    it('polls until the device reaches Booted and returns the whole record it read', async () => {
       // `Shutdown` first on purpose: `simctl boot` has already returned by the time this runs, and the
       // list can still report the pre-boot state for a moment. The call count is what says neither
       // that reading nor `Booting` was accepted — three readings for three states.
       const runner = transitioningRunner(['Shutdown', 'Booting', 'Booted'])
-      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', 5_000, 0)
-      expect(device.status).toBe('booted')
-      expect(device.name).toBe('iPhone 15')
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0 })
+      expect(device).toEqual({
+        id: 'device-1',
+        name: 'iPhone 15',
+        platform: 'ios',
+        status: 'booted',
+        typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+        osVersion: 'iOS 17.0',
+      })
       expect(runner.exec).toHaveBeenCalledTimes(3)
     })
 
@@ -130,21 +152,88 @@ describe('SimctlWrapper', () => {
       // The deadline is checked after the read rather than before it. With the order reversed a device
       // that is already booted would still have to wait out a poll interval to be reported as up.
       const runner = transitioningRunner(['Booted'])
-      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', 0, 0)
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 0, pollIntervalMs: 0 })
       expect(device.status).toBe('booted')
       expect(runner.exec).toHaveBeenCalledTimes(1)
     })
 
+    it('sleeps between polls, at the default interval', async () => {
+      // Both halves matter. Without the sleep this spawns `xcrun simctl list` as fast as the event
+      // loop allows for the whole deadline, and deleting it changes no other assertion here — every
+      // other test passes an interval of 0. And production calls this with no interval at all
+      // (`IOSAgent.handleDeviceBoot`), so the default is the value that actually runs: at 500ms a
+      // 1200ms deadline admits three readings, and a default of 0 would admit hundreds.
+      const runner = transitioningRunner(['Booting'])
+      const started = Date.now()
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 1_200 }))
+        .rejects.toThrow(/did not finish booting within 1200ms/)
+      expect(Date.now() - started).toBeGreaterThanOrEqual(1_000)
+      expect((runner.exec as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(4)
+    })
+
     it('gives up at the deadline and names the last status it saw', async () => {
       const runner = transitioningRunner(['Booting'])
-      await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', 20, 5))
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 20, pollIntervalMs: 5 }))
         .rejects.toThrow(/did not finish booting within 20ms \(last seen: unknown\)/)
     })
 
-    it('reports a device that is not in the list at all', async () => {
-      const runner = transitioningRunner(['Booted'])
-      await expect(new SimctlWrapper(runner).waitUntilBooted('device-404', 0, 0))
-        .rejects.toThrow(/last seen: no longer listed/)
+    it('keeps polling when a reading fails, and reports the failure if it runs out', async () => {
+      // A failed `list` is not evidence about the device. This spawns a subprocess up to
+      // `timeoutMs / pollIntervalMs` times during the window when CoreSimulator is busiest, and the
+      // old code read the list once — so without this, one unlucky spawn kills a healthy boot and
+      // reports a `Command failed: xcrun simctl …` line that says nothing about booting.
+      const recovered = transitioningRunner(['throw', 'throw', 'Booted'])
+      const device = await new SimctlWrapper(recovered).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0 })
+      expect(device.status).toBe('booted')
+      expect(recovered.exec).toHaveBeenCalledTimes(3)
+
+      const persistent = transitioningRunner(['throw'])
+      await expect(new SimctlWrapper(persistent).waitUntilBooted('device-1', { timeoutMs: 20, pollIntervalMs: 5 }))
+        .rejects.toThrow(/last poll failed: service invalidated/)
+    })
+
+    it('stops early when the device is settled rather than coming up', async () => {
+      // `shutdown` and "gone from the list" mean nothing is bringing this device up, and
+      // `handleDeviceBoot` reaches here without calling `boot` when the device was already `booted`
+      // when it read the list — so a shutdown landing in that window leaves nobody booting anything.
+      // The grace covers CoreSimulator still reporting the pre-boot state; past it, waiting out the
+      // full deadline would spend 90s on an answer the first reading already had.
+      const off = transitioningRunner(['Shutdown'])
+      const started = Date.now()
+      await expect(new SimctlWrapper(off).waitUntilBooted('device-1', { timeoutMs: 60_000, pollIntervalMs: 5, settledGraceMs: 30 }))
+        .rejects.toThrow(/is not coming up — it reports shutdown, 30ms after the boot began/)
+      expect(Date.now() - started).toBeLessThan(1_000)
+
+      const gone = transitioningRunner(['Booted'])
+      await expect(new SimctlWrapper(gone).waitUntilBooted('device-404', { timeoutMs: 60_000, pollIntervalMs: 5, settledGraceMs: 0 }))
+        .rejects.toThrow(/is not coming up — it is no longer listed/)
+    })
+
+    it('does not let a settled reading end a boot that then comes up', async () => {
+      // The grace is a window, not a verdict on the first reading. `boot` returning before
+      // CoreSimulator has left `Shutdown` is the ordinary case this exists for.
+      const runner = transitioningRunner(['Shutdown', 'Shutdown', 'Booting', 'Booted'])
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', { timeoutMs: 5_000, pollIntervalMs: 0, settledGraceMs: 5_000 })
+      expect(device.status).toBe('booted')
+    })
+
+    it('abandons the poll as soon as the boot is superseded', async () => {
+      // The handler is fire-and-forget and its `bootSeq` check runs only once this returns, so
+      // without the signal a shutdown mid-wait leaves this spawning a process twice a second
+      // against a device that is deliberately off and will never converge.
+      const runner = transitioningRunner(['Booting'])
+      let stale = false
+      const wait = new SimctlWrapper(runner).waitUntilBooted('device-1', {
+        timeoutMs: 60_000,
+        pollIntervalMs: 5,
+        isStale: () => stale,
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      stale = true
+      await expect(wait).rejects.toThrow(/was superseded while waiting/)
+      const callsAtRejection = (runner.exec as ReturnType<typeof vi.fn>).mock.calls.length
+      await new Promise((r) => setTimeout(r, 40))
+      expect(runner.exec).toHaveBeenCalledTimes(callsAtRejection)
     })
   })
 

--- a/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
+++ b/packages/ios-agent/src/__tests__/SimctlWrapper.test.ts
@@ -95,6 +95,59 @@ describe('SimctlWrapper', () => {
     })
   })
 
+  describe('waitUntilBooted', () => {
+    // One `list` reading per call, walking the states in order and holding on the last — the shape a
+    // real boot has. `mockRunner` answers every `list` identically, which cannot express a transition.
+    function transitioningRunner(states: string[]): SimctlRunner {
+      let i = 0
+      const listing = (state: string) => JSON.stringify({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.iOS-17-0': [
+            { udid: 'device-1', name: 'iPhone 15', state, isAvailable: true },
+          ],
+        },
+      })
+      return {
+        exec: vi.fn(async (...args: string[]) =>
+          args[0] === 'list' ? listing(states[Math.min(i++, states.length - 1)]) : ''),
+        execBinary: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+        execWithOpts: vi.fn().mockResolvedValue(''),
+      }
+    }
+
+    it('polls until the device reaches Booted and returns what it read', async () => {
+      // `Shutdown` first on purpose: `simctl boot` has already returned by the time this runs, and the
+      // list can still report the pre-boot state for a moment. The call count is what says neither
+      // that reading nor `Booting` was accepted — three readings for three states.
+      const runner = transitioningRunner(['Shutdown', 'Booting', 'Booted'])
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', 5_000, 0)
+      expect(device.status).toBe('booted')
+      expect(device.name).toBe('iPhone 15')
+      expect(runner.exec).toHaveBeenCalledTimes(3)
+    })
+
+    it('reads once when the device is already up, even at a zero deadline', async () => {
+      // The deadline is checked after the read rather than before it. With the order reversed a device
+      // that is already booted would still have to wait out a poll interval to be reported as up.
+      const runner = transitioningRunner(['Booted'])
+      const device = await new SimctlWrapper(runner).waitUntilBooted('device-1', 0, 0)
+      expect(device.status).toBe('booted')
+      expect(runner.exec).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up at the deadline and names the last status it saw', async () => {
+      const runner = transitioningRunner(['Booting'])
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-1', 20, 5))
+        .rejects.toThrow(/did not finish booting within 20ms \(last seen: unknown\)/)
+    })
+
+    it('reports a device that is not in the list at all', async () => {
+      const runner = transitioningRunner(['Booted'])
+      await expect(new SimctlWrapper(runner).waitUntilBooted('device-404', 0, 0))
+        .rejects.toThrow(/last seen: no longer listed/)
+    })
+  })
+
   describe('shutdown', () => {
     it('calls simctl shutdown with the deviceId', async () => {
       const runner = mockRunner()


### PR DESCRIPTION
Closes #486.

`simctl boot` returns when CoreSimulator has *accepted* the boot, not when the device reaches `Booted`. Measured on an iPhone 17 Pro / iOS 26.5: `xcrun simctl bootstatus` reported `Finished` **7.6 seconds** after `boot` had already returned. `device:ready` went out inside that window, so it announced something that was not yet true.

A human is slower than the gap and rarely notices. `mcp-server` installs and taps the moment it sees `device:ready`, and #440's *app install intermittently fails with "No devices are booted"* was this — targeting the session's udid removed one of its two causes and left this one, because the two were indistinguishable at the time. Android has waited since the beginning (`EmulatorLauncher.waitForBoot`), so this closes an asymmetry rather than adding a policy.

## What changed

`SimctlWrapper.waitUntilBooted` polls the device list until the device reports `booted` and returns the record it read. `handleDeviceBoot` awaits it before `sendChromeData`, and a boot that never finishes ends as `device:boot-error` at a 90s deadline.

Four details of that poll are load-bearing, and three of them are holes the first commit shipped and the reviews found:

- **Every status other than `booted` counts as still coming up, `shutdown` included.** `toDeviceStatus` collapses `Booting` into `unknown`, and the wait only ever runs after a `boot` was accepted, so a `shutdown` reading is the transition not yet observed. A draft gave it a 3s grace and failed early on it; that was reverted, because the reading is not distinguishable from a slow machine's healthy boot and the 3000ms answered no measurement.
- **The boot is now issued on every path, including when the list already said `booted`** — which is what makes the sentence above true. That skip arrived with the original on-demand boot feature (`42a5ea6`) with no recorded reason, and became the only route into the wait with *nothing bringing the device up*: a tester who quits the simulator inside one `xcrun` round trip paid the whole deadline. `SimctlWrapper.boot` swallows `Unable to boot device in current state: Booted`, so a device that really is up costs one no-op subprocess.
- **A failed reading is not a reading.** This spawns `xcrun simctl list` up to 180 times where the old code spawned it once, each an independent chance to kill a healthy boot while CoreSimulator is busiest. Failures are retried, and the last is reported with the deadline — only if it is genuinely the last, which is why the success path clears it.
- **`isStale` cancels the poll from inside.** The handler is fire-and-forget and its `bootSeq` check runs only once the wait returns, so a shutdown mid-wait would otherwise leave a process spawning twice a second against a device that is deliberately off. The check after the wait stays too — it covers the microtask-thin case where the wait has resolved and the seq moves before the handler resumes.

`DeviceStatus` is left alone: widening it to carry `booting` would change a union `agent-core` publishes and the dashboard consumes, and the poll's exit condition never needed the distinction.

The hardcoded `status: 'booted'` on the chrome data is gone. It was written over a value that had just been fetched and discarded, and `sendChromeData` never reads `status`, so nothing observable changes — the value is now the one that was observed.

## Known gap, not fixed here

`mcp-server`'s `boot_device` waiter has a 30s deadline, which now sits *inside* the agent's 90s one. A cold or full-erase boot past 30s reports a bare timeout to the LLM rather than the reason the agent is about to send. That ceiling was unreachable while the agent answered on boot acceptance — with the answer `No devices are booted` came from. Raising it belongs with the `mcp-server` client.

## Verification

- `pnpm --filter @tapflowio/ios-agent test` → 15 files, 395 passed
- `pnpm --filter tapflow test` → 22 files, 246 passed
- `pnpm -w exec tsc -b` → clean

Five mutations run against the final HEAD, each confirmed to fail its intended test: deleting the post-wait `bootSeq` check; sending `device:ready` before the wait; replacing the inter-poll sleep with `await Promise.resolve()`; deleting `lastError = null` on the success path; restoring the `else if (target.status !== 'booted')` skip.

## Review

Three rounds of adversarial review, 14 findings, recorded in `.work/reviews/fix__ios-boot-readiness.md`. Round 1 ran two parallel lenses (runtime correctness; whether the tests hold their claims) and round 2 refuted the fix round 1 produced — the 3s grace above. Two drafts of the ordering test passed under the mutation they existed to catch and were rewritten; both stamped a read rather than an arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - iOS devices now report readiness only after fully booting.
  - Booting is handled consistently, including devices already marked as booted.
  - Temporary status-read failures are retried automatically.
  - Stale, interrupted, or shutdown boot operations stop polling cleanly.
  - Boot failures provide clearer details, including timeout information after 90 seconds.
  - Device status reported at readiness now reflects the observed device state.

- **Documentation**
  - Updated iOS agent guidance to describe the revised boot-readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->