### PR TITLE
Answer an undeliverable shutdown, release every held session, and make a re-join idempotent

### DIFF
--- a/.changeset/error-is-addressed.md
+++ b/.changeset/error-is-addressed.md
@@ -15,7 +15,7 @@ be true.
 The correlation work settled it by removing the general role rather than the specific one. A request naming no
 session is dropped at the relay's door, because answering it would ship a frame whose own required `sessionId`
 `JSON.stringify` erases — and `error` has no `requestId` either, so a caller could not attribute the answer and
-would wait out the same deadline silence costs. With nothing left needing an unaddressed failure, all four
+would wait out the same deadline silence costs. With nothing left needing an unaddressed failure, all five
 producers answer one specific join.
 
 ## What the address buys

--- a/.changeset/input-ack-correlation.md
+++ b/.changeset/input-ack-correlation.md
@@ -75,7 +75,8 @@ differently — and it is the only member that can promise nothing reached the d
 says "retry after joining" without a hedge (#491). Two prose strings behind it (`ownershipRefusal`), because
 telling a caller the session is in use when it is idle steers it off a device it could have had.
 
-**`device:shutdown` is the one command left out**, and the blocker is the dashboard rather than the relay:
+**`device:shutdown` is the one command left out of the ownership gate**, and the blocker is the dashboard
+rather than the relay:
 three of its four senders come from `useAgentSession`, whose socket never joins, so the gate would break going
 back and the unmount teardown. The question is whether that hook should join — #527.
 

--- a/.changeset/relay-session-ownership-seam.md
+++ b/.changeset/relay-session-ownership-seam.md
@@ -1,0 +1,42 @@
+---
+'@tapflowio/protocol': minor
+'@tapflowio/relay': minor
+'@tapflowio/mcp-server': minor
+---
+
+Answer a shutdown the relay cannot deliver, release every session a closing socket held, and let a viewer re-join a session it already holds
+
+Three defects that share a subject — who holds a session — and none of which needed the question that
+sounds like their root. That one is *who should be allowed to*, and it is open: `device:shutdown` still
+has no ownership check, because three of the dashboard's four senders come from a socket that never
+joins the session and gating it there would break going back and the unmount teardown.
+
+What a user can observe:
+
+- **A device shut down from an MCP client fails in a second instead of half a minute.** `device:shutdown`
+  was the one browser command the relay never answered when it could not deliver it — a stale session id
+  or an agent that went away produced no reply at all, and `shutdown_device` reported `Request timed out`
+  with no cause after 30 seconds. It now says which of the two happened.
+- **A device list stops getting stuck on "Shutting down…".** The same silence left that row inert with
+  both its buttons hidden for the life of the page.
+- **A tester whose browser reconnects lands back in their session instead of being thrown out of it.**
+  Re-sending `session:start` for a session the socket already held was answered `session-not-found` — for
+  a live session, held by the caller, that the device list reported as theirs two lines later. The viewer
+  reads that reason as the agent having disconnected and takes the tester off a session that is fine.
+  A re-join is idempotent now: same reply as a fresh join, and the session's cached state is replayed.
+- **Devices no longer stay booted with nobody watching them.** The relay tracked one session per browser
+  socket while the relation is one-to-many — `mcp-server` runs a single socket for the whole process and
+  joins a session per device. Closing it released only the last one joined; the rest stayed marked in-use
+  for the life of the relay, with no idle timer, so their simulators kept running. All of them are
+  released now, each with its own idle timeout.
+
+`@tapflowio/protocol` gains `device:shutdown-error` on the browser-inbound surface. It is relay-produced
+only: neither agent has a failure path that emits a message, so a shutdown that reaches a device either
+completes or times out. Its `requestId` is optional because the request's is — the relay originates
+`device:shutdown` from its own idle timer, and a reply cannot demand a field the request need not carry.
+
+`SessionManager.join()` returns its two expected failures instead of throwing them. It used to throw both
+as `ValidationError`, which left the caller's `catch` unable to tell an expected refusal from a bug — so
+it guessed a reason, and guessed wrong for the most common one. Nothing in tapflow depended on the throw;
+this affects code outside it that called `SessionManager` directly. `getByBrowserSocket` returns an array
+for the same reason the index changed.

--- a/.changeset/session-lifecycle-clients.md
+++ b/.changeset/session-lifecycle-clients.md
@@ -45,10 +45,11 @@ so the advice says so rather than sending a caller at a reinstall it does not ne
 
 - Waiters now carry their session, so one session ending settles that session's requests and no others.
   `agents:list` carries no session on the wire and is explicitly unaffected.
-- `mcp-server` refuses a `shutdown_device` on a terminated session locally. It is the one command the
-  relay drops in silence when it cannot dispatch it — there is no `device:shutdown-error` on the wire to
-  answer with — so it was the only waiter whose 30 seconds of nothing had no explanation. The relay half
-  is tracked in #542.
+- `mcp-server` refuses a `shutdown_device` on a terminated session locally, saving a round trip and
+  naming *why* the session was dropped — which the relay's generic "session not found" cannot. It was
+  written when this was the one command the relay dropped in silence; #542, in this same release, gave the
+  pair a `device:shutdown-error`, so the local refusal is now an improvement on an answer rather than a
+  stand-in for none.
 - `mcp-server`'s timeout and disconnect branches are distinguished by error class rather than by
   comparing the message string, which stopped being reliable the moment a deadline started carrying why
   it expired.

--- a/.changeset/wire-l5b-app-command-correlation.md
+++ b/.changeset/wire-l5b-app-command-correlation.md
@@ -37,8 +37,8 @@ worse than the literal it replaces since a literal at least gets its whole shape
 keeps its `<Pair>ReplyBody` — worth it there, with ~20 literal sites — and the request side is held by
 tests, one per handler, asserting the forwarded id is the one that came in.
 
-**`device:shutdown` was in this slice and came out.** It has no error type, and two properties this shape
-cannot express: the relay **originates** one itself when a browser socket closes (`DeviceShutdown` is a
+**`device:shutdown` was in this slice and came out.** It had no error type at the time (#542 added one
+later in the same release), and two properties this shape cannot express: the relay **originates** one itself when a browser socket closes (`DeviceShutdown` is a
 single interface shared by both directions, so a required correlator would force the relay to invent an id
 for a request nobody made — exactly what the door checks exist to prevent), and `device:shutdown-done` is
 consumed by `SessionList` as a **device-status broadcast** rather than as a reply to its own request. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Shutting a device down through an MCP client fails in a second instead of half a minute.**
+  `device:shutdown` was the one command from a browser that the relay never answered when it could not
+  deliver it — a stale session id or an agent that had gone away produced no reply at all, so
+  `shutdown_device` reported "Request timed out" with no cause after 30 seconds. It now says which of the
+  two happened. The device list had the other half of the same silence: a row stuck on "Shutting down…"
+  with both its buttons hidden for the rest of the page's life.
+- **A tester whose browser reconnects lands back in their session instead of being thrown out of it.**
+  Re-joining a session the tab already held was refused as "session not found" — for a live session, held
+  by that tab, which the device list reported as theirs. The viewer reads that as the agent having
+  disconnected, so a two-second Wi-Fi blip ended a session that was fine. Re-joining is now the same as
+  joining, cached screen state included.
+- **Devices no longer stay booted with nobody watching them.** The relay tracked one session per browser
+  connection, but one connection can hold several — an AI agent driving two devices uses a single one. When
+  it went away only the most recent session was released; the rest stayed marked in use for as long as the
+  relay ran, with no idle timeout, so their simulators kept running. Every session a connection held is
+  released now, each with its own timeout.
 - **An input that never reached the device was reported as having landed.** Every path that could refuse
   or drop an input — a simulator that is not booted, an input channel still starting, an agent that went
   away, a helper process that died — either said nothing or said success. An LLM driving the device through

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -51,7 +51,7 @@ The audience is the whole team (PO, PM, designers, backend, QA) — not just QA.
 
 ### Every browser-inbound message has a declared disposition
 
-`lib/inboundDisposition.ts` says, for each of the 28 messages a browser socket can receive, either which
+`lib/inboundDisposition.ts` says, for each of the 29 messages a browser socket can receive, either which
 files handle it or why it is deliberately ignored. It is written with
 `satisfies Record<BrowserInbound['type'], Disposition>`, so **a message added to the wire breaks that file**
 until someone picks a category.

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -23,6 +23,11 @@ export function SessionList({ onSelect }: Props) {
   // The shutdown whose `session:start` has not been answered yet. A ref, not state: the relay's reply
   // lands in a handler that must read the current value, and a re-render is neither needed nor wanted.
   const pendingRef = useRef<{ deviceId: string; sessionId: string } | null>(null)
+  // Shutdowns that have been sent and not yet answered, `sessionId → deviceId`. `device:shutdown-error`
+  // is addressed to the session and carries no `payload`, while `shutting` is keyed by device — so
+  // without this the failure could clear the spinner for a device that is still shutting down: the
+  // inert row's mirror image, a row that says it is done when it is not.
+  const inFlightRef = useRef(new Map<string, string>())
   // `send` is what `useRelay` returns, so the handler passed *into* it cannot name it directly. Same
   // indirection `DeviceViewer` uses (`sendRef`), for the same reason.
   const sendRef = useRef<(msg: BrowserToRelay) => void>(() => {})
@@ -49,8 +54,23 @@ export function SessionList({ onSelect }: Props) {
         for (const k of Object.keys(prev)) next[k] = 'error'
         return next
       })
+    } else if (msg.type === 'device:shutdown-error') {
+      // The relay could not deliver the shutdown — no such session, or its agent is gone (#542). Before
+      // that message existed this arrived as nothing at all, and `device:shutdown-done` is the only thing
+      // that clears `shutting`, so the row sat on "Shutting down…" with both buttons hidden for good. The
+      // same inert row the `error` branch below was written for, reached by the other door.
+      const deviceId = inFlightRef.current.get(msg.sessionId)
+      if (deviceId === undefined) return
+      inFlightRef.current.delete(msg.sessionId)
+      setShutting((prev) => {
+        const next = { ...prev }
+        delete next[deviceId]
+        return next
+      })
+      toast.error('Could not shut that device down.', { description: msg.message })
     } else if (msg.type === 'device:shutdown-done') {
       const { deviceId } = msg.payload
+      inFlightRef.current.delete(msg.sessionId)
       setShutting((prev) => {
         const next = { ...prev }
         delete next[deviceId]
@@ -76,6 +96,7 @@ export function SessionList({ onSelect }: Props) {
       const pending = pendingRef.current
       if (pending && msg.sessionId === pending.sessionId) {
         pendingRef.current = null
+        inFlightRef.current.set(pending.sessionId, pending.deviceId)
         sendRef.current({ type: 'device:shutdown', sessionId: pending.sessionId, payload: { deviceId: pending.deviceId } })
       }
     } else if (msg.type === 'error') {

--- a/packages/dashboard/lib/inboundDisposition.ts
+++ b/packages/dashboard/lib/inboundDisposition.ts
@@ -5,8 +5,9 @@ import type { BrowserInbound } from '@tapflowio/protocol'
  *
  * The bug class this whole wire-contract program started from was **a reply arriving and nobody
  * answering** (#489, #485, #492, #457). L1–L3 made the declarations honest; a declared message with no
- * handler is still silent. Measured when this file was written: the dashboard handled 22 of the 28 and
- * dropped 6 — and the three reasons those 6 were dropped for are *indistinguishable in code*, because
+ * handler is still silent. Measured when this file was written: of the 28 messages then on the wire the
+ * dashboard handled 22 and dropped 6 — and the three reasons those 6 were dropped for are
+ * *indistinguishable in code*, because
  * "handled elsewhere", "deliberately ignored" and "nobody ever wrote it" all look like an absent branch.
  *
  * `satisfies Record<BrowserInbound['type'], …>` is what makes that a decision instead of an oversight:
@@ -27,7 +28,7 @@ import type { BrowserInbound } from '@tapflowio/protocol'
  *    relay, so a reply to its request lands on the dashboard once the dashboard joins. "We never send
  *    `input:type`, so its replies cannot arrive" is true per *session*, not per socket.
  *
- * Any browser socket can receive any of the 28. That is why every entry is present and `ignored` says
+ * Any browser socket can receive any of the 29. That is why every entry is present and `ignored` says
  * *why* rather than *cannot happen*.
  */
 type Disposition =
@@ -51,7 +52,12 @@ export const INBOUND_DISPOSITION = {
   'device:booting': { at: 'DeviceViewer' },
   'device:ready': { at: 'DeviceViewer, SessionList' },
   'device:shutdown-done': { at: 'SessionList' },
-  // **`useAgentSession`'s branch cannot fire, and it is still named here.** L5d measured it: all four
+  // The relay's half of the pair (#542), so it reaches whichever socket asked — which for this app is
+  // `SessionList` or `useAgentSession`. Only the first is named because `at` answers *which files compare
+  // `.type` against this literal*, and only `SessionList` does — the other hook receives it and has no
+  // branch, which is right: its three senders fire on the way out of a view and nothing there waits.
+  'device:shutdown-error': { at: 'SessionList' },
+  // **`useAgentSession`'s branch cannot fire, and it is still named here.** L5d measured it: all five
   // producers are `sendTo(ws, …)` to the socket that sent `session:start`, and that hook's socket only ever
   // sends `agents:list` and `device:shutdown`. So relay failures do **not** surface in the device list, which
   // naming three files here implies.

--- a/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
+++ b/packages/dashboard/src/__tests__/DeviceViewer.sessionScope.test.tsx
@@ -75,7 +75,7 @@ describe('DeviceViewer ignores messages addressed to another session (#445)', ()
     //
     // The consequence is not reachable today, and that is a property of the dashboard rather than of this
     // line. `useRelay` opens a socket per hook instance, so this viewer's socket sends exactly one
-    // `session:start` — for the session it holds — and all four producers answer `sendTo(ws, …)` to that
+    // `session:start` — for the session it holds — and all five producers answer `sendTo(ws, …)` to that
     // socket. So no foreign refusal can arrive here now.
     //
     // It is tested anyway because the unreachability **expires**, and the thing that expires it is already

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -44,7 +44,9 @@ const TWO_DEVICES: SessionInfo[] = [{
 }]
 
 describe('SessionList when a shutdown is refused', () => {
-  beforeEach(() => { send.mockClear(); deliver = null })
+  // `toast` is module-mocked, so its call history outlives a test. Two of the cases below count toasts,
+  // and with only `send` cleared the second one to run inherits the first's calls.
+  beforeEach(() => { vi.clearAllMocks(); deliver = null })
 
   it('clears the shutting badge and says why, instead of leaving the row inert', async () => {
     const { toast } = await import('sonner')
@@ -109,6 +111,46 @@ describe('SessionList when a shutdown is refused', () => {
     // And the request survives, so the real answer still works.
     act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
     expect(send.mock.calls.some(([m]) => m.type === 'device:shutdown' && m.sessionId === 's1')).toBe(true)
+  })
+
+  // The other door into the same inert row. Everything above is about a refused **join**; this is a join
+  // that succeeded and a **shutdown** the relay could not deliver — no such session, or its agent gone.
+  // Until #542 that arrived as nothing at all, so the row sat on "Shutting down…" for the page's life with
+  // both buttons hidden, exactly as a refused join used to.
+  it('clears the badge when the relay could not deliver the shutdown', async () => {
+    const { toast } = await import('sonner')
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: SESSIONS }) })
+    act(() => { screen.getByRole('button', { name: /shutdown/i }).click() })
+    act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+    expect(screen.getByText(/shutting down/i)).toBeInTheDocument()
+
+    act(() => {
+      deliver!({ type: 'device:shutdown-error', sessionId: 's1', message: 'agent offline' })
+    })
+
+    expect(screen.queryByText(/shutting down/i)).not.toBeInTheDocument()
+    expect(vi.mocked(toast.error)).toHaveBeenCalledOnce()
+    expect(vi.mocked(toast.error).mock.calls[0][1]).toMatchObject({ description: 'agent offline' })
+  })
+
+  it('ignores a shutdown-error for a session it never shut down', () => {
+    // The reply is addressed to a session and carries no `payload`, while `shutting` is keyed by device —
+    // so the deviceId comes from what this list actually sent. Without that lookup the handler would have
+    // to clear something, and the honest options are "nothing" or "the wrong row". This pins the first:
+    // `useAgentSession` shares no socket with this list, but the relay's own idle timer and any future
+    // sender make an unrelated error reachable, and clearing a badge for a shutdown still in progress is
+    // the inert row's mirror image — a row that says it is done when it is not.
+    render(<SessionList onSelect={vi.fn()} />)
+    act(() => { deliver!({ type: 'agents:listed', sessions: TWO_DEVICES }) })
+    act(() => { screen.getAllByRole('button', { name: /shutdown/i })[0].click() })
+    act(() => { deliver!({ type: 'session:joined', sessionId: 's1', capabilities: [] }) })
+
+    act(() => {
+      deliver!({ type: 'device:shutdown-error', sessionId: 's2', message: 'Session not found' })
+    })
+
+    expect(screen.getByText(/shutting down/i)).toBeInTheDocument()
   })
 
   it('refuses a second shutdown while one is still unanswered', () => {

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -134,7 +134,8 @@ describe('SessionList when a shutdown is refused', () => {
     expect(vi.mocked(toast.error).mock.calls[0][1]).toMatchObject({ description: 'agent offline' })
   })
 
-  it('ignores a shutdown-error for a session it never shut down', () => {
+  it('ignores a shutdown-error for a session it never shut down', async () => {
+    const { toast } = await import('sonner')
     // The reply is addressed to a session and carries no `payload`, while `shutting` is keyed by device —
     // so the deviceId comes from what this list actually sent. Without that lookup the handler would have
     // to clear something, and the honest options are "nothing" or "the wrong row". This pins the first:
@@ -151,6 +152,10 @@ describe('SessionList when a shutdown is refused', () => {
     })
 
     expect(screen.getByText(/shutting down/i)).toBeInTheDocument()
+    // And it stays quiet. Correlating before clearing the badge but not before toasting would leave this
+    // tester reading someone else's failure — a second reply routed to a socket that did not ask, which
+    // is the class the correlation work exists to close.
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
   })
 
   it('refuses a second shutdown while one is still unanswered', () => {

--- a/packages/mcp-server/AGENTS.md
+++ b/packages/mcp-server/AGENTS.md
@@ -38,7 +38,7 @@ Connects to the relay over WebSocket + REST (`TapflowClient`), registers MCP too
 
 ### Tool semantics (non-obvious)
 
-`disconnect_device` only leaves the session (`session:leave`) — the device stays booted. `shutdown_device` powers the device down (`device:shutdown` → agent runs simctl/adb shutdown → `device:shutdown-done`); use it to free resources or force a cold boot.
+`disconnect_device` only leaves the session (`session:leave`) — the device stays booted. `shutdown_device` powers the device down (`device:shutdown` → agent runs simctl/adb shutdown → `device:shutdown-done`); use it to free resources or force a cold boot. Its waiter takes `device:shutdown-error` as well, and that half is the relay's alone — the agents have no failure reply, so a shutdown that *reaches* a device either completes or times out. #542 added the error for the case where it never reaches one.
 
 `run_flow` replays a `@tapflowio/flow-runner` YAML flow deterministically (no LLM at replay time) over this process's existing relay connection — it shares the session joined via `connect_device`, so it never opens a second WebSocket or hits "Session busy".
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -290,6 +290,43 @@ describe('TapflowClient', () => {
       relay.send({ type: 'device:shutdown-done', sessionId: 'sess-1' })
       await expect(p).resolves.toBeUndefined()
     })
+
+    it('fails on device:shutdown-error instead of waiting out the 30s deadline', async () => {
+      // #542. The relay used to resolve this command's session inline and drop the frame when it could
+      // not — the only browser command it never answered — so a shutdown addressed to a dead session
+      // reported `Request timed out` with no cause, half a minute later.
+      //
+      // **The relay half alone would not have fixed this caller.** The predicate matched
+      // `device:shutdown-done` only, so the new reply would have been ignored and the deadline would run
+      // exactly as before — and nothing would say so, because inbound here is `Record<string, unknown>`
+      // (#512) and the symptom is identical to the bug.
+      const p = client.shutdownDevice('sess-1', 'dev-1')
+      const sent = await waitForMessage(relay, 'device:shutdown')
+      relay.send({
+        type: 'device:shutdown-error', sessionId: 'sess-1',
+        requestId: sent['requestId'], message: 'agent offline',
+      })
+      await expect(p).rejects.toThrow(/agent offline/)
+    })
+
+    it('does not take another request\'s shutdown-error as its own answer', async () => {
+      // The correlator is optional on this pair, so `correlatesWith` falls back to the session when the
+      // reply carries none — but a reply that carries a *different* id is another request's, and taking
+      // it would resolve one shutdown with another's outcome. Same shape as the `-done` guard below.
+      const p = client.shutdownDevice('sess-1', 'dev-1')
+      await waitForMessage(relay, 'device:shutdown')
+      relay.send({
+        type: 'device:shutdown-error', sessionId: 'sess-1',
+        requestId: 'someone-elses', message: 'agent offline',
+      })
+      const outcome = await Promise.race([
+        p.then(() => 'settled', () => 'settled'),
+        new Promise<string>((r) => setTimeout(() => r('pending'), 40)),
+      ])
+      expect(outcome).toBe('pending')
+      relay.send({ type: 'device:shutdown-done', sessionId: 'sess-1' })
+      await expect(p).resolves.toBeUndefined()
+    })
   })
 
   describe('tap', () => {
@@ -1024,10 +1061,10 @@ describe('TapflowClient', () => {
       expect(err.message).not.toMatch(/reset/i)
     })
 
-    // `device:shutdown` is the one command the relay drops in silence when it cannot dispatch it — it
-    // resolves its session inline rather than through `dispatchTarget`, and there is no
-    // `device:shutdown-error` to answer with (#542). So this is the one waiter whose silence nothing else
-    // explains, and a terminated session is the case that can be ruled out from here.
+    // The relay answers an undispatchable shutdown as of #542, so this check is no longer the difference
+    // between a diagnosis and 30s of nothing. What it still buys is a round trip and a better cause: the
+    // relay's answer for a session it has dropped is `Session not found`, while this names *why* it was
+    // dropped and throws the type the tool layer branches on.
     it('refuses a shutdown on a terminated session instead of waiting out 30s of silence', async () => {
       relay.send(terminated('sess-1'))
       await settle(relay, client)

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -554,33 +554,40 @@ export class TapflowClient {
   }
 
   // Powers the session's booted device down (agent runs simctl/adb shutdown, replies device:shutdown-done).
-  // payload carries deviceId, matching the agent handler and the relay's own shutdown path. There is no
-  // shutdown-error message: Android replies done regardless, iOS surfaces a failed shutdown as a wait timeout.
+  // payload carries deviceId, matching the agent handler and the relay's own shutdown path. **The agent has
+  // no failure reply**: Android replies done regardless, iOS surfaces a failed shutdown as a wait timeout.
+  // `device:shutdown-error` is the relay's, and only the relay's — see its declaration.
   async shutdownDevice(sessionId: string, deviceId: string): Promise<void> {
-    // **The one command the relay does not answer when it cannot dispatch it.** `device:shutdown` resolves
-    // its session inline rather than through `dispatchTarget`, so a message addressed to a session that no
-    // longer exists is dropped in silence — and there is no `device:shutdown-error` on the wire to answer
-    // with, which is why fixing it there is a protocol change (#542). Every other command in this file has
-    // the relay refusing it within a round trip; this waiter's silence is the only one nothing explains, so
-    // the case we can rule out from here is worth ruling out: 30s of nothing, versus saying why.
+    // Kept after #542, with a different job. The relay answers an undispatchable shutdown now, so this is no
+    // longer the difference between a diagnosis and 30s of nothing — it saves a round trip and says more
+    // than the relay can: the relay's answer for a session it has dropped is `Session not found`, while this
+    // names *why* it was dropped. The sentence that used to justify it — that no `device:shutdown-error`
+    // exists on the wire — is what this change made false.
     const terminated = this.lifecycle.get(sessionId)?.terminated
     if (terminated) {
       throw new SessionEndedError(
-        `The relay ended session ${sessionId} (${terminated}), so a shutdown addressed to it would be ` +
-        'dropped with no reply at all. Call list_devices to see which sessions are live.',
+        `The relay ended session ${sessionId} (${terminated}), so a shutdown addressed to it cannot reach a ` +
+        'device. Call list_devices to see which sessions are live.',
         terminated,
       )
     }
     const requestId = randomUUID()
     this.send({ type: 'device:shutdown', sessionId, requestId, payload: { deviceId } })
-    await this.waitFor(
+    // **Both members of the pair, or the fix does not reach this caller.** The relay gaining an error reply
+    // changes nothing here on its own: this predicate would ignore it and the deadline would run exactly as
+    // before. Nothing would report that either — inbound is `Record<string, unknown>` (#512), so no compiler
+    // sees the omission, and the symptom is identical to the bug being fixed.
+    const reply = await this.waitFor(
       (m) =>
-        m['type'] === 'device:shutdown-done' &&
+        (m['type'] === 'device:shutdown-done' || m['type'] === 'device:shutdown-error') &&
         m['sessionId'] === sessionId &&
         correlatesWith(m, requestId),
       30_000,
       sessionId,
     )
+    if (reply['type'] === 'device:shutdown-error') {
+      throw this.failed(sessionId, (reply['message'] as string | undefined) ?? 'Shutdown failed')
+    }
   }
 
   /**

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -186,6 +186,14 @@ is required and every reply is `requestId?`. Absence has exactly one meaning, an
 at each declaration: **this frame is not the answer to a request.** Not "an old agent" — that reading is what
 made the first draft of this pair wrong.
 
+**The shutdown half had no failure member until #542, and that absence was doing work.** The relay resolved
+that one command's session inline instead of through the shared resolver, so a shutdown it could not deliver
+was dropped in silence — and there was no shape to answer with, which is what kept it a protocol change
+rather than a relay one. `device:shutdown-error` is that shape: relay-produced only, because neither agent
+has a failure path that emits a message, and `requestId?` because the request's own correlator is optional.
+It is the one member of this pair a consumer **should** correlate — `shutdownDevice` awaits both halves on
+one predicate, since matching only `-done` would leave the fix invisible to the caller it was written for.
+
 **Optional means the reply's echo is enforced by tests alone.** `<Pair>ReplyBody` cannot be built for an
 optional field — `Omit<T,'sessionId'|'requestId'>` is satisfied by an object that simply has no correlator, so
 the excess-property trick that catches a freshly minted id has nothing to bite on. Everything the compiler does
@@ -277,10 +285,16 @@ another tester was looking at, and the reply routed to that session's browser ra
 
 Every branch that can take the check now has it: the five acked inputs, `device:boot`, `open-url`,
 `app:install`, `app:launch`, `app:clear-state`, `clipboard:read`, `clipboard:write`, `session:leave`,
-`session:end`. **`device:shutdown` is the exception**, and the blocker is in the dashboard rather than the
-relay — three of its four senders never join the session. #527.
+`session:end`. **`device:shutdown` is the exception to the *ownership* clause**, and the blocker is in the
+dashboard rather than the relay — three of its four senders never join the session. #527. It is no longer an
+exception to being *answered*: #542 gave the pair a failure member and the relay routes the command through
+the same resolver minus that one clause.
 
-A refusal is **answered where a waiter exists** and dropped where none does. Answering matters more than it
+A refusal is **answered where a waiter exists** and dropped where none does — with `device:shutdown-error`
+as the deliberate loosening, answered to the sender whether or not one is waiting. The relay cannot tell
+which of the dashboard's four senders asked, three of them wait on nothing, and the fourth
+(`SessionList`) is left with an inert row without it. Sending to a socket that ignores it costs one frame;
+withholding it costs that row. Answering matters more than it
 looks: `awaitInputAck` reports silence from a session that has never acked as *success* — unless the relay
 has already said the session's agent went away — so a silent refusal would report a command that never left
 the relay as landed, worse than the misrouting it replaced. The two
@@ -317,7 +331,7 @@ dropped at the relay's door — by the schema in `src/validate/` since #444, and
 predicate before that — because answering it would ship a frame whose own required
 `sessionId` `JSON.stringify` erases — and `error` has no `requestId` either, so a caller could not attribute
 the answer and would wait out the same deadline silence costs. With nothing left needing an unaddressed
-failure, all four producers answer one specific join, and `error` **extends `SessionScoped`**: the shape is the
+failure, all five producers answer one specific join, and `error` **extends `SessionScoped`**: the shape is the
 base verbatim, and the base's own definition — a failure a *session* is waiting on — is now exactly what it is.
 
 **What the address buys.** The join waiters in `mcp-server` and `flow-runner` matched
@@ -386,7 +400,7 @@ verify `session.agentSocket === ws` before resolving, and these two do not.
 
 ## Browser-inbound messages are split by producer, and one union is shared
 
-A browser receives 28 message types. They come from two producers, and the difference matters to the
+A browser receives 29 message types. They come from two producers, and the difference matters to the
 **relay**, not to the consumer:
 
 - **`RelayToBrowser`** — the relay builds these itself, so `sendTo(socket, msg: RelayOutbound)` holds

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -644,6 +644,32 @@ export interface GenericError extends SessionScoped {
   reason: SessionStartFailure
 }
 
+/**
+ * A `device:shutdown` the relay could not deliver.
+ *
+ * **The pair's error member, added late and by a different producer than its `-done`.** Every other
+ * browser-originated command answers when the relay cannot dispatch it; this one resolved its session
+ * inline and dropped the frame in silence, so `mcp-server`'s `shutdownDevice` burned a 30s deadline and
+ * reported `Request timed out` with no cause (#542). There was no shape to answer *with*, which is why
+ * fixing it was a protocol change rather than a relay one.
+ *
+ * **`RelayToBrowser`, not `RelayOrAgentToBrowser`**, unlike `DeviceBootError` beside it. Both agents ack
+ * a shutdown they cannot perform by simply not sending `device:shutdown-done`; neither has a failure
+ * path that produces a message. Declaring it in the shared union would claim a producer that does not
+ * exist, and would add an `AgentToBrowser` member with no forwarding case — which is exactly what
+ * `browserInboundRouting.test.mjs`'s second assertion exists to report. If an agent later grows one,
+ * moving the member is one line and that check enforces the case at the same time.
+ *
+ * `requestId` is optional because **the request's is** — the relay originates `device:shutdown` from its
+ * own idle timer, so a reply cannot demand a field the request need not carry. Absent here means the
+ * same thing it means on `DeviceShutdownDone`: this frame answers no request.
+ */
+export interface DeviceShutdownError extends SessionScoped {
+  type: 'device:shutdown-error'
+  message: string
+  requestId?: string
+}
+
 /** Messages the relay originates and no agent sends. */
 export type RelayToBrowser =
   | RelayOrAgentToBrowser
@@ -652,6 +678,7 @@ export type RelayToBrowser =
   | SessionTerminated
   | SessionAgentAway
   | SessionRebound
+  | DeviceShutdownError
   | GenericError
 
 export interface DeviceBooting {

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -11,7 +11,8 @@ import type {
   AppClearState, AppClearStateDone, AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent,
   AppInstallToRelay, AppLaunchDone, AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound,
   BrowserToRelay, ClipboardData, ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone,
-  DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone, GenericError,
+  DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone,
+  DeviceShutdownError, GenericError,
   InputButton, InputDone, InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove,
   InputPinchStart, InputRotate, InputTouchEnd, InputTouchMove, InputTouchStart, InputType, InputTypeDone,
   InputTypeError, KeyboardToggled, OpenUrl, OpenUrlDone, OpenUrlError, RelayOutbound, ScreenshotDone,
@@ -144,6 +145,7 @@ export const _DeviceBooting: DeviceBooting['type'] = 'device:booting'
 export const _DeviceReady: DeviceReady['type'] = 'device:ready'
 export const _DeviceShutdown: DeviceShutdown['type'] = 'device:shutdown'
 export const _DeviceShutdownDone: DeviceShutdownDone['type'] = 'device:shutdown-done'
+export const _DeviceShutdownError: DeviceShutdownError['type'] = 'device:shutdown-error'
 export const _GenericError: GenericError['type'] = 'error'
 export const _InputButton: InputButton['type'] = 'input:button'
 export const _InputDone: InputDone['type'] = 'input:done'
@@ -199,7 +201,10 @@ export const _UiTreeError: UiTreeError['type'] = 'ui:tree:error'
 // **Not blanket disjointness between directions.** `device:shutdown` is deliberately a member of both
 // `RelayToAgent` and `BrowserToRelay`, identical in both; it is not agent-produced, so it is not here.
 // And a *relay*-produced message added to `BrowserToRelay` is outside this claim — `route()` has no
-// case for one, and #557 is where the forwarding half is tracked.
+// case for one. The forwarding half is `browserInboundRouting.test.mjs`, which asserts both that every
+// forward is declared in `AgentToBrowser` and that no literal is in `BrowserToRelay` **and** forwarded.
+// #557 asked for that against `AGENT_MSG_TYPE_LIST`, which no longer exists — #444 replaced it with
+// `directionOf`, derived from the schema maps.
 type AgentProduced = (AgentControlOutbound | StreamToRelay)['type']
 type AssertTrue<T extends true> = T
 type NoOverlap<A, B> = [Extract<A, B>] extends [never] ? true : false

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -89,11 +89,17 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   has never acked as *success*, so a silent refusal would report a command that never left the relay as
   having landed. `session:leave` and `session:end` are dropped, because neither has a reply and inventing
   one would grow the wire for a message no consumer reads.
-  **`device:shutdown` is the one exception, and the blocker is not here** — three of the dashboard's four
-  senders come from `useAgentSession`, whose socket never joins, so the gate would break going back and the
-  unmount teardown. `SessionList` joins before shutting down and documents why, so the dashboard already
-  carries two conventions for this message. Tracked in #527; the question there is whether
-  `useAgentSession` should join, not whether the relay should check.
+  **`device:shutdown` is the one exception to the *ownership* clause, and the blocker is not here** — three
+  of the dashboard's four senders come from `useAgentSession`, whose socket never joins, so the gate would
+  break going back and the unmount teardown. `SessionList` joins before shutting down and documents why, so
+  the dashboard already carries two conventions for this message. Tracked in #527; the question there is
+  whether `useAgentSession` should join, not whether the relay should check.
+  It is **not** an exception to being answered, and used to be both. `reachableTarget` is `dispatchTarget`
+  minus the ownership clause, so the other two refusals — no such session, agent gone — come back as
+  `device:shutdown-error` instead of the silence that burned `shutdownDevice`'s 30s deadline with no cause
+  (#542). Splitting the resolver rather than inlining two checks is what makes closing #527 a one-line
+  move to `dispatchTarget`; the cost, written down rather than waved past, is that a non-owner now learns
+  whether a session id exists — small against being able to shut that device down, which it still can.
   The app-command handlers check ownership **after** the session lookup and **before** the build lookup,
   deliberately not through `dispatchTarget`: that resolver also decides agent liveness, and using it there
   would move `agent offline` ahead of `Build not found`, changing which of two simultaneous problems the

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -51,7 +51,10 @@ export function isExternalAddress(addr: string): boolean {
 }
 // Min gap between IDR requests per session — one IDR resyncs the stream, so avoid
 // spamming the agent in the frames between request and the IDR arriving.
-const IDR_REQUEST_THROTTLE_MS = 500
+/** Exported for the re-join test, which pins both edges of this window rather than hardcoding 500 —
+ *  a test carrying its own copy of the number passes when the constant moves, which is the drift the
+ *  wire-contract work keeps finding. Not re-exported from the package index. */
+export const IDR_REQUEST_THROTTLE_MS = 500
 // Ping every socket each interval; a missed pong window (~2× this) terminates the dead socket.
 const HEARTBEAT_MS = 30_000
 // How long a session outlives its agent's socket, waiting for that agent to come back (#426).
@@ -427,6 +430,25 @@ export class RelayServer {
   }
 
   /**
+   * Drop every per-session stream record keyed by this id.
+   *
+   * **Four maps that have to move together, called from four places that did not.** They were deleted
+   * inline in `session:end` and `session:leave` and nowhere else, so a session ending any other way —
+   * the agent going away, the idle timer, a device disappearing from a re-register — left all four
+   * behind for the life of the process.
+   *
+   * Pre-existing, and this slice is what makes it worth fixing here rather than filing: `idrRequesters`
+   * used to be populated only by the binary drop path, i.e. only under backpressure, and a re-join now
+   * creates an entry for any streaming session (#515). The leak went from rare to ordinary.
+   */
+  private forgetSessionStreamState(sessionId: string): void {
+    this.dropHandlers.delete(sessionId)
+    this.audioDropHandlers.delete(sessionId)
+    this.droppers.delete(sessionId)
+    this.idrRequesters.delete(sessionId)
+  }
+
+  /**
    * Throttled callback asking the session's agent for an on-demand IDR (fast drop recovery); ignored by
    * agents that don't support it.
    *
@@ -763,20 +785,14 @@ export class RelayServer {
       case 'session:end': {
         if (this.ownsSession(ws, this.sessions.get(msg.sessionId))) {
           this.sessions.remove(msg.sessionId)
-          this.dropHandlers.delete(msg.sessionId)
-          this.audioDropHandlers.delete(msg.sessionId)
-          this.droppers.delete(msg.sessionId)
-          this.idrRequesters.delete(msg.sessionId)
+          this.forgetSessionStreamState(msg.sessionId)
         }
         break
       }
       case 'session:leave': {
         if (this.ownsSession(ws, this.sessions.get(msg.sessionId))) {
           this.sessions.clearBrowser(msg.sessionId)
-          this.dropHandlers.delete(msg.sessionId)
-          this.audioDropHandlers.delete(msg.sessionId)
-          this.droppers.delete(msg.sessionId)
-          this.idrRequesters.delete(msg.sessionId)
+          this.forgetSessionStreamState(msg.sessionId)
         }
         break
       }
@@ -952,12 +968,12 @@ export class RelayServer {
         // rather than wrong: the schema declares `sessionId` required, so the parser refuses the frame and
         // the log it would have bought is the one `logInboundRejection` writes.
         //
-        // **`reachableTarget`, not `dispatchTarget`** — the ownership clause is #527 and its blocker is in
+        // **`reachableTargetWithoutOwnership`, not `dispatchTarget`** — that clause is #527, and its blocker is in
         // the dashboard, not here. What this fixes is the other half: until #542 this case resolved the
         // session inline and dropped the frame when it could not, making it the only browser-originated
         // command the relay never answers. `mcp-server`'s `shutdownDevice` waits 30s on `device:shutdown-done`
         // and then reports `Request timed out` with no cause, which is the silence, not a diagnosis.
-        const target = this.reachableTarget(msg.sessionId)
+        const target = this.reachableTargetWithoutOwnership(msg.sessionId)
         if (!target.ok) {
           // Echoed, and the relay is the producer — the same obligation `device:boot-error` carries and for
           // the same reason: an MCP caller that receives a diagnosis uncorrelated reads it as unsolicited
@@ -1216,7 +1232,10 @@ export class RelayServer {
         })
       }
     }
-    for (const s of agentSessions) this.sessions.remove(s.id)
+    for (const s of agentSessions) {
+      this.sessions.remove(s.id)
+      this.forgetSessionStreamState(s.id)
+    }
     this.sessions.removeResources(ws)
     logger.info(cause === 'replaced'
       ? `agent re-registered — ${agentSessions.length} previous session(s) replaced`
@@ -1287,6 +1306,7 @@ export class RelayServer {
           this.sendTo(s.browserSocket, { type: 'session:terminated', sessionId: s.id, reason: 'agent-disconnected' })
         }
         this.sessions.remove(s.id)
+        this.forgetSessionStreamState(s.id)
       }
     }
 
@@ -1461,10 +1481,14 @@ export class RelayServer {
     // state. Composed rather than inlined so `device:shutdown` can take the other two checks alone.
     const session = this.sessions.get(sessionId)
     if (session && !this.ownsSession(ws, session)) return { ok: false, message: ownershipRefusal(session) }
-    return this.reachableTarget(sessionId)
+    return this.reachableTargetWithoutOwnership(sessionId)
   }
 
   /** `dispatchTarget` without the ownership clause: is there a session here, and is its agent listening?
+   *
+   *  **The name carries the omission because a doc block does not reach an autocomplete.** This is the
+   *  resolver a future handler must not pick by accident — it is the general-looking one and the unsafe
+   *  one at the same time, which is the pairing worth spelling out.
    *
    *  **Exists for `device:shutdown` alone, and only until #527.** That command cannot take the ownership
    *  check yet — three of the dashboard's four senders come from `useAgentSession`, whose socket never
@@ -1478,7 +1502,7 @@ export class RelayServer {
    *  whether a session id exists and whether its agent is up — recorded rather than waved past, and small
    *  against what it can already do, which is shut that device down.
    */
-  private reachableTarget(
+  private reachableTargetWithoutOwnership(
     sessionId: string,
   ): { ok: true; session: Session } | { ok: false; message: string } {
     const session = this.sessions.get(sessionId)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -426,10 +426,22 @@ export class RelayServer {
     }
   }
 
-  // Throttled callback asking the session's agent for an on-demand IDR (fast drop recovery); ignored by agents that don't support it.
-  private makeIdrRequester(sessionId: string): () => void {
+  /**
+   * Throttled callback asking the session's agent for an on-demand IDR (fast drop recovery); ignored by
+   * agents that don't support it.
+   *
+   * **One per session, and the construction is folded in here on purpose.** The throttle is `lastAt` in
+   * the closure, so a second requester for the same session is a second budget — which is what the
+   * `idrRequesters` map exists to prevent, and it prevented it only as long as every caller remembered
+   * to look the session up first. There are two callers now (the drop path and the re-join in
+   * `handleSessionStart`), and a separate `makeIdrRequester` was a factory either of them could reach
+   * past the map. Measured: calling it directly from one caller left every test green.
+   */
+  private idrRequester(sessionId: string): () => void {
+    const existing = this.idrRequesters.get(sessionId)
+    if (existing) return existing
     let lastAt = 0
-    return () => {
+    const requester = () => {
       const now = Date.now()
       if (now - lastAt < IDR_REQUEST_THROTTLE_MS) return
       lastAt = now
@@ -438,6 +450,8 @@ export class RelayServer {
         this.sendTo(session.agentSocket, { type: 'stream:request-idr', sessionId })
       }
     }
+    this.idrRequesters.set(sessionId, requester)
+    return requester
   }
 
   // Extracted so tests can simulate non-loopback origins (all test traffic is loopback).
@@ -520,11 +534,7 @@ export class RelayServer {
             dropper = createKeyframeAwareSender()
             this.droppers.set(session.id, dropper)
           }
-          let requestIdr = this.idrRequesters.get(session.id)
-          if (!requestIdr) {
-            requestIdr = this.makeIdrRequester(session.id)
-            this.idrRequesters.set(session.id, requestIdr)
-          }
+          const requestIdr = this.idrRequester(session.id)
           // JPEG and H.264 IDRs are resync points; only P-frames must wait for a keyframe after a drop.
           let isKeyframe = true
           if (hasEnvelope(frameBuf)) {
@@ -590,26 +600,28 @@ export class RelayServer {
       // coming back (#426), rather than ending them where they stand.
       if (this.holdAgentSocket(ws)) return
 
-      // Stream socket disconnected → clear the streamSocket reference
+      // Stream socket disconnected → clear the streamSocket reference.
+      //
+      // **No `return`.** One socket can be both: the role gate refuses a `browser`-role socket sending a
+      // non-browser type, and says nothing about a `stream`-role one sending `session:start` — so a
+      // socket that registered a stream first can go on to hold sessions. Returning here skipped the
+      // release below for exactly those, which is the state the loop exists to end.
       const streamSession = this.sessions.getByStreamSocket(ws)
-      if (streamSession) {
-        this.sessions.clearStreamSocket(streamSession.id)
-        return
-      }
+      if (streamSession) this.sessions.clearStreamSocket(streamSession.id)
 
-      // Browser socket disconnected → clear browserSocket, start idle timer
-      const browserSession = this.sessions.getByBrowserSocket(ws)
-      if (browserSession) {
-        this.sessions.clearBrowser(browserSession.id, () => {
-          const session = this.sessions.get(browserSession.id)
-          if (session?.agentSocket.readyState === WebSocket.OPEN) {
-            this.sendTo(session.agentSocket, {
-              type: 'device:shutdown',
-              sessionId: session.id,
-              payload: { deviceId: session.deviceId },
-            })
-          }
-        })
+      // Browser socket disconnected → release **every** session it held, each with its own idle timer.
+      //
+      // `getByBrowserSocket` used to answer with one session because the index held one, and a socket
+      // holding several is not exotic: `mcp-server` runs one socket for the whole process and joins a
+      // session per device. So closing it released the last join and left the rest bound to a dead
+      // socket — `busy: true` forever, no timer, and their devices booted with nobody watching (#507).
+      //
+      // The `stopping` guard is `holdAgentSocket`'s, for its stated reason: `stop()` terminates every
+      // client, and a timer armed on the way out survives the promise `stop()` resolves. That was one
+      // stray timer per relay before this loop and is one per held session after it.
+      if (this.stopping) return
+      for (const held of this.sessions.getByBrowserSocket(ws)) {
+        this.sessions.clearBrowser(held.id, () => this.idleShutdown(held.id))
       }
     })
   }
@@ -938,11 +950,28 @@ export class RelayServer {
         // Addressing used to have no gate either, on the grounds that an unaddressed shutdown resolves no
         // session and is dropped by the miss, so a gate would buy only its log. That reasoning is now moot
         // rather than wrong: the schema declares `sessionId` required, so the parser refuses the frame and
-        // the log it would have bought is the one `logInboundRejection` writes. Ownership is #527.
-        const session = this.sessions.get(msg.sessionId)
-        if (session?.agentSocket.readyState === WebSocket.OPEN) {
-          session.agentSocket.send(JSON.stringify(msg))
+        // the log it would have bought is the one `logInboundRejection` writes.
+        //
+        // **`reachableTarget`, not `dispatchTarget`** — the ownership clause is #527 and its blocker is in
+        // the dashboard, not here. What this fixes is the other half: until #542 this case resolved the
+        // session inline and dropped the frame when it could not, making it the only browser-originated
+        // command the relay never answers. `mcp-server`'s `shutdownDevice` waits 30s on `device:shutdown-done`
+        // and then reports `Request timed out` with no cause, which is the silence, not a diagnosis.
+        const target = this.reachableTarget(msg.sessionId)
+        if (!target.ok) {
+          // Echoed, and the relay is the producer — the same obligation `device:boot-error` carries and for
+          // the same reason: an MCP caller that receives a diagnosis uncorrelated reads it as unsolicited
+          // and waits out the deadline anyway, so the answer arrives and is discarded. `requestId` is
+          // optional on both sides here, so an absent one stays absent rather than being invented.
+          this.sendTo(ws, {
+            type: 'device:shutdown-error',
+            sessionId: msg.sessionId,
+            ...(msg.requestId === undefined ? {} : { requestId: msg.requestId }),
+            message: target.message,
+          })
+          break
         }
+        target.session.agentSocket.send(JSON.stringify(msg))
         break
       }
       // Door checks, one policy per request: an uncorrelatable request is not forwarded, not rebuilt and
@@ -1289,7 +1318,7 @@ export class RelayServer {
     logger.info(`agent connected: ${msg.agentName || msg.agentId || 'unknown'} (${msg.platform || 'unknown'}) — ${registeredSessions.length} device(s)`)
   }
 
-  /** The only producer of `error` — all four exits below, and nothing else in the repo sends that message.
+  /** The only producer of `error` — all five exits below, and nothing else in the repo sends that message.
    *
    *  That is what makes the address possible rather than aspirational: `msg.sessionId` is narrowed to a
    *  non-empty `string` by the door — the inbound schema, `isAddressed` before it — so every refusal can
@@ -1326,15 +1355,29 @@ export class RelayServer {
       }
     }
     try {
-      this.sessions.join(msg.sessionId, ws)
+      const joined = this.sessions.join(msg.sessionId, ws)
+      if (!joined.ok) {
+        // Both of these are answered above, so arriving here means the state moved between that check and
+        // this call. They are **values now rather than throws** (#515), and that is what fixes the defect:
+        // the most common way into the old `catch` was a socket re-joining the session it already holds —
+        // exempted by the `!== ws` check above, then refused by `join()`, then reported as
+        // `session-not-found` for a live session the caller was holding.
+        const reason = joined.failure === 'held-by-another' ? 'session-busy' : 'session-not-found'
+        const message = joined.failure === 'held-by-another' ? 'Session busy' : 'Session not found'
+        this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message, reason })
+        return
+      }
     } catch (e) {
-      // `join()` throws for not-found as well as busy, and the check above already answered busy — so
-      // reaching here means something this handler did not anticipate. Reporting it as `session-busy`
-      // would put a specific claim on an unknown cause, which is what `reason` exists to stop. Bare
-      // `catch {}` also discarded the error entirely: nothing reached the route-level handler, because
-      // this swallowed it first.
+      // Only a bug reaches here now — the two expected failures return above instead of throwing, which is
+      // what stops this arm from having to guess. It still answers rather than dropping: both clients await
+      // `session:joined | error` on this request, so silence costs them a full deadline.
+      //
+      // `session-not-found` is chosen for **the action it names**, not as a diagnosis. Its own declaration
+      // says "nothing else is ever coming for it", and that half is true of any failed join — no
+      // `session:joined` will follow. `session-busy` would be the wrong action: it tells a viewer the
+      // session is alive and someone else has it. The prose carries what is actually known.
       logger.error(`session:start could not join ${msg.sessionId}:`, e)
-      this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session not found', reason: 'session-not-found' })
+      this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session could not be joined', reason: 'session-not-found' })
       return
     }
     // Include the agent's capabilities so the viewer knows up front what is implemented on
@@ -1375,10 +1418,28 @@ export class RelayServer {
       // keyframe immediately, instead of waiting for the next periodic one — and so it isn't
       // left blank when the encoder is static-skipping an unchanged screen. Agents that don't
       // support on-demand IDR ignore the message.
-      if (session.agentSocket.readyState === WebSocket.OPEN) {
-        this.sendTo(session.agentSocket, { type: 'stream:request-idr', sessionId: session.id })
-      }
+      //
+      // **Through the session's throttled requester, not a bare `sendTo`.** This was unreachable for a
+      // socket that already held the session — `join()` threw and the handler answered above this line —
+      // and #515 made a re-join run the whole body. A client re-sending `session:start` therefore drives
+      // one forced keyframe per frame it sends, and a 1080p IDR is two orders of magnitude larger than
+      // the P-frames around it, so the amplification lands on the tester who is actually watching. The
+      // backpressure path already throttles this exact message per session; sharing that requester is
+      // what keeps the two callers from having two policies.
+      this.idrRequester(session.id)()
     }
+  }
+
+  /** Shut the device down because nobody is watching it any more. The idle timer's payload, hoisted out
+   *  of the close handler so the release loop there reads as one line per session. */
+  private idleShutdown(sessionId: string): void {
+    const session = this.sessions.get(sessionId)
+    if (session?.agentSocket.readyState !== WebSocket.OPEN) return
+    this.sendTo(session.agentSocket, {
+      type: 'device:shutdown',
+      sessionId: session.id,
+      payload: { deviceId: session.deviceId },
+    })
   }
 
   /** Where a browser-role command can be dispatched, or what its sender needs to be told instead.
@@ -1395,9 +1456,33 @@ export class RelayServer {
     ws: WebSocket,
     sessionId: string,
   ): { ok: true; session: Session } | { ok: false; message: string } {
+    // Ownership first and liveness second, which is the order the refusals were written in and worth
+    // keeping: a non-owner is told it does not hold the session rather than being handed the agent's
+    // state. Composed rather than inlined so `device:shutdown` can take the other two checks alone.
+    const session = this.sessions.get(sessionId)
+    if (session && !this.ownsSession(ws, session)) return { ok: false, message: ownershipRefusal(session) }
+    return this.reachableTarget(sessionId)
+  }
+
+  /** `dispatchTarget` without the ownership clause: is there a session here, and is its agent listening?
+   *
+   *  **Exists for `device:shutdown` alone, and only until #527.** That command cannot take the ownership
+   *  check yet — three of the dashboard's four senders come from `useAgentSession`, whose socket never
+   *  joins, so gating it would break going back and the unmount teardown, the two paths that stop a device
+   *  costing money when a tester walks away. It still needs the other two, because without them a shutdown
+   *  addressed to a missing session or a closed agent socket was dropped in silence and `mcp-server`'s
+   *  caller burned a 30s deadline for it (#542).
+   *
+   *  So the split is the seam: when #527 answers who may shut a device down, `device:shutdown` moves up to
+   *  `dispatchTarget` and this method goes away. The cost of the seam is that a non-owner now learns
+   *  whether a session id exists and whether its agent is up — recorded rather than waved past, and small
+   *  against what it can already do, which is shut that device down.
+   */
+  private reachableTarget(
+    sessionId: string,
+  ): { ok: true; session: Session } | { ok: false; message: string } {
     const session = this.sessions.get(sessionId)
     if (!session) return { ok: false, message: 'Session not found' }
-    if (!this.ownsSession(ws, session)) return { ok: false, message: ownershipRefusal(session) }
     if (session.agentSocket.readyState !== WebSocket.OPEN) return { ok: false, message: 'agent offline' }
     return { ok: true, session }
   }

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto'
 import { WebSocket } from 'ws'
 import type { DeviceStatus } from '@tapflowio/agent-core'
-import { ValidationError } from '@tapflowio/agent-core'
 import type { AgentResources, SessionInfo } from './types.js'
 import type { ChromePayload, DeviceDetails, DeviceReport } from '@tapflowio/protocol'
 
@@ -31,6 +30,15 @@ export interface Session {
   idleTimer: ReturnType<typeof setTimeout> | null
 }
 
+/**
+ * Why a `session:start` could not bind, or that it did.
+ *
+ * The two failures are the ones a caller can be told about truthfully, and they are values rather than
+ * exceptions for that reason — see `join()`. Anything else that goes wrong in there is a bug and still
+ * throws, which keeps the two apart at the call site instead of at a `catch`.
+ */
+export type JoinResult = { ok: true } | { ok: false; failure: 'not-found' | 'held-by-another' }
+
 /** What an `agent:register` says about the agent itself, as opposed to its devices. */
 export type AgentIdentity = {
   agentId?: string
@@ -46,7 +54,21 @@ export class SessionManager {
   private agentResources = new Map<WebSocket, AgentResources>()
   private agentSocketIndex = new Map<WebSocket, Set<string>>()
   private streamSocketIndex = new Map<WebSocket, Session>()
-  private browserSocketIndex = new Map<WebSocket, Session>()
+  /**
+   * Which sessions a browser socket holds. **A set, because the relation is one-to-many** — and it was a
+   * single `Session` until #507 was diagnosed, which is the whole of that defect.
+   *
+   * `mcp-server` opens exactly one socket (`client.ts`, one `new WebSocket`) and sends a `session:start`
+   * per device, because an LLM can hold several sessions at once and its waiters are keyed per session.
+   * With one slot per socket, the second join silently overwrote the first — `A.browserSocket` still
+   * pointed at the socket, so *commands* kept working, and only the reverse lookup lost A. The close
+   * handler resolves through that lookup, so **A was never released**: `busy: true` for the life of the
+   * relay, no idle timer, and a device left booted with nobody watching it.
+   *
+   * That is also why the obvious reading of #507 — "release the previous session when a socket joins
+   * another" — is a regression rather than a fix. Two independent design reviews reached it separately.
+   */
+  private browserSocketIndex = new Map<WebSocket, Set<Session>>()
   private readonly idleTimeoutMs: number
 
   constructor(options: { idleTimeoutMs?: number } = {}) {
@@ -135,20 +157,60 @@ export class SessionManager {
     return this.streamSocketIndex.get(ws)
   }
 
-  getByBrowserSocket(ws: WebSocket): Session | undefined {
-    return this.browserSocketIndex.get(ws)
+  /** Every session this socket holds. **Plural**, and the caller must treat it as such — the close
+   *  handler releasing only the first is the defect the index comment above describes. */
+  getByBrowserSocket(ws: WebSocket): Session[] {
+    return [...(this.browserSocketIndex.get(ws) ?? [])]
   }
 
-  join(sessionId: string, browserSocket: WebSocket): void {
+  /** Drop `session` from its browser socket's set, and the key with it when the set empties. Leaving an
+   *  empty `Set` behind would keep a closed socket referenced for the life of the relay. */
+  private unindexBrowser(session: Session): void {
+    const ws = session.browserSocket
+    if (!ws) return
+    const held = this.browserSocketIndex.get(ws)
+    if (!held) return
+    held.delete(session)
+    if (held.size === 0) this.browserSocketIndex.delete(ws)
+  }
+
+  /**
+   * @returns `not-found` and `held-by-another` rather than throwing them, **so an unexpected failure and
+   *          an expected one stop sharing a channel.** `session:start` answered both from one `catch`, and
+   *          the comment there said reaching it meant something the handler did not anticipate — while the
+   *          most common way to reach it was a socket re-joining the session it already holds (#515). An
+   *          expected failure that travels as an exception is indistinguishable from a bug by the time it
+   *          is caught, and the handler then has to guess a `reason`.
+   */
+  join(sessionId: string, browserSocket: WebSocket): JoinResult {
     const session = this.sessions.get(sessionId)
-    if (!session) throw new ValidationError(`Session not found: ${sessionId}`)
-    if (session.browserSocket?.readyState === WebSocket.OPEN) {
-      throw new ValidationError(`Session busy: ${sessionId}`)
+    if (!session) return { ok: false, failure: 'not-found' }
+    // `!== browserSocket` is #515. The relay's handler already exempts the owning socket from the
+    // occupancy refusal one layer up, and this line not matching it is what made that exemption fall
+    // through to a `Session busy` throw — reported to the caller as `session-not-found`, for a live
+    // session it was holding. A re-join is now idempotent: it keeps the binding, cancels the idle timer
+    // below, and the handler replays the session's cached state exactly as it does for a fresh join.
+    if (
+      session.browserSocket &&
+      session.browserSocket !== browserSocket &&
+      session.browserSocket.readyState === WebSocket.OPEN
+    ) {
+      return { ok: false, failure: 'held-by-another' }
     }
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }
-    if (session.browserSocket) this.browserSocketIndex.delete(session.browserSocket)
+    // Unconditional, and **the order is what makes it safe**: this releases the session from whichever
+    // socket held it, which on a re-join is the socket joining. Removing and re-adding the same entry is a
+    // no-op; doing it *after* the add below would delete the entry this join just made, leaving the
+    // session bound for commands and invisible to the close handler — #507 rebuilt one method over.
+    //
+    // A guard reading `!== browserSocket` stood here with that reasoning written as its justification. It
+    // was dead: mutation testing removed the guard and every test still passed, because the add follows.
+    this.unindexBrowser(session)
     session.browserSocket = browserSocket
-    this.browserSocketIndex.set(browserSocket, session)
+    let held = this.browserSocketIndex.get(browserSocket)
+    if (!held) { held = new Set(); this.browserSocketIndex.set(browserSocket, held) }
+    held.add(session)
+    return { ok: true }
   }
 
   remove(sessionId: string): void {
@@ -156,7 +218,7 @@ export class SessionManager {
     if (!session) return
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }
     if (session.streamSocket) this.streamSocketIndex.delete(session.streamSocket)
-    if (session.browserSocket) this.browserSocketIndex.delete(session.browserSocket)
+    this.unindexBrowser(session)
     const agentIds = this.agentSocketIndex.get(session.agentSocket)
     agentIds?.delete(sessionId)
     if (agentIds?.size === 0) this.agentSocketIndex.delete(session.agentSocket)
@@ -167,7 +229,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId)
     if (!session) return
     if (session.browserSocket) {
-      this.browserSocketIndex.delete(session.browserSocket)
+      this.unindexBrowser(session)
       session.browserSocket = null
     }
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ValidationError } from '@tapflowio/agent-core'
 import { SessionManager } from '../SessionManager'
 import type { WebSocket } from 'ws'
 
@@ -187,31 +186,90 @@ describe('SessionManager', () => {
       expect(sm.get(id)?.browserSocket).toBe(browserWs)
     })
 
-    it('throws when session is not found', () => {
+    // The two expected failures are **returned**, not thrown, as of #515. Both used to be
+    // `ValidationError`s, and the handler's single `catch` could not tell them from a bug — so it
+    // guessed a `reason`, and guessed wrong for the most common case (see the re-join tests below).
+    it('reports a session that is not there', () => {
       const sm = new SessionManager()
-      let thrown: unknown
-      try {
-        sm.join('bad-id', mockSocket())
-      } catch (error) {
-        thrown = error
-      }
-      expect(thrown).toBeInstanceOf(ValidationError)
-      expect((thrown as Error).message).toBe('Session not found: bad-id')
+      expect(sm.join('bad-id', mockSocket())).toEqual({ ok: false, failure: 'not-found' })
     })
 
-    it('throws when session is busy (browserSocket is OPEN)', () => {
+    it('reports a session another OPEN socket holds', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const busyWs = { readyState: OPEN } as WebSocket
       sm.join(id, busyWs)
-      let thrown: unknown
-      try {
-        sm.join(id, mockSocket())
-      } catch (error) {
-        thrown = error
-      }
-      expect(thrown).toBeInstanceOf(ValidationError)
-      expect((thrown as Error).message).toContain('Session busy')
+      expect(sm.join(id, mockSocket())).toEqual({ ok: false, failure: 'held-by-another' })
+      // The refusal must not have moved the binding — a rejected join that stole the session would be
+      // the defect this check exists to prevent, wearing a refusal's clothes.
+      expect(sm.get(id)?.browserSocket).toBe(busyWs)
+    })
+
+    it('a re-join by the owning socket succeeds and keeps the binding (#515)', () => {
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      const owner = { readyState: OPEN } as WebSocket
+      sm.join(id, owner)
+      expect(sm.join(id, owner)).toEqual({ ok: true })
+      expect(sm.get(id)?.browserSocket).toBe(owner)
+      // And the socket still holds it exactly once. `unindexBrowser` reads `session.browserSocket`, so a
+      // re-join that ran it would drop the entry this join is re-establishing — leaving the session bound
+      // for commands while invisible to the close handler, which is #507 rebuilt one method over.
+      expect(sm.getByBrowserSocket(owner).map((s) => s.id)).toEqual([id])
+    })
+
+    it('one socket holds several sessions at once', () => {
+      // `mcp-server` runs a single WebSocket for the whole process and joins a session per device. The
+      // index was `Map<WebSocket, Session>` until #507, so the second join here evicted the first from the
+      // reverse lookup — and the close handler, which resolves through it, then released only one.
+      const sm = new SessionManager()
+      const agent = mockSocket()
+      const [a, b] = sm.create(agent, [
+        { id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' },
+        { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
+      ])
+      const ws = { readyState: OPEN } as WebSocket
+      sm.join(a!, ws)
+      sm.join(b!, ws)
+      expect(sm.getByBrowserSocket(ws).map((s) => s.id).sort()).toEqual([a, b].sort())
+      expect(sm.get(a!)?.browserSocket).toBe(ws)
+      expect(sm.get(b!)?.browserSocket).toBe(ws)
+    })
+
+    it('releasing one of several leaves the others held, and empties the key at the end', () => {
+      const sm = new SessionManager()
+      const [a, b] = sm.create(mockSocket(), [
+        { id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' },
+        { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
+      ])
+      const ws = { readyState: OPEN } as WebSocket
+      sm.join(a!, ws)
+      sm.join(b!, ws)
+      sm.clearBrowser(a!)
+      expect(sm.getByBrowserSocket(ws).map((s) => s.id)).toEqual([b])
+      sm.clearBrowser(b!)
+      expect(sm.getByBrowserSocket(ws)).toEqual([])
+      // **The key is gone, not merely empty.** `getByBrowserSocket` spreads the set, so it answers `[]`
+      // either way — the assertion above cannot see the difference, and a first version of this test
+      // claimed it could. The index is a `Map` keyed by socket, so a leftover entry pins a closed socket
+      // for the life of the relay: a leak the old one-slot index could not have, introduced by the fix
+      // for it. Reaching the private field is the only way to state it, and it is what mutation testing
+      // said was missing.
+      const index = (sm as unknown as { browserSocketIndex: Map<WebSocket, unknown> }).browserSocketIndex
+      expect(index.has(ws)).toBe(false)
+    })
+
+    it('remove() takes the session out of its socket set', () => {
+      const sm = new SessionManager()
+      const [a, b] = sm.create(mockSocket(), [
+        { id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' },
+        { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
+      ])
+      const ws = { readyState: OPEN } as WebSocket
+      sm.join(a!, ws)
+      sm.join(b!, ws)
+      sm.remove(a!)
+      expect(sm.getByBrowserSocket(ws).map((s) => s.id)).toEqual([b])
     })
   })
 

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type {
+  AgentRegistered, DeviceShutdown, DeviceShutdownError, GenericError, SessionChrome, SessionJoined,
+} from '@tapflowio/protocol'
+
+// Three defects that share a subject — who holds a session — and **not** the question of who *should*.
+// That one is #527/#507(2) and needs a definition of owner that survives a reconnect, which is a
+// different slice. What is here is the part that needed no such decision:
+//
+//  - #515 a socket re-joining the session it already holds was told `session-not-found`
+//  - #507 the reverse index held one session per socket while the relation is one-to-many
+//  - #542 `device:shutdown` was the one browser command the relay never answered
+describe('session ownership seam', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-ownership-seam-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  async function registerAgent(name: string, devices = 1) {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: name,
+      devices: Array.from({ length: devices }, (_, i) => ({
+        id: `dev${i}`, name: `iPhone ${i}`, platform: 'ios', status: 'shutdown',
+      })),
+    }))
+    const reply = await waitForType<AgentRegistered>(agent, 'agent:registered')
+    return { agent, sessionIds: reply.registeredSessions.map((s) => s.sessionId) }
+  }
+
+  async function browserSocket() {
+    const ws = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(ws)
+    return ws
+  }
+
+  // ── #515 — re-joining a session this socket already holds ─────────────────────────────────────────
+
+  it('answers a re-join by the owning socket with session:joined, not an error', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-rejoin')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType<SessionJoined>(browser, 'session:joined')
+
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const again = await waitForType<SessionJoined>(browser, 'session:joined')
+    expect(again.sessionId).toBe(sessionId)
+
+    // The refusal is the thing being ruled out, so it is waited for rather than assumed absent: the
+    // relay used to send `error` with `reason: 'session-not-found'` here, for a session this socket was
+    // holding — `DeviceViewer` maps that reason to `onSessionEnded('agent-disconnected')` and takes the
+    // viewer off a session that is fine.
+    expect(await waitForTypeOrNull<GenericError>(browser, 'error', 200)).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  it('replays the session cache to a re-joining owner, as it does for a fresh join', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-replay')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    agent.send(JSON.stringify({
+      type: 'session:chrome', sessionId, payload: { platform: 'ios', model: 'iPhone 15' },
+    }))
+    await waitForType<SessionChrome>(browser, 'session:chrome')
+
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    // Idempotent means the *whole* handler runs again, not just its reply. A re-join that answered and
+    // returned early would leave a reconnecting viewer with no bezel — which is the state #515's
+    // consumers were in for a different reason.
+    const chrome = await waitForType<SessionChrome>(browser, 'session:chrome')
+    expect(chrome.payload).toMatchObject({ model: 'iPhone 15' })
+
+    agent.close(); browser.close()
+  })
+
+  it('a re-join leaves the socket owning the session, and holding it exactly once', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-keeps')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    // Ownership survived: an acked input from this socket is forwarded rather than refused. Asserted
+    // through the wire because `ownsSession` is what every command consults, and a re-join that dropped
+    // the binding would leave the viewer connected and unable to touch anything.
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-1', payload: { x: 0.5, y: 0.5 },
+    }))
+    const forwarded = await waitForType(agent, 'input:touch:end')
+    expect(forwarded.sessionId).toBe(sessionId)
+    expect(await waitForTypeOrNull(browser, 'input:error', 200)).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  it('still refuses a socket that does not hold the session', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-busy')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket()
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const other = await browserSocket()
+    other.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const refusal = await waitForType<GenericError>(other, 'error')
+    expect(refusal.reason).toBe('session-busy')
+
+    agent.close(); holder.close(); other.close()
+  })
+
+  // `join()`'s two failures are answered above it in the handler, so nothing reaches its result branch by
+  // ordinary means — and an arm no input can reach is an arm whose reply drifts. `RelayServer.test.ts`
+  // forces the `catch` next door with the same technique and for the same stated reason. The mapping is
+  // what is under test: reporting `held-by-another` as `session-not-found` is #515's defect exactly, and
+  // without this the mutation that reintroduces it survives the whole suite.
+  it.each([
+    ['not-found', 'session-not-found', 'Session not found'],
+    ['held-by-another', 'session-busy', 'Session busy'],
+  ])('maps a %s from join() to %s', async (failure, reason, message) => {
+    const { agent, sessionIds } = await registerAgent(`seam-map-${failure}`)
+    const sessionId = sessionIds[0]!
+    const sessions = (server as unknown as {
+      sessions: { join(id: string, ws: WebSocket): { ok: boolean } }
+    }).sessions
+    const spy = vi.spyOn(sessions, 'join').mockReturnValue({ ok: false, failure } as never)
+    try {
+      const browser = await browserSocket()
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      const err = await waitForType<GenericError>(browser, 'error')
+      expect(err.reason).toBe(reason)
+      expect(err.message).toBe(message)
+      expect(err.sessionId).toBe(sessionId)
+      browser.close()
+    } finally { spy.mockRestore() }
+    agent.close()
+  })
+
+  // ── #507 — one socket, several sessions ───────────────────────────────────────────────────────────
+
+  it('releases every session a closing socket held, not just the last one joined', async () => {
+    // `mcp-server` runs one WebSocket for the whole process and joins a session per device, so this is
+    // the ordinary shape rather than an edge case. With the old one-slot index the close handler found
+    // only `b`: `a` kept a `browserSocket` pointing at a dead socket, stayed `busy: true` for the life of
+    // the relay, and never got an idle timer — a booted device with nobody watching and nothing to stop
+    // it. The relay is built with a 50ms idle timeout here so the timer's effect is observable.
+    await server.stop()
+    server = new RelayServer({ port: 0, idleTimeoutMs: 50 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+
+    const { agent, sessionIds } = await registerAgent('seam-multi', 2)
+    const [a, b] = sessionIds as [string, string]
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId: a }))
+    await waitForType(browser, 'session:joined')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId: b }))
+    await waitForType(browser, 'session:joined')
+
+    browser.close()
+
+    // Both idle timers fire, so the agent is asked to shut both devices down. Collected by session id
+    // rather than counted: the failure this replaces produced exactly one of these, and a count of two
+    // would also pass if the same session were released twice.
+    const first = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
+    const second = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
+    expect([first.sessionId, second.sessionId].sort()).toEqual([a, b].sort())
+
+    agent.close()
+  })
+
+  it('keeps the first session usable while the same socket holds a second', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-both-live', 2)
+    const [a, b] = sessionIds as [string, string]
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId: a }))
+    await waitForType(browser, 'session:joined')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId: b }))
+    await waitForType(browser, 'session:joined')
+
+    // The first design for #507 released `a` here, which would refuse this input and, five minutes on,
+    // shut a device down under a caller that is still driving it. Two independent design reviews found
+    // that before it was written; this is what says so afterwards.
+    browser.send(JSON.stringify({
+      type: 'input:touch:end', sessionId: a, requestId: 'rq-a', payload: { x: 0.1, y: 0.1 },
+    }))
+    const forwarded = await waitForType(agent, 'input:touch:end')
+    expect(forwarded.sessionId).toBe(a)
+
+    agent.close(); browser.close()
+  })
+
+  it('arms no idle timer for a socket closed by stop() itself', async () => {
+    // `stop()` sets `stopping` and then terminates every client, so the release loop runs during
+    // shutdown with as many sessions as the socket held — and each `clearBrowser(id, cb)` arms a timer
+    // that outlives the promise `stop()` resolves. `holdAgentSocket` carries the same guard with the
+    // same reason beside it; the browser side did not, and #507 turned one stray timer into N.
+    //
+    // **The agent has to be inside its reconnect hold, and finding that out is the test.** A first
+    // version just stopped a healthy relay and found the sessions already gone: `stop()` terminates the
+    // agent socket too, its close hits `holdAgentSocket`'s own `stopping` guard, and `evictAgentSocket`
+    // removes every session — which clears any timer the browser's close had armed a moment earlier.
+    // So the guard is load-bearing in exactly one state, and it is a state #426 made ordinary: the
+    // agent dropped uncleanly, its socket is no longer in `wss.clients`, so nothing evicts on the way
+    // out and the sessions — with their timers — survive the server.
+    //
+    // **Asserted on `session.idleTimer`, not on the absence of a shutdown.** A test that waits out the
+    // timeout and finds nothing passes when nothing happens, which is its definition: it cannot tell a
+    // working guard from a relay that has stopped answering. The field is a positive statement.
+    const own = new RelayServer({ port: 0, idleTimeoutMs: 50 })
+    await own.start()
+    const ownPort = (own.address() as { port: number }).port
+
+    const agent = new WebSocket(`ws://localhost:${ownPort}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: 'seam-stopping',
+      devices: [
+        { id: 'dev0', name: 'iPhone 0', platform: 'ios', status: 'shutdown' },
+        { id: 'dev1', name: 'iPhone 1', platform: 'ios', status: 'shutdown' },
+      ],
+    }))
+    const reg = await waitForType<AgentRegistered>(agent, 'agent:registered')
+    const ids = reg.registeredSessions.map((s) => s.sessionId)
+
+    const browser = new WebSocket(`ws://localhost:${ownPort}`)
+    await waitForOpen(browser)
+    for (const id of ids) {
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: id }))
+      await waitForType(browser, 'session:joined')
+    }
+
+    // Into the hold. `session:agent-away` is the relay saying it kept the sessions rather than ending
+    // them, so waiting for it is what proves the state is set up — a sleep would not.
+    const closed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await closed
+    await waitForType(browser, 'session:agent-away')
+
+    // `stop()` resolves only after `wss.close()` has seen every remaining client close, so the handler
+    // under test has run by the time this returns. No sleep, and nothing to race.
+    await own.stop()
+
+    const sessions = (own as unknown as {
+      sessions: { get(id: string): { idleTimer: unknown; browserSocket: unknown } | undefined }
+    }).sessions
+    for (const id of ids) {
+      // Present, which is the premise — an evicted session would make the timer assertion vacuous, and
+      // that is precisely how the first version of this test passed against the unguarded code.
+      expect(sessions.get(id), `${id} was evicted, so this proves nothing`).toBeDefined()
+      expect(sessions.get(id)?.idleTimer, `${id} armed a timer during stop()`).toBeNull()
+    }
+    // The cost of the guard, stated rather than left implicit: the sessions stay bound to a socket that
+    // is gone. Correct here and only here — the process is on its way out, and the alternative is a
+    // timer firing at a relay that no longer exists.
+    expect(sessions.get(ids[0]!)?.browserSocket).not.toBeNull()
+
+    browser.close()
+  })
+
+  it('does not let repeated re-joins force one keyframe each', async () => {
+    // #515 made a re-join run the handler's whole body, and the tail of that body asks the agent for an
+    // IDR when the session is streaming. That line was unreachable for a socket already holding the
+    // session — `join()` threw and the handler answered above it — so making the re-join succeed opened
+    // a request-per-frame path on the direction a viewer with devtools controls. A 1080p IDR is two
+    // orders of magnitude larger than the P-frames around it, so the cost lands on the tester watching.
+    //
+    // Counted rather than sampled: the assertion that discriminates a throttled call from a bare
+    // `sendTo` is **how many** arrive, and no shape of "did one arrive" can see the difference.
+    const { agent, sessionIds } = await registerAgent('seam-idr')
+    const sessionId = sessionIds[0]!
+    const idrs: unknown[] = []
+    agent.on('message', (d) => {
+      const m = JSON.parse(String(d)) as { type?: string }
+      if (m.type === 'stream:request-idr') idrs.push(m)
+    })
+
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    // `readySent` is what gates the IDR, and only a `device:ready` from the agent sets it.
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType(browser, 'device:ready')
+
+    for (let i = 0; i < 5; i++) {
+      browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+      await waitForType(browser, 'session:joined')
+    }
+    // The relay answered all five; a round trip on the agent's own socket proves anything it sent them
+    // has been flushed to this end too.
+    await barrier(agent)
+
+    expect(idrs).toHaveLength(1)
+
+    agent.close(); browser.close()
+  })
+
+  it('releases the sessions a socket that also registered a stream was holding', async () => {
+    // The close handler tried the stream branch first and **returned** from it, so a socket that was both
+    // never reached the release below — the exact state the loop above exists to end, reachable because
+    // the role gate refuses a `browser`-role socket sending a non-browser type and says nothing about a
+    // `stream`-role one sending `session:start`. Order matters: `stream:register` first is what makes the
+    // socket stream-role, and a socket that joined first would be closed with 1008 for registering.
+    await server.stop()
+    server = new RelayServer({ port: 0, idleTimeoutMs: 50 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+
+    const { agent, sessionIds } = await registerAgent('seam-stream-holder')
+    const sessionId = sessionIds[0]!
+    const both = await browserSocket()
+    both.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    await waitForType(both, 'stream:registered')
+    both.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(both, 'session:joined')
+
+    both.close()
+
+    const fired = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
+    expect(fired.sessionId).toBe(sessionId)
+
+    agent.close()
+  })
+
+  // ── #542 — device:shutdown is answered when it cannot be dispatched ───────────────────────────────
+
+  it('answers a shutdown addressed to a session that does not exist', async () => {
+    const { agent } = await registerAgent('seam-shutdown-missing')
+    const browser = await browserSocket()
+
+    browser.send(JSON.stringify({
+      type: 'device:shutdown', sessionId: 'no-such-session', requestId: 'rq-gone',
+      payload: { deviceId: 'dev0' },
+    }))
+    const err = await waitForType<DeviceShutdownError>(browser, 'device:shutdown-error')
+    expect(err.message).toBe('Session not found')
+    expect(err.sessionId).toBe('no-such-session')
+    // Echoed by the relay itself, the obligation `device:boot-error` carries next door: a caller that
+    // receives this uncorrelated reads it as unsolicited and waits out its 30s anyway.
+    expect(err.requestId).toBe('rq-gone')
+
+    agent.close(); browser.close()
+  })
+
+  it('answers a shutdown whose agent has gone', async () => {
+    const { agent, sessionIds } = await registerAgent('seam-shutdown-away')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    const closed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await closed
+    await waitForType(browser, 'session:agent-away')
+
+    browser.send(JSON.stringify({
+      type: 'device:shutdown', sessionId, requestId: 'rq-away', payload: { deviceId: 'dev0' },
+    }))
+    const err = await waitForType<DeviceShutdownError>(browser, 'device:shutdown-error')
+    // The two prose strings are one distinction #492 settled: a held session with a dead socket is the
+    // agent's fault, a missing session is not, and telling them apart is what stops a caller chasing the
+    // wrong problem.
+    expect(err.message).toBe('agent offline')
+
+    browser.close()
+  })
+
+  it('leaves the correlator absent when the request carried none', async () => {
+    // The dashboard's three teardown senders mint no id, deliberately — nothing there waits on the
+    // reply. Inventing one would produce a frame that correlates with a request nobody made, and the
+    // declaration is `requestId?` on both sides precisely so this can stay absent.
+    const { agent } = await registerAgent('seam-shutdown-uncorrelated')
+    const browser = await browserSocket()
+
+    browser.send(JSON.stringify({
+      type: 'device:shutdown', sessionId: 'no-such-session', payload: { deviceId: 'dev0' },
+    }))
+    const err = await waitForType<DeviceShutdownError>(browser, 'device:shutdown-error')
+    expect(err.message).toBe('Session not found')
+    expect('requestId' in err).toBe(false)
+
+    agent.close(); browser.close()
+  })
+
+  it('still forwards a shutdown from a socket that does not hold the session', async () => {
+    // #527, not this slice. `reachableTarget` deliberately omits the ownership clause, because three of
+    // the dashboard's four senders come from a socket that never joins — gating it here would break
+    // going back and the unmount teardown, the two paths that stop a device costing money. This pins the
+    // omission so that closing #527 is a decision someone makes rather than a line that drifts in.
+    const { agent, sessionIds } = await registerAgent('seam-shutdown-nonowner')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket()
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const stranger = await browserSocket()
+    stranger.send(JSON.stringify({
+      type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' },
+    }))
+    const forwarded = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
+    expect(forwarded.sessionId).toBe(sessionId)
+    expect(await waitForTypeOrNull(stranger, 'device:shutdown-error', 200)).toBeNull()
+
+    agent.close(); holder.close(); stranger.close()
+  })
+
+  it('does not answer the shutdown the relay originates from its own idle timer', async () => {
+    // There is no browser behind that one — it is built and sent inside the timer callback and never
+    // enters `route()`, so `reachableTarget` cannot see it. Worth pinning because the obvious way to
+    // implement #542 is to answer inside a shared helper, and this is the caller that has nobody to
+    // answer.
+    await server.stop()
+    server = new RelayServer({ port: 0, idleTimeoutMs: 50 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+
+    const { agent, sessionIds } = await registerAgent('seam-idle')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    const observer = await browserSocket()
+    await barrier(observer)
+    browser.close()
+
+    const fired = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
+    expect(fired.sessionId).toBe(sessionId)
+    expect(await waitForTypeOrNull(observer, 'device:shutdown-error', 200)).toBeNull()
+
+    agent.close(); observer.close()
+  })
+})

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -393,7 +393,11 @@ describe('session ownership seam', () => {
     stream.send(JSON.stringify({ type: 'stream:register', sessionId }))
     await waitForType(stream, 'stream:registered')
     stream.send(Buffer.from([0x01, 0x02, 0x03]), { binary: true })
-    await barrier(browser)
+    // **On `stream`, not on `browser`.** A barrier only orders against traffic on its own socket —
+    // WebSocket guarantees ordering within a connection and says nothing across two. Barriering the
+    // browser here proved the relay had handled a frame *that socket* sent, which is not the frame the
+    // assertions below depend on, so they could run before the binary handler had written the maps.
+    await barrier(stream)
 
     const maps = server as unknown as Record<string, Map<string, unknown>>
     for (const name of ['idrRequesters', 'droppers', 'dropHandlers']) {

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -3,7 +3,8 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { WebSocket } from 'ws'
-import { RelayServer } from '../RelayServer'
+import { RelayServer, IDR_REQUEST_THROTTLE_MS } from '../RelayServer'
+import type { JoinResult } from '../SessionManager'
 import { initDb, closeDb } from '../db'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 import type {
@@ -150,13 +151,15 @@ describe('session ownership seam', () => {
   it.each([
     ['not-found', 'session-not-found', 'Session not found'],
     ['held-by-another', 'session-busy', 'Session busy'],
-  ])('maps a %s from join() to %s', async (failure, reason, message) => {
+  ] as const)('maps a %s from join() to %s', async (failure, reason, message) => {
     const { agent, sessionIds } = await registerAgent(`seam-map-${failure}`)
     const sessionId = sessionIds[0]!
+    // Typed against the exported result rather than a local shape plus `as never`: the mocked value is
+    // then checked, so widening the failure union without widening this mapping fails here.
     const sessions = (server as unknown as {
-      sessions: { join(id: string, ws: WebSocket): { ok: boolean } }
+      sessions: { join(id: string, ws: WebSocket): JoinResult }
     }).sessions
-    const spy = vi.spyOn(sessions, 'join').mockReturnValue({ ok: false, failure } as never)
+    const spy = vi.spyOn(sessions, 'join').mockReturnValue({ ok: false, failure })
     try {
       const browser = await browserSocket()
       browser.send(JSON.stringify({ type: 'session:start', sessionId }))
@@ -300,6 +303,22 @@ describe('session ownership seam', () => {
     //
     // Counted rather than sampled: the assertion that discriminates a throttled call from a bare
     // `sendTo` is **how many** arrive, and no shape of "did one arrive" can see the difference.
+    //
+    // **Time is frozen rather than the count loosened.** Review proposed `< 5`, on the grounds that five
+    // round trips could cross the 500ms window on a loaded runner — a real risk, and a fix that spends
+    // the assertion to buy it: `< 5` passes on four, so a throttle shortened to 1ms would survive, and
+    // that mutation is the one this test exists for. Faking `Date` alone removes the dependency instead
+    // of trading it away. `setTimeout` stays real, so the sockets and the relay's own timers are
+    // untouched — it is only `Date.now()` that the throttle reads.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      await runIdrCount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  async function runIdrCount() {
     const { agent, sessionIds } = await registerAgent('seam-idr')
     const sessionId = sessionIds[0]!
     const idrs: unknown[] = []
@@ -325,7 +344,120 @@ describe('session ownership seam', () => {
 
     expect(idrs).toHaveLength(1)
 
+    // **The window's size, not just its existence.** With `Date.now()` frozen, `now - lastAt` is always
+    // zero, so *any* positive threshold coalesces the burst — a throttle shortened to 1ms would pass the
+    // assertion above, and that mutation survived until these two steps existed. Moving the clock inside
+    // the window and then past it pins both edges against the constant rather than against wall time.
+    vi.setSystemTime(Date.now() + Math.floor(IDR_REQUEST_THROTTLE_MS / 5))
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    await barrier(agent)
+    expect(idrs, 'the throttle window is shorter than it declares').toHaveLength(1)
+
+    vi.setSystemTime(Date.now() + IDR_REQUEST_THROTTLE_MS)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    await barrier(agent)
+    // And it does reopen — a throttle that never lets a second one through would starve a viewer that
+    // re-joins minutes later, which is the case the IDR exists for.
+    expect(idrs, 'the throttle window never reopens').toHaveLength(2)
+
     agent.close(); browser.close()
+  }
+
+  it('forgets a session\'s stream state when the session is evicted, not only on end/leave', async () => {
+    // The four per-session maps were emptied inline in `session:end` and `session:leave` and nowhere
+    // else, so a session ending any other way left all four behind for the life of the process.
+    // Pre-existing — and this slice is why it is fixed here rather than filed: `idrRequesters` used to
+    // be populated only by the binary drop path, i.e. only under backpressure, and the re-join above
+    // now creates an entry for any streaming session. The leak went from rare to ordinary.
+    //
+    // Eviction is reached the way a restarted agent reaches it: the same identity registering a
+    // *different* device list, so nothing is rebound and the old session is replaced outright.
+    const { agent, sessionIds } = await registerAgent('seam-evict')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType(browser, 'device:ready')
+    // The re-join is what creates the entry — the premise, asserted rather than assumed.
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    // **All three maps have to be populated or the assertion below cannot see them.** A first version
+    // checked four empty maps and passed against a helper that deleted only one of them — the vacuity
+    // that mutation testing keeps finding in this slice. `droppers` and `dropHandlers` are created by
+    // the binary path, which reads the *stream* socket, so the frame has to come from one.
+    const stream = await browserSocket()
+    stream.send(JSON.stringify({ type: 'stream:register', sessionId }))
+    await waitForType(stream, 'stream:registered')
+    stream.send(Buffer.from([0x01, 0x02, 0x03]), { binary: true })
+    await barrier(browser)
+
+    const maps = server as unknown as Record<string, Map<string, unknown>>
+    for (const name of ['idrRequesters', 'droppers', 'dropHandlers']) {
+      expect(maps[name]!.has(sessionId), `${name} has no entry, so clearing it proves nothing`).toBe(true)
+    }
+
+    const replacement = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(replacement)
+    replacement.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: 'seam-evict',
+      devices: [{ id: 'devZ', name: 'iPhone Z', platform: 'ios', status: 'shutdown' }],
+    }))
+    await waitForType(replacement, 'agent:registered')
+    await waitForType(browser, 'session:terminated')
+
+    for (const name of ['idrRequesters', 'droppers', 'dropHandlers']) {
+      expect(maps[name]!.has(sessionId), `${name} kept the evicted session`).toBe(false)
+    }
+    // `audioDropHandlers` is the fourth and is **not** asserted: populating it needs an audio-tagged
+    // envelope, which is a frame-format fixture this file has no other use for. It is cleared by the
+    // same line as the three above, so what is unheld here is one map's membership in a four-line
+    // helper rather than a behaviour of its own. Said plainly instead of asserted vacuously.
+
+    agent.close(); browser.close(); stream.close(); replacement.close()
+  })
+
+  it('forgets stream state when a session is dropped by the device relist, not the eviction path', async () => {
+    // The *other* new call site. `evictAgentSocket` covers a restarting agent that keeps its identity;
+    // this loop covers a device that turns up under a **different** agent while its old session sits on
+    // a socket that has gone. One line apart in the source and reached by different inputs, so the
+    // mutation that deletes this one survives the test above.
+    const { agent, sessionIds } = await registerAgent('seam-relist-a')
+    const sessionId = sessionIds[0]!
+    const browser = await browserSocket()
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    agent.send(JSON.stringify({ type: 'device:ready', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType(browser, 'device:ready')
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+
+    const maps = server as unknown as Record<string, Map<string, unknown>>
+    expect(maps['idrRequesters']!.has(sessionId), 'the re-join created no entry').toBe(true)
+
+    const closed = new Promise<void>((r) => agent.on('close', () => r()))
+    agent.close()
+    await closed
+    await waitForType(browser, 'session:agent-away')
+
+    // A different name, so the rebind block finds no socket for this identity and nothing is rebound —
+    // the device is then picked up by the relist loop instead.
+    const other = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(other)
+    other.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: 'seam-relist-b',
+      devices: [{ id: 'dev0', name: 'iPhone 0', platform: 'ios', status: 'shutdown' }],
+    }))
+    await waitForType(other, 'agent:registered')
+    await waitForType(browser, 'session:terminated')
+
+    expect(maps['idrRequesters']!.has(sessionId), 'the relist path kept the session\'s stream state')
+      .toBe(false)
+
+    browser.close(); other.close()
   })
 
   it('releases the sessions a socket that also registered a stream was holding', async () => {

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -183,6 +183,30 @@ describe('browser-inbound routing matches the protocol union', () => {
     expect(relaySrc).not.toMatch(/browserSocket\.send\(JSON\.stringify\(msg\)\)/)
   })
 
+  // #557, restated for the door that exists now. The issue asks that `AGENT_MSG_TYPE_LIST` be tied to
+  // `route()`'s forwarding cases rather than to a proxy type — and that list is gone: #444 replaced it
+  // with `directionOf`, derived from the inbound schema maps. Its worked example is already caught, too,
+  // by the first assertion in this file: `session:terminated` lives in `RelayToBrowser` and not in
+  // `AgentToBrowser`, so a forwarding case for it fails there.
+  //
+  // What survives is the property underneath, which nothing states. A forward resolves the session from
+  // the message and sends to *that session's* browser without checking that the sender is that session's
+  // agent — `clipboard:*` is the deliberate exception, bound to `session.agentSocket` with the reason
+  // beside it. The door is what makes that safe, and it is safe only while the two sets are disjoint: a
+  // literal that is **both** browser-sendable and browser-forwardable passes the role gate and is then
+  // injected into another tester's viewer, which acts on it.
+  //
+  // Derived from `BrowserToRelay` rather than from the schema map, and they are the same set by
+  // construction: `_BrowserCovers` and `_BrowserInventsNothing` in `protocol/src/validate/index.ts` make
+  // a divergence a compile error. So this reads the union the door is held to, not a second copy of it.
+  it('no literal is both browser-sendable and browser-forwardable', () => {
+    const sendable = unionMembers(protocolSrc, 'BrowserToRelay')
+    // Anti-vacuity on both operands. `forwarded` is pinned at 22 above; this one has no other pin, and an
+    // empty set would make the intersection empty for the wrong reason.
+    expect(sendable.size).toBeGreaterThanOrEqual(20)
+    expect([...forwarded].filter((t) => sendable.has(t)).sort()).toEqual([])
+  })
+
   it('RelayOrAgentToBrowser is shared by both directions rather than copied', () => {
     const shared = unionMembers(protocolSrc, 'RelayOrAgentToBrowser')
     expect(shared.size).toBe(11)
@@ -283,6 +307,11 @@ describe('browser-inbound routing matches the protocol union', () => {
       'session:terminated': 'reason sessionId',
       'session:agent-away': 'sessionId',
       'session:rebound': 'capabilities sessionId',
+      // Added with the member (#542). The loop below iterates *this map's* keys, so a union member absent
+      // here is field-checked by nothing — and `message` turning optional would then pass the whole suite,
+      // leaving a diagnosis with no cause, which is the failure #542 was opened for wearing a fix's
+      // clothes. That the map is not held to the union is its own gap, tracked separately.
+      'device:shutdown-error': 'message requestId? sessionId',
       error: 'message reason sessionId',
     },
   }

--- a/scripts/__tests__/inboundDisposition.test.mjs
+++ b/scripts/__tests__/inboundDisposition.test.mjs
@@ -61,10 +61,11 @@ function entries(src) {
 const table_entries = entries(table)
 
 describe('inbound disposition', () => {
-  it('parsed every entry — 28, the browser-inbound surface', () => {
+  it('parsed every entry — 29, the browser-inbound surface', () => {
     // The compiler already refuses a missing key, so this is not the coverage assertion; it is the
     // parser's own honesty check. Without it the two assertions below pass on an empty map.
-    expect(table_entries.size).toBe(28)
+    // 29 as of #542: `device:shutdown-error` gave the shutdown pair the failure member it lacked.
+    expect(table_entries.size).toBe(29)
   })
 
   it('every entry is exactly one of at / ignored', () => {

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -168,8 +168,9 @@ describe('protocol message interfaces', () => {
     // derived so that a parser that stops matching says so, instead of reporting full coverage of
     // nothing. L2 shipped that exact failure in the other direction. 58 is 57 from L1's conversion plus
     // `InputKey`, which was already named and is a message like any other. L4a added the seven agent→relay
-    // messages, the last direction that had none.
-    expect(messages.size).toBe(65)
+    // messages, the last direction that had none. 66 is `DeviceShutdownError`, #542 — the shutdown pair had
+    // no failure member, so an undeliverable shutdown had nothing to be answered with.
+    expect(messages.size).toBe(66)
     // `InputKey` predates L1 and has always been named; it must be in here too.
     expect(messages.has('InputKey')).toBe(true)
   })
@@ -280,12 +281,17 @@ describe('protocol message interfaces', () => {
       if (base !== 'SessionScoped') offenders.push(`${name} ('${literal}')`)
     }
     expect(offenders).toEqual([])
-    expect([...messages].filter(([, m]) => m.extends === 'SessionScoped')).toHaveLength(9)
+    expect([...messages].filter(([, m]) => m.extends === 'SessionScoped')).toHaveLength(10)
     // `error` is the ninth, as of L5d. Pinned by name rather than only by the count, because the count alone
     // would be satisfied by any new member and this is the one whose membership was argued.
     expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: 'SessionScoped' })
+    // `device:shutdown-error` is the tenth (#542), and it reached the family through the predicate above
+    // rather than by being added to a list — it ends in `error`, it is not request-scoped, and it names a
+    // session. Pinned by name for the same reason as `error`: a count alone cannot say *which* member.
+    expect(messages.get('DeviceShutdownError'))
+      .toMatchObject({ literal: 'device:shutdown-error', extends: 'SessionScoped' })
     // #491 moved `message` off the base onto each member that requires it, so the family relation is no
-    // longer implied by the shared pair — the `extends` is the only thing left saying these nine are one
+    // longer implied by the shared pair — the `extends` is the only thing left saying these ten are one
     // kind. That makes this assertion load-bearing in a way it was not when the base carried two fields.
     for (const [name, { body, extends: base }] of messages) {
       if (base !== 'SessionScoped' || name === 'InputError') continue


### PR DESCRIPTION
## Summary

Three defects with one subject — **who holds a session** — and deliberately not the question that sounds like their root. *Who should be allowed to* is #527 and #507's second item, both still open, and both need a definition of owner that survives a reconnect.

- **#515** a socket re-joining a session it already holds was answered `session-not-found`, and the viewer reads that reason as the agent having disconnected. A re-join is idempotent now.
- **#507** the reverse index held one session per socket while the relation is one-to-many. **The issue's own diagnosis was wrong**, and the release-on-join it implies is a regression — `mcp-server` runs a single socket and joins per device.
- **#542** `device:shutdown` was the only browser command the relay never answered when it could not dispatch it. `reachableTarget` is `dispatchTarget` minus the ownership clause, which is the seam #527 closes in one line.
- **#557** its premise is stale — `AGENT_MSG_TYPE_LIST` was replaced by `directionOf` in #444, and the issue's worked example is already caught. The property underneath is now a check.

Reasoning is beside the code; the release note is in `.changeset/relay-session-ownership-seam.md`.

## Checklist

- [x] Tests written and passing — 2608 across the monorepo, 37 mutations run and 37 caught
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a, the wire contract is `@tapflowio/protocol` and it goes first here
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- Plan: `.work/2026-08-16-relay-session-ownership-seam-plan.md`
- Review: `.work/reviews/feat__relay-session-ownership-seam.md` — four independent channels (two over the design before any code, two over the diff), pinned to `7ad6343656e546cb6d6de022f39b6dea05cca184`

The design pass is what makes this diff the shape it is: two lenses independently found that the fix #507 implies would break `mcp-server`, so the plan was redone rather than patched. Three tests turned out to be vacuous under mutation, one of them a guard I had reported as untestable.

Split out rather than deferred quietly: #567 · #568 · #569 · #570.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear, correlated error responses when device shutdown requests cannot be delivered.
  * Shutdown failures now include session-aware details in the MCP interface and dashboard notifications.
  * Sessions can rejoin after browser reconnection, with cached state replayed.
  * Disconnected browser connections release all held sessions with individual timeout handling.

* **Bug Fixes**
  * Prevented shutdown requests after refused or terminated session joins.
  * Improved cleanup and handling of multiple sessions on one browser connection.
  * Shutdown errors now clear pending dashboard states and display useful notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->