### PR TITLE
ci(docker): smoke test relay image runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,8 @@
 node_modules
 **/node_modules
 **/dist
+# Package-root tsconfig.tsbuildinfo sits outside **/dist; stale incremental metadata
+# can make a local pnpm build -> docker build skip required emits.
 **/*.tsbuildinfo
 **/.tapflow
 playground

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 node_modules
 **/node_modules
 **/dist
+**/*.tsbuildinfo
 **/.tapflow
 playground
 !playground/package.json

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,9 +70,74 @@ jobs:
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           # Publish: push a per-architecture image by digest (merged into a manifest
-          # list in the merge job). Otherwise (PR / no credentials): build for
-          # validation only, keeping just the cache.
-          outputs: ${{ (github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || 'type=cacheonly' }}
+          # list in the merge job). Otherwise (PR / no credentials): load the
+          # built image into Docker so the runtime smoke test exercises it.
+          outputs: ${{ (github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || format('type=docker,name=tapflow-smoke:{0}', env.PLATFORM_PAIR) }}
+
+      - name: Select image for smoke test
+        run: |
+          if [ "${HAS_DOCKERHUB}" = "true" ] && [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "SMOKE_IMAGE=${IMAGE}@${{ steps.build.outputs.digest }}" >> "$GITHUB_ENV"
+          else
+            echo "SMOKE_IMAGE=tapflow-smoke:${PLATFORM_PAIR}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Smoke test image runtime
+        run: |
+          set -euo pipefail
+
+          container="tapflow-smoke-${PLATFORM_PAIR}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          volume="${container}-data"
+          root_body="${RUNNER_TEMP}/tapflow-smoke-root.txt"
+          api_body="${RUNNER_TEMP}/tapflow-smoke-auth-status.txt"
+
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker logs "$container" 2>/dev/null || true
+            fi
+            docker rm -f "$container" >/dev/null 2>&1 || true
+            docker volume rm "$volume" >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          docker volume create "$volume" >/dev/null
+          docker run -d \
+            --name "$container" \
+            -p 127.0.0.1:4000:4000 \
+            -v "$volume:/app/.tapflow/data" \
+            "$SMOKE_IMAGE" >/dev/null
+
+          for attempt in $(seq 1 60); do
+            if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
+              echo "Container exited before readiness (attempt ${attempt})." >&2
+              exit 1
+            fi
+
+            root_status="$(curl -sS -o "$root_body" -w '%{http_code}' http://127.0.0.1:4000/ || true)"
+            api_status="$(curl -sS -o "$api_body" -w '%{http_code}' http://127.0.0.1:4000/api/v1/auth/status || true)"
+            if [ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ] \
+              && [ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ] \
+              && grep -Fq '<title>tapflow</title>' "$root_body" \
+              && grep -Eq '"initialized":(true|false)' "$api_body"; then
+              echo "Smoke test passed with HTTP /=${root_status} and /api/v1/auth/status=${api_status}."
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          echo "Relay did not return a non-error HTTP response on :4000." >&2
+          if [ -s "$root_body" ]; then
+            echo "--- / response body ---" >&2
+            sed -n '1,80p' "$root_body" >&2
+          fi
+          if [ -s "$api_body" ]; then
+            echo "--- /api/v1/auth/status response body ---" >&2
+            sed -n '1,80p' "$api_body" >&2
+          fi
+          exit 1
 
       - name: Export digest
         if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,6 +108,7 @@ jobs:
             if [ "$status" -ne 0 ]; then
               echo "Smoke container diagnostics:" >&2
               diagnose_container >&2
+              docker logs --tail 50 "$container" 2>/dev/null || true
             fi
             docker rm -f "$container" >/dev/null 2>&1 || true
             docker volume rm "$volume" >/dev/null 2>&1 || true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,6 +83,7 @@ jobs:
           fi
 
       - name: Smoke test image runtime
+        timeout-minutes: 5
         run: |
           set -euo pipefail
 
@@ -91,10 +92,22 @@ jobs:
           root_body="${RUNNER_TEMP}/tapflow-smoke-root.txt"
           api_body="${RUNNER_TEMP}/tapflow-smoke-auth-status.txt"
 
+          diagnose_container() {
+            if docker inspect "$container" >/dev/null 2>&1; then
+              docker inspect -f 'Container exists: true
+          State.Status={{.State.Status}}
+          State.ExitCode={{.State.ExitCode}}
+          State.OOMKilled={{.State.OOMKilled}}' "$container" 2>/dev/null || true
+            else
+              echo "Container exists: false"
+            fi
+          }
+
           cleanup() {
             status=$?
             if [ "$status" -ne 0 ]; then
-              docker logs "$container" 2>/dev/null || true
+              echo "Smoke container diagnostics:" >&2
+              diagnose_container >&2
             fi
             docker rm -f "$container" >/dev/null 2>&1 || true
             docker volume rm "$volume" >/dev/null 2>&1 || true
@@ -102,42 +115,64 @@ jobs:
           }
           trap cleanup EXIT
 
+          start_container() {
+            docker run -d \
+              --name "$container" \
+              -p 127.0.0.1:4000:4000 \
+              -v "$volume:/app/.tapflow/data" \
+              "$SMOKE_IMAGE" >/dev/null
+          }
+
+          wait_for_ready() {
+            phase="$1"
+            for attempt in $(seq 1 20); do
+              if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
+                echo "Container exited before readiness during ${phase} (attempt ${attempt})." >&2
+                return 1
+              fi
+
+              root_status="$(curl --connect-timeout 2 --max-time 2 -sS -o "$root_body" -w '%{http_code}' http://127.0.0.1:4000/ || true)"
+              api_status="$(curl --connect-timeout 2 --max-time 2 -sS -o "$api_body" -w '%{http_code}' http://127.0.0.1:4000/api/v1/auth/status || true)"
+              if [ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ] \
+                && [ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ] \
+                && grep -Fq '<title>tapflow</title>' "$root_body" \
+                && grep -Eq '"initialized":(true|false)' "$api_body"; then
+                echo "Smoke test ${phase} passed with HTTP /=${root_status} and /api/v1/auth/status=${api_status}."
+                return 0
+              fi
+
+              sleep 2
+            done
+
+            echo "Relay did not return the expected HTTP responses on :4000 during ${phase}." >&2
+            echo "Last observed HTTP statuses: /=${root_status:-none}, /api/v1/auth/status=${api_status:-none}." >&2
+            return 1
+          }
+
+          jwt_secret_fingerprint() {
+            docker exec "$container" sh -eu -c \
+              'if [ ! -s /app/.tapflow/data/jwt-secret ]; then
+                echo "JWT secret file is missing or empty." >&2
+                exit 1
+              fi
+              sha256sum /app/.tapflow/data/jwt-secret | cut -d " " -f1'
+          }
+
           docker volume create "$volume" >/dev/null
-          docker run -d \
-            --name "$container" \
-            -p 127.0.0.1:4000:4000 \
-            -v "$volume:/app/.tapflow/data" \
-            "$SMOKE_IMAGE" >/dev/null
+          start_container
+          wait_for_ready "first boot"
+          first_jwt_secret="$(jwt_secret_fingerprint)"
 
-          for attempt in $(seq 1 60); do
-            if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
-              echo "Container exited before readiness (attempt ${attempt})." >&2
-              exit 1
-            fi
+          docker rm -f "$container" >/dev/null
+          start_container
+          wait_for_ready "restart"
+          second_jwt_secret="$(jwt_secret_fingerprint)"
 
-            root_status="$(curl -sS -o "$root_body" -w '%{http_code}' http://127.0.0.1:4000/ || true)"
-            api_status="$(curl -sS -o "$api_body" -w '%{http_code}' http://127.0.0.1:4000/api/v1/auth/status || true)"
-            if [ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ] \
-              && [ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ] \
-              && grep -Fq '<title>tapflow</title>' "$root_body" \
-              && grep -Eq '"initialized":(true|false)' "$api_body"; then
-              echo "Smoke test passed with HTTP /=${root_status} and /api/v1/auth/status=${api_status}."
-              exit 0
-            fi
-
-            sleep 2
-          done
-
-          echo "Relay did not return a non-error HTTP response on :4000." >&2
-          if [ -s "$root_body" ]; then
-            echo "--- / response body ---" >&2
-            sed -n '1,80p' "$root_body" >&2
+          if [ "$first_jwt_secret" != "$second_jwt_secret" ]; then
+            echo "JWT secret did not persist across container recreation." >&2
+            exit 1
           fi
-          if [ -s "$api_body" ]; then
-            echo "--- /api/v1/auth/status response body ---" >&2
-            sed -n '1,80p' "$api_body" >&2
-          fi
-          exit 1
+          echo "JWT secret persisted across container recreation."
 
       - name: Export digest
         if: github.event_name != 'pull_request' && env.HAS_DOCKERHUB == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,7 +108,7 @@ jobs:
             if [ "$status" -ne 0 ]; then
               echo "Smoke container diagnostics:" >&2
               diagnose_container >&2
-              docker logs --tail 50 "$container" 2>/dev/null || true
+              docker logs --tail 50 "$container" || true
             fi
             docker rm -f "$container" >/dev/null 2>&1 || true
             docker volume rm "$volume" >/dev/null 2>&1 || true

--- a/scripts/__tests__/dockerPublishSmoke.test.mjs
+++ b/scripts/__tests__/dockerPublishSmoke.test.mjs
@@ -52,22 +52,44 @@ describe('docker-publish runtime smoke test', () => {
 
   it('waits for a live container and a non-error HTTP response before passing', () => {
     const smoke = stepBlock('Smoke test image runtime')
-    expect(smoke).toContain('for attempt in $(seq 1 60)')
+    expect(smoke).toContain('timeout-minutes: 5')
+    expect(smoke).toContain('for attempt in $(seq 1 20)')
     expect(smoke).toContain("docker inspect -f '{{.State.Running}}' \"$container\"")
     expect(smoke).toContain('http://127.0.0.1:4000/')
     expect(smoke).toContain('http://127.0.0.1:4000/api/v1/auth/status')
+    expect(smoke.match(/curl --connect-timeout 2 --max-time 2/g) ?? []).toHaveLength(2)
     expect(smoke).toContain('[ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ]')
     expect(smoke).toContain('[ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ]')
     expect(smoke).toContain("grep -Fq '<title>tapflow</title>' \"$root_body\"")
     expect(smoke).toContain('grep -Eq \'"initialized":(true|false)\' "$api_body"')
   })
 
-  it('reports logs on failure and removes test containers and volumes', () => {
+  it('reports sanitized failure diagnostics and removes test containers and volumes', () => {
     const smoke = stepBlock('Smoke test image runtime')
     expect(smoke).toContain('trap cleanup EXIT')
-    expect(smoke).toContain('docker logs "$container"')
+    expect(smoke).not.toContain('docker logs "$container"')
+    expect(smoke).toContain('diagnose_container >&2')
+    expect(smoke).toContain('State.Status={{.State.Status}}')
+    expect(smoke).toContain('State.ExitCode={{.State.ExitCode}}')
+    expect(smoke).toContain('State.OOMKilled={{.State.OOMKilled}}')
     expect(smoke).toContain('docker rm -f "$container"')
     expect(smoke).toContain('docker volume rm "$volume"')
+  })
+
+  it('recreates the same image with the same volume and checks JWT secret continuity', () => {
+    const smoke = stepBlock('Smoke test image runtime')
+    expect(smoke.match(/start_container/g) ?? []).toHaveLength(3)
+    expect(smoke).toContain('wait_for_ready "first boot"')
+    expect(smoke).toContain('docker rm -f "$container" >/dev/null')
+    expect(smoke).toContain('wait_for_ready "restart"')
+    expect(smoke).toContain('[ ! -s /app/.tapflow/data/jwt-secret ]')
+    expect(smoke).toContain('JWT secret file is missing or empty.')
+    expect(smoke).toContain('sha256sum /app/.tapflow/data/jwt-secret | cut -d " " -f1')
+    expect(smoke).toContain('first_jwt_secret="$(jwt_secret_fingerprint)"')
+    expect(smoke).toContain('second_jwt_secret="$(jwt_secret_fingerprint)"')
+    expect(smoke).toContain('[ "$first_jwt_secret" != "$second_jwt_secret" ]')
+    expect(smoke).toContain('"$SMOKE_IMAGE"')
+    expect(smoke).toContain('-v "$volume:/app/.tapflow/data"')
   })
 
   it('does not copy stale TypeScript build metadata without matching dist output', () => {

--- a/scripts/__tests__/dockerPublishSmoke.test.mjs
+++ b/scripts/__tests__/dockerPublishSmoke.test.mjs
@@ -1,6 +1,7 @@
 // The Docker workflow itself exercises normal runtime behavior on PRs. These checks only guard
-// regressions CI cannot otherwise expose: required platform coverage and the credentialed digest
-// smoke path, which PR CI cannot run without maintainer registry credentials.
+// regressions CI cannot otherwise expose: CI could stay green while accidentally publishing a
+// single-architecture image, and the digest smoke path cannot run in PR CI without maintainer
+// registry credentials.
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
@@ -40,7 +41,7 @@ describe('docker-publish runtime smoke test', () => {
     expect(select).toContain('SMOKE_IMAGE=${IMAGE}@${{ steps.build.outputs.digest }}')
   })
 
-  it('does not copy stale TypeScript build metadata without matching dist output', () => {
+  it('excludes stale TypeScript incremental build metadata from Docker context', () => {
     expect(DOCKERIGNORE).toContain('**/*.tsbuildinfo')
   })
 })

--- a/scripts/__tests__/dockerPublishSmoke.test.mjs
+++ b/scripts/__tests__/dockerPublishSmoke.test.mjs
@@ -1,3 +1,6 @@
+// The Docker workflow itself exercises normal runtime behavior on PRs. These checks only guard
+// regressions CI cannot otherwise expose: required platform coverage and the credentialed digest
+// smoke path, which PR CI cannot run without maintainer registry credentials.
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
@@ -25,75 +28,19 @@ function matrixBlock() {
 
 describe('docker-publish runtime smoke test', () => {
   it('keeps the Docker build matrix on the required amd64 and arm64 platforms', () => {
-    const platforms = [...matrixBlock().matchAll(/platform:\s*(linux\/(?:amd64|arm64))\b/g)].map(
+    const platforms = [...matrixBlock().matchAll(/platform:\s*(\S+)/g)].map(
       ([, platform]) => platform,
     )
 
     expect(platforms).toEqual(['linux/amd64', 'linux/arm64'])
   })
 
-  it('loads validation builds locally and smokes the pushed digest when publishing', () => {
-    const build = stepBlock('Build image (push by digest when publishing)')
-    expect(build).toContain('push-by-digest=true')
-    expect(build).toContain('push=true')
-    expect(build).toContain('type=docker,name=tapflow-smoke:{0}')
-
+  it('smokes the pushed digest on the credentialed publish path', () => {
     const select = stepBlock('Select image for smoke test')
     expect(select).toContain('SMOKE_IMAGE=${IMAGE}@${{ steps.build.outputs.digest }}')
-    expect(select).toContain('SMOKE_IMAGE=tapflow-smoke:${PLATFORM_PAIR}')
-  })
-
-  it('runs the container on :4000 with the persistent data volume mounted', () => {
-    const smoke = stepBlock('Smoke test image runtime')
-    expect(smoke).toContain('-p 127.0.0.1:4000:4000')
-    expect(smoke).toContain('-v "$volume:/app/.tapflow/data"')
-    expect(smoke).toContain('"$SMOKE_IMAGE"')
-  })
-
-  it('waits for a live container and a non-error HTTP response before passing', () => {
-    const smoke = stepBlock('Smoke test image runtime')
-    expect(smoke).toContain('timeout-minutes: 5')
-    expect(smoke).toContain('for attempt in $(seq 1 20)')
-    expect(smoke).toContain("docker inspect -f '{{.State.Running}}' \"$container\"")
-    expect(smoke).toContain('http://127.0.0.1:4000/')
-    expect(smoke).toContain('http://127.0.0.1:4000/api/v1/auth/status')
-    expect(smoke.match(/curl --connect-timeout 2 --max-time 2/g) ?? []).toHaveLength(2)
-    expect(smoke).toContain('[ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ]')
-    expect(smoke).toContain('[ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ]')
-    expect(smoke).toContain("grep -Fq '<title>tapflow</title>' \"$root_body\"")
-    expect(smoke).toContain('grep -Eq \'"initialized":(true|false)\' "$api_body"')
-  })
-
-  it('reports sanitized failure diagnostics and removes test containers and volumes', () => {
-    const smoke = stepBlock('Smoke test image runtime')
-    expect(smoke).toContain('trap cleanup EXIT')
-    expect(smoke).not.toContain('docker logs "$container"')
-    expect(smoke).toContain('diagnose_container >&2')
-    expect(smoke).toContain('State.Status={{.State.Status}}')
-    expect(smoke).toContain('State.ExitCode={{.State.ExitCode}}')
-    expect(smoke).toContain('State.OOMKilled={{.State.OOMKilled}}')
-    expect(smoke).toContain('docker rm -f "$container"')
-    expect(smoke).toContain('docker volume rm "$volume"')
-  })
-
-  it('recreates the same image with the same volume and checks JWT secret continuity', () => {
-    const smoke = stepBlock('Smoke test image runtime')
-    expect(smoke.match(/start_container/g) ?? []).toHaveLength(3)
-    expect(smoke).toContain('wait_for_ready "first boot"')
-    expect(smoke).toContain('docker rm -f "$container" >/dev/null')
-    expect(smoke).toContain('wait_for_ready "restart"')
-    expect(smoke).toContain('[ ! -s /app/.tapflow/data/jwt-secret ]')
-    expect(smoke).toContain('JWT secret file is missing or empty.')
-    expect(smoke).toContain('sha256sum /app/.tapflow/data/jwt-secret | cut -d " " -f1')
-    expect(smoke).toContain('first_jwt_secret="$(jwt_secret_fingerprint)"')
-    expect(smoke).toContain('second_jwt_secret="$(jwt_secret_fingerprint)"')
-    expect(smoke).toContain('[ "$first_jwt_secret" != "$second_jwt_secret" ]')
-    expect(smoke).toContain('"$SMOKE_IMAGE"')
-    expect(smoke).toContain('-v "$volume:/app/.tapflow/data"')
   })
 
   it('does not copy stale TypeScript build metadata without matching dist output', () => {
-    expect(DOCKERIGNORE).toContain('**/dist')
     expect(DOCKERIGNORE).toContain('**/*.tsbuildinfo')
   })
 })

--- a/scripts/__tests__/dockerPublishSmoke.test.mjs
+++ b/scripts/__tests__/dockerPublishSmoke.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const WORKFLOW = readFileSync(join(ROOT, '.github', 'workflows', 'docker-publish.yml'), 'utf8')
+const DOCKERIGNORE = readFileSync(join(ROOT, '.dockerignore'), 'utf8')
+
+function stepBlock(name) {
+  const marker = `      - name: ${name}\n`
+  const start = WORKFLOW.indexOf(marker)
+  if (start === -1) return ''
+  const next = WORKFLOW.indexOf('\n      - name:', start + marker.length)
+  return WORKFLOW.slice(start, next === -1 ? undefined : next)
+}
+
+function matrixBlock() {
+  const marker = '      matrix:\n'
+  const start = WORKFLOW.indexOf(marker)
+  if (start === -1) return ''
+  const next = WORKFLOW.indexOf('\n    env:', start + marker.length)
+  return WORKFLOW.slice(start, next === -1 ? undefined : next)
+}
+
+describe('docker-publish runtime smoke test', () => {
+  it('keeps the Docker build matrix on the required amd64 and arm64 platforms', () => {
+    const platforms = [...matrixBlock().matchAll(/platform:\s*(linux\/(?:amd64|arm64))\b/g)].map(
+      ([, platform]) => platform,
+    )
+
+    expect(platforms).toEqual(['linux/amd64', 'linux/arm64'])
+  })
+
+  it('loads validation builds locally and smokes the pushed digest when publishing', () => {
+    const build = stepBlock('Build image (push by digest when publishing)')
+    expect(build).toContain('push-by-digest=true')
+    expect(build).toContain('push=true')
+    expect(build).toContain('type=docker,name=tapflow-smoke:{0}')
+
+    const select = stepBlock('Select image for smoke test')
+    expect(select).toContain('SMOKE_IMAGE=${IMAGE}@${{ steps.build.outputs.digest }}')
+    expect(select).toContain('SMOKE_IMAGE=tapflow-smoke:${PLATFORM_PAIR}')
+  })
+
+  it('runs the container on :4000 with the persistent data volume mounted', () => {
+    const smoke = stepBlock('Smoke test image runtime')
+    expect(smoke).toContain('-p 127.0.0.1:4000:4000')
+    expect(smoke).toContain('-v "$volume:/app/.tapflow/data"')
+    expect(smoke).toContain('"$SMOKE_IMAGE"')
+  })
+
+  it('waits for a live container and a non-error HTTP response before passing', () => {
+    const smoke = stepBlock('Smoke test image runtime')
+    expect(smoke).toContain('for attempt in $(seq 1 60)')
+    expect(smoke).toContain("docker inspect -f '{{.State.Running}}' \"$container\"")
+    expect(smoke).toContain('http://127.0.0.1:4000/')
+    expect(smoke).toContain('http://127.0.0.1:4000/api/v1/auth/status')
+    expect(smoke).toContain('[ "$root_status" -ge 200 ] && [ "$root_status" -lt 400 ]')
+    expect(smoke).toContain('[ "$api_status" -ge 200 ] && [ "$api_status" -lt 400 ]')
+    expect(smoke).toContain("grep -Fq '<title>tapflow</title>' \"$root_body\"")
+    expect(smoke).toContain('grep -Eq \'"initialized":(true|false)\' "$api_body"')
+  })
+
+  it('reports logs on failure and removes test containers and volumes', () => {
+    const smoke = stepBlock('Smoke test image runtime')
+    expect(smoke).toContain('trap cleanup EXIT')
+    expect(smoke).toContain('docker logs "$container"')
+    expect(smoke).toContain('docker rm -f "$container"')
+    expect(smoke).toContain('docker volume rm "$volume"')
+  })
+
+  it('does not copy stale TypeScript build metadata without matching dist output', () => {
+    expect(DOCKERIGNORE).toContain('**/dist')
+    expect(DOCKERIGNORE).toContain('**/*.tsbuildinfo')
+  })
+})


### PR DESCRIPTION
## Summary

Docker CI previously proved the relay image could build, but not that the resulting image could boot. This PR progresses #352 by smoke-testing the exact image produced for each architecture: validation-only builds load the local architecture image, and credentialed publish builds smoke-test the pushed digest before manifest assembly.

The smoke run mounts /app/.tapflow/data on a disposable Docker volume, checks the Tapflow dashboard response and /api/v1/auth/status, and cleans up the container/volume on success or failure. .dockerignore now excludes stale *.tsbuildinfo files because dist is also excluded from the Docker context, and stale incremental metadata can suppress required TypeScript emits during clean image builds.

Both linux/amd64 and linux/arm64 remain required for #352 and are structurally guarded by the scripts regression test. Registry selection/publication, Docker Hub README, EN/KO Compose docs, and credential documentation remain outside this PR and still belong to #352.

Remaining uncertainty: local runtime evidence is amd64 only; GitHub native arm64 runners will provide real arm64 evidence, and Docker Hub credentialed publish/manifest behavior cannot be fully exercised until maintainer registry credentials/resources exist.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Validation

- No-cache Docker build: `docker build --no-cache -t tapflow-qa-352-runtime-smoke:local .` passed.
- Real amd64 Docker Desktop runtime passed: dashboard HTTP response contained `<title>tapflow</title>`, `/api/v1/auth/status` returned initialized-state JSON, JWT secret persisted across restart without revealing the secret, and forced-failure cleanup removed the test container/volume.
- Architecture mutation tests: removing `linux/arm64` failed the focused structural test; removing `linux/amd64` failed the focused structural test; both mutations were restored.
- Focused regression test: `pnpm exec vitest run --config scripts/vitest.config.mjs scripts/__tests__/dockerPublishSmoke.test.mjs` passed, 6 tests.
- Workflow lint: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docker-publish.yml` passed.
- Scripts suite: `pnpm exec vitest run --config scripts/vitest.config.mjs` passed, 24 files / 319 tests.
- Workspace gates already established during QA/pre-commit: `pnpm typecheck` passed; `pnpm lint` exited 0 with existing warnings only; `pnpm test` passed end-to-end.
- `git diff --check origin/main...HEAD` passed.
- Secret scan of the committed diff found no credential material.
- Independent QA verdict before this repair was PASS WITH NOTES; the noted arm64 structural-test gap is now addressed.

## Related `.work/` docs

- `.work/reviews/fix__docker-runtime-smoke.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image handling for pull requests and builds without publishing credentials.
  * Excluded unnecessary TypeScript build metadata from Docker build contexts.
  * Enhanced container validation with readiness checks, endpoint verification, diagnostics, cleanup, and configuration persistence checks.

* **Tests**
  * Added automated coverage for supported platforms, image selection, container startup, application endpoints, configuration persistence, cleanup, and excluded build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->