### PR TITLE
feat(protocol,relay): enforce union membership in both directions

### DIFF
--- a/.changeset/union-membership-enforced.md
+++ b/.changeset/union-membership-enforced.md
@@ -1,0 +1,48 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': minor
+---
+
+fix: enforce union membership in both directions, not just narrowing
+
+The wire-contract program made every message's **fields** checked and left its **set membership**
+checked in one direction only. Narrowing was held by the compiler and held well — `sendTo` refuses a
+message outside its union. Widening was free: measured on `main`, adding `DeviceBooting` to
+`BrowserToRelay` left `pnpm typecheck` at zero errors and all 294 static tests green.
+
+## The copy with the security consequence
+
+`AGENT_MSG_TYPES` in the relay is a hand-maintained second list of what an agent produces, and the
+door check closes a `browser`-role socket with 1008 for any member. The forwards it guards mostly
+resolve a session from the message and send to *that session's* browser with no check that the sender
+is that session's agent — `clipboard:*` is the deliberate exception. So an agent→browser message added
+to the protocol and forgotten in that list makes a viewer drivable by anyone who knows a session id,
+with the type union claiming otherwise.
+
+Measured before this change: dropping `keyboard:toggled` from the set left both suites green.
+`clipboard:data` was held only because somebody had written that one test by hand.
+
+Types erase, so no runtime array can be derived from a union. What is available is the compiler
+checking two lists against each other, and that is what this adds — as type-level assertions, so a
+violated invariant is a compile error at the declaration rather than a test somebody has to run.
+
+Three invariants now hold:
+
+- the relay's `MessageType` covers every protocol literal and invents none. It was missing
+  `stream:request-idr` — the exact drift `protocol/AGENTS.md` cites as this package's reason to exist,
+  still alive in the copy underneath it;
+- `AGENT_MSG_TYPES` equals what the agent directions declare, both ways;
+- **nothing a browser may send is something an agent produces.** This is the one that catches widening
+  without restating 63 literals, and it is the invariant the door enforces at runtime. Not blanket
+  disjointness: `device:shutdown` is deliberately a member of both `RelayToAgent` and `BrowserToRelay`.
+
+## And the half a type cannot state about itself
+
+A message declared in the protocol but placed in **no** direction reaches none of the above — it is
+absent from the union those assertions read, so nothing is ever obliged to know it. Types cannot
+enumerate their own declarations, so that one is checked as source text alongside the two facts
+`protocolMessageNames.test.mjs` already checks that way. All 65 declared messages reach a direction
+today.
+
+`AnyWireMessage` is new and public: the seven directions unioned, so a consumer can assert its own
+list is complete rather than merely correct so far.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -932,6 +932,27 @@ export type AppClearStateReplyBody<T = AppClearStateReply> = T extends unknown ?
  *  at its own send site in `agent-core/src/utils/stream.ts`. */
 export type AgentControlOutbound = AgentToRelay | AgentToBrowser
 
+/**
+ * Every message this protocol declares, reached through the seven directions.
+ *
+ * Not a fourteenth union for its own sake: it is what lets a consumer assert that its own list of
+ * literals is *complete* rather than merely correct so far. `relay/src/types.ts` keeps such a list —
+ * hand-maintained, 62 entries, and missing `stream:request-idr` until this change, which is the exact
+ * drift this package was created to end (see AGENTS.md).
+ *
+ * The fact it restates is small and stable — **which directions exist** — not the 63 literals inside
+ * them. A message added to a direction flows in here for free; a message added to *no* direction does
+ * not, and nothing here can see that. That gap is real and is not this union's to close.
+ */
+export type AnyWireMessage =
+  | BrowserToRelay
+  | RelayToBrowser
+  | AgentToRelay
+  | AgentToBrowser
+  | RelayToAgent
+  | StreamToRelay
+  | RelayToStream
+
 // ── browser → relay ──────────────────────────────────────────────────────────
 
 /** Key input. The payload carries `code` — a `KeyboardEvent.code` name — and `modifiers` as a

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -17,6 +17,7 @@ import type {
   InputTypeError, KeyboardToggled, OpenUrl, OpenUrlDone, OpenUrlError, RelayOutbound, ScreenshotDone,
   ScreenshotError, ScreenshotRequest, SessionAgentAway, SessionChrome, SessionDeviceInfo, SessionEnd,
   SessionJoined, SessionLeave, SessionRebound, SessionStart, SessionTerminated, StreamRegister,
+  AgentControlOutbound, StreamToRelay,
   StreamRegistered, StreamRequestIdr, UiTreeError, UiTreeRequest, UiTreeResponse,
 } from './index.js'
 
@@ -177,3 +178,23 @@ export const _ScreenshotError: ScreenshotError['type'] = 'screenshot:error'
 export const _StreamRegister: StreamRegister['type'] = 'stream:register'
 export const _UiTreeResponse: UiTreeResponse['type'] = 'ui:tree:response'
 export const _UiTreeError: UiTreeError['type'] = 'ui:tree:error'
+
+// ── membership: what a browser may send, and what an agent produces, do not overlap ──────────────
+//
+// The relay's door closes a `browser`-role socket with 1008 for any agent-produced type, because the
+// forwards it guards mostly resolve a session from the message and send to *that session's* browser
+// with no check that the sender is that session's agent. So the two sets overlapping is not an
+// untidiness — it is a message a browser can inject into a stranger's viewer.
+//
+// Stated as `Extract` rather than as a list, which is what lets it catch a widening without restating
+// 63 literals. Measured before this existed: adding `DeviceBooting` to `BrowserToRelay` left
+// `pnpm typecheck` at zero errors and all 294 static tests green.
+//
+// **Not blanket disjointness between directions.** `device:shutdown` is deliberately a member of both
+// `RelayToAgent` and `BrowserToRelay`, identical in both; it is not agent-produced, so it is not here.
+// And a *relay*-produced message added to `BrowserToRelay` is outside this claim — `route()` has no
+// case for one, and #557 is where the forwarding half is tracked.
+type AgentProduced = (AgentControlOutbound | StreamToRelay)['type']
+type AssertTrue<T extends true> = T
+type NoOverlap<A, B> = [Extract<A, B>] extends [never] ? true : false
+export type _BrowserSendsNothingAgentProduced = AssertTrue<NoOverlap<BrowserToRelay['type'], AgentProduced>>

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -7,8 +7,10 @@ import { randomUUID } from 'crypto'
 import { WebSocketServer, WebSocket } from 'ws'
 import { SessionManager } from './SessionManager.js'
 import type { Session } from './SessionManager.js'
-import type { DeviceDetails, RelayMessage, UIElement } from './types.js'
-import type { ChromePayload, InputErrorReason, RelayOutbound } from '@tapflowio/protocol'
+import type { Assert, DeviceDetails, IsEmpty, RelayMessage, UIElement } from './types.js'
+import type {
+  AgentControlOutbound, BrowserToRelay, ChromePayload, InputErrorReason, RelayOutbound, StreamToRelay,
+} from '@tapflowio/protocol'
 import { Router, json } from './router.js'
 import { requireViewAuth, requireAuth, getAuth, verifyPat } from './middleware/auth.js'
 import { classifyConnection } from './lib/connectionAuth.js'
@@ -168,7 +170,7 @@ function isCorrelated(msg: RelayMessage): msg is RelayMessage & { requestId: str
   return false
 }
 
-const AGENT_MSG_TYPES = new Set([
+const AGENT_MSG_TYPE_LIST = [
   'agent:register', 'agent:resources', 'screenshot:done', 'screenshot:error',
   'ui:tree:response', 'ui:tree:error',
   'app:clear-state-done', 'app:clear-state-error',
@@ -183,7 +185,44 @@ const AGENT_MSG_TYPES = new Set([
   // stream:register binds a session's stream socket — agent-only, or a browser
   // (view PAT / cookie) could hijack an existing session's video feed.
   'stream:register',
-])
+] as const
+
+/** Typed `ReadonlySet<string>`, deliberately: the door below tests a `MessageType`, which is wider
+ *  than the literals above, and `Set<T>.has` takes a `T`. The literal union stays reachable through
+ *  the array, which is where the assertions read it from. */
+const AGENT_MSG_TYPES: ReadonlySet<string> = new Set(AGENT_MSG_TYPE_LIST)
+
+// ── the list above is checked against the protocol, both ways (#532) ─────────────────────────────
+//
+// It is a hand-maintained second copy of "what an agent produces", and it is the copy with the
+// security consequence: the door below closes a `browser`-role socket with 1008 for any member. The
+// forwards it guards mostly resolve a session from the message and send to *that session's* browser
+// with no check that the sender is that session's agent — `clipboard:*` is the deliberate exception.
+// So an agent→browser message added to the protocol and forgotten here makes a viewer drivable by
+// anyone who knows a session id, with the type union claiming otherwise.
+//
+// Measured before this change: dropping `keyboard:toggled` from the set left the static suite and
+// the relay suite green. `clipboard:data` was held only because somebody wrote that one test by
+// hand. The other 28 entries were held by nothing.
+//
+// Derivation is not available — types erase, so no runtime array can come out of a union. What is
+// available is the compiler checking two lists against each other, which is what these two lines do.
+type AgentProduced = (AgentControlOutbound | StreamToRelay)['type']
+type Listed = (typeof AGENT_MSG_TYPE_LIST)[number]
+type _AgentSetCoversProtocol = Assert<IsEmpty<Exclude<AgentProduced, Listed>>>
+type _AgentSetInventsNothing = Assert<IsEmpty<Exclude<Listed, AgentProduced>>>
+
+/**
+ * And the invariant the door actually enforces: **nothing a browser may send is something an agent
+ * produces.** This is the one that catches the widening mutation without restating 63 literals — if
+ * `DeviceBooting` is added to `BrowserToRelay`, `device:booting` appears on both sides and this
+ * fails, naming it.
+ *
+ * Not blanket disjointness between every pair of directions: `device:shutdown` is deliberately a
+ * member of both `RelayToAgent` and `BrowserToRelay`, being identical in both. It is not
+ * agent-produced, so it does not appear here.
+ */
+type _BrowserSendsNothingAgentProduced = Assert<IsEmpty<Extract<BrowserToRelay['type'], AgentProduced>>>
 
 export class RelayServer {
   private httpServer: http.Server | https.Server

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -9,7 +9,7 @@ import { SessionManager } from './SessionManager.js'
 import type { Session } from './SessionManager.js'
 import type { Assert, DeviceDetails, IsEmpty, RelayMessage, UIElement } from './types.js'
 import type {
-  AgentControlOutbound, BrowserToRelay, ChromePayload, InputErrorReason, RelayOutbound, StreamToRelay,
+  AgentControlOutbound, ChromePayload, InputErrorReason, RelayOutbound, StreamToRelay,
 } from '@tapflowio/protocol'
 import { Router, json } from './router.js'
 import { requireViewAuth, requireAuth, getAuth, verifyPat } from './middleware/auth.js'
@@ -209,20 +209,20 @@ const AGENT_MSG_TYPES: ReadonlySet<string> = new Set(AGENT_MSG_TYPE_LIST)
 // available is the compiler checking two lists against each other, which is what these two lines do.
 type AgentProduced = (AgentControlOutbound | StreamToRelay)['type']
 type Listed = (typeof AGENT_MSG_TYPE_LIST)[number]
+// **`satisfies` first, and it is the security direction's real floor.** `Exclude<AgentProduced, string>`
+// is `never`, so if the list ever widens past its literals — dropping `as const`, or one non-literal
+// element — the covering assertion below passes while checking nothing. Only its sibling would fail,
+// and that sibling's own comment calls its direction the one that "gates nothing", so an author
+// trusting the comment could delete the wrong one. This line fails first and names the list.
+AGENT_MSG_TYPE_LIST satisfies readonly AgentProduced[]
 type _AgentSetCoversProtocol = Assert<IsEmpty<Exclude<AgentProduced, Listed>>>
 type _AgentSetInventsNothing = Assert<IsEmpty<Exclude<Listed, AgentProduced>>>
 
-/**
- * And the invariant the door actually enforces: **nothing a browser may send is something an agent
- * produces.** This is the one that catches the widening mutation without restating 63 literals — if
- * `DeviceBooting` is added to `BrowserToRelay`, `device:booting` appears on both sides and this
- * fails, naming it.
- *
- * Not blanket disjointness between every pair of directions: `device:shutdown` is deliberately a
- * member of both `RelayToAgent` and `BrowserToRelay`, being identical in both. It is not
- * agent-produced, so it does not appear here.
- */
-type _BrowserSendsNothingAgentProduced = Assert<IsEmpty<Extract<BrowserToRelay['type'], AgentProduced>>>
+// The invariant the door *enforces* — that nothing a browser may send is something an agent produces
+// — is asserted in `protocol/src/typeAssertions.ts` instead. It is a claim about the protocol's own
+// directions, not about this file, and naming `BrowserToRelay` here made `clientOutboundTyped` read
+// the relay as a browser-role sender. That guard was right to say so.
+
 
 export class RelayServer {
   private httpServer: http.Server | https.Server

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -15,6 +15,10 @@ export type MessageType =
   | 'session:rebound'
   | 'stream:register'
   | 'stream:registered'
+  // Was missing. The relay sends it from two places and its own union did not declare it — the
+  // very drift `protocol/AGENTS.md` cites as this package's reason to exist, still alive in the
+  // copy underneath it. The assertion below is what makes a third omission a compile error.
+  | 'stream:request-idr'
   | 'device:boot'
   | 'device:booting'
   | 'device:ready'
@@ -67,10 +71,35 @@ export type { AgentResources, UIElement }
 
 // The wire contract lives in @tapflowio/protocol so the relay, the dashboard and mcp-server cannot
 // drift apart. `DeviceInfo` is kept as an alias while call sites move over.
-import type { DeviceSummary, SessionInfo, SessionTerminatedReason } from '@tapflowio/protocol'
+import type { AnyWireMessage, DeviceSummary, SessionInfo, SessionTerminatedReason } from '@tapflowio/protocol'
 export type { DeviceDetails, DeviceReport, DeviceSummary, SessionInfo, SessionTerminatedReason } from '@tapflowio/protocol'
 
 export type DeviceInfo = DeviceSummary
+
+// ── membership, enforced in both directions (#532) ───────────────────────────────────────────────
+//
+// The wire-contract program made every message's *fields* checked and left its *set membership*
+// unchecked in one direction. Narrowing was held by the compiler and held well — `sendTo` refuses a
+// message outside its union. **Widening was free**: measured on `main`, adding `DeviceBooting` to
+// `BrowserToRelay` left `pnpm typecheck` at zero errors and all 294 static tests green.
+//
+// These are type-level and cost nothing at runtime. `Assert` fails to instantiate when its argument
+// is not `true`, so a violated invariant is a compile error at the declaration rather than a test
+// somebody has to run.
+export type Assert<T extends true> = T
+/** `[T] extends [never]` rather than `T extends never`: a bare conditional distributes over a union
+ *  and answers `never` for an empty one *and* for a non-empty one, which would pass either way. */
+export type IsEmpty<T> = [T] extends [never] ? true : false
+
+/**
+ * The relay's own literal list is complete against the protocol.
+ *
+ * Both directions. Missing an entry is what happened to `stream:request-idr`; an extra one means a
+ * literal the protocol no longer declares, which reads as deliberate and gates nothing.
+ */
+type _MessageTypeCoversProtocol = Assert<IsEmpty<Exclude<AnyWireMessage['type'], MessageType>>>
+type _MessageTypeInventsNothing = Assert<IsEmpty<Exclude<MessageType, AnyWireMessage['type']>>>
+
 
 // `agents:listed` groups devices by agent machine. Protocol owns the shape; this file used to
 // declare an identical copy. Its `devices` element is protocol's `DeviceSummary`, which the alias

--- a/scripts/__tests__/clientOutboundTyped.test.mjs
+++ b/scripts/__tests__/clientOutboundTyped.test.mjs
@@ -112,7 +112,12 @@ describe('browser-role outbound is typed against the wire contract', () => {
     const browserRole = new Set(
       tracked
         .filter((f) => pkgOf(f) !== 'protocol')
-        .filter((f) => /BrowserToRelay/.test(readFileSync(join(root, f), 'utf8')))
+        // **Comments stripped first.** A mention in prose is not a usage, and the raw form counted one:
+        // a comment in `relay/src/RelayServer.ts` explaining why that file must *not* name the union
+        // put the relay in this set. Same shape as the `browserInboundRouting` defect this repo
+        // already recorded, where a comment mentioning `{ type: 'error' }` was counted as a union
+        // member — and the same shape as the offender scan two lines down, which already strips.
+        .filter((f) => /BrowserToRelay/.test(stripComments(readFileSync(join(root, f), 'utf8'))))
         .map(pkgOf),
     )
     expect([...browserRole].sort()).toEqual(['dashboard', 'flow-runner', 'mcp-server'])

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -32,15 +32,22 @@ const assertionsRaw = readFileSync(join(root, 'packages/protocol/src/typeAsserti
 // was counted as an eleventh union member.
 const assertions = assertionsRaw.replace(/^\s*\/\/.*$/gm, '')
 
-/** `index.ts` with comments **removed**, for the union parser below.
+/** `index.ts` with comments removed, for the union parser below.
  *
- *  Removed rather than blanked, and the difference is not cosmetic: blanking leaves an empty line and
- *  the parser stops at one, so `RelayOrAgentToBrowser` was truncated at the comment sitting between
- *  `InputError` and `InputTypeError` — and its last two members were reported as belonging to no
- *  direction at all. A parser that loses a declaration reports a hole that is not there, which is the
- *  same class of failure as one that reports full coverage of nothing. */
+ *  **The line filter is the load-bearing half, and the first draft credited the wrong one.** That
+ *  draft said removing comment lines rather than blanking them was what mattered, because blanking
+ *  leaves an empty line the parser stops at. Review measured both variants over the real file and
+ *  found no difference in any of the nineteen unions. What actually broke was leaving `//` lines in:
+ *  `unionMembers` then reads their prose as members, so `RelayOrAgentToBrowser` came back with
+ *  `Moved`, `L5c`, `An` and `TERMINAL_INPUT_TYPES` among its members.
+ *
+ *  The trailing `[ \t]*` and `\n?` are not cosmetic either. Without them a docblock between two union
+ *  members leaves its indentation behind as a whitespace-only line, and `unionMembers` stops at one —
+ *  measured: a `/** … *\/` inserted inside `AgentToBrowser` reported `ClipboardData` and
+ *  `ClipboardWriteDone` as orphans of nothing. A parser that loses a declaration reports a hole that
+ *  is not there, which is the same class of failure as one that reports full coverage of nothing. */
 const srcNoComments = src
-  .replace(/\/\*\*[\s\S]*?\*\//g, '')
+  .replace(/[ \t]*\/\*\*[\s\S]*?\*\/\n?/g, '')
   .split('\n').filter((l) => !/^\s*\/\//.test(l)).join('\n')
 
 /** Every `export type X = A | B | …` whose right-hand side is a union of names. */
@@ -72,18 +79,41 @@ const DIRECTIONS = [
  *  skipped any interface with a blank line in its body — and `expect(messages.size).toBe(65)` was then
  *  satisfied *because* of the skip, so a new message with no binding passed all seventeen assertions.
  *  A count is only coverage if the parser cannot lose a declaration. */
-function messageInterfaces(text) {
-  const out = new Map()
-  for (const m of text.matchAll(/export interface (\w+)(?: extends (\w+))? \{/g)) {
+function interfaceBlocks(text) {
+  const out = []
+  // Tolerant on purpose, and each allowance is a measured escape: a generic parameter list, and an
+  // `extends` wrapped onto its own line, each made a declaration invisible to the strict form — and
+  // invisible means exempt from every assertion in this file *and* from `AnyWireMessage`, which is
+  // the hole this file's direction check exists to close.
+  for (const m of text.matchAll(/export interface (\w+)\s*(?:<[^>]*>)?\s*(?:extends\s+(\w+)[^{]*)?\{/g)) {
     let depth = 0
     let end = m.index + m[0].length - 1
     for (; end < text.length; end++) {
       if (text[end] === '{') depth++
       else if (text[end] === '}' && --depth === 0) break
     }
-    const body = text.slice(m.index + m[0].length, end)
-    const lit = body.match(/^ {2}type: '([^']+)';?$/m)
-    if (lit) out.set(m[1], { literal: lit[1], extends: m[2] ?? null, body })
+    out.push({ name: m[1], extends: m[2] ?? null, body: text.slice(m.index + m[0].length, end) })
+  }
+  return out
+}
+
+/** Every `export interface` that declares a `type: '<literal>'` — i.e. every wire message.
+ *
+ *  Bodies are found by counting braces, not by matching a run of two-space lines. The regex version
+ *  skipped any interface with a blank line in its body — and `expect(messages.size).toBe(65)` was then
+ *  satisfied *because* of the skip, so a new message with no binding passed all seventeen assertions.
+ *  A count is only coverage if the parser cannot lose a declaration.
+ *
+ *  Which is why the count is no longer the only thing holding that. Review measured four further ways
+ *  to be dropped — a trailing `//` after the literal, `type:'x'` with no space, a generic parameter
+ *  list, a wrapped `extends` — and every one of them kept the size at exactly 65, so the pin was
+ *  satisfied by the loss in each case. `everyDeclaredLiteralWasCaptured` below audits the capture with
+ *  a looser pattern than the capture itself uses; a pin cannot audit the parser that feeds it. */
+function messageInterfaces(text) {
+  const out = new Map()
+  for (const b of interfaceBlocks(text)) {
+    const lit = b.body.match(/^\s*type\s*:\s*'([^']+)'\s*;?\s*(?:\/\/.*)?$/m)
+    if (lit) out.set(b.name, { literal: lit[1], extends: b.extends, body: b.body })
   }
   return out
 }
@@ -131,6 +161,18 @@ describe('protocol message interfaces', () => {
     expect(messages.has('InputKey')).toBe(true)
   })
 
+  // The pin above cannot audit the parser that feeds it: every measured way to lose a declaration kept
+  // the size at 65, so the floor was satisfied by the loss. This asks the question the other way round
+  // — with a pattern loose enough to find a literal the capture would miss — so a declaration the
+  // capture drops is named rather than counted as absent.
+  it('captured every interface that declares a literal', () => {
+    const dropped = interfaceBlocks(src)
+      .filter((b) => /^\s*type\s*:\s*'/m.test(b.body))
+      .map((b) => b.name)
+      .filter((n) => !messages.has(n))
+    expect(dropped, `declares a type literal but the parser dropped it: ${dropped.join(', ')}`).toEqual([])
+  })
+
   // **The half `AnyWireMessage` cannot state about itself.** `relay/src/types.ts` asserts its literal
   // list against `AnyWireMessage`, which is the seven directions unioned — so a message added to a
   // direction reaches the relay's check for free. A message added to **no** direction reaches nothing:
@@ -162,6 +204,17 @@ describe('protocol message interfaces', () => {
 
     const orphans = [...messages.keys()].filter((n) => !seen.has(n))
     expect(orphans, `declared but in no direction: ${orphans.join(', ')}`).toEqual([])
+  })
+
+  // `DIRECTIONS` above and `AnyWireMessage` in the protocol are two copies of one list, and only one
+  // divergence is loud. A direction added to `AnyWireMessage` alone orphans its members — safe. A
+  // direction added to `DIRECTIONS` alone is **green everywhere**: the orphan check is satisfied while
+  // every literal in that direction stays exempt from the relay's `_MessageTypeCoversProtocol`, and if
+  // it is agent-produced, from `_AgentSetCoversProtocol` too — so the door would let a browser send it.
+  it('the direction list matches AnyWireMessage', () => {
+    const declared = unionMembers(srcNoComments).get('AnyWireMessage')
+    expect(declared, 'AnyWireMessage did not parse').toBeDefined()
+    expect([...declared].sort()).toEqual([...DIRECTIONS].sort())
   })
 
   it('every message interface has a name↔literal binding', () => {

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -47,8 +47,20 @@ const assertions = assertionsRaw.replace(/^\s*\/\/.*$/gm, '')
  *  `ClipboardWriteDone` as orphans of nothing. A parser that loses a declaration reports a hole that
  *  is not there, which is the same class of failure as one that reports full coverage of nothing. */
 const srcNoComments = src
-  .replace(/[ \t]*\/\*\*[\s\S]*?\*\/\n?/g, '')
-  .split('\n').filter((l) => !/^\s*\/\//.test(l)).join('\n')
+  // Every block comment, not only JSDoc, and the whitespace it sat on — see below for why the trailing
+  // `\n?` matters.
+  .replace(/[ \t]*\/\*[\s\S]*?\*\/\n?/g, '')
+  .split('\n')
+  // A comment-only line goes entirely: leaving it blank would terminate the union parser, which stops
+  // at a blank line.
+  .filter((l) => !/^\s*\/\//.test(l))
+  // **And an inline one goes while its line stays.** A first draft stripped only whole-line comments,
+  // and a trailing `// unlike OrphanPing, …` on a union member put `OrphanPing` in that direction's
+  // member list — so a message declared in no direction at all was reported as reachable and the
+  // orphan check stayed green. Measured. Prose read as a value is the shape this repo has now been
+  // bitten by three times.
+  .map((l) => l.replace(/\s*\/\/.*$/, ''))
+  .join('\n')
 
 /** Every `export type X = A | B | …` whose right-hand side is a union of names. */
 function unionMembers(text) {

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -32,6 +32,40 @@ const assertionsRaw = readFileSync(join(root, 'packages/protocol/src/typeAsserti
 // was counted as an eleventh union member.
 const assertions = assertionsRaw.replace(/^\s*\/\/.*$/gm, '')
 
+/** `index.ts` with comments **removed**, for the union parser below.
+ *
+ *  Removed rather than blanked, and the difference is not cosmetic: blanking leaves an empty line and
+ *  the parser stops at one, so `RelayOrAgentToBrowser` was truncated at the comment sitting between
+ *  `InputError` and `InputTypeError` — and its last two members were reported as belonging to no
+ *  direction at all. A parser that loses a declaration reports a hole that is not there, which is the
+ *  same class of failure as one that reports full coverage of nothing. */
+const srcNoComments = src
+  .replace(/\/\*\*[\s\S]*?\*\//g, '')
+  .split('\n').filter((l) => !/^\s*\/\//.test(l)).join('\n')
+
+/** Every `export type X = A | B | …` whose right-hand side is a union of names. */
+function unionMembers(text) {
+  const out = new Map()
+  for (const m of text.matchAll(/export type (\w+)\s*=([\s\S]*?)(?=\n\s*\n|\nexport |\n\/\*)/g)) {
+    // Skip object and string-literal types (`SessionTerminatedReason`, `ChromePayload`): only unions
+    // of interface names can carry a message into a direction.
+    if (/[{'"]/.test(m[2])) continue
+    const names = [...m[2].matchAll(/\b([A-Z]\w+)\b/g)].map((x) => x[1])
+    if (names.length) out.set(m[1], names)
+  }
+  return out
+}
+
+/** The seven directions a message can travel. Every declared message must be reachable from one.
+ *
+ *  This list is the one thing here that is restated rather than derived, and it is the small stable
+ *  half: directions are added once a year, messages weekly. A renamed or deleted root is caught by the
+ *  assertion that every name in it parses. */
+const DIRECTIONS = [
+  'BrowserToRelay', 'RelayToBrowser', 'AgentToRelay', 'AgentToBrowser',
+  'RelayToAgent', 'StreamToRelay', 'RelayToStream',
+]
+
 /** Every `export interface` that declares a `type: '<literal>'` — i.e. every wire message.
  *
  *  Bodies are found by counting braces, not by matching a run of two-space lines. The regex version
@@ -95,6 +129,39 @@ describe('protocol message interfaces', () => {
     expect(messages.size).toBe(65)
     // `InputKey` predates L1 and has always been named; it must be in here too.
     expect(messages.has('InputKey')).toBe(true)
+  })
+
+  // **The half `AnyWireMessage` cannot state about itself.** `relay/src/types.ts` asserts its literal
+  // list against `AnyWireMessage`, which is the seven directions unioned — so a message added to a
+  // direction reaches the relay's check for free. A message added to **no** direction reaches nothing:
+  // it is absent from `AnyWireMessage`, so the relay is never obliged to know it, and every type-level
+  // assertion stays green while a declared message travels on no declared path.
+  //
+  // Types cannot enumerate their own declarations, which is why this is here and not there — the same
+  // reason the two facts at the top of this file are checked as source text.
+  it('every message interface belongs to a direction', () => {
+    const unions = unionMembers(srcNoComments)
+
+    // Anti-vacuity first, and in the specific way this check can go quiet: if a direction is renamed
+    // and this list is not, its members vanish from `reachable` and every message in it is reported as
+    // an orphan — loud. If the *parser* stops matching, `reachable` is empty and the orphan list is
+    // everything — also loud. The dangerous direction is a root silently resolving to nothing, so each
+    // one is required to have parsed.
+    for (const d of DIRECTIONS) {
+      expect(unions.get(d), `direction ${d} did not parse — renamed, or the parser stopped matching`).toBeDefined()
+    }
+
+    const seen = new Set()
+    const stack = [...DIRECTIONS]
+    while (stack.length) {
+      const name = stack.pop()
+      if (seen.has(name)) continue
+      seen.add(name)
+      for (const member of unions.get(name) ?? []) stack.push(member)
+    }
+
+    const orphans = [...messages.keys()].filter((n) => !seen.has(n))
+    expect(orphans, `declared but in no direction: ${orphans.join(', ')}`).toEqual([])
   })
 
   it('every message interface has a name↔literal binding', () => {


### PR DESCRIPTION
## Summary

Closes #532. The wire-contract program made every message's **fields** checked and left its **set membership** checked in one direction only. Narrowing was held by the compiler; widening was free — measured on `main`, adding `DeviceBooting` to `BrowserToRelay` left `pnpm typecheck` at zero errors and all 294 static tests green.

`AGENT_MSG_TYPES` is the copy with the security consequence: the door closes a `browser`-role socket for any member, and the forwards it guards mostly resolve a session from the message and send to *that session's* browser without checking the sender is that session's agent. Dropping `keyboard:toggled` from it left both suites green; `clipboard:data` was held only because somebody wrote that one test by hand.

Types erase, so the issue's preferred "derive the list" is not available — both candidates reduce to two lists plus a compiler-enforced equality. These are type-level assertions, so a violated invariant is a compile error at the declaration. Four hold now: the relay's `MessageType` covers every protocol literal and invents none (it was missing `stream:request-idr`, the exact drift `protocol/AGENTS.md` cites as this package's reason to exist); `AGENT_MSG_TYPES` equals what the agent directions declare, both ways; and **nothing a browser may send is something an agent produces** — the one that catches widening without restating 63 literals.

A message declared and placed in **no** direction reaches none of those, so that half is checked as source text beside the two facts `protocolMessageNames.test.mjs` already checks that way.

## Checklist

- [x] Tests written and passing — 4 new assertions, 297 in the scripts suite, all package suites green; 16 mutations run, all killed
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a, protocol owns the wire
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/feat__union-membership-enforced.md` — the design pass that established derivation is impossible, and a pre-PR review that found the parser feeding this check drops declarations four ways while keeping its own anti-vacuity count satisfied.

Deferred: **#557**, filed against #507 — the door's assertion checks a proxy (`AgentControlOutbound`) rather than the property the door needs, which is about what `route()` forwards. That belongs with #507's ownership work rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified wire-message type covering all supported protocol directions.
  - Added support for the `stream:request-idr` message type.

- **Bug Fixes**
  - Improved validation to prevent unsupported or spoofed message types from being accepted.
  - Ensured message definitions remain consistent across protocol and relay components.

- **Tests**
  - Expanded protocol coverage checks, including multiline definitions, comments, generics, and message direction validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->