### PR TITLE
fix: a screenshot's format is what the bytes are, not what was asked for

### DIFF
--- a/.changeset/android-screenshot-format.md
+++ b/.changeset/android-screenshot-format.md
@@ -1,0 +1,51 @@
+---
+'@tapflowio/protocol': patch
+'@tapflowio/android-agent': patch
+'@tapflowio/relay': patch
+'@tapflowio/mcp-server': patch
+---
+
+fix: a screenshot's format is what the bytes are, not what was asked for
+
+An Android screenshot requested as JPEG came back as **PNG bytes labelled `image/jpeg`** (#508).
+`AdbWrapper.screenshot()` runs `screencap -p` and takes no format argument, so Android always produces
+PNG — but the reply echoed the *requested* format, and the relay turns that field into the HTTP
+`Content-Type`.
+
+## The part that is not cosmetic
+
+`mcp-server`'s `getImageDimensions` picks a parser **by format**. Handed PNG bytes and told they are
+JPEG, it scans for a JPEG SOF0 marker; in a few hundred KB of IDAT a stray `ff c0` is close to certain,
+so it returned a **wrong** width and height. Those numbers go into the response text the LLM reads and
+hands back as `tap`'s `screenshotWidth` / `screenshotHeight`, which are its divisors — so the tap lands
+somewhere else on the screen. The usual reassurance that decoders sniff magic bytes and render anyway
+does not apply here: this format is not deciding how to render, it is deciding how to measure.
+
+## What changed, and what each edit is worth on its own
+
+- **`protocol`** now says what the request's `format` means: a **preference**, not a requirement. That
+  asymmetry is the platform contract rather than slack — `DeviceAgent.screenshot()` takes no format
+  argument, so no agent was ever asked to honour it. iOS happens to (`simctl io … --type`), Android
+  cannot, and a third-party platform registered through `AgentRegistry` is free to produce whatever it
+  can. Only `ScreenshotDone.format` describes an outcome, and even that is a claim.
+- **`android-agent`** answers `format: 'png'` unconditionally, because that is what it produced. On its
+  own this fixes **no in-repo consumer** — it makes the HTTP `Content-Type` honest for anything reading
+  the REST endpoint directly, and makes protocol's declaration true.
+- **`mcp-server`** reads the magic bytes instead of the request. This is the edit users feel, and it
+  works against an agent that has **not** been upgraded — agents are separate processes on separate
+  release lines and this protocol has no version handshake, so a self-hosted install running an older
+  Mac agent is the ordinary case, not an edge one. When the format differs from what was asked for, the
+  response says so; when the bytes match neither signature it falls back to the request and says that
+  too, rather than presenting a guess as a reading.
+- **`relay`** logs a mismatch between the bytes and the agent's claim, and **does not overwrite it**.
+  Correcting the field there would make the relay the authority on something only the agent can know,
+  which is a contract change where this is a drift detector. It costs four bytes of a buffer the relay
+  had already decoded. Without it the consumer-side sniff would hide a lying agent forever — #508 was
+  found by a person noticing, and nothing reported it.
+
+The MCP `screenshot` tool keeps its `format` parameter: dropping it is a change to a published tool
+schema, and it is a working feature on iOS. Its description and the docs now name the platform
+difference.
+
+Not addressed: `relay/src/types.ts` keeps its own `format?: 'png' | 'jpeg'` while protocol declares it
+required — the drift that package exists to remove, and a separate slice.

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -100,7 +100,7 @@ Any MCP-compatible client can use tapflow. Add the following to your MCP config 
 | `disconnect_device` | End a session |
 | `boot_device` | Boot a simulator or emulator |
 | `shutdown_device` | Power the device down (frees resources; forces a cold boot next time) |
-| `screenshot` | Capture the current screen (PNG or JPEG) |
+| `screenshot` | Capture the current screen (PNG, or JPEG on iOS when requested) |
 | `query_ui_tree` | Read the on-screen UI as a structured accessibility tree (role, label, identifier, frame) |
 | `tap` | Tap at a coordinate |
 | `swipe` | Swipe between two coordinates |

--- a/docs/ko/guide/mcp-server.md
+++ b/docs/ko/guide/mcp-server.md
@@ -100,7 +100,7 @@ MCP를 지원하는 클라이언트라면 모두 tapflow를 사용할 수 있습
 | `disconnect_device` | 세션 종료 |
 | `boot_device` | 시뮬레이터·에뮬레이터 부팅 |
 | `shutdown_device` | 기기 전원 종료 (리소스 반납·다음 콜드 부팅 강제) |
-| `screenshot` | 현재 화면 캡처 (PNG 또는 JPEG) |
+| `screenshot` | 현재 화면 캡처 (PNG, iOS는 요청 시 JPEG) |
 | `query_ui_tree` | 화면 UI를 구조화된 접근성 트리로 조회 (role·label·identifier·frame) |
 | `tap` | 좌표 터치 |
 | `swipe` | 스와이프 |

--- a/packages/android-agent/AGENTS.md
+++ b/packages/android-agent/AGENTS.md
@@ -51,6 +51,17 @@ Measured against a killed emulator: the gRPC RPC rejects in **4ms** with `14 UNA
 - `ANDROID_HOME` or `ADB_PATH` environment variable is required. Missing → clear error and immediate exit.
 - Apple Silicon Mac: `system-images;android-34;google_apis;arm64-v8a` image required.
 
+### A screenshot reply names what was produced, never what was asked for
+
+`screencap -p` produces PNG and takes no format argument, so `screenshot:done` answers `format: 'png'`
+unconditionally — including for a JPEG request. The request's `format` is a **preference** and this
+platform cannot honour it; only the reply describes an outcome (see `ScreenshotRequest` in protocol).
+
+Echoing the request is #508: the relay writes that field into the HTTP `Content-Type`, so PNG bytes went
+out as `image/jpeg`, and `mcp-server` picked a JPEG parser for the dimensions it hands the LLM as
+`tap`'s divisors. The type system cannot see it — `'png' | 'jpeg'` is correct on both sides — so the
+test that pins a jpeg request to a `png` answer is the whole enforcement.
+
 ### Mapping internal reasons onto the wire
 
 `inputOutcome.ts` keeps this agent's seven internal reasons; `wireReason()` maps them onto the closed

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -1305,8 +1305,11 @@ export class AndroidAgent implements DeviceAgent {
         break
       }
       case 'screenshot:request': {
+        // `format` is deliberately destructured and unused — it is on the wire and this platform
+        // cannot honour it, which is the whole of #508. Reading it here and answering with it is
+        // exactly the bug.
         const raw = msg as unknown as { requestId: string; format?: 'png' | 'jpeg'; sessionId?: string }
-        const { requestId, format } = raw
+        const { requestId } = raw
         const sessionId = msg.sessionId
         const state = this.deviceStates.get(sessionId!)
         const serial = state ? this.adb.getSerial(state.deviceId) : undefined
@@ -1319,7 +1322,11 @@ export class AndroidAgent implements DeviceAgent {
             type: 'screenshot:done',
             sessionId,
             requestId,
-            format: format ?? 'png',
+            // `'png'`, never the requested format. `screencap -p` produces PNG and takes no format
+            // argument, and this field means what was produced — the request's is a preference (see
+            // `ScreenshotRequest` in protocol). Echoing it sent PNG bytes out under `image/jpeg`
+            // (#508), which the relay then wrote into the HTTP Content-Type.
+            format: 'png',
             data: buf.toString('base64'),
           }))
           .catch((e: unknown) => {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -1377,6 +1377,28 @@ describe('AndroidAgent', () => {
         expect(sent['format']).toBe('png')
         expect(sent['data']).toBe(Buffer.from('PNGDATA').toString('base64'))
       })
+
+      it('answers png for a jpeg request, because that is what it produced (#508)', async () => {
+        // `screencap -p` produces PNG and takes no format argument, so the request is a preference
+        // this platform cannot honour (see `ScreenshotRequest` in protocol). Echoing it sent PNG
+        // bytes out under `format: 'jpeg'`, which the relay wrote into the HTTP Content-Type — and
+        // `mcp-server` then picked a JPEG parser for the dimensions it feeds to `tap` as divisors.
+        vi.spyOn(adb, 'screenshot').mockResolvedValue(Buffer.from('PNGDATA'))
+        const sendSpy = vi.spyOn(internals(agent).ws!, 'send')
+
+        inject({ type: 'screenshot:request', requestId: 'req-2', format: 'jpeg' })
+
+        const sent = await vi.waitFor(() => {
+          const msg = sendSpy.mock.calls
+            .map((c) => JSON.parse(c[0] as string) as Record<string, unknown>)
+            .find((m) => m['type'] === 'screenshot:done')
+          expect(msg).toBeDefined()
+          return msg!
+        }, { timeout: 1000 })
+
+        expect(sent['format']).toBe('png')
+        expect(sent['requestId']).toBe('req-2')
+      })
     })
   })
 

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -24,6 +24,17 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 - Client: `src/client.ts` — WebSocket connection to relay + REST calls for build/app data. Its `send()` takes `BrowserToRelay` from [`@tapflowio/protocol`](../protocol/AGENTS.md), so a new outbound message goes in that union first. Receiving stays loose (`Record<string, unknown>` + a predicate) — a **deferral, not a settled decision**, tracked in #512. Narrowing it would catch a live defect (`error` is matched on a `sessionId` that message does not have, so one session's failure can be reported against another's join) but it also makes `message: string`, turning this file's `?? 'failed'` fallbacks into unreachable code. Deleting those while nothing validates inbound JSON removes a real defence, so the validators (#444) come first.
 - Tools: `src/tools.ts` — all MCP tool definitions. One `registerTools(server, client)` call registers everything.
 - Screenshots are saved to a temp file and returned as MCP `image` content with base64 encoding.
+- **The screenshot's format is read from its magic bytes, not from the request or the reply** (#508).
+  The request's `format` is a preference (`ScreenshotRequest` in protocol) and the reply's is a claim, so
+  neither can decide how to *parse* the bytes — and `getImageDimensions` picks a parser by format, feeding
+  numbers the LLM hands back as `tap`'s divisors. Android produces PNG whatever is asked and used to echo
+  the request, so a JPEG request was measured with a JPEG parser against PNG bytes, where a stray `ff c0`
+  in the IDAT reads as a SOF0 marker and yields a wrong size. Sniffing here rather than trusting the
+  agent's fix is what makes it work against an agent that has **not** been upgraded — separate processes,
+  separate release lines, no version handshake. Unrecognised bytes fall back to the request and the
+  response says so.
+
+
 
 ### Tool semantics (non-obvious)
 

--- a/packages/mcp-server/src/__tests__/tools.screenshot.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.screenshot.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerTools } from '../tools.js'
+import type { TapflowClient } from '../client.js'
+
+type ToolResult = {
+  content: Array<{ type: string; text?: string; mimeType?: string }>
+  isError?: boolean
+}
+type Handler = (args: Record<string, unknown>) => Promise<ToolResult>
+
+function captureTools(client: TapflowClient): Map<string, Handler> {
+  const handlers = new Map<string, Handler>()
+  const server = {
+    registerTool: (name: string, _config: unknown, handler: Handler) => { handlers.set(name, handler) },
+  }
+  registerTools(server as unknown as McpServer, client)
+  return handlers
+}
+
+/** A 1×1 PNG header: signature, then IHDR with width and height at bytes 16–23. */
+function pngBytes(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(64)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0)
+  buf.write('IHDR', 12)
+  buf.writeUInt32BE(width, 16)
+  buf.writeUInt32BE(height, 20)
+  return buf
+}
+
+/** A JPEG whose SOF0 marker carries the dimensions, laid out the way the parser reads it. */
+function jpegBytes(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(64)
+  buf[0] = 0xff
+  buf[1] = 0xd8
+  buf[20] = 0xff
+  buf[21] = 0xc0
+  buf.writeUInt16BE(height, 25)
+  buf.writeUInt16BE(width, 27)
+  return buf
+}
+
+function clientReturning(buf: Buffer): TapflowClient {
+  return {
+    screenshot: vi.fn(async () => buf),
+  } as unknown as TapflowClient
+}
+
+const text = (res: ToolResult) => res.content.find((c) => c.type === 'text')?.text ?? ''
+const image = (res: ToolResult) => res.content.find((c) => c.type === 'image')
+
+// #508. The request's `format` is a preference and the reply's is a claim, so neither can decide how
+// to parse the bytes. Android produces PNG whatever is asked — `screencap -p` takes no format — and
+// used to echo the request, so a JPEG request arrived as PNG bytes that the dimension parser scanned
+// for a JPEG SOF0 marker. A stray `ff c0` in a few hundred KB of IDAT is close to certain, so the
+// numbers were wrong, and they go into the text the LLM hands back as `tap`'s divisors.
+describe('screenshot — the bytes decide the format, not the request', () => {
+  const handler = (buf: Buffer) => captureTools(clientReturning(buf)).get('screenshot') as Handler
+
+  it('reports PNG for PNG bytes even when jpeg was asked for', async () => {
+    const res = await handler(pngBytes(1170, 2532))({ sessionId: 's1', format: 'jpeg' })
+    expect(image(res)?.mimeType).toBe('image/png')
+    expect(text(res)).toContain('.png')
+    // The dimensions are the ones a PNG parser reads. Under the old code this asked a JPEG parser for
+    // them, which is the half that reaches `tap`.
+    expect(text(res)).toContain('1170×2532px')
+    expect(text(res)).toContain('jpeg was requested but the device produced png')
+  })
+
+  it('still honours a JPEG that really is one', async () => {
+    // The path that already worked gets mutated first (`contributing/test-and-guard-coverage.md` §4):
+    // a sniffer that answered `png` for everything would fix Android and silently break iOS, whose
+    // JPEG request is the only one any platform fulfils.
+    const res = await handler(jpegBytes(828, 1792))({ sessionId: 's1', format: 'jpeg' })
+    expect(image(res)?.mimeType).toBe('image/jpeg')
+    expect(text(res)).toContain('.jpg')
+    expect(text(res)).toContain('828×1792px')
+    // Nothing to report when the request was met.
+    expect(text(res)).not.toContain('but the device produced')
+  })
+
+  it('leaves the ordinary png request quiet', async () => {
+    const res = await handler(pngBytes(400, 800))({ sessionId: 's1' })
+    expect(image(res)?.mimeType).toBe('image/png')
+    expect(text(res)).toContain('400×800px')
+    expect(text(res)).not.toContain('produced')
+    expect(text(res)).not.toContain('unrecognised')
+  })
+
+  it('says so when the bytes match neither signature', async () => {
+    // Reachable only from a platform registered through `AgentRegistry` that produces something else
+    // — `DeviceAgent.screenshot()` takes no format, so nothing constrains it. Falling back to the
+    // request keeps the old behaviour; saying so is what stops it being presented as a reading, and
+    // `tap` takes these dimensions as required arguments.
+    const res = await handler(Buffer.from('RIFF....WEBPVP8 '))({ sessionId: 's1', format: 'jpeg' })
+    expect(image(res)?.mimeType).toBe('image/jpeg')
+    expect(text(res)).toContain('unrecognised format, read as jpeg')
+  })
+})

--- a/packages/mcp-server/src/__tests__/tools.screenshot.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.screenshot.test.ts
@@ -87,6 +87,17 @@ describe('screenshot — the bytes decide the format, not the request', () => {
     expect(text(res)).not.toContain('unrecognised')
   })
 
+  it('does not accept a PNG signature that only starts right', async () => {
+    // The four-byte prefix is not the signature. `0d 0a 1a 0a` is there to catch a mangled transfer —
+    // CRLF translation, a truncated read — and that is exactly the buffer that must not be measured as
+    // a PNG, because `getImageDimensions` would read a width and height out of bytes 16-23 regardless.
+    const mangled = pngBytes(1170, 2532)
+    mangled[4] = 0x0a // the `0d` translated away, which is what a text-mode transfer does to it
+    const res = await handler(mangled)({ sessionId: 's1', format: 'jpeg' })
+    expect(text(res)).toContain('unrecognised format')
+    expect(text(res)).not.toContain('1170×2532px')
+  })
+
   it('says so when the bytes match neither signature', async () => {
     // Reachable only from a platform registered through `AgentRegistry` that produces something else
     // — `DeviceAgent.screenshot()` takes no format, so nothing constrains it. Falling back to the

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -26,6 +26,29 @@ function makeFlowDriver(client: TapflowClient, sessionId: string, buildId?: numb
   }
 }
 
+/**
+ * What a buffer actually is, from its magic bytes, or `null` for anything else.
+ *
+ * The request's `format` is a **preference** (see `ScreenshotRequest` in protocol) and the reply's is
+ * a claim, so neither can decide how to parse these bytes. Android produces PNG whatever is asked —
+ * `screencap -p` takes no format — and used to echo the request, so a JPEG request arrived as PNG
+ * bytes that `getImageDimensions` then scanned for a JPEG SOF0 marker. In a few hundred KB of IDAT a
+ * stray `ff c0` is close to certain, which yielded a **wrong** width and height, and those numbers go
+ * into the response text the LLM reads and hands back as `tap`'s divisors. The tap lands somewhere
+ * else on the screen (#508).
+ *
+ * Sniffing here rather than trusting the agent's fix is what makes this work against an agent that
+ * has *not* been upgraded: agents are separate processes on separate release lines and this protocol
+ * has no version handshake, so a self-hosted user running an older Mac agent is the ordinary case.
+ *
+ * Duplicated in the relay for the same reason its copy is duplicated here — see that one's note.
+ */
+function sniffImageFormat(buf: Buffer): 'png' | 'jpeg' | null {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png'
+  if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xd8) return 'jpeg'
+  return null
+}
+
 function getImageDimensions(buf: Buffer, format: string): { width: number; height: number } | null {
   if (format === 'png' && buf.length >= 24) {
     return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
@@ -246,24 +269,39 @@ export function registerTools(server: McpServer, client: TapflowClient): void {
       description: 'Capture the current screen of a device. Returns the image so you can analyze it.',
       inputSchema: {
         sessionId: z.string().describe('Session ID from list_devices'),
-        format: z.enum(['png', 'jpeg']).optional().describe('Image format (default: png)'),
+        format: z.enum(['png', 'jpeg']).optional().describe(
+          'Preferred image format (default: png). Honoured on iOS; Android always returns PNG, and the ' +
+          'response says so when it differs.',
+        ),
       },
     },
     async ({ sessionId, format }) => {
       try {
-        const fmt = format ?? 'png'
-        const buf = await client.screenshot(sessionId, fmt)
-        const mimeType = fmt === 'jpeg' ? 'image/jpeg' : 'image/png'
-        const ext = fmt === 'jpeg' ? 'jpg' : 'png'
+        const requested = format ?? 'png'
+        const buf = await client.screenshot(sessionId, requested)
+        // The bytes decide, not what was asked for and not what the reply claims. Falling back to the
+        // request when nothing matches keeps the old behaviour for a producer neither signature
+        // covers, and says so rather than presenting a guess as a reading.
+        const sniffed = sniffImageFormat(buf)
+        const actual = sniffed ?? requested
+        const mimeType = actual === 'jpeg' ? 'image/jpeg' : 'image/png'
+        const ext = actual === 'jpeg' ? 'jpg' : 'png'
         const filename = `tapflow-${sessionId.slice(0, 8)}-${Date.now()}.${ext}`
         const filePath = path.join(os.tmpdir(), filename)
         fs.writeFileSync(filePath, buf)
-        const dims = getImageDimensions(buf, fmt)
+        const dims = getImageDimensions(buf, actual)
         const dimText = dims ? ` (${dims.width}×${dims.height}px)` : ''
+        // Named only when it differs, so the ordinary case stays quiet — and named at all because the
+        // caller asked for something it did not get, and `tap` takes these dimensions as divisors.
+        const formatNote = sniffed === null
+          ? ` — the image is in an unrecognised format, read as ${requested}`
+          : sniffed !== requested
+            ? ` — ${requested} was requested but the device produced ${sniffed}`
+            : ''
         return {
           content: [
             { type: 'image' as const, data: buf.toString('base64'), mimeType },
-            { type: 'text' as const, text: `Screenshot saved: ${filePath}${dimText}` },
+            { type: 'text' as const, text: `Screenshot saved: ${filePath}${dimText}${formatNote}` },
           ],
         }
       } catch (e) {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -43,8 +43,15 @@ function makeFlowDriver(client: TapflowClient, sessionId: string, buildId?: numb
  *
  * Duplicated in the relay for the same reason its copy is duplicated here — see that one's note.
  */
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
 function sniffImageFormat(buf: Buffer): 'png' | 'jpeg' | null {
-  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png'
+  // All eight signature bytes, not the leading four. The trailing `0d 0a 1a 0a` is the part that
+  // detects a mangled transfer — CRLF translation, a truncated read — and those produce exactly the
+  // buffer this must not call a PNG, because `getImageDimensions` would then read a width and height
+  // out of whatever sits at bytes 16-23.
+  if (buf.length >= PNG_SIGNATURE.length && PNG_SIGNATURE.every((b, i) => buf[i] === b)) return 'png'
+  // JPEG has no counterpart: SOI is two bytes and that is the whole marker.
   if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xd8) return 'jpeg'
   return null
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -243,6 +243,20 @@ export interface ScreenshotRequest {
   type: 'screenshot:request'
   sessionId: string
   requestId: string
+  /**
+   * A **preference, not a requirement.** An agent may produce something else, and says what it
+   * produced in `ScreenshotDone.format`.
+   *
+   * That asymmetry is not slack, it is the platform contract: `DeviceAgent.screenshot()` takes no
+   * format argument at all, so no agent has ever been asked to honour this — iOS happens to
+   * (`simctl io … --type`), Android cannot (`screencap -p` produces PNG and takes no format), and a
+   * third-party platform registered through `AgentRegistry.register()` is free to produce whatever
+   * it can. Required here only because every in-repo sender supplies one; absence would have to mean
+   * "no preference", which is what `'png'` already means.
+   *
+   * A consumer that needs to know what it is holding reads the **bytes**, not this field and not the
+   * reply's echo of it — #508 was this field being read as an outcome.
+   */
   format: 'png' | 'jpeg'
 }
 
@@ -785,8 +799,17 @@ export interface ScreenshotDone {
   type: 'screenshot:done'
   sessionId: string
   requestId: string
-  /** What the agent says it produced — the relay turns this into the HTTP `Content-Type`. Android
-   *  currently echoes the *requested* format while always producing PNG (#508). */
+  /**
+   * What the agent produced — the relay turns this into the HTTP `Content-Type`.
+   *
+   * The **only** field on this pair that describes an outcome; the request's `format` is a
+   * preference (see `ScreenshotRequest`). Android echoed the request here while always producing
+   * PNG, so a JPEG request came back as PNG bytes labelled `image/jpeg` (#508).
+   *
+   * Still a claim rather than a guarantee: it is what the agent *says*, and an agent older than the
+   * fix says the wrong thing. The relay logs a mismatch against the bytes but does not overwrite
+   * this — a consumer whose behaviour depends on the real format sniffs the bytes itself.
+   */
   format: 'png' | 'jpeg'
   /** base64. */
   data: string

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -66,8 +66,12 @@ const DEFAULT_AGENT_GRACE_MS = 15_000
  * situation as `correlatesWith` across the two clients, and the same answer — each copy has tests.
  * These two signatures have not changed since 1992 and 1996, so there is little for them to drift to.
  */
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
 function sniffImageFormat(buf: Buffer): 'png' | 'jpeg' | null {
-  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png'
+  // All eight signature bytes — see the note on the `mcp-server` copy for why the trailing four earn
+  // their place. Here a false `png` would report a mismatch that is not one.
+  if (buf.length >= PNG_SIGNATURE.length && PNG_SIGNATURE.every((b, i) => buf[i] === b)) return 'png'
   if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xd8) return 'jpeg'
   return null
 }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -57,6 +57,20 @@ const HEARTBEAT_MS = 30_000
 // times over and about half of a hand-typed restart. What bounds it is the other direction: the
 // device stays claimed by a session nobody can use until the window closes.
 const DEFAULT_AGENT_GRACE_MS = 15_000
+
+/**
+ * What a buffer actually is, from its magic bytes, or `null` for anything else.
+ *
+ * Duplicated in `mcp-server` rather than shared: `protocol`'s entry must erase under `import type`
+ * so it cannot hold a runtime value, and `mcp-server` does not depend on `agent-core`. The same
+ * situation as `correlatesWith` across the two clients, and the same answer — each copy has tests.
+ * These two signatures have not changed since 1992 and 1996, so there is little for them to drift to.
+ */
+function sniffImageFormat(buf: Buffer): 'png' | 'jpeg' | null {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png'
+  if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xd8) return 'jpeg'
+  return null
+}
 import { handleVerifyReset, handleDoReset, handleSendMemberReset } from './api/passwordReset.js'
 import { handleListBuilds, handleGetBuild, handleUpdateBuild, handleUploadBuild, handleScheduleBuildDeletion, handleCancelBuildDeletion, purgeExpiredBuilds } from './api/builds.js'
 import { handleListApps, handleCreateApp, handleUpdateApp, handleDeleteApp } from './api/apps.js'
@@ -1605,7 +1619,21 @@ export class RelayServer {
     const pending = this.pendingScreenshots.get(msg.requestId)
     if (!pending) return
     const buf = Buffer.from(msg.data ?? '', 'base64')
-    pending.resolve(buf, msg.format ?? 'png')
+    const claimed = msg.format ?? 'png'
+    // Logged, **not** overwritten. The field means what the agent says it produced, and correcting it
+    // here would make the relay the authority on something only the agent can know — a contract
+    // change, where this is a drift detector. It costs four bytes of an already-decoded buffer.
+    //
+    // Worth having because the consumer-side fix for #508 sniffs the bytes and would otherwise hide a
+    // lying agent forever: #508 was found by a person noticing, and nothing would have reported it.
+    const actual = sniffImageFormat(buf)
+    if (actual !== null && actual !== claimed) {
+      logger.warn(
+        `[relay] screenshot from session ${msg.sessionId ?? '?'} is ${actual} but the agent called it ` +
+        `${claimed} — the Content-Type will be wrong. Upgrade the agent (#508).`,
+      )
+    }
+    pending.resolve(buf, claimed)
   }
 
   private handleScreenshotError(msg: RelayMessage): void {

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
 import http from 'http'
 import fs from 'fs'
 import os from 'os'
@@ -103,6 +103,43 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     expect(res.body).toEqual(FAKE_PNG)
 
     agent.close()
+  })
+
+  it('TC1b: 라벨과 바이트가 어긋나면 경고를 남기되 라벨을 덮어쓰지는 않는다 (#508)', async () => {
+    // 소비자 쪽 sniff는 거짓말하는 agent를 영구히 감춘다. #508은 사람이 눈치채서 발견됐고 아무것도
+    // 보고하지 않았다. relay는 이미 base64를 디코드하므로 4바이트를 더 읽는 비용으로 탐지가 남는다.
+    //
+    // 덮어쓰지 않는 것이 핵심이다. 이 필드는 agent가 자기 생산물에 대해 말한 것이고, relay가 고치면
+    // agent만 알 수 있는 것의 권한을 relay가 가져가는 계약 변경이 된다. 그래서 Content-Type은 여전히
+    // 어긋난 채 나가고, 그 사실이 경고에 적힌다.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { agent, sessionId } = await setupAgent()
+      agent.on('message', (data) => {
+        const msg = JSON.parse(data.toString()) as RelayMessage
+        if (msg.type === 'screenshot:request') {
+          agent.send(JSON.stringify({
+            type: 'screenshot:done',
+            sessionId: msg.sessionId,
+            requestId: msg.requestId,
+            format: 'jpeg',
+            data: FAKE_PNG.toString('base64'),
+          }))
+        }
+      })
+
+      const res = await httpGet(
+        port,
+        `/api/v1/sessions/${sessionId}/screenshot?format=jpeg`,
+        { Cookie: makeAuthCookie() },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers['content-type']).toBe('image/jpeg')
+      expect(warn.mock.calls.flat().join(' ')).toMatch(/is png but the agent called it jpeg/)
+
+      agent.close()
+    } finally { warn.mockRestore() }
   })
 
   it('TC2: JPEG 포맷 요청 — agent가 jpeg 응답 시 200 image/jpeg', async () => {

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -105,13 +105,14 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     agent.close()
   })
 
-  it('TC1b: 라벨과 바이트가 어긋나면 경고를 남기되 라벨을 덮어쓰지는 않는다 (#508)', async () => {
-    // 소비자 쪽 sniff는 거짓말하는 agent를 영구히 감춘다. #508은 사람이 눈치채서 발견됐고 아무것도
-    // 보고하지 않았다. relay는 이미 base64를 디코드하므로 4바이트를 더 읽는 비용으로 탐지가 남는다.
+  it('TC1b: warns when the label disagrees with the bytes, without overwriting it (#508)', async () => {
+    // The consumer-side sniff fixes the symptom and hides a lying agent forever. #508 was found by a
+    // person noticing, and nothing reported it — so the detector is worth the eight bytes read off a
+    // buffer the relay had already decoded.
     //
-    // 덮어쓰지 않는 것이 핵심이다. 이 필드는 agent가 자기 생산물에 대해 말한 것이고, relay가 고치면
-    // agent만 알 수 있는 것의 권한을 relay가 가져가는 계약 변경이 된다. 그래서 Content-Type은 여전히
-    // 어긋난 채 나가고, 그 사실이 경고에 적힌다.
+    // Not overwriting is the point. The field is what the agent says it produced, and correcting it
+    // here would make the relay the authority on something only the agent can know. So the
+    // Content-Type still goes out wrong, and the warning is what says so.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       const { agent, sessionId } = await setupAgent()
@@ -142,9 +143,10 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     } finally { warn.mockRestore() }
   })
 
-  it('TC1c: 라벨과 바이트가 맞으면 아무 말도 하지 않는다', async () => {
-    // TC1b의 짝. 저 테스트만으로는 조건을 `true`로 바꾼 구현이 통과한다 — 경고가 매 스크린샷마다
-    // 나가면 드리프트 탐지기가 아니라 소음이 되고, 진짜 불일치가 그 안에 묻힌다.
+  it('TC1c: stays silent when the label and the bytes agree', async () => {
+    // TC1b's twin. On its own that test passes for an implementation whose condition is `true` — a
+    // warning on every screenshot is not a drift detector but noise, and a real mismatch is then
+    // buried in it.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       const { agent, sessionId } = await setupAgent()

--- a/packages/relay/src/__tests__/screenshot.test.ts
+++ b/packages/relay/src/__tests__/screenshot.test.ts
@@ -142,6 +142,38 @@ describe('GET /api/v1/sessions/:sessionId/screenshot', () => {
     } finally { warn.mockRestore() }
   })
 
+  it('TC1c: 라벨과 바이트가 맞으면 아무 말도 하지 않는다', async () => {
+    // TC1b의 짝. 저 테스트만으로는 조건을 `true`로 바꾼 구현이 통과한다 — 경고가 매 스크린샷마다
+    // 나가면 드리프트 탐지기가 아니라 소음이 되고, 진짜 불일치가 그 안에 묻힌다.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { agent, sessionId } = await setupAgent()
+      agent.on('message', (data) => {
+        const msg = JSON.parse(data.toString()) as RelayMessage
+        if (msg.type === 'screenshot:request') {
+          agent.send(JSON.stringify({
+            type: 'screenshot:done',
+            sessionId: msg.sessionId,
+            requestId: msg.requestId,
+            format: 'png',
+            data: FAKE_PNG.toString('base64'),
+          }))
+        }
+      })
+
+      const res = await httpGet(
+        port,
+        `/api/v1/sessions/${sessionId}/screenshot`,
+        { Cookie: makeAuthCookie() },
+      )
+
+      expect(res.status).toBe(200)
+      expect(warn.mock.calls.flat().join(' ')).not.toMatch(/the agent called it/)
+
+      agent.close()
+    } finally { warn.mockRestore() }
+  })
+
   it('TC2: JPEG 포맷 요청 — agent가 jpeg 응답 시 200 image/jpeg', async () => {
     const { agent, sessionId } = await setupAgent()
 


### PR DESCRIPTION
Closes #508.

An Android screenshot requested as JPEG came back as **PNG bytes labelled `image/jpeg`**. `AdbWrapper.screenshot()` runs `screencap -p` and takes no format argument, so Android always produces PNG — but the reply echoed the *requested* format, and the relay turns that field into the HTTP `Content-Type`.

## The part that is not cosmetic

`mcp-server`'s `getImageDimensions` picks a parser **by format**. Handed PNG bytes and told they are JPEG, it scans for a JPEG SOF0 marker; in a few hundred KB of IDAT a stray `ff c0` is close to certain, so it returned a **wrong** width and height. Those numbers go into the response text the LLM reads and hands back as `tap`'s `screenshotWidth` / `screenshotHeight`, which are its divisors — so the tap lands somewhere else on the screen.

The usual reassurance that decoders sniff magic bytes and render anyway does not apply here: this format is not deciding how to render, it is deciding how to **measure**.

## Four edits, worth different things

- **`protocol`** states what the request's `format` means: a **preference**, not a requirement. That asymmetry is the platform contract rather than slack — `DeviceAgent.screenshot()` takes no format argument, so no agent was ever asked to honour it. iOS happens to (`simctl io … --type`), Android cannot, and a third-party platform registered through `AgentRegistry` is free to produce whatever it can. Only `ScreenshotDone.format` describes an outcome, and even that is a claim.
- **`android-agent`** answers `format: 'png'` unconditionally. On its own this fixes **no in-repo consumer** — it makes the `Content-Type` honest for anything reading the REST endpoint directly, and makes protocol's declaration true.
- **`mcp-server`** reads the magic bytes instead of the request. This is the edit users feel, and it works against an agent that has **not** been upgraded — agents are separate processes on separate release lines with no version handshake, so a self-hosted install running an older Mac agent is the ordinary case. When the format differs from what was asked for the response says so; when the bytes match neither signature it falls back to the request and says that too.
- **`relay`** logs a mismatch between the bytes and the agent's claim, and **does not overwrite it**. Correcting the field there would make the relay the authority on something only the agent can know. It costs four bytes of a buffer the relay had already decoded, and without it the consumer-side sniff would hide a lying agent forever — #508 was found by a person noticing, and nothing reported it.

The MCP `screenshot` tool keeps its `format` parameter: dropping it changes a published tool schema, and it is a working feature on iOS. Its description and the docs now name the platform difference.

## Not addressed

- `relay/src/types.ts` keeps its own `format?: 'png' | 'jpeg'` while protocol declares it required — the drift that package exists to remove.
- `MjpegStreamer` produces PNG and stamps `CODEC_JPEG`, so `ios-agent/AGENTS.md`'s "the MjpegStreamer fallback is always JPEG" is false about the bytes. Unreachable in production (only tests pass `intervalMs`), so user impact is zero.

## Verification

- `pnpm --filter @tapflowio/android-agent test` → 264 passed
- `pnpm --filter @tapflowio/relay test` → 622 passed, 1 skipped
- `pnpm --filter @tapflowio/mcp-server test` → 87 passed
- `pnpm -w exec tsc -b` → clean

Three mutations confirmed to fail their intended tests: restoring the request echo in `AndroidAgent`; replacing the sniff result with the requested format; making the relay's mismatch condition unconditional.

## Review

Two rounds, recorded in `.work/reviews/fix__android-screenshot-format.md`. The **design** pass ran before any code (two packages) and refuted both stated grounds of the first plan: the relay already decodes the base64 so sniffing there is free, and nothing in-repo reads the HTTP `Content-Type` so it buys nothing — version skew is the real reason the sniff belongs at the consumer. It also found that `DeviceAgent` never had a format argument, which is why the protocol sentence had to land before the agent change. The **code** pass found the mismatch log had no test for staying silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android screenshots now accurately report PNG format, including when JPEG is requested.
  * Screenshot handling detects the actual image format and identifies mismatches or unknown formats.
  * Relay services warn about format discrepancies without altering reported results.

* **Documentation**
  * Clarified screenshot format behavior across MCP, Android, and protocol documentation.
  * Documented that PNG is generally provided, while iOS may return JPEG when requested.

* **Tests**
  * Added coverage for PNG, JPEG, mislabeled, and unrecognized screenshot formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->