### PR TITLE
test(ios-agent): give the reconnect test a budget the sequence needs

### DIFF
--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -912,21 +912,12 @@ describe('IOSAgent', () => {
       )
       const browser = new WebSocket(`ws://localhost:${port}`)
       await waitForOpen(browser)
-      // `handshakeTimeoutMs` alongside `reconnectDelays`, and it is the one that made this flake.
-      //
-      // This test stops the relay and starts a new one on the same port, then waits ~3s for the agent's
-      // own reconnect to re-register. The retry interval was already shortened to 20ms — but a reconnect
-      // that opens a socket and then does not receive `agent:registered` waits out
-      // `handshakeTimeoutMs`, which defaults to **10 seconds**. One attempt landing in that window is
-      // longer than the whole budget, so no further retry happens and the join below sees no session.
-      // The interval alone was never enough: it only decides how soon the *next* attempt starts, and the
-      // failing attempt is the one that never ends.
-      //
-      // Reachable whenever the agent connects to a relay that is not yet answering — the socket is
-      // accepted before the handler is ready, or the event loop is busy enough that the register round
-      // trip misses the window. Both are ordinary on a loaded CI runner and neither reproduces locally:
-      // this passed 8/8 in isolation while failing twice on CI.
-      const agent = new IOSAgent({ intervalMs: 50, reconnectDelays: [20], handshakeTimeoutMs: 200 }, simctl)
+      // A one-second handshake, not the 10s default and not the 200ms a first attempt at this flake
+      // used. 10s is longer than the whole budget below, so a single attempt landing in it stops every
+      // later one — `_scheduleReconnect` runs only from `connect()`'s `.catch`. 200ms went too far the
+      // other way: on a loaded runner the register round trip can miss it, and then *every* attempt
+      // fails for a reason the agent could not avoid. Neither reproduces locally.
+      const agent = new IOSAgent({ intervalMs: 50, reconnectDelays: [20], handshakeTimeoutMs: 1_000 }, simctl)
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
       await waitForType(browser, 'session:joined')
@@ -946,10 +937,16 @@ describe('IOSAgent', () => {
       await waitForOpen(rejoined)
       // A join only succeeds once the agent has re-registered, so this is the barrier that says
       // the socket is live again — and therefore that `!this.ws` no longer guards anything.
+      //
+      // 15s of budget, up from 3. Stopping a relay, starting another on the same port and waiting
+      // for the agent's own reconnect to re-register is the heaviest sequence in this file, and 3s
+      // was a guess that CI disproved twice — the second time with the handshake already shortened,
+      // so the deadline was never the whole story. The cost of the larger budget is nothing when the
+      // reconnect is prompt, which is every run that was already passing.
       let joined = null
-      for (let i = 0; i < 20 && joined === null; i++) {
+      for (let i = 0; i < 60 && joined === null; i++) {
         rejoined.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-        joined = await waitForTypeOrNull(rejoined, 'session:joined', 150)
+        joined = await waitForTypeOrNull(rejoined, 'session:joined', 250)
       }
       expect(joined).not.toBeNull()
 
@@ -972,7 +969,10 @@ describe('IOSAgent', () => {
 
       agent.disconnect()
       rejoined.close()
-    })
+      // Above vitest's 5s default, because the wait above is allowed 15: stopping a relay, starting
+      // another on the same port and re-registering is the heaviest sequence in this file, and the
+      // budget is what CI twice proved too small.
+    }, 25_000)
 
     it('answers input:type-error when the paste chord is dropped', async () => {
       // No pasteboard deadline guards this path, unlike the copy in clipboard:read — the text


### PR DESCRIPTION
Follow-up to #536, which was not enough. The same assertion failed again on #537 — this time on **both node 22 and node 24**, so not a flake that happened to land twice.

## Where #536 was wrong

Its diagnosis was half right. `_scheduleReconnect` does run only from `connect()`'s `.catch`, so a 10s handshake genuinely does block every later attempt. What was wrong was concluding that **200ms** was therefore the fix.

On a loaded runner the register round trip can miss a 200ms window, and then *every* attempt fails for a reason the agent cannot avoid. The CI log shows it directly: `reconnecting in 0.02s (attempt 64)` with `reconnect failed` 63 times. Retries were running; none of them could land. #536 did not just fail to fix this — it made it deterministic.

## This change

- **Handshake 1s** — long enough for a slow round trip, short enough that one bad attempt does not eat the budget.
- **Poll budget 3s → 15s** (60 × 250ms). Stopping a relay, starting another on the same port and waiting out the agent's own reconnect is the heaviest sequence in this file, and 3s was a guess rather than a measurement. It costs nothing on runs that were already passing — a prompt reconnect finishes on the first iteration.

## Tried and discarded

Watching `internals(agent).ws` for an OPEN socket with `vi.waitFor`, instead of polling the join. That asks the agent directly rather than inferring from a round trip, and the sibling reconnect test lower in the same file uses that shape.

**It never resolved, locally, within 25s.** Why is worth knowing — `connect()` sets `this.ws` on success, so a reconnect that reports success while that stays unobservable would be a real question about the agent rather than the test. Recorded as follow-up; it is not this fix. The join poll is the shape that has always worked here, and what was wrong with it was the number.

## Verification

- Target test 3/3 locally
- `pnpm --filter @tapflowio/ios-agent test` → 396 passed

Adversarial review skipped, reason recorded in `.work/reviews/test__ios-reconnect-observe-socket.md`: no production code changes, and the evidence this time came from the CI log rather than from judgement — the 64-attempt trace is what a reviewer would have been asked to weigh.

<!-- no-changeset: test-only — two constants in one test and its comments -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reconnect robustness test stability by allowing more time for handshakes and reconnect/join retries.
  * Increased the overall test timeout to accommodate slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->