### PR TITLE
docs: decide adjacent defects by the reviewer's lens, not by the file they sit in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ For the product direction and philosophy behind these — Manual First, Flow Cap
 ## Core Principles
 
 - **Evidence-based**: verify a root cause with code, logs, or tests before fixing — no guess-driven changes.
-- **Minimal changes**: stay within the requested scope; follow the file's existing conventions.
+- **Minimal changes**: stay within the requested scope; follow the file's existing conventions. Scope
+  is decided by [what a reviewer has to hold in their head](#an-adjacent-defect-is-fixed-here-unless-it-needs-its-own-decision),
+  not by which file a line sits in.
 - **Verifiable goal**: know how success will be measured before starting (a reproducing test, same tests passing after a refactor, etc.).
 - **Stop before risky actions** — get user confirmation before any hard-to-reverse operation (`git push --force`, `git reset --hard`, sending messages to external systems, DB drops, etc.). Specifically:
   - Only create commits or PRs when the user explicitly requests it.
@@ -88,6 +90,34 @@ The authoring session inherits its own assumptions, so before creating a PR the 
 - **A change spanning two or more packages, or both platforms, needs a second, earlier review — of the design, before the code.** One adversarial pass over the plan, in addition to the pre-PR one.
 
 **Read [contributing/adversarial-review.md](./contributing/adversarial-review.md) before launching a reviewer.** It covers how to design the channels, how to run the cross-cutting design pass, why a reviewer's "checked and cleared" list expires as soon as you fix the findings, why the reason written beside the code is part of the fix rather than documentation of it, and how to keep the cost in minutes rather than hours — the same review can take 4 minutes or 106 depending only on what its prompt makes it execute.
+
+### An adjacent defect is fixed here unless it needs its own decision
+
+A good review produces findings next to the one you came for. Deferring each of them is the default
+that feels safe and is not: **one four-issue session deferred six, and three of those were a single
+line each** — a `format?` that should have been required, a package missing from `changeset`'s
+`ignore`, one sentence in an AGENTS.md. Each cost a branch, a review, a PR and a CI run to land
+later. The overhead was an order of magnitude larger than the fix.
+
+The line is what a reviewer has to hold in their head, not which file a line sits in:
+
+| Fix it in this PR | Split it out |
+|---|---|
+| Under ~10 lines and judged by the lens already running | It needs a design decision |
+| The other half of the same defect, even in another package | It needs a different lens (perf, security, a11y) |
+| Prose the change just made false | It is hard to reverse, or breaking |
+
+Two habits keep this honest:
+
+- **Ask the reviewer to classify.** A findings list with no now/later column leaves the split to
+  whoever is holding the diff, which is the person least able to see the cost of deferring.
+- **What is split out becomes an issue in the same session, not a line in `.work/reviews/`.** That
+  directory is gitignored and nobody reads it looking for work. Six deferrals lived only in one
+  conversation until someone asked what was left.
+
+Splitting is still right when it is right — `#508`'s relay type drift genuinely belongs elsewhere.
+The rule is that it must be a decision with a reason, and the reason may not be "it was in a
+different file".
 
 ### Design Principles (SOLID — priority subset)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ The line is what a reviewer has to hold in their head, not which file a line sit
 | Fix it in this PR | Split it out |
 |---|---|
 | Under ~10 lines and judged by the lens already running | It needs a design decision |
-| The other half of the same defect, even in another package | It needs a different lens (perf, security, a11y) |
+| The other half of the same defect in another package, **when the running lens can judge both sides** | It needs a different lens (perf, security, a11y) |
 | Prose the change just made false | It is hard to reverse, or breaking |
 
 Two habits keep this honest:
@@ -113,7 +113,8 @@ Two habits keep this honest:
   whoever is holding the diff, which is the person least able to see the cost of deferring.
 - **What is split out becomes an issue in the same session, not a line in `.work/reviews/`.** That
   directory is gitignored and nobody reads it looking for work. Six deferrals lived only in one
-  conversation until someone asked what was left.
+  conversation until someone asked what was left. The reviewer prompt asks for the issue title and
+  body alongside the reason, so writing "later" costs the same as filing it.
 
 Splitting is still right when it is right — `#508`'s relay type drift genuinely belongs elsewhere.
 The rule is that it must be a decision with a reason, and the reason may not be "it was in a

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -179,6 +179,12 @@ What made the 4m30s pair cheap was structural, not stylistic. Each prompt carrie
 4. **The commands not to run**, by name.
 5. **A findings cap and a time budget.**
 6. **A required "checked and cleared" list**, so coverage is visible when nothing is found.
+7. **A now/later column on every finding, with the reason for later.** Without it the split falls to
+   whoever holds the diff, who is the person least able to see what deferring costs — and the answer
+   defaults to "later" because that is what keeps the diff small. The root
+   [AGENTS.md](../AGENTS.md#an-adjacent-defect-is-fixed-here-unless-it-needs-its-own-decision) has
+   the line: roughly ten lines under the lens already running is fixed here, a design decision is
+   not. Measured once: six deferrals from a four-issue session, three of them a single line each.
 
 ## Cross-cutting changes — review the design before the code
 

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -179,11 +179,13 @@ What made the 4m30s pair cheap was structural, not stylistic. Each prompt carrie
 4. **The commands not to run**, by name.
 5. **A findings cap and a time budget.**
 6. **A required "checked and cleared" list**, so coverage is visible when nothing is found.
-7. **A now/later column on every finding, with the reason for later.** Without it the split falls to
-   whoever holds the diff, who is the person least able to see what deferring costs — and the answer
-   defaults to "later" because that is what keeps the diff small. The root
-   [AGENTS.md](../AGENTS.md#an-adjacent-defect-is-fixed-here-unless-it-needs-its-own-decision) has
-   the line: roughly ten lines under the lens already running is fixed here, a design decision is
+7. **A now/later column on every finding — and for every `later`, the reason plus a one-line issue
+   title and body.** Without the column the split falls to whoever holds the diff, who is the person
+   least able to see what deferring costs, and the answer defaults to "later" because that is what
+   keeps the diff small. Without the issue text, "later" costs a sentence while filing costs a task,
+   and the cheaper one wins — which is how six deferrals came to live in a single conversation. The
+   root [AGENTS.md](../AGENTS.md#an-adjacent-defect-is-fixed-here-unless-it-needs-its-own-decision)
+   has the line: roughly ten lines under the lens already running is fixed here, a design decision is
    not. Measured once: six deferrals from a four-issue session, three of them a single line each.
 
 ## Cross-cutting changes — review the design before the code


### PR DESCRIPTION
A four-issue session (#486, #512, #508, #422) deferred **six** findings, and three of them were a single line each:

| Deferred | Actual size |
|---|---|
| `relay/src/types.ts:103` `format?` — protocol declares it required | 1 line |
| `@tapflowio/test-utils` missing from `changeset`'s `ignore` | one string in an array |
| The MjpegStreamer sentence in `ios-agent/AGENTS.md` | one sentence |

Each now costs a branch, a review, a PR and a CI run to land — an order of magnitude more than the fix.

## What went wrong

The rule being applied was "Minimal changes: stay within the requested scope", read as *different file, different scope*. That is not the question. The question is whether the reviewer already running can judge it.

The second cause is structural, and it gets worse as reviews get better: **all six findings came from adversarial review.** Running it harder surfaces more adjacent defects, and with no rule for handling them, every one becomes debt.

## The line

| Fix it in this PR | Split it out |
|---|---|
| Under ~10 lines and judged by the lens already running | It needs a design decision |
| The other half of the same defect, even in another package | It needs a different lens (perf, security, a11y) |
| Prose the change just made false | It is hard to reverse, or breaking |

Two habits keep it honest:

- **The reviewer classifies each finding now/later**, with a reason for later — added as item 7 of the prompt skeleton in `contributing/adversarial-review.md`. Leaving the split to whoever holds the diff hands it to the person least able to see what deferring costs, and "later" is what keeps a diff small.
- **What is split becomes an issue in the same session**, not a line in `.work/reviews/` — that directory is gitignored and nobody reads it looking for work, which is exactly how six deferrals came to live in one conversation and nowhere else.

## It applies to itself

The three one-line fixes above were going to ride along here. They do not: a process rule and a set of declaration corrections are different lenses, which is the table's own second row. The rule passes its own test.

Review skipped per the docs-only clause, record in `.work/reviews/docs__adjacent-defect-scope-rule.md`.

<!-- no-changeset: docs-only — two markdown files, no published source -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to define minimal change scope during reviews.
  * Added guidance for deciding whether adjacent defects belong in the current change or should be deferred.
  * Review findings must now include a “now” or “later” disposition with justification.
  * Deferred work must be tracked as an issue rather than only noted in review comments.
  * Added an example showing how to measure deferred work and its estimated size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->