### PR TITLE
test(ios-agent): give the reconnect test a handshake budget, not just a retry interval

### DIFF
--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -912,7 +912,21 @@ describe('IOSAgent', () => {
       )
       const browser = new WebSocket(`ws://localhost:${port}`)
       await waitForOpen(browser)
-      const agent = new IOSAgent({ intervalMs: 50, reconnectDelays: [20] }, simctl)
+      // `handshakeTimeoutMs` alongside `reconnectDelays`, and it is the one that made this flake.
+      //
+      // This test stops the relay and starts a new one on the same port, then waits ~3s for the agent's
+      // own reconnect to re-register. The retry interval was already shortened to 20ms — but a reconnect
+      // that opens a socket and then does not receive `agent:registered` waits out
+      // `handshakeTimeoutMs`, which defaults to **10 seconds**. One attempt landing in that window is
+      // longer than the whole budget, so no further retry happens and the join below sees no session.
+      // The interval alone was never enough: it only decides how soon the *next* attempt starts, and the
+      // failing attempt is the one that never ends.
+      //
+      // Reachable whenever the agent connects to a relay that is not yet answering — the socket is
+      // accepted before the handler is ready, or the event loop is busy enough that the register round
+      // trip misses the window. Both are ordinary on a loaded CI runner and neither reproduces locally:
+      // this passed 8/8 in isolation while failing twice on CI.
+      const agent = new IOSAgent({ intervalMs: 50, reconnectDelays: [20], handshakeTimeoutMs: 200 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')


### PR DESCRIPTION
`does not install a helper onto a state that a reconnect has already dropped` failed on CI twice — on #533 and again on #535, **a branch that does not touch ios-agent at all**. That second failure is what makes it a problem in main rather than in either PR. It passes 8/8 locally in isolation and 3/3 as a full suite.

Both failures were the same assertion: `expect(joined).not.toBeNull()` — the agent had not re-registered within the ~3s the test spends polling after the relay is stopped and restarted on the same port.

## Why the retry interval was not the fix it looked like

The test already shortens `reconnectDelays` to `[20]`, and the reconnect loop is unbounded, so 3s allows ~150 attempts. That reasoning is what hid this: **the interval decides when the next attempt starts, and the failing attempt is the one that never ends.**

`_scheduleReconnect` runs only from `connect()`'s `.catch` (`IOSAgent.ts:380`), and `handshakeTimeoutMs` defaults to **10 seconds** (`IOSAgent.ts:202`) — which the test never overrode. An attempt that opens a socket and then does not receive `agent:registered` blocks every later attempt for those 10 seconds, longer than the entire budget. One attempt landing in that window is enough.

The window is ordinary on a loaded runner: the socket is accepted before the new relay is answering, or the event loop is busy enough that the register round trip misses its slot. Neither reproduces on a fast local machine, which is why the suite looked clean.

## Other explanations ruled out

- **`relay.start()` taking >3s** — other tests in the file would fail too, and they did not.
- **A changed `sessionId` after re-registration** — the loop re-reads `agent.sessionId` every iteration, so it follows the update.
- **The relay refusing with `session-not-found`** — that leaves `waitForTypeOrNull` null and the loop retries; for all ~150 to be refused the agent must never re-register, which is the diagnosis above.

## Left alone

The two other `reconnectDelays` tests (`IOSAgent.test.ts:2284`, `AndroidAgent.test.ts:781`) drop the socket while the relay stays up, so their handshake answers immediately and no failure has been observed on either.

## Review

Adversarial review skipped, with the reason recorded in `.work/reviews/test__ios-reconnect-flake.md`: no production code changes, and the diagnosis is settled by reading the code rather than by judgement — `_scheduleReconnect` is reachable only from the `.catch`, the default is 10s, and the budget is 3s.

`pnpm --filter @tapflowio/ios-agent test` × 3 → 396 passed.

<!-- no-changeset: test-only — a test option and its comment, no published source touched -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reconnect robustness coverage by adding a handshake timeout to stalled registration attempts.
  * Preserved the short retry delay to verify reconnection behavior within the expected timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->