### PR TITLE
feat(protocol)!: make input:error's reason required and its message optional

### DIFF
--- a/.changeset/input-error-reason-required.md
+++ b/.changeset/input-error-reason-required.md
@@ -1,0 +1,49 @@
+---
+'@tapflowio/protocol': minor
+---
+
+fix(protocol)!: invert `input:error` — `reason` is required, `message` is optional
+
+**This is a breaking wire-contract change**, shipped as `minor` because the package is pre-1.0 and
+CONTRIBUTING says breaking changes may land in a minor until `v1.0.0` is tagged.
+
+`input:error` declared `message: string` required and `reason?: InputErrorReason` optional. The
+package's own AGENTS.md states that split on purpose — `message` is free prose each agent owns,
+`reason` is the closed union consumers branch on — so the field a consumer was **guaranteed** to
+receive was the one it must not depend on, and the one it should depend on could be absent. Every
+consumer carried an unknown-reason branch for as long as that held, and "absence means unknown" had to
+be re-derived by each new one.
+
+That was the right way to *ship* it in #490: an agent predating the field omitted it and nothing broke.
+It was never a correct end state, and the prerequisite closed with #492 — the relay used to be the one
+producer sending prose alone.
+
+## What it costs
+
+**Nothing inside this repo.** All six production sites already send a reason, two of them with
+`satisfies InputErrorReason` on the literal, and the two clients that read it type inbound as
+`Record<string, unknown>` deliberately, so the declaration obliges producers and changes no call site.
+Exactly one thing in the tree needed editing: the assertion that pinned the old shape.
+
+**What it buys** is an agent outside this repo, which can no longer omit the field, and a consumer
+written tomorrow, which cannot be handed a failure it has no way to branch on. Both absence branches
+stay, and now say why beside themselves: they exist for producers predating the field, which a required
+declaration corrects going forward and cannot retroactively fix.
+
+`message` is optional rather than removed — it still carries parameterised detail a closed union
+cannot (`unknown key code: KeyFoo`), which is a debug and forward-compatibility field. A structured
+`params` is the honest way to keep that once prose is demoted and is deliberately **not** added here:
+#485 is what will say whether a rendered UI misses the variable.
+
+`InputTypeError` keeps `reason?`, and that asymmetry is deliberate. Its agent-side producers answer
+with prose from a rejected `adb` or pasteboard write and have no reason to give; only the relay sets one.
+
+## `SessionError` is now `SessionScoped`, and carries only `sessionId`
+
+TypeScript cannot narrow an inherited required member to optional, so making `message` optional on one
+member meant moving it off the base — onto each of the nine that keep it required. What is left is the
+one thing all nine share, and the name follows the shape.
+
+The `extends` is now the only thing stating the family relation, where the shared field pair used to
+imply it. `protocolMessageNames.test.mjs` gains an assertion that each member still declares `message`
+for that reason.

--- a/.changeset/input-error-reason-required.md
+++ b/.changeset/input-error-reason-required.md
@@ -20,10 +20,11 @@ producer sending prose alone.
 
 ## What it costs
 
-**Nothing inside this repo.** All six production sites already send a reason, two of them with
-`satisfies InputErrorReason` on the literal, and the two clients that read it type inbound as
-`Record<string, unknown>` deliberately, so the declaration obliges producers and changes no call site.
-Exactly one thing in the tree needed editing: the assertion that pinned the old shape.
+**No producer had to change.** All six production sites already send a reason, two of them with
+`satisfies InputErrorReason` on the literal. The clients that read it through
+`Record<string, unknown>` are unaffected by the declaration — but the dashboard is a *typed* consumer
+and did need editing: `message` becoming optional meant it rendered `(undefined)` into a toast, which
+is fixed here with a test on it.
 
 **What it buys** is an agent outside this repo, which can no longer omit the field, and a consumer
 written tomorrow, which cannot be handed a failure it has no way to branch on. Both absence branches
@@ -33,7 +34,7 @@ declaration corrects going forward and cannot retroactively fix.
 `message` is optional rather than removed — it still carries parameterised detail a closed union
 cannot (`unknown key code: KeyFoo`), which is a debug and forward-compatibility field. A structured
 `params` is the honest way to keep that once prose is demoted and is deliberately **not** added here:
-#485 is what will say whether a rendered UI misses the variable.
+issue #485 is what will say whether a rendered UI misses the variable.
 
 `InputTypeError` keeps `reason?`, and that asymmetry is deliberate. Its agent-side producers answer
 with prose from a rejected `adb` or pasteboard write and have no reason to give; only the relay sets one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **An agent must now send a machine-readable `reason` when it refuses an input.** `input:error` used
+  to guarantee only `message`, the human-readable prose each agent writes for itself, while `reason` —
+  the closed set a caller actually branches on — was optional. That is backwards: the field you were
+  guaranteed was the one you must not depend on. `reason` is required now and `message` is optional.
+  Every agent shipped with tapflow already sends one, so nothing in this repo changed behaviour; this
+  affects a third-party or self-modified agent built against an older contract.
+  `Migrate:` add `reason` to every `input:error` your agent sends, choosing from `not-booted`,
+  `channel-starting`, `channel-unavailable`, `no-gesture`, `dispatch-failed`, `unsupported` or
+  `malformed`. Pick by what the caller should do differently, not by which of your internal states
+  produced it — the set is deliberately smaller than any one agent's internals. (`not-session-owner`
+  is the eighth member and is the relay's alone: it refuses such a frame at its door, before any agent
+  sees it.) Prose stays welcome in `message` and may now be omitted.
+
 ### Changed
 
 - Split stable dashboard vendor dependencies into smaller chunks to reduce maximum bundle size and improve cache reuse across releases.

--- a/packages/dashboard/components/DeviceViewer.tsx
+++ b/packages/dashboard/components/DeviceViewer.tsx
@@ -281,14 +281,20 @@ export function DeviceViewer({ sessionId, deviceId, buildId, resetMode, onRecord
         // refreshed by a failure in the next one.
         toast.error(notice.title, {
           id: `input:${sessionId}:${key}`,
-          description: `${notice.action} (${msg.message})`,
+          // **The parenthetical is dropped when there is no prose**, not filled with a placeholder.
+          // `message` became optional in #491 — the closed `reason` is the contract now and prose is
+          // the producer's own — so an agent that sends only a reason is legal, and this is the one
+          // place its text reaches a person. A template literal accepts `string | undefined` and
+          // `restrict-template-expressions` is configured nowhere here, so nothing would have caught
+          // "(undefined)" appearing in a toast read by a PO or a designer.
+          description: msg.message ? `${notice.action} (${msg.message})` : notice.action,
           // The only "state" this design has. A finite lifetime is what makes the toast disappear
           // when inputs stop failing, with no clear signal — set explicitly and above sonner's
           // 4000ms default, which is short enough to lapse between two unhurried taps.
           duration: 6000,
         });
       } else {
-        console.debug(`[tapflow] input refused, shown nowhere: ${key} — ${msg.message}`);
+        console.debug(`[tapflow] input refused, shown nowhere: ${key}${msg.message ? ` — ${msg.message}` : ''}`);
       }
     }
     // `input:done` is deliberately not handled. It was only ever needed to release the latch above,

--- a/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.inputError.test.tsx
@@ -51,6 +51,15 @@ function inputError(reason?: string, message = 'input channel not ready') {
   })
 }
 
+/** The same message with no prose at all. Legal since #491 demoted `message` to optional, and this
+ *  fixture is the only thing between that and a toast reading "(undefined)" to a PO or a designer —
+ *  a template literal takes `string | undefined` without complaint and no lint rule here forbids it. */
+function inputErrorWithoutMessage(reason: string) {
+  act(() => {
+    deliver!({ type: 'input:error', sessionId: 's1', reason } as unknown as BrowserInbound)
+  })
+}
+
 const opts = () => toastError.mock.calls.map(([, o]) => o as { id: string; description: string; duration: number })
 
 describe('DeviceViewer — input:error (#485)', () => {
@@ -67,6 +76,26 @@ describe('DeviceViewer — input:error (#485)', () => {
     // is the opposite of the design, so this is pinned rather than left to a default.
     expect(opts()[0]!.duration).toBe(6000)
     expect(opts()[0]!.duration).toBeGreaterThan(4000) // sonner's default, short enough to lapse between two unhurried taps
+  })
+
+  // **#491 made `message` optional, and this is where its absence reaches a person.** A producer that
+  // sends only a reason is legal now, and the description used to interpolate the field unguarded —
+  // so the tester would read "Start it again to continue testing. (undefined)". Nothing else could
+  // catch it: a template literal accepts `string | undefined`, `restrict-template-expressions` is
+  // configured nowhere in this repo, and every other fixture here defaults `message` to a string.
+  it('drops the parenthetical when the producer sent no prose', () => {
+    mounted()
+    inputErrorWithoutMessage('not-booted')
+    expect(toastError).toHaveBeenCalledTimes(1)
+    expect(opts()[0]!.description).toBe(INPUT_ERROR_NOTICE['not-booted']!.action)
+    expect(opts()[0]!.description).not.toMatch(/undefined|\(\s*\)/)
+  })
+
+  // And the prose is still shown when there is some — the guard must not have turned it off.
+  it('still shows the prose when the producer sent it', () => {
+    mounted()
+    inputError('not-booted', 'simulator is shutting down')
+    expect(opts()[0]!.description).toContain('simulator is shutting down')
   })
 
   // A dead channel produces one error per tap, at whatever rate the tester taps. Nothing dedupes

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import type { BrowserToRelay, DeviceSummary, SessionStartFailure, SessionTerminatedReason } from '@tapflowio/protocol'
+import type {
+  BrowserToRelay, DeviceSummary, InputErrorReason, SessionStartFailure, SessionTerminatedReason,
+} from '@tapflowio/protocol'
 import { WebSocket } from 'ws'
 import type { UIElement } from '@tapflowio/agent-core'
 import { PlatformError } from '@tapflowio/agent-core'
@@ -109,6 +111,34 @@ const SESSION_START_FAILURES: Record<SessionStartFailure, true> = {
 // member would otherwise pass. The agents narrow key codes the same way for the same reason.
 function isSessionStartFailure(v: unknown): v is SessionStartFailure {
   return typeof v === 'string' && Object.hasOwn(SESSION_START_FAILURES, v)
+}
+
+/**
+ * The same mirror for `InputErrorReason`, and it exists because the comment below it was describing
+ * behaviour this file did not have.
+ *
+ * That comment said absence **and a member this build does not know** both read as
+ * `channel-unavailable`, the conservative reading protocol/AGENTS.md makes the contract. The code
+ * tested `typeof === 'string'` and passed anything else straight through, so a reason added to the
+ * union after this build shipped reached the step's message verbatim and any caller branching on it
+ * got a value it could not act on. `mcp-server` had it right — `Object.hasOwn(REASON_ADVICE, …)`.
+ *
+ * `Record<InputErrorReason, true>` rather than a `string[]`, for the reason stated on the twin above:
+ * the array form degrades silently when the union grows, and this makes that a compile error here.
+ */
+const INPUT_ERROR_REASONS: Record<InputErrorReason, true> = {
+  'not-booted': true,
+  'channel-unavailable': true,
+  'channel-starting': true,
+  'dispatch-failed': true,
+  unsupported: true,
+  malformed: true,
+  'no-gesture': true,
+  'not-session-owner': true,
+}
+
+function asInputErrorReason(v: unknown): InputErrorReason {
+  return typeof v === 'string' && Object.hasOwn(INPUT_ERROR_REASONS, v) ? (v as InputErrorReason) : 'channel-unavailable'
 }
 
 /**
@@ -652,7 +682,7 @@ export class RelayClient {
     // outside this repo that predates the field — the population the required declaration exists to correct
     // and cannot retroactively fix. Absent, or a member this build does not know, both read as
     // `channel-unavailable`, which is the conservative one (protocol/AGENTS.md).
-    const reason = typeof msg['reason'] === 'string' ? msg['reason'] : 'channel-unavailable'
+    const reason = asInputErrorReason(msg['reason'])
     throw this.failed(sessionId, `${what} was refused by the device (${reason}): ${(msg['message'] as string) ?? 'no detail'}`)
   }
 

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -646,9 +646,12 @@ export class RelayClient {
       )
     }
     if (msg['type'] !== 'input:error') return
-    // `reason` is optional on the wire and absent means *unknown*, never *fine* — an agent predating the
-    // field. Absent, or a member this build does not know, both read as `channel-unavailable`, which is the
-    // conservative one (protocol/AGENTS.md).
+    // **`reason` is required on the wire as of #491, and this branch stays.** That is not an oversight: this
+    // client reads inbound as `Record<string, unknown>` on purpose (see `RelayMsg` above), so the declaration
+    // obliges producers and buys this call site nothing. What can still arrive without one is an agent
+    // outside this repo that predates the field — the population the required declaration exists to correct
+    // and cannot retroactively fix. Absent, or a member this build does not know, both read as
+    // `channel-unavailable`, which is the conservative one (protocol/AGENTS.md).
     const reason = typeof msg['reason'] === 'string' ? msg['reason'] : 'channel-unavailable'
     throw this.failed(sessionId, `${what} was refused by the device (${reason}): ${(msg['message'] as string) ?? 'no detail'}`)
   }

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -167,7 +167,7 @@ describe('RelayClient — the input senders mint a correlator and await the ack'
   })
 
   it('reads an ack with no reason as channel-unavailable, not as fine', async () => {
-    // `reason` is optional on the wire — an agent predating the field omits it — and absence means
+    // `reason` is required on the wire as of #491; what still omits it is an agent outside this repo predating that — and absence means
     // *unknown*. protocol/AGENTS.md makes the conservative reading the contract, and the failure still has
     // to name something rather than an empty parenthesis.
     const { client } = await capture((m) => ({

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -177,6 +177,20 @@ describe('RelayClient — the input senders mint a correlator and await the ack'
       .rejects.toThrow(/pressKey Enter was refused by the device \(channel-unavailable\): no channel/)
   })
 
+  // **The other half of the same rule, which the code did not have until CodeRabbit asked for it.** The
+  // comment above the branch claimed absence *and a member this build does not know* both read as
+  // `channel-unavailable`; the code tested `typeof === 'string'` and passed anything else through, so a
+  // reason added to the union after this build shipped reached the step's message verbatim.
+  it('reads a reason it does not know as channel-unavailable too', async () => {
+    const { client } = await capture((m) => ({
+      type: 'input:error', sessionId: m['sessionId'], requestId: m['requestId'],
+      reason: 'invented-in-a-later-release', message: 'no channel',
+    }))
+    const err = await client.pressKey('s1', 'Enter').catch((e: unknown) => e) as Error
+    expect(err.message).toMatch(/\(channel-unavailable\)/)
+    expect(err.message).not.toMatch(/invented-in-a-later-release/)
+  })
+
   it('reports a lost relay as unconfirmed, and does not blame the agent for it', async () => {
     // `IOSAgent.ackInput` awaits an untimed `simctl list` on the first input after a boot, on the same Mac
     // the relay gates at 80% CPU — so an ack that never reaches this waiter can still belong to an input

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -313,7 +313,7 @@ describe('TapflowClient', () => {
     })
 
     it('behaves exactly as before for an agent that sends no reason', async () => {
-      // The field is optional so an older agent can omit it — absence must not change anything.
+      // The field is required as of #491; an agent outside this repo predating it still omits one, which is the population the branch is for — absence must not change anything.
       relay.setInputAck('error')
       await expect(client.tap('sess-1', 1, 2)).rejects.toThrow('device not booted')
     })

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -178,6 +178,12 @@ export const REASON_ADVICE: Record<InputErrorReason, string> = {
   'not-session-owner': 'You do not hold this session, so the input was refused and nothing reached the device. Call connect_device for it first, then send the input again — the accompanying message says whether the session is idle or held by someone else. If the join is refused it is in use; pick another device.',
 }
 
+/** Advice for a reason, including the one this build cannot name.
+ *
+ *  **`undefined` stays in the signature although `reason` is required on the wire as of #491.** This client
+ *  reads inbound as `Record<string, unknown>`, so the declaration obliges producers and proves nothing here;
+ *  an agent outside this repo predating the field still sends none, and that population is what the required
+ *  declaration exists to correct rather than something it can retroactively fix. */
 export function reasonAdvice(reason: string | undefined): string {
   // Absent or unrecognised resolves to `channel-unavailable`, per the protocol's conservative rule.
   // `Object.hasOwn`, not `in`: a reason of `toString` would otherwise return a function.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -43,10 +43,10 @@ The cost of a broad name is ambiguity about what belongs — answered by the two
 
 A message is `export interface AppInstallDone { type: 'app:install-done'; … }`, and the unions are
 unions of those names. That is what lets a consumer refer to one message, and what gives shared
-structure (`SessionError`) and per-message documentation somewhere to live.
+structure (`SessionScoped`) and per-message documentation somewhere to live.
 
 **`interface`, not `type X = { … }`** — the alias form cannot be `extends`ed, and the intersection
-workaround (`type X = SessionError & { … }`) stops `Extract<Union, { type: 'x' }>` resolving to a single
+workaround (`type X = SessionScoped & { … }`) stops `Extract<Union, { type: 'x' }>` resolving to a single
 member, which `useClipboardBridge` depends on to read a reply without a cast.
 
 Two properties were given up for that, neither visible to the type-equivalence check that proved the
@@ -300,7 +300,7 @@ L5c settled it by removing the general role rather than the specific one. A requ
 dropped at the relay's door (`isAddressed`), because answering it would ship a frame whose own required
 `sessionId` `JSON.stringify` erases — and `error` has no `requestId` either, so a caller could not attribute
 the answer and would wait out the same deadline silence costs. With nothing left needing an unaddressed
-failure, all four producers answer one specific join, and `error` **extends `SessionError`**: the shape is the
+failure, all four producers answer one specific join, and `error` **extends `SessionScoped`**: the shape is the
 base verbatim, and the base's own definition — a failure a *session* is waiting on — is now exactly what it is.
 
 **What the address buys.** The join waiters in `mcp-server` and `flow-runner` matched
@@ -356,8 +356,8 @@ Both checks read a union's *name* at the sink. Neither read its contents, and ap
 `| Record<string, unknown>` to `BrowserToRelay` passed every static check while making all three clients accept
 anything. Guards that name a type also have to assert the type is still a union of named messages.
 
-**`screenshot:error` and `ui:tree:error` do not extend `SessionError`, and that is the boundary of the
-family.** `SessionError` is for a failure a *session* is waiting on. Those two are request-scoped: the relay
+**`screenshot:error` and `ui:tree:error` do not extend `SessionScoped`, and that is the boundary of the
+family.** The base is for a failure a *session* is waiting on. Those two are request-scoped: the relay
 resolves the pending promise by `requestId` alone and never reads their `sessionId`.
 
 Their `sessionId` is nevertheless **required**, like every other producer field. A draft made it optional because
@@ -406,7 +406,7 @@ settled — and `device:shutdown` is on the request side with no ownership gate 
 - `'Session not found'` answers a sessionId that did not **match** — a stale tab, a terminated
   session — not one that was absent.
 - `{ type: 'error' }` **is not** an escape hatch, as of L5d — it is the answer to a `session:start` the relay
-  refused, it extends `SessionError`, and it names the session it refuses. The paragraph that stood here said
+  refused, it extends `SessionScoped`, and it names the session it refuses. The paragraph that stood here said
   the right move with no sessionId was to send *that*; L5c settled it the other way, by dropping a request
   that names no session at the door. Both halves of the old advice are gone: there is no unaddressed failure
   left to send, and nothing left that would need one.
@@ -436,18 +436,20 @@ a message that never arrives could inform it. #457 is that one.)
   consumer's move is identical for them.
 - **`message` stays free prose and `reason` is closed.** That is what lets iOS keep
   `` `unknown key code: ${code}` `` — the parameterised wording survives because the machine field is
-  separate. Consumers switch on `reason` and display `message`.
+  separate. Consumers switch on `reason`; they may show `message`, and since #491 made it optional a
+  consumer that renders it needs a path for its absence — the dashboard drops the parenthetical rather
+  than printing a placeholder.
 
-The field is **optional**, so an agent that predates it omits it and nothing breaks. Absence
-therefore means *unknown*, never *fine*, and **a consumer meeting a reason it does not know must
-treat it as `channel-unavailable`** — the conservative reading. Making the field required is the
-breaking step and has not been taken.
+The field is **required** as of #491, and `message` is the optional one. It shipped the other way
+round on purpose — an agent predating `reason` omitted it and nothing broke — but that left the field
+a consumer was guaranteed the one it must not depend on. The relay was the last in-repo producer
+sending prose alone (#492); once it stopped, all six sent a reason and the flip cost no call site.
 
-Every in-repo producer now sends one. The relay was the last that did not (#492) — it answers a
-terminal input it cannot dispatch, and being the only producer that reads a socket rather than
-inferring from its own state, it was the one whose reason was least in doubt. So absence today means
-an agent older than this field and nothing else, which is what #491 needs before the field can become
-required.
+**Absence still means *unknown*, never *fine*, and a consumer meeting a reason it does not know must
+treat it as `channel-unavailable`** — the conservative reading. Both clients keep that branch
+deliberately: they read inbound as `Record<string, unknown>`, so the declaration obliges producers and
+proves nothing at the call site, and an agent outside this repo predating the field is exactly the
+producer a required declaration corrects going forward and cannot retroactively fix.
 
 There is deliberately **no shared message table**. One would be a runtime value, and this entry point
 must erase under `import type` (see HOW NOT) — so each agent owns its own wording. A static check in

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -441,18 +441,19 @@ export interface DeviceReady {
  * L5d, and the door predicates drop such a request rather than answering it, because a reply carrying no
  * `requestId` cannot be attributed and costs the caller the same deadline silence would.
  */
-export interface SessionError {
+export interface SessionScoped {
   sessionId: string
-  message: string
 }
 
-export interface AppInstallError extends SessionError {
+export interface AppInstallError extends SessionScoped {
   type: 'app:install-error'
+  message: string
   requestId: string
 }
 
-export interface AppLaunchError extends SessionError {
+export interface AppLaunchError extends SessionScoped {
   type: 'app:launch-error'
+  message: string
   requestId: string
 }
 
@@ -461,27 +462,61 @@ export interface AppLaunchError extends SessionError {
 // that died mid-session and failed to come back, reported through the one field the dashboard renders.
 // So an unsolicited producer is not a possibility here, it is in the repo with a test on it, and a
 // consumer that correlates this message drops the only report of a dead stream. See AGENTS.md.
-export interface DeviceBootError extends SessionError {
+export interface DeviceBootError extends SessionScoped {
   type: 'device:boot-error'
+  message: string
   requestId?: string
 }
 
-export interface OpenUrlError extends SessionError {
+export interface OpenUrlError extends SessionScoped {
   type: 'open-url:error'
+  message: string
   requestId: string
 }
 
-export interface AppClearStateError extends SessionError {
+export interface AppClearStateError extends SessionScoped {
   type: 'app:clear-state-error'
+  message: string
   requestId: string
 }
 
-export interface InputError extends SessionError {
+/**
+ * **The guaranteed half is now the half that is a contract** (#491).
+ *
+ * `message` used to be required and `reason` optional, which is the inversion this message could least
+ * afford: `packages/protocol/AGENTS.md` states the split on purpose — `message` is free prose each agent
+ * owns, `reason` is the closed union consumers branch on — so the field a consumer was guaranteed to
+ * receive was the one it must not depend on, and the one it should depend on could be absent.
+ *
+ * That was the correct way to *ship* it (#490): an agent predating the field omitted it and nothing broke.
+ * It is not a correct end state, because every consumer carries an unknown-reason branch for as long as it
+ * holds, and "absence means unknown" has to be re-derived by each new one.
+ *
+ * **Measured before flipping it: all six in-repo producers already send a reason**, two of them with
+ * `satisfies InputErrorReason` on the literal — `IOSAgent.ts` (three sites), `AndroidAgent.ts` (two) and
+ * `RelayServer.refuseInput`. The prerequisite was the relay, which used to send prose alone (#492, closed).
+ * So this costs no in-repo change; what it buys is that an agent outside this repo cannot omit it, and that
+ * a consumer written tomorrow cannot be handed an unanswerable failure.
+ *
+ * **`message` is optional rather than removed.** It still carries parameterised detail a closed union
+ * cannot — `unknown key code: KeyFoo` — which is a debug and forward-compatibility field, and a debug field
+ * should not be required. Display copy belongs to the presentation layer: agent-authored English cannot be
+ * localised, and this product's audience is PO, PM, designers and QA. A structured `params` field is the
+ * honest way to keep `KeyFoo` once prose is demoted, and it is deliberately **not** added here — #485 is
+ * what will say whether a rendered UI misses the variable, and adding it now means guessing a schema from
+ * no requirement.
+ *
+ * `InputTypeError` keeps `reason?` and that asymmetry is deliberate, not an oversight: its agent-side
+ * producers answer with prose from a rejected `adb` or pasteboard write and have no reason to give. Only
+ * the relay sets one. The field's own doc there records it.
+ */
+export interface InputError extends SessionScoped {
   type: 'input:error'
   /** Required — see `InputDone`. The relay produces this message too, so omission is a compile error there
    *  rather than something only a test could hold. */
   requestId: string
-  reason?: InputErrorReason
+  reason: InputErrorReason
+  message?: string
 }
 
 // `requestId` is required on the same terms, and with a narrower guarantee behind it: the forward
@@ -492,8 +527,9 @@ export interface InputError extends SessionError {
 // them gains a clipboard tool, this required field is what turns a missing id into a compile error
 // instead of a reply the bridge drops on `if (!msg.requestId) return`. Holding the untyped senders
 // to it is L4.
-export interface ClipboardError extends SessionError {
+export interface ClipboardError extends SessionScoped {
   type: 'clipboard:error'
+  message: string
   requestId: string
   payload?: ClipboardErrorPayload
 }
@@ -588,10 +624,12 @@ export type SessionStartFailure =
  * attribute the answer and would wait out the same deadline silence costs. With nothing left needing an
  * unaddressed failure, every producer of this message answers one specific join.
  *
- * **So it extends `SessionError`**, and that is the honest form rather than a field bolted on: the shape is
- * the base verbatim, and the base's own definition — a failure a *session* is waiting on — is now exactly
- * what this is. `protocolMessageNames.test.mjs` enforces that membership, and its note saying `error`
- * "cannot be a `SessionError`" described a nature this change replaced.
+ * **So it extends `SessionScoped`**, and that is the honest form rather than a field bolted on: the base's
+ * own definition — a failure a *session* is waiting on — is now exactly what this is.
+ * `protocolMessageNames.test.mjs` enforces that membership, and its note saying `error` "cannot be a
+ * `SessionError`" described a nature that argument replaced. The base was called `SessionError` and carried
+ * `message` until #491 demoted prose on `input:error`; `message` now sits on each member that requires it,
+ * and what the base states is the one thing all nine share — the failure is addressed to a session.
  *
  * What the address buys: the join waiters in `mcp-server` and `flow-runner` matched
  * `sessionId === undefined || sessionId === mine`, and with no such key the left half was **always true**, so
@@ -603,8 +641,9 @@ export type SessionStartFailure =
  * shadows the global, so the exception exists for the literal rather than the role — renaming to
  * `SessionStartError` needs an exception entry just the same, and removing it needs a new wire literal.
  */
-export interface GenericError extends SessionError {
+export interface GenericError extends SessionScoped {
   type: 'error'
+  message: string
   reason: SessionStartFailure
 }
 
@@ -676,8 +715,9 @@ export interface InputTypeDone {
   requestId: string
 }
 
-export interface InputTypeError extends SessionError {
+export interface InputTypeError extends SessionScoped {
   type: 'input:type-error'
+  message: string
   requestId: string
   /**
    * Optional because the agents' own failures carry none — they answer with prose from a rejected `adb` or
@@ -817,9 +857,9 @@ export interface ScreenshotDone {
 
 /** A screenshot that failed.
  *
- *  **Does not extend `SessionError`**, unlike every other `*-error`, because it is not addressed to a
- *  session: the relay resolves the pending promise by `requestId` alone. `SessionError` is for a failure
- *  a *session* is waiting on, and drawing that line is what keeps the base meaningful.
+ *  **Does not extend `SessionScoped`**, unlike every other `*-error`, because it is not addressed to a
+ *  session: the relay resolves the pending promise by `requestId` alone. The base is for a failure a
+ *  *session* is waiting on, and drawing that line is what keeps it meaningful.
  *
  *  `sessionId` is still **required**, because every producer has one. An earlier draft made it optional
  *  on the grounds that the agents pass through an optional id — true when written, and false by the end

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -92,11 +92,17 @@ export const streamRegistered: RelayOutbound = { type: 'stream:registered' }
 export const streamIsNotBrowserInbound: BrowserInbound = { type: 'stream:registered' }
 
 // ── input:error reason ───────────────────────────────────────────────────────
-// The field is optional on purpose: an agent that predates it omits it, and a consumer must read
-// absence as "unknown" rather than "fine". Making it required is the breaking step.
+// The field was optional so an agent predating it could omit one, and a consumer had to read absence
+// as "unknown" rather than "fine". #491 took the breaking step: all six in-repo producers already sent
+// a reason, so what this closes is an agent outside the repo omitting it, and a consumer being handed a
+// failure it cannot branch on.
 
+// @ts-expect-error - reason is required as of #491; prose alone is not an answer a caller can act on
 export const errorWithoutReason: RelayOutbound = { type: 'input:error', sessionId: 's', requestId: 'rq', message: 'agent offline' }
 export const errorWithReason: RelayOutbound = { type: 'input:error', sessionId: 's', requestId: 'rq', message: 'agent offline', reason: 'channel-unavailable' }
+// The other half of the inversion: prose is now the optional one, and a producer with nothing
+// parameterised to add may leave it out.
+export const errorWithoutMessage: RelayOutbound = { type: 'input:error', sessionId: 's', requestId: 'rq', reason: 'channel-unavailable' }
 
 // @ts-expect-error - the reason set is closed; a free string would let each agent invent its own
 export const errorWithFreeReason: RelayOutbound = { type: 'input:error', sessionId: 's', message: 'x', reason: 'something-else' }

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -136,7 +136,7 @@ function ownershipRefusal(session: Session): string {
  *  these doors produce declares `sessionId` **required**, so answering means putting a frame on the wire
  *  whose required field `JSON.stringify` erases, which every consumer's session gate then discards.
  *
- *  **So the request is dropped, not answered.** `SessionError`'s doc argued the opposite until L5d — "the
+ *  **So the request is dropped, not answered.** The base's doc argued the opposite until L5d — "the
  *  only correct thing for it to send with no sessionId is `{ type: 'error' }`" — and its own premise refutes
  *  it: `GenericError` has no `requestId`, so a caller that receives one cannot attribute it and waits out the
  *  same deadline it would have waited out on silence. Answering buys nothing it did not already have; not

--- a/packages/relay/src/__tests__/inputErrorReason.test.ts
+++ b/packages/relay/src/__tests__/inputErrorReason.test.ts
@@ -306,7 +306,7 @@ describe('input:error from the relay carries a reason (#492)', () => {
   // hand and no way to attribute it.
   //
   // Dropped rather than answered, the same policy as an uncorrelatable request, and for a reason the note on
-  // `SessionError` used to contradict: `GenericError` carries no `requestId`, so answering an unaddressed
+  // The message base used to contradict: `GenericError` carries no `requestId`, so answering an unaddressed
   // request is *also* unattributable — it buys the caller nothing that silence did not, while widening what
   // `error` means. See `isAddressed`.
   for (const bad of [undefined, ''] as Array<string | undefined>) {

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -75,14 +75,14 @@ function interfaceBodies(src) {
 
 const IFACES = interfaceBodies(protocolSrc)
 
-/** The `type` literal an interface declares. A base like `SessionError` carries none. */
+/** The `type` literal an interface declares. A base like `SessionScoped` carries none. */
 function literalOf(name) {
   const m = IFACES.get(name)?.body.match(/^ {2}type: '([^']+)';?$/m)
   return m ? m[1] : null
 }
 
 /** Fields of an interface with `extends` resolved, each suffixed `?` when optional, **sorted**.
- *  Declaration order carries no meaning, and `extends SessionError` puts the inherited pair first —
+ *  Declaration order carries no meaning, and `extends SessionScoped` puts the inherited field first —
  *  which reordered three signatures that had not otherwise changed. Sorting keeps the check aimed at
  *  what a consumer can observe: which fields exist and which are optional. */
 function fieldsOf(name) {
@@ -211,7 +211,11 @@ describe('browser-inbound routing matches the protocol union', () => {
       'device:boot-error': 'message requestId? sessionId',
       'open-url:error': 'message requestId sessionId',
       'app:clear-state-error': 'message requestId sessionId',
-      'input:error': 'message reason? requestId sessionId',
+      // #491 inverted this pair: `reason` is the closed union a consumer branches on and is now
+      // required, `message` is producer prose and is now optional. The sibling below keeps `reason?`
+      // because its agent-side producers answer with a rejected `adb` or pasteboard write and have no
+      // reason to give — only the relay sets one there.
+      'input:error': 'message? reason requestId sessionId',
       // Moved here from AgentToBrowser in L5c: the relay refuses an `input:type` whose session the sender
       // does not hold, and the waiters key on this pair rather than on `input:error`.
       'input:type-error': 'message reason? requestId sessionId',

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -16,7 +16,7 @@ import { join } from 'node:path'
 // are what catch it, and this file asserts every message interface has one — a guard you can forget an
 // entry of is a guard with 57-of-58 coverage, and the missing one is invisible.
 //
-// **2. That a session-scoped failure declares `extends SessionError`.** This cannot be asserted with a
+// **2. That a session-scoped failure declares `extends SessionScoped`.** This cannot be asserted with a
 // type: every object with `{ sessionId, message }` is assignable to `SessionError`, so the assignment
 // succeeds whether or not the interface declares the inheritance. And `extends` is transparent to
 // `Equals` — inherited members arrive in the resolved member set, so an error written inline instead
@@ -133,24 +133,31 @@ describe('protocol message interfaces', () => {
   // the base is for a failure a session is waiting on.
   const REQUEST_SCOPED = new Set(['screenshot:error', 'ui:tree:error'])
 
-  it('a session-scoped failure declares extends SessionError', () => {
+  it('a session-scoped failure declares extends SessionScoped', () => {
     const offenders = []
     for (const [name, { literal, extends: base, body }] of messages) {
       const isFailure = /error$/.test(literal) && !REQUEST_SCOPED.has(literal)
-      const hasSession = /^ {2}sessionId[?]?:/m.test(body) || base === 'SessionError'
+      const hasSession = /^ {2}sessionId[?]?:/m.test(body) || base === 'SessionScoped'
       // `error` used to be excluded here, on the grounds that it was the escape hatch for a failure that
       // could not be attributed to a session — "the member's nature, not an exception". L5d replaced that
       // nature: a request naming no session is dropped at the relay's door, so every producer of `error`
       // answers one specific join, and it joins the family like every other session-scoped failure. The
       // predicate needed no change; what changed is that `error` now satisfies it.
       if (!isFailure || !hasSession) continue
-      if (base !== 'SessionError') offenders.push(`${name} ('${literal}')`)
+      if (base !== 'SessionScoped') offenders.push(`${name} ('${literal}')`)
     }
     expect(offenders).toEqual([])
-    expect([...messages].filter(([, m]) => m.extends === 'SessionError')).toHaveLength(9)
+    expect([...messages].filter(([, m]) => m.extends === 'SessionScoped')).toHaveLength(9)
     // `error` is the ninth, as of L5d. Pinned by name rather than only by the count, because the count alone
     // would be satisfied by any new member and this is the one whose membership was argued.
-    expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: 'SessionError' })
+    expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: 'SessionScoped' })
+    // #491 moved `message` off the base onto each member that requires it, so the family relation is no
+    // longer implied by the shared pair — the `extends` is the only thing left saying these nine are one
+    // kind. That makes this assertion load-bearing in a way it was not when the base carried two fields.
+    for (const [name, { body, extends: base }] of messages) {
+      if (base !== 'SessionScoped' || name === 'InputError') continue
+      expect(/^ {2}message: string$/m.test(body), `${name} lost its message declaration`).toBe(true)
+    }
     expect(REQUEST_SCOPED.size).toBe(2)
     for (const literal of REQUEST_SCOPED) {
       const entry = [...messages].find(([, m]) => m.literal === literal)
@@ -164,12 +171,16 @@ describe('protocol message interfaces', () => {
     }
     // What the base carries, pinned. `browserInboundRouting`'s signatures resolve `extends` and sort,
     // so they cannot tell an inherited field from an own-declared one: moving `sessionId` out of the
-    // base and into all eight subclasses leaves every signature identical and every check green.
+    // base and into all nine subclasses leaves every signature identical and every check green.
     // Measured. This line is what makes the inheritance mean something.
+    //
+    // It carried `message` too until #491, which demoted prose to optional on `input:error` alone —
+    // TypeScript cannot narrow an inherited required member, so the field moved onto each of the nine.
+    // That left the base with the one thing all nine actually share, and the name followed the shape.
     const base = readFileSync(join(root, 'packages/protocol/src/index.ts'), 'utf8')
-      .match(/export interface SessionError \{([^}]*)\}/)
-    expect(base, 'SessionError is gone').not.toBeNull()
-    expect([...base[1].matchAll(/^ {2}(\w+)(\??):/gm)].map((m) => m[1] + m[2]).sort()).toEqual(['message', 'sessionId'])
+      .match(/export interface SessionScoped \{([^}]*)\}/)
+    expect(base, 'SessionScoped is gone').not.toBeNull()
+    expect([...base[1].matchAll(/^ {2}(\w+)(\??):/gm)].map((m) => m[1] + m[2]).sort()).toEqual(['sessionId'])
   })
 
   it('the L1 conversion net is gone', () => {

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -17,7 +17,8 @@ import { join } from 'node:path'
 // entry of is a guard with 57-of-58 coverage, and the missing one is invisible.
 //
 // **2. That a session-scoped failure declares `extends SessionScoped`.** This cannot be asserted with a
-// type: every object with `{ sessionId, message }` is assignable to `SessionError`, so the assignment
+// type: every object with `{ sessionId }` is assignable to `SessionScoped` — a weaker bar than the
+// `{ sessionId, message }` pair this argued from before #491, so the assignment
 // succeeds whether or not the interface declares the inheritance. And `extends` is transparent to
 // `Equals` — inherited members arrive in the resolved member set, so an error written inline instead
 // passes every type-level check. The inheritance exists for the family relation, which is source text,
@@ -129,7 +130,7 @@ describe('protocol message interfaces', () => {
   })
 
   // Failures addressed to a *request*, not to a session: the relay resolves both by `requestId` alone
-  // (`RelayServer.ts:1293-1312`). Listing them draws the boundary of `SessionError` rather than widening it —
+  // (`RelayServer.ts:1293-1312`). Listing them draws the boundary of the family rather than widening it —
   // the base is for a failure a session is waiting on.
   const REQUEST_SCOPED = new Set(['screenshot:error', 'ui:tree:error'])
 

--- a/scripts/__tests__/protocolPayloadTypes.test.mjs
+++ b/scripts/__tests__/protocolPayloadTypes.test.mjs
@@ -120,8 +120,9 @@ const protoDecls = interfaces(protoSrc)
 // wire-contract program), and L1 turned 58 of them into interfaces — many sharing a low-arity set like
 // `{type, sessionId}`.
 //
-// **Bases that messages inherit.** `SessionError` carries no `type`, so the first rule keeps it, and
-// its shape `{sessionId, message}` is the most common local error DTO in this repo. Measured: a plain
+// **Bases that messages inherit.** `SessionScoped` carries no `type`, so the first rule keeps it. Its
+// shape was `{sessionId, message}` until #491 moved the prose onto each member; the reasoning below was
+// measured against that pair and holds the same way for the field it kept. Measured: a plain
 // `interface RelayFailure { sessionId: string; message: string }` in `mcp-server` was reported as
 // re-declaring a protocol payload — and the advice this check gives ("import it from protocol instead")
 // is wrong for that case. A message base is a structural fragment of the message family, not a shape a


### PR DESCRIPTION
## Summary

Closes #491. **Breaking wire-contract change**, shipped as `minor` because the package is pre-1.0 and `CONTRIBUTING.md` permits that until `v1.0.0`.

`input:error` guaranteed `message` — free prose each agent owns — and made `reason` — the closed union consumers branch on — optional. The field you were guaranteed was the one you must not depend on. That was right for shipping it (#490); it was never a correct end state, and the last prerequisite closed with #492.

It costs nothing in this repo: all six producers already send a reason, two with `satisfies` on the literal. What it buys is an agent outside this repo, which can no longer omit it. Both absence branches stay and now say why beside themselves.

Making `message` optional meant moving it off the shared base — TypeScript cannot narrow an inherited required member — so `SessionError` is now `SessionScoped`, carrying only `sessionId`, with `message: string` re-declared on each of the nine members that keep it.

## Checklist

- [x] Tests written and passing — 2 new dashboard tests; all package suites green; 5 mutations run, all killed
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a, protocol owns the wire
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/feat__input-error-reason-required.md` — a design pass that found the "without touching siblings" requirement unsatisfiable, and a pre-PR review that found the change shipping `(undefined)` into a toast.

That last one is worth naming here: the dashboard is a **third, typed** consumer, and it interpolated `message` unguarded. An out-of-repo agent sending only a reason — the population this change exists to serve — made the tester read *"Start it again to continue testing. (undefined)"*. No gate could have caught it: a template literal accepts `string | undefined`, `restrict-template-expressions` is configured nowhere here, and every fixture in that suite defaulted `message` to a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * `input:error` events now require a machine-readable `reason`; the human-readable `message` is optional.
  * Update integrations that produce or consume input-error events to follow the revised contract.
  * Unknown or missing reasons are handled as `channel-unavailable` for compatibility with older agents.
  * Session-scoped errors now share a simplified session identifier structure.

* **Bug Fixes**
  * Error notifications no longer show empty parentheses or `undefined` when diagnostic text is unavailable.

* **Documentation**
  * Updated protocol documentation, changelog guidance, and migration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->