### PR TITLE
A session belongs to a client, and occupancy is judged by liveness

### DIFF
--- a/.changeset/relay-session-ownership-seam.md
+++ b/.changeset/relay-session-ownership-seam.md
@@ -7,8 +7,8 @@
 Answer a shutdown the relay cannot deliver, release every session a closing socket held, and let a viewer re-join a session it already holds
 
 Three defects that share a subject — who holds a session — and none of which needed the question that
-sounds like their root. That one is *who should be allowed to*, and it is answered in this same release — see the note titled "A
-session belongs to whoever opened it". It could not be answered in this slice because the dashboard's four
+sounds like their root. The root question — **who should be allowed to drive a session** — is answered in this same release; see
+the note titled "A session belongs to whoever opened it". It could not be answered in this slice because the dashboard's four
 senders per tab are four connections, and a socket-shaped owner refuses the tab's own teardown.
 
 What a user can observe:

--- a/.changeset/relay-session-ownership-seam.md
+++ b/.changeset/relay-session-ownership-seam.md
@@ -7,9 +7,9 @@
 Answer a shutdown the relay cannot deliver, release every session a closing socket held, and let a viewer re-join a session it already holds
 
 Three defects that share a subject — who holds a session — and none of which needed the question that
-sounds like their root. That one is *who should be allowed to*, and it is open: `device:shutdown` still
-has no ownership check, because three of the dashboard's four senders come from a socket that never
-joins the session and gating it there would break going back and the unmount teardown.
+sounds like their root. That one is *who should be allowed to*, and it is answered in this same release — see the note titled "A
+session belongs to whoever opened it". It could not be answered in this slice because the dashboard's four
+senders per tab are four connections, and a socket-shaped owner refuses the tab's own teardown.
 
 What a user can observe:
 

--- a/.changeset/session-owner-is-a-tab.md
+++ b/.changeset/session-owner-is-a-tab.md
@@ -19,8 +19,8 @@ What a user can observe:
 - **A Wi-Fi blip no longer costs you your session.** The relay treated a connection as present until TCP
   or a heartbeat noticed otherwise, up to a minute after a laptop went to sleep. Returning within that
   window meant being told the device was in use — by yourself. The tab is now recognised as the same tab, and the
-  session is simply resumed — unless you reload while the connection is down, which makes a new tab and
-  waits out the window.
+  session is simply resumed — unless you reload while the connection is down, which gives the page a new
+  identity even though it is the same tab, and waits out the window.
 - **A device whose tester's connection died frees up in at most 45 seconds** rather than up to a minute,
   and no longer appears free while it is still in use. (A tester who leaves a tab open is a different
   case — that is the idle timer's, not this.) Both questions — "can I take this?" and the "In use" badge — now read the same signal, and
@@ -29,10 +29,11 @@ What a user can observe:
 
 The relay reads an optional `client` parameter on the WebSocket handshake and pairs it with the signed-in
 user, so a leaked identifier is useless to anyone else's account. A connection that sends none is given one
-of its own, which is per-connection ownership — what it had before — and the shutdown check is skipped
-entirely for such a client, because every one of its connections is a stranger to the others and gating
-them would refuse that client's own cleanup. So an older dashboard build keeps today's behaviour on both
-counts.
+of its own, which is per-connection ownership — what it had before. The shutdown check is then relaxed for
+that session, because every one of such a client's connections is a stranger to the others and gating them
+would refuse the client's own cleanup — **but only for the same signed-in user**, so an older build never
+becomes a way to power off someone else's device. Whether an identity was claimed or granted is recorded by
+the relay, not read back out of the identifier, which the caller supplies.
 
 The dashboard sends one value per open page. Deliberately not stored: browsers copy that storage into a tab
 opened from another one, and two tabs sharing an identity would take each other's devices silently.

--- a/.changeset/session-owner-is-a-tab.md
+++ b/.changeset/session-owner-is-a-tab.md
@@ -1,0 +1,38 @@
+---
+'@tapflowio/relay': minor
+'@tapflowio/mcp-server': patch
+'@tapflowio/flow-runner': patch
+---
+
+A session belongs to whoever opened it, not to one of their connections
+
+Two defects met on the same two lines, and both came from the relay answering "who holds this session?"
+with a socket.
+
+What a user can observe:
+
+- **Nobody else can power off a device you are using.** Any signed-in client that knew a session id could
+  shut down a colleague's simulator mid-test. The check that stops it could not be added before, because
+  the browser tab that holds a session and the one that sends the shutdown when you navigate away are
+  different connections — so refusing "not the holder" would have refused the tab's own cleanup and left
+  devices running.
+- **A Wi-Fi blip no longer costs you your session.** The relay treated a connection as present until TCP
+  or a heartbeat noticed otherwise, up to a minute after a laptop went to sleep. Returning within that
+  window meant being told the device was in use — by yourself. The tab is now recognised as the same tab, and the
+  session is simply resumed — unless you reload while the connection is down, which makes a new tab and
+  waits out the window.
+- **A device whose tester's connection died frees up in at most 45 seconds** rather than up to a minute,
+  and no longer appears free while it is still in use. (A tester who leaves a tab open is a different
+  case — that is the idle timer's, not this.) Both questions — "can I take this?" and the "In use" badge — now read the same signal, and
+  that signal is when the holder last answered rather than a flag that read every healthy connection as
+  gone for the length of a round trip.
+
+The relay reads an optional `client` parameter on the WebSocket handshake and pairs it with the signed-in
+user, so a leaked identifier is useless to anyone else's account. A connection that sends none is given one
+of its own, which is per-connection ownership — what it had before — and the shutdown check is skipped
+entirely for such a client, because every one of its connections is a stranger to the others and gating
+them would refuse that client's own cleanup. So an older dashboard build keeps today's behaviour on both
+counts.
+
+The dashboard sends one value per open page. Deliberately not stored: browsers copy that storage into a tab
+opened from another one, and two tabs sharing an identity would take each other's devices silently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nobody else can power off a device you are using.** Any signed-in client that knew a session id could
+  shut down a colleague's simulator mid-test. The check that stops it could not be added before: the
+  browser tab that holds a session and the one that sends the shutdown when you navigate away are
+  different connections, so refusing "not the holder" would have refused the tab's own cleanup and left
+  devices running. A session now belongs to whoever opened it rather than to one of their connections.
+- **A Wi-Fi blip no longer costs you your session.** The relay treated a connection as present until TCP
+  or a heartbeat noticed otherwise — up to a minute after a laptop went to sleep — so returning inside
+  that window meant being told the device was in use, by yourself. A device whose tester's connection
+  died — a sleeping laptop, a dropped network — frees up in at most 45 seconds rather than up to a minute,
+  and no longer shows as free while it is still in use: "can I take this?" and the
+  "In use" badge read the same signal now.
 - **A refused `connect_device` says which of the three refusals it was.** It reported the relay's prose
   alone, so "the device is open in another browser session" and "this Mac is over its resource ceiling"
   arrived as sentences a model had to guess at rather than the closed reason it can act on. A failed

--- a/packages/dashboard/hooks/useRelay.ts
+++ b/packages/dashboard/hooks/useRelay.ts
@@ -1,10 +1,43 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { BrowserInbound } from '@/lib/types'
 import type { BrowserToRelay } from '@tapflowio/protocol'
+import { newRequestId } from '@/lib/requestId'
 
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
 const RELAY_URL = import.meta.env.VITE_RELAY_URL ?? `${wsProtocol}//${location.host}`
 const RECONNECT_DELAY = 2000
+
+/**
+ * Who this tab is, for the relay's ownership check. One value for the whole document, so the four sockets
+ * this app opens (`SessionList`, `DeviceViewer`, `useAgentSession`, `MacResources`) are one holder — which
+ * is what lets the unmount teardown shut down a device the viewer's socket was holding.
+ *
+ * **In memory, deliberately not `sessionStorage`.** That store is *copied* into a tab opened from this one
+ * — duplicate tab, ⌘-click on a same-origin link, session restore — so two tabs would share an identity
+ * and the second would silently take the first's device. A per-document value has no such twin: a new
+ * document is a new tab is a new identity.
+ *
+ * It survives what it needs to. The reconnect below runs inside this document, so a Wi-Fi blip returns as
+ * the same client and re-joins its own session instead of waiting out the relay's occupancy window. A
+ * *reload* is a new document and a new identity, which is correct for a duplicate and costs a reloading
+ * tester nothing in the ordinary case — the socket closes cleanly, so the relay releases the session. The
+ * exception is a reload *during* a blip: no clean close, new identity, so the relay's window applies.
+ *
+ * **`newRequestId`, not `crypto.randomUUID`.** The latter is secure-context only and a LAN deployment is
+ * plain HTTP — the primary manual-testing path. This module is loaded by every route, so a throw here is
+ * a blank page rather than a broken socket, and it would have looked correct in dev (localhost is a secure
+ * context) and in vitest (jsdom is not a browser). `lib/requestId.ts` records this exact lesson from the
+ * last time; this is the third caller it warned about.
+ */
+const CLIENT_ID = newRequestId()
+
+/** `RELAY_URL` is operator-supplied and may already carry a path or query, so this is built rather than
+ *  concatenated. */
+function relayUrl(): string {
+  const url = new URL(RELAY_URL)
+  url.searchParams.set('client', CLIENT_ID)
+  return url.toString()
+}
 
 export function useRelay(
   onMessage: (msg: BrowserInbound) => void,
@@ -30,7 +63,7 @@ export function useRelay(
     const connect = () => {
       if (cancelled) return
 
-      const socket = new WebSocket(RELAY_URL)
+      const socket = new WebSocket(relayUrl())
       socket.binaryType = 'arraybuffer'
       ws.current = socket
 

--- a/packages/dashboard/lib/requestId.ts
+++ b/packages/dashboard/lib/requestId.ts
@@ -10,7 +10,9 @@
  *
  * Lived inside `useClipboardBridge` until the correlation work (L5) gave a second caller — `open-url`,
  * whose reply the viewer toasts. Moved rather than copied, because a second `randomUUID` would have
- * looked correct in every dev environment and thrown only on the deployment tapflow is for.
+ * looked correct in every dev environment and thrown only on the deployment tapflow is for. It happened:
+ * the third caller, `useRelay`'s per-document client id, was written as `crypto.randomUUID()` and would
+ * have blanked the whole dashboard over plain HTTP — caught by review, not by a green suite.
  */
 export function newRequestId(): string {
   const b = new Uint8Array(16)

--- a/packages/dashboard/src/pages/QASession.tsx
+++ b/packages/dashboard/src/pages/QASession.tsx
@@ -41,15 +41,20 @@ const SESSION_ENDED_NOTICE: Record<ViewerStoppedReason, { title: string; descrip
     title: 'The agent disconnected — this session ended.',
     description: 'Pick the Mac again to start a new session.',
   },
-  // Deliberately does not say *who*. The relay answers `session-busy` whenever the session's browser
-  // socket still reads OPEN, and the commonest cause is the tester's own previous socket: a sleeping
-  // laptop or a Wi-Fi blip reconnects in 2s while the relay takes up to a heartbeat (30s) to notice the
-  // old one died. Claiming "someone else is testing this" would be false in exactly the case
-  // `DeviceViewer`'s own comment calls routine, and it would send them to look for a colleague who does
-  // not exist. So it names the situation and gives the wait that actually resolves it.
+  // **This copy used to lead with "it is probably your own tab", and that stopped being the common case.**
+  // The relay answered `session-busy` whenever the browser socket still read OPEN, so an automatic
+  // reconnect after a Wi-Fi blip collided with its own predecessor — routine, and the reason the wording
+  // hedged. A session belongs to a client now (#527), and the reconnect runs inside the same document, so
+  // it is recognised and handed back rather than refused.
+  //
+  // What still self-collides is a **reload** during a blip: a new document is a new identity, and the old
+  // socket has not been noticed as gone. So the hedge stays, second rather than first, and names the
+  // window that actually applies — the relay stops treating a holder as present about 45 seconds after it
+  // last answered, not the 30 this used to quote.
   'busy-elsewhere': {
     title: 'This device is already open in another browser session.',
-    description: 'That may be your own tab from before a reconnect — wait about a minute and try again.',
+    description: 'Someone else may be testing it. If you reloaded while your connection was down it is '
+      + 'your own tab, and that clears within about 45 seconds.',
   },
   // The Mac is over its ceiling, so a different Mac is the actionable move — and unlike the other two
   // this one is about the machine, not the session.

--- a/packages/flow-runner/src/RelayClient.ts
+++ b/packages/flow-runner/src/RelayClient.ts
@@ -241,6 +241,9 @@ const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 // the dashboard and mcp-server already use.
 export class RelayClient {
   private ws: WebSocket | null = null
+  /** One identity per process, so a reconnect re-joins its own sessions instead of contending with the
+   *  socket it replaces. Minted here rather than supplied: nothing outside this process shares it. */
+  private readonly clientId = randomUUID()
   private waiters: Waiter[] = []
 
   constructor(
@@ -251,7 +254,10 @@ export class RelayClient {
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       const headers = this.token ? { Authorization: `Bearer ${this.token}` } : undefined
-      const ws = new WebSocket(this.relayUrl, { headers })
+      // One identity for the run — see `mcp-server`'s twin.
+      const url = new URL(this.relayUrl)
+      url.searchParams.set('client', this.clientId)
+      const ws = new WebSocket(url.toString(), { headers })
       ws.once('open', () => {
         this.ws = ws
         resolve()

--- a/packages/flow-runner/src/__tests__/RelayClient.test.ts
+++ b/packages/flow-runner/src/__tests__/RelayClient.test.ts
@@ -847,6 +847,36 @@ describe('RelayClient — session lifecycle (#512, finding 4)', () => {
   }, 15_000)
 })
 
+describe('RelayClient — the socket identifies its client to the relay (#527, #579)', () => {
+  let wss: WebSocketServer | null = null
+  afterEach(async () => {
+    const s = wss
+    wss = null
+    if (!s) return
+    for (const c of s.clients) c.terminate()
+    await new Promise<void>((r) => s.close(() => r()))
+  })
+
+  // The twin of `mcp-server`'s, and here for the same reason: the ownership change touched this file and
+  // no test in this package, so removing the parameter would be silent.
+  it('sends a stable client id on the handshake, and the same one after a reconnect', async () => {
+    const seen: string[] = []
+    wss = new WebSocketServer({ port: 0 })
+    wss.on('connection', (_ws, req) => {
+      seen.push(new URL(req.url ?? '/', 'http://x').searchParams.get('client') ?? '')
+    })
+    const port = (wss.address() as { port: number }).port
+    const client = new RelayClient(`ws://localhost:${port}`, '')
+    await client.connect()
+    await client.connect()
+    client.disconnect()
+
+    expect(seen).toHaveLength(2)
+    expect(seen[0], 'no client id was sent').not.toBe('')
+    expect(seen[1], 'a reconnect introduced itself as a different client').toBe(seen[0])
+  })
+})
+
 describe('RelayClient — leaving a session settles what was waiting on it (#514)', () => {
   let wss: WebSocketServer | null = null
 

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -1274,6 +1274,32 @@ describe('REASON_ADVICE', () => {
   })
 })
 
+describe('the socket identifies its client to the relay (#527, #579)', () => {
+  // **Nothing else holds this.** The diff that added ownership changed no test in this package, so
+  // deleting the `client` parameter — or minting it per `connect()` instead of per instance — passes the
+  // whole suite while costing this client the half of the change it is the beneficiary of: a reconnect
+  // that re-joins its own sessions rather than contending with the socket it is replacing.
+  it('sends a stable client id on the handshake, and the same one after a reconnect', async () => {
+    const relay = createMockRelay()
+    const seen: string[] = []
+    relay.wss.on('connection', (_ws, req) => {
+      seen.push(new URL(req.url ?? '/', 'http://x').searchParams.get('client') ?? '')
+    })
+    const client = new TapflowClient(`ws://localhost:${relay.port}`, '')
+    await client.connect()
+    // Disconnect between the two, which is what a reconnect is — and what keeps the first socket from
+    // outliving the mock relay's `close()`, which waits on its clients.
+    client.disconnect()
+    await client.connect()
+    client.disconnect()
+    await relay.close()
+
+    expect(seen).toHaveLength(2)
+    expect(seen[0], 'no client id was sent').not.toBe('')
+    expect(seen[1], 'a reconnect introduced itself as a different client').toBe(seen[0])
+  })
+})
+
 describe('disconnect_device settles what was waiting on the session (#514)', () => {
   let relay: ReturnType<typeof createMockRelay>
   let client: TapflowClient

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -213,6 +213,9 @@ export function reasonAdvice(reason: string | undefined): string {
 
 export class TapflowClient {
   private ws: WebSocket | null = null
+  /** One identity per process, so a reconnect re-joins its own sessions instead of contending with the
+   *  socket it replaces. Minted here rather than supplied: nothing outside this process shares it. */
+  private readonly clientId = randomUUID()
   private waiters: Waiter[] = []
   /** Sessions that have answered at least one input **in a form this client's waiter can match**.
    *
@@ -283,7 +286,17 @@ export class TapflowClient {
 
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(this.relayUrl)
+      // One identity for the process, so a reconnect re-joins its own sessions rather than contending
+      // with the socket it is replacing. The relay mints one per connection when this is absent, which is
+      // the same behaviour a socket had before ownership moved off it.
+      //
+      // **This socket carries no `Authorization`** — the token is REST-only here — so the relay pairs the
+      // claim with no user and the owner key is `anon:<clientId>`. The user half of its forgery protection
+      // does not apply to this client; what protects the id is that it never leaves this process except in
+      // its own handshake.
+      const url = new URL(this.relayUrl)
+      url.searchParams.set('client', this.clientId)
+      const ws = new WebSocket(url.toString())
       ws.once('open', () => {
         this.ws = ws
         resolve()

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -285,10 +285,11 @@ another tester was looking at, and the reply routed to that session's browser ra
 
 Every branch that can take the check now has it: the five acked inputs, `device:boot`, `open-url`,
 `app:install`, `app:launch`, `app:clear-state`, `clipboard:read`, `clipboard:write`, `session:leave`,
-`session:end`. **`device:shutdown` is the exception to the *ownership* clause**, and the blocker is in the
-dashboard rather than the relay — three of its four senders never join the session. #527. It is no longer an
-exception to being *answered*: #542 gave the pair a failure member and the relay routes the command through
-the same resolver minus that one clause.
+`session:end`. **`device:shutdown` takes a weaker gate than the ownership clause** (#527): refused when
+another client holds the session, permitted when nobody does — because the dashboard's unmount teardown
+races its own viewer socket's close on a different connection, and an owns-it gate would refuse the very
+teardown that stops a device costing money. It is no longer an exception to being *answered* either: #542
+gave the pair a failure member.
 
 A refusal is **answered where a waiter exists** and dropped where none does — with `device:shutdown-error`
 as the deliberate loosening, answered to the sender whether or not one is waiting. The relay cannot tell
@@ -431,8 +432,8 @@ written to catch. Two numbers stood in this paragraph before that — seven repl
 door predicates, then eleven reads — and each outlived its own basis, which is why there is no count
 here now.
 
-`device:shutdown` is still on the request side with no **ownership** gate (#527); that is a different
-question from addressing and the parse does not answer it. The declaration was nevertheless right to
+`device:shutdown` carries its own gate as of #527 — "not someone else's" rather than "mine"; that is still
+a different question from addressing, and the parse does not answer it. The declaration was nevertheless right to
 stay required rather than be widened:
 
 - Every in-repo sender does supply one. `BrowserToRelay` declares `sessionId: string` on every member

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -73,14 +73,14 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   The eleven `input:*` cases are **two clauses**, split by whether an ack answers them, and the split is
   load-bearing rather than tidy — the correlator gate belongs on the answered five, and written into the
   shared body it would have dropped every opening and move frame with it.
-- **A browser-role command is acted on only from the socket the session is bound to.** The mirror of the
+- **A browser-role command is acted on only from the client the session is bound to** — one client's several sockets are one holder, which is what a browser tab needs and what a socket could not express. The mirror of the
   clipboard rule above, and it was missing until L5c on **every** branch: the relay resolved the session and
   forwarded without asking who was asking, so any authenticated client that knew a session id could drive a
   device another tester was looking at — `clipboard:write` pasting its text into that device,
   `clipboard:read` pressing copy or cut on it with the payload landing on *that* tester's host OS clipboard,
   `session:end` deleting their session. The reply then routed to the session's own browser, never to the
   injector.
-  `dispatchTarget` decides it once for all of them — session exists, **this socket holds it**, agent
+  `dispatchTarget` decides it once for all of them — session exists, **this client owns it**, agent
   connected — and each case wraps the prose it returns in the reply type its own waiter reads. The two
   ownership strings are one reason with different prose (`ownershipRefusal`), the treatment #492 settled:
   telling a caller the session is in use when it is idle steers it off a device it could have had.
@@ -89,11 +89,17 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   has never acked as *success*, so a silent refusal would report a command that never left the relay as
   having landed. `session:leave` and `session:end` are dropped, because neither has a reply and inventing
   one would grow the wire for a message no consumer reads.
-  **`device:shutdown` is the one exception to the *ownership* clause, and the blocker is not here** — three
-  of the dashboard's four senders come from `useAgentSession`, whose socket never joins, so the gate would
-  break going back and the unmount teardown. `SessionList` joins before shutting down and documents why, so
-  the dashboard already carries two conventions for this message. Tracked in #527; the question there is
-  whether `useAgentSession` should join, not whether the relay should check.
+  **A session is owned by a *client*, not by a socket** (#527). The owner is `<userId>:<clientId>`, taken
+  from the `?client=` query parameter at the handshake and minted per connection when absent — so there is
+  no fallback branch, and a caller that identifies itself gets an identity spanning its sockets while one
+  that does not gets the per-socket identity ownership used to have. The dashboard sends one value per
+  *document*, deliberately not `sessionStorage`: that store is copied into a tab opened from another, and
+  two tabs sharing an identity would silently take each other's devices.
+  **`device:shutdown` has its own, weaker gate** — refused when another client holds the session, permitted
+  when nobody does. Not "owned by me", because the unmount teardown races its own viewer socket's close on
+  a different connection: if the close lands first the session is unheld, and an owns-it gate would refuse
+  the very teardown that stops a device costing money. The residual surface — a device between owners — is
+  the price, and it is unchanged from before, when this command had no gate at all.
   It is **not** an exception to being answered, and used to be both. `reachableTarget` is `dispatchTarget`
   minus the ownership clause, so the other two refusals — no such session, agent gone — come back as
   `device:shutdown-error` instead of the silence that burned `shutdownDevice`'s 30s deadline with no cause
@@ -108,7 +114,8 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
 - Serves the `public/` directory as HTTP static files (dashboard build output).
 - The relay does not buffer stream data — it forwards immediately on arrival.
 - WebSocket upgrade requests and regular HTTP requests are split on the same port.
-- A heartbeat (`runHeartbeat`, every `HEARTBEAT_MS`=30s) pings every socket (agent/browser/stream); one missed pong window → `ws.terminate()`, which fires the existing `close` cleanup — detects dead sockets without waiting for TCP timeout.
+- A heartbeat (`runHeartbeat`, every `HEARTBEAT_MS`=30s) pings every socket (agent/browser/stream); a socket that has not answered for 1.5 intervals → `ws.terminate()`, which fires the existing `close` cleanup — detects dead sockets without waiting for TCP timeout.
+  **Liveness is a pong timestamp, not a swept flag**, and the difference matters beyond termination. The flag was set `false` for every socket at the start of a sweep and back to `true` when the pong returned, so a healthy socket read as dead for a whole round trip — harmless while it only decided termination, and not once session occupancy and `busy` read it. The window was longest for the holder: video goes out on that socket and the ping is queued behind it. Occupancy and `busy` take the same predicate; two that disagreed would show a device as free while a join for it was refused (#579).
 
 ### API Endpoints (builds / apps)
 

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -100,6 +100,12 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   a different connection: if the close lands first the session is unheld, and an owns-it gate would refuse
   the very teardown that stops a device costing money. The residual surface — a device between owners — is
   the price, and it is unchanged from before, when this command had no gate at all.
+  A session held by a client that identified itself with **nothing** relaxes the gate further, since each
+  of that client's connections was granted a separate identity and none of them can pass an ownership
+  test — **but only for the same signed-in user**, so a build predating the parameter never becomes a way
+  to power off a colleague's device. Whether an identity was *claimed* or *granted* is a field on the
+  session: a first version recovered it from the identifier, which the caller supplies, so claiming one
+  that looked granted handed the caller its own exemption.
   It is **not** an exception to being answered, and used to be both. `reachableTarget` is `dispatchTarget`
   minus the ownership clause, so the other two refusals — no such session, agent gone — come back as
   `device:shutdown-error` instead of the silence that burned `shutdownDevice`'s 30s deadline with no cause

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -136,16 +136,20 @@ function ownershipRefusal(session: Session): string {
  * Exported for the test that holds the pairing. Inline in the handler it was unreachable without standing
  * up an authenticated handshake, and a mutation dropping the user id survived the whole suite.
  */
-export function ownerKeyFor(userId: number | string | undefined, claimed: string | null): string {
-  // The mint is prefixed so the relay can tell an identity a client *claimed* from one it was *given*.
-  // That distinction is what keeps the shutdown gate from breaking a client that predates it: a minted
-  // owner is per-socket, so gating on it would refuse a multi-socket client's own teardown — every time,
-  // not as a race. See `mayShutDown`.
-  return `${userId ?? 'anon'}:${claimed || `${MINTED_PREFIX}${randomUUID()}`}`
+export function ownerKeyFor(
+  userId: number | string | undefined,
+  claimed: string | null,
+): { key: string; user: string; minted: boolean } {
+  const user = String(userId ?? 'anon')
+  // **Mintedness is a separate field, not a marker inside the key.** A first version prefixed the mint
+  // with `minted-` and had `mayShutDown` recover the fact with `includes(':minted-')` — which the client
+  // controls, because `claimed` comes straight off the handshake query and is never validated. Connecting
+  // as `?client=minted-1` produced `anon:minted-1` and silently disabled the shutdown gate for that
+  // holder; `?client=x:minted-y` did it while keeping a real user id, so a *different* user could then
+  // power the device off. Encoding a security-relevant fact in a caller-supplied string is the forgery
+  // this whole key was introduced to avoid, reintroduced one layer down.
+  return { key: `${user}:${claimed || randomUUID()}`, user, minted: !claimed }
 }
-
-/** Marks an owner key the relay generated because the connection claimed none. */
-const MINTED_PREFIX = 'minted-'
 
 /** One line per rejecting socket per second, at most. See `RelayServer.logInboundRejection`. */
 const REJECT_LOG_INTERVAL_MS = 1_000
@@ -219,7 +223,7 @@ export class RelayServer {
    * There is deliberately no fallback branch: one model, and a client that does not identify itself gets an
    * identity that happens to be per-socket, which is exactly today's behaviour.
    */
-  private ownerKey = new WeakMap<WebSocket, string>()
+  private ownerKey = new WeakMap<WebSocket, { key: string; user: string; minted: boolean }>()
   private dropHandlers = new Map<string, () => void>()
   // Per-session throttled drop-warn for audio (kept separate so audio drops don't mask video drops in logs).
   private audioDropHandlers = new Map<string, () => void>()
@@ -602,6 +606,7 @@ export class RelayServer {
     // processes on the same PAT are the same principal, which is right; two on different PATs are not,
     // which is what this restores. `pat` is already resolved above and was being discarded.
     this.ownerKey.set(ws, ownerKeyFor(getAuth(request)?.userId ?? pat?.userId, claimed))
+
     // Heartbeat liveness: a fresh socket counts as having just answered, and each pong renews it.
     this.lastPongAt.set(ws, Date.now())
     ws.on('pong', () => this.lastPongAt.set(ws, Date.now()))
@@ -1478,7 +1483,7 @@ export class RelayServer {
       }
     }
     try {
-      const joined = this.sessions.join(msg.sessionId, ws, this.ownerOf(ws), (h) => this.isAlive(h))
+      const joined = this.sessions.join(msg.sessionId, ws, this.ownerRecord(ws), (h) => this.isAlive(h))
       if (!joined.ok) {
         // Both of these are answered above, so arriving here means the state moved between that check and
         // this call. They are **values now rather than throws** (#515), and that is what fixes the defect:
@@ -1634,7 +1639,17 @@ export class RelayServer {
   /** Which owner this socket speaks for. Every connection has one — supplied or minted — so this never
    *  answers `undefined` and two anonymous sockets can never match by both lacking an identity. */
   private ownerOf(ws: WebSocket): string {
-    return this.ownerKey.get(ws) ?? 'unidentified'
+    return this.ownerKey.get(ws)?.key ?? 'unidentified'
+  }
+
+  /** The principal behind a socket — a user id, or `anon` for a connection carrying no cookie and no PAT. */
+  private userOf(ws: WebSocket): string {
+    return this.ownerKey.get(ws)?.user ?? 'unidentified'
+  }
+
+  /** Everything the bind needs to record about who is joining. */
+  private ownerRecord(ws: WebSocket): { key: string; user: string; minted: boolean } {
+    return this.ownerKey.get(ws) ?? { key: 'unidentified', user: 'unidentified', minted: false }
   }
 
   /**
@@ -1659,9 +1674,12 @@ export class RelayServer {
     // upgraded relay is exactly that, and refusing it would leave a device booted until the idle timer on
     // every Back press: the cost #527 was filed to avoid, reintroduced by #527's fix.
     //
-    // So the gate holds between clients that say who they are, and everyone else keeps the behaviour this
-    // command had before it existed — which is what the release note promises.
-    return session.owner.includes(`:${MINTED_PREFIX}`)
+    // **Scoped to the same principal, though.** The exemption exists so a legacy client's own teardown
+    // works, and its own teardown is by definition the same signed-in user — so extending it across users
+    // buys nothing and would leave one tester able to power off another's device for as long as anyone is
+    // running an older build. That is unchanged from before this gate existed, but "unchanged" is not a
+    // reason to carry it forward when the narrower rule costs one comparison.
+    return session.ownerMinted && session.ownerUser === this.userOf(ws)
   }
 
   /** Input that no ack answers: opening and move frames, rotation, the keyboard-forwarding toggle.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -1639,17 +1639,32 @@ export class RelayServer {
   /** Which owner this socket speaks for. Every connection has one — supplied or minted — so this never
    *  answers `undefined` and two anonymous sockets can never match by both lacking an identity. */
   private ownerOf(ws: WebSocket): string {
-    return this.ownerKey.get(ws)?.key ?? 'unidentified'
+    return this.ownerRecord(ws).key
   }
 
   /** The principal behind a socket — a user id, or `anon` for a connection carrying no cookie and no PAT. */
   private userOf(ws: WebSocket): string {
-    return this.ownerKey.get(ws)?.user ?? 'unidentified'
+    return this.ownerRecord(ws).user
   }
 
-  /** Everything the bind needs to record about who is joining. */
+  /** Everything the bind needs to record about who is joining.
+   *
+   *  **A socket with no record gets one of its own rather than a shared sentinel.** `handleConnection`
+   *  seeds every accepted connection before a message can arrive, so the fallback is unreachable today —
+   *  but a literal would make any two unseeded sockets *equal*, and equal keys pass `ownsSession` while
+   *  equal users pass `mayShutDown`'s same-principal exemption. That rests the whole ownership invariant
+   *  on one call site staying total, which is the shape of dependency the sentinel is supposed to remove.
+   *  Minting keeps the answer "this socket and no other"; storing it keeps repeat calls consistent, since
+   *  a fresh value each time would fail to recognise the very socket that bound the session. `minted` is
+   *  `false` deliberately — the legacy exemption exists for a client that identified itself with nothing,
+   *  not for one the relay failed to record. */
   private ownerRecord(ws: WebSocket): { key: string; user: string; minted: boolean } {
-    return this.ownerKey.get(ws) ?? { key: 'unidentified', user: 'unidentified', minted: false }
+    const known = this.ownerKey.get(ws)
+    if (known) return known
+    const unseeded = `unidentified:${randomUUID()}`
+    const record = { key: unseeded, user: unseeded, minted: false }
+    this.ownerKey.set(ws, record)
+    return record
   }
 
   /**

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -122,6 +122,31 @@ function ownershipRefusal(session: Session): string {
   return session.browserSocket ? 'session held by another client' : 'session not joined'
 }
 
+/**
+ * The owner key a connection speaks for, from the authenticated user and the client id it claimed.
+ *
+ * **Both halves, and a pure function so both can be tested.** The user id is what keeps a leaked client id
+ * useless to anyone else — without it this would be the relay's first ownership claim a caller can forge,
+ * where socket identity could not be. It comes from the cookie *or* the PAT: reading only the cookie would
+ * have made every agent and every non-browser client `anon:`, which is the population most likely to have
+ * its handshake URL end up in a reverse proxy's access log. The mint is what removes the fallback branch: a connection that
+ * claims nothing gets an identity of its own, which is per-socket, which is the behaviour ownership had
+ * before it moved off the socket.
+ *
+ * Exported for the test that holds the pairing. Inline in the handler it was unreachable without standing
+ * up an authenticated handshake, and a mutation dropping the user id survived the whole suite.
+ */
+export function ownerKeyFor(userId: number | string | undefined, claimed: string | null): string {
+  // The mint is prefixed so the relay can tell an identity a client *claimed* from one it was *given*.
+  // That distinction is what keeps the shutdown gate from breaking a client that predates it: a minted
+  // owner is per-socket, so gating on it would refuse a multi-socket client's own teardown — every time,
+  // not as a race. See `mayShutDown`.
+  return `${userId ?? 'anon'}:${claimed || `${MINTED_PREFIX}${randomUUID()}`}`
+}
+
+/** Marks an owner key the relay generated because the connection claimed none. */
+const MINTED_PREFIX = 'minted-'
+
 /** One line per rejecting socket per second, at most. See `RelayServer.logInboundRejection`. */
 const REJECT_LOG_INTERVAL_MS = 1_000
 
@@ -165,8 +190,36 @@ export class RelayServer {
   private purgeBuildsTimer: ReturnType<typeof setInterval> | null = null
   private flushResourcesTimer: ReturnType<typeof setInterval> | null = null
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
-  // Liveness per socket for the heartbeat sweep. WeakMap → no manual cleanup on close (GC handles it).
-  private wsAlive = new WeakMap<WebSocket, boolean>()
+  /**
+   * When each socket last answered a ping. WeakMap → no manual cleanup on close (GC handles it).
+   *
+   * **A timestamp, not the swept boolean it replaced.** That flag was set `false` for *every* socket at the
+   * start of each sweep and back to `true` only when the pong returned, so a perfectly healthy socket read
+   * as dead for the whole round trip — a normal state on a 30s cycle rather than an edge case. And the
+   * window is longest for exactly the socket that matters: video goes out on `browserSocket`, and the ping
+   * is written behind whatever is already queued there, so an external viewer's pong can take a second or
+   * two.
+   *
+   * That was invisible while the flag only decided termination, because a sweep that finds `false` has by
+   * definition already waited a full interval. Reading it to answer *"is this holder alive right now"* is
+   * what exposes it: occupancy would hand a live tester's session away, and `busy` would flash a device as
+   * free every 30 seconds — the dashboard polls every 5s and `disabled={isBusy}`, so the UI would open the
+   * button rather than a race being needed.
+   */
+  private lastPongAt = new WeakMap<WebSocket, number>()
+  /**
+   * Who each socket speaks for — `<userId>:<clientId>`, the key a session's ownership is compared against.
+   *
+   * **Two parts, and both are load-bearing.** The client id is supplied by the caller (`?client=`), so on
+   * its own it is the relay's first *forgeable* ownership claim: today's ownership is socket identity,
+   * which nothing can spoof. Binding it to the authenticated user — which `getAuth` already resolves at
+   * the handshake — keeps a leaked id useless to anyone else's account.
+   *
+   * **A connection that supplies no client id is given one**, rather than falling back to socket identity.
+   * There is deliberately no fallback branch: one model, and a client that does not identify itself gets an
+   * identity that happens to be per-socket, which is exactly today's behaviour.
+   */
+  private ownerKey = new WeakMap<WebSocket, string>()
   private dropHandlers = new Map<string, () => void>()
   // Per-session throttled drop-warn for audio (kept separate so audio drops don't mask video drops in logs).
   private audioDropHandlers = new Map<string, () => void>()
@@ -416,10 +469,29 @@ export class RelayServer {
   // Terminate sockets that missed the previous pong; ping the rest. Covers all roles via wss.clients.
   private runHeartbeat(clients: Iterable<WebSocket> = this.wss.clients): void {
     for (const ws of clients) {
-      if (this.wsAlive.get(ws) === false) { ws.terminate(); continue }
-      this.wsAlive.set(ws, false)
+      if (!this.isAlive(ws)) { ws.terminate(); continue }
       if (ws.readyState === WebSocket.OPEN) ws.ping()
     }
+  }
+
+  /**
+   * Has this socket answered recently enough to be treated as present?
+   *
+   * `1.5` intervals rather than one: a pong that arrives *during* a sweep must not be read as late, and a
+   * socket pinged at the end of one interval has until halfway through the next. The cost is that a
+   * genuinely dead socket is recognised in up to 45s instead of 30 — **and 45 seconds with no false
+   * negative beats 30 with one every cycle**, because a false negative here does not merely delay: it
+   * hands a live tester's session to whoever asked next.
+   */
+  private isAlive(ws: WebSocket): boolean {
+    const at = this.lastPongAt.get(ws)
+    // **No entry means just connected, not dead.** `handleConnection` seeds one, but a socket is in
+    // `wss.clients` from the upgrade, so there is a tick where a sweep could see it first — and the flag
+    // this replaced was explicitly safe there ("alive until proven otherwise"). Reading absence as dead
+    // would terminate a connection that had done nothing wrong, and occupancy would read the same absence
+    // as a free session.
+    if (at === undefined) return true
+    return Date.now() - at <= HEARTBEAT_MS * 1.5
   }
 
   // 갱신된 cert를 재시작 없이 핫스왑한다(https 종단일 때만 의미 있음).
@@ -520,9 +592,19 @@ export class RelayServer {
       return
     }
     this.wsExternal.set(ws, isExternalAddress(addr))
-    // Heartbeat liveness: alive until proven otherwise; each pong revives it (see runHeartbeat).
-    this.wsAlive.set(ws, true)
-    ws.on('pong', () => this.wsAlive.set(ws, true))
+    // Read from the upgrade URL because a browser cannot set WebSocket headers, and because it has to be
+    // known **per connection** rather than per join: the dashboard socket that sends the unmount teardown
+    // never joins anything. `new URL` against a dummy base — `request.url` is path-relative.
+    const claimed = new URL(request.url ?? '/', 'http://relay').searchParams.get('client')
+    // **The PAT counts as a principal, and a first version dropped it.** `getAuth` reads the cookie only,
+    // so every agent, `mcp-server` and `flow-runner` connection would have been `anon:` — and the whole
+    // point of pairing the claim with a user is that a leaked client id is useless to anyone else. Two
+    // processes on the same PAT are the same principal, which is right; two on different PATs are not,
+    // which is what this restores. `pat` is already resolved above and was being discarded.
+    this.ownerKey.set(ws, ownerKeyFor(getAuth(request)?.userId ?? pat?.userId, claimed))
+    // Heartbeat liveness: a fresh socket counts as having just answered, and each pong renews it.
+    this.lastPongAt.set(ws, Date.now())
+    ws.on('pong', () => this.lastPongAt.set(ws, Date.now()))
     if (decision.role === 'browser') this.wsRoles.set(ws, 'browser')
     // 'first-message' → role is determined by the first message (agent:register / stream:register)
 
@@ -759,7 +841,10 @@ export class RelayServer {
       case 'ui:tree:response':   this.handleUITreeResponse(msg); break
       case 'ui:tree:error':      this.handleUITreeError(msg); break
       case 'agents:list': {
-        this.sendTo(ws, { type: 'agents:listed', sessions: this.sessions.list() })
+        this.sendTo(ws, {
+          type: 'agents:listed',
+          sessions: this.sessions.list(this.ownerOf(ws), (holder) => this.isAlive(holder)),
+        })
         break
       }
 
@@ -973,6 +1058,16 @@ export class RelayServer {
         // session inline and dropped the frame when it could not, making it the only browser-originated
         // command the relay never answers. `mcp-server`'s `shutdownDevice` waits 30s on `device:shutdown-done`
         // and then reports `Request timed out` with no cause, which is the silence, not a diagnosis.
+        const session = this.sessions.get(msg.sessionId)
+        if (session && !this.mayShutDown(ws, session)) {
+          this.sendTo(ws, {
+            type: 'device:shutdown-error',
+            sessionId: msg.sessionId,
+            ...(msg.requestId === undefined ? {} : { requestId: msg.requestId }),
+            message: ownershipRefusal(session),
+          })
+          break
+        }
         const target = this.reachableTargetWithoutOwnership(msg.sessionId)
         if (!target.ok) {
           // Echoed, and the relay is the producer — the same obligation `device:boot-error` carries and for
@@ -1358,7 +1453,15 @@ export class RelayServer {
     //
     // `!== ws` because a socket re-joining the session it already holds is not contending with anyone:
     // `SessionList` sends `session:start` before a shutdown, so pressing shutdown twice hit this.
-    if (session.browserSocket && session.browserSocket !== ws && session.browserSocket.readyState === WebSocket.OPEN) {
+    // The same three conditions `join()` applies, and they have to agree: this one answers the caller and
+    // that one performs the bind, so a disagreement is a refusal for a session the bind would have allowed.
+    if (
+      session.browserSocket &&
+      session.owner !== null &&
+      session.owner !== this.ownerOf(ws) &&
+      session.browserSocket.readyState === WebSocket.OPEN &&
+      this.isAlive(session.browserSocket)
+    ) {
       this.sendTo(ws, { type: 'error', sessionId: msg.sessionId, message: 'Session busy', reason: 'session-busy' })
       return
     }
@@ -1375,7 +1478,7 @@ export class RelayServer {
       }
     }
     try {
-      const joined = this.sessions.join(msg.sessionId, ws)
+      const joined = this.sessions.join(msg.sessionId, ws, this.ownerOf(ws), (h) => this.isAlive(h))
       if (!joined.ok) {
         // Both of these are answered above, so arriving here means the state moved between that check and
         // this call. They are **values now rather than throws** (#515), and that is what fixes the defect:
@@ -1490,17 +1593,19 @@ export class RelayServer {
    *  resolver a future handler must not pick by accident — it is the general-looking one and the unsafe
    *  one at the same time, which is the pairing worth spelling out.
    *
-   *  **Exists for `device:shutdown` alone, and only until #527.** That command cannot take the ownership
-   *  check yet — three of the dashboard's four senders come from `useAgentSession`, whose socket never
-   *  joins, so gating it would break going back and the unmount teardown, the two paths that stop a device
-   *  costing money when a tester walks away. It still needs the other two, because without them a shutdown
-   *  addressed to a missing session or a closed agent socket was dropped in silence and `mcp-server`'s
-   *  caller burned a 30s deadline for it (#542).
+   *  **Still here after #527, and this paragraph used to say it would not be.** It predicted that
+   *  answering "who may shut a device down" would move `device:shutdown` up to `dispatchTarget`. The
+   *  answer turned out to be a *different* gate rather than that one: `mayShutDown` refuses a session
+   *  another client holds and permits an unheld one, because the dashboard's unmount teardown races its
+   *  own viewer socket's close and an owns-it gate refuses the teardown whenever the close lands first —
+   *  leaving the device booted until the idle timer, which is the cost #527 was filed to avoid.
    *
-   *  So the split is the seam: when #527 answers who may shut a device down, `device:shutdown` moves up to
-   *  `dispatchTarget` and this method goes away. The cost of the seam is that a non-owner now learns
-   *  whether a session id exists and whether its agent is up — recorded rather than waved past, and small
-   *  against what it can already do, which is shut that device down.
+   *  So the two are ordered rather than merged: `mayShutDown` decides *who*, this decides *whether it can
+   *  be delivered at all*, and without the second a shutdown addressed to a missing session or a closed
+   *  agent socket is dropped in silence and `mcp-server`'s caller burns a 30s deadline (#542).
+   *
+   *  The disclosure it was written to record stands: a caller that is not the holder still learns whether
+   *  a session id exists and whether its agent is up.
    */
   private reachableTargetWithoutOwnership(
     sessionId: string,
@@ -1523,7 +1628,40 @@ export class RelayServer {
    *  is deliberate rather than incidental: it makes an input arriving inside the reconnect grace fail fast
    *  instead of being applied to a device with nobody watching the result. */
   private ownsSession(ws: WebSocket, session: Session | undefined): boolean {
-    return session?.browserSocket === ws
+    return session?.owner !== null && session?.owner === this.ownerOf(ws)
+  }
+
+  /** Which owner this socket speaks for. Every connection has one — supplied or minted — so this never
+   *  answers `undefined` and two anonymous sockets can never match by both lacking an identity. */
+  private ownerOf(ws: WebSocket): string {
+    return this.ownerKey.get(ws) ?? 'unidentified'
+  }
+
+  /**
+   * May this socket shut the session's device down?
+   *
+   * **"Not someone else's" rather than "mine", and the difference is the reason #527 stayed open.** The
+   * dashboard's unmount teardown sends `device:shutdown` from one socket while another socket's `close`
+   * races it to the relay — two connections, no ordering — and if the close lands first the session is
+   * unheld. An owns-it gate refuses the teardown there, and the device stays booted until the five-minute
+   * idle timer: the path #527 named as the reason a gate could not be added at all.
+   *
+   * An unheld session therefore stays shutdownable by anyone authenticated, which is unchanged from today
+   * — this command has never had a gate — and is written down rather than implied. What changes is the
+   * case the issue is about: a device another tester is *holding* can no longer be powered off.
+   */
+  private mayShutDown(ws: WebSocket, session: Session | undefined): boolean {
+    if (session?.owner == null) return true
+    if (session.owner === this.ownerOf(ws)) return true
+    // **A holder that never identified itself is not gated**, because it cannot pass a gate: every one of
+    // its sockets was minted a separate identity, so its own teardown socket is a stranger to the socket
+    // holding the session — deterministically, not as a race. An older dashboard bundle re-attaching to an
+    // upgraded relay is exactly that, and refusing it would leave a device booted until the idle timer on
+    // every Back press: the cost #527 was filed to avoid, reintroduced by #527's fix.
+    //
+    // So the gate holds between clients that say who they are, and everyone else keeps the behaviour this
+    // command had before it existed — which is what the release note promises.
+    return session.owner.includes(`:${MINTED_PREFIX}`)
   }
 
   /** Input that no ack answers: opening and move frames, rotation, the keyboard-forwarding toggle.

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -26,6 +26,12 @@ export interface Session {
    * nobody is watching.
    */
   owner: string | null
+  /** Whether that owner is an identity the relay minted because the connection claimed none, and the
+   *  principal behind it. Recorded as facts rather than recovered from `owner`'s text: the client half of
+   *  that string comes off the handshake query unvalidated, so a caller could otherwise hand itself the
+   *  legacy exemption by claiming an id that looked minted. */
+  ownerMinted: boolean
+  ownerUser: string | null
   streamSocket: WebSocket | null
   deviceId: string
   deviceName: string
@@ -124,6 +130,8 @@ export class SessionManager {
         agentSocket,
         browserSocket: null,
         owner: null,
+        ownerMinted: false,
+        ownerUser: null,
         streamSocket: null,
         deviceId: d.id,
         readySent: false,
@@ -197,7 +205,12 @@ export class SessionManager {
    *          expected failure that travels as an exception is indistinguishable from a bug by the time it
    *          is caught, and the handler then has to guess a `reason`.
    */
-  join(sessionId: string, browserSocket: WebSocket, owner: string, isAlive: (ws: WebSocket) => boolean): JoinResult {
+  join(
+    sessionId: string,
+    browserSocket: WebSocket,
+    owner: { key: string; user: string; minted: boolean },
+    isAlive: (ws: WebSocket) => boolean,
+  ): JoinResult {
     const session = this.sessions.get(sessionId)
     if (!session) return { ok: false, failure: 'not-found' }
     // **Three conditions, and each one is an issue.** A session is occupied only when someone *else* holds
@@ -215,7 +228,7 @@ export class SessionManager {
     if (
       session.browserSocket &&
       session.owner !== null &&
-      session.owner !== owner &&
+      session.owner !== owner.key &&
       session.browserSocket.readyState === WebSocket.OPEN &&
       isAlive(session.browserSocket)
     ) {
@@ -231,7 +244,9 @@ export class SessionManager {
     // was dead: mutation testing removed the guard and every test still passed, because the add follows.
     this.unindexBrowser(session)
     session.browserSocket = browserSocket
-    session.owner = owner
+    session.owner = owner.key
+    session.ownerMinted = owner.minted
+    session.ownerUser = owner.user
     let held = this.browserSocketIndex.get(browserSocket)
     if (!held) { held = new Set(); this.browserSocketIndex.set(browserSocket, held) }
     held.add(session)
@@ -258,6 +273,8 @@ export class SessionManager {
       session.browserSocket = null
     }
     session.owner = null
+    session.ownerMinted = false
+    session.ownerUser = null
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }
     if (onTimeout) {
       session.idleTimer = setTimeout(() => {

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -12,6 +12,20 @@ export interface Session {
   agentCapabilities?: string[]
   agentSocket: WebSocket
   browserSocket: WebSocket | null
+  /**
+   * Who may command this session — `<userId>:<clientId>`, not a socket.
+   *
+   * Split from `browserSocket` because that one field was answering two questions: *who may command* and
+   * *where do replies go*. Only the first moves. A browser tab holds four sockets (`SessionList`,
+   * `DeviceViewer`, `useAgentSession`, `MacResources`) and the one that holds the session is not the one
+   * that sends the teardown, which is why a socket-shaped answer could not be given to #527.
+   *
+   * Cleared with `browserSocket`, in `clearBrowser` and `remove`. Keeping it past the release would let a
+   * client that has left go on driving the device, and would let input through in the reconnect grace —
+   * a window `ownsSession` deliberately fails fast in, because the alternative is applying it to a device
+   * nobody is watching.
+   */
+  owner: string | null
   streamSocket: WebSocket | null
   deviceId: string
   deviceName: string
@@ -109,6 +123,7 @@ export class SessionManager {
         ...SessionManager.agentFields(agent, d),
         agentSocket,
         browserSocket: null,
+        owner: null,
         streamSocket: null,
         deviceId: d.id,
         readySent: false,
@@ -182,18 +197,27 @@ export class SessionManager {
    *          expected failure that travels as an exception is indistinguishable from a bug by the time it
    *          is caught, and the handler then has to guess a `reason`.
    */
-  join(sessionId: string, browserSocket: WebSocket): JoinResult {
+  join(sessionId: string, browserSocket: WebSocket, owner: string, isAlive: (ws: WebSocket) => boolean): JoinResult {
     const session = this.sessions.get(sessionId)
     if (!session) return { ok: false, failure: 'not-found' }
-    // `!== browserSocket` is #515. The relay's handler already exempts the owning socket from the
-    // occupancy refusal one layer up, and this line not matching it is what made that exemption fall
-    // through to a `Session busy` throw — reported to the caller as `session-not-found`, for a live
-    // session it was holding. A re-join is now idempotent: it keeps the binding, cancels the idle timer
-    // below, and the handler replays the session's cached state exactly as it does for a fresh join.
+    // **Three conditions, and each one is an issue.** A session is occupied only when someone *else* holds
+    // it, on a socket that is open, and that socket is answering.
+    //
+    // - `owner !== owner` is #527 and #515: a re-join by the same client is idempotent whether or not the
+    //   socket is the same one, which is what makes a tab's four sockets one holder and an automatic
+    //   reconnect a takeover rather than a refusal.
+    // - `readyState === OPEN` was the whole test, and it is not a liveness signal. A laptop that went to
+    //   sleep leaves it OPEN until TCP or the heartbeat notices.
+    // - `isAlive` is that signal, passed in because liveness lives on the server rather than here — as a
+    //   predicate over the socket rather than a thunk, so it is applied to *this* session's holder and
+    //   cannot be closed over a stale one. `list()` below takes the same shape for the same reason.
+    //   #579 is the gap between `readyState` and this.
     if (
       session.browserSocket &&
-      session.browserSocket !== browserSocket &&
-      session.browserSocket.readyState === WebSocket.OPEN
+      session.owner !== null &&
+      session.owner !== owner &&
+      session.browserSocket.readyState === WebSocket.OPEN &&
+      isAlive(session.browserSocket)
     ) {
       return { ok: false, failure: 'held-by-another' }
     }
@@ -207,6 +231,7 @@ export class SessionManager {
     // was dead: mutation testing removed the guard and every test still passed, because the add follows.
     this.unindexBrowser(session)
     session.browserSocket = browserSocket
+    session.owner = owner
     let held = this.browserSocketIndex.get(browserSocket)
     if (!held) { held = new Set(); this.browserSocketIndex.set(browserSocket, held) }
     held.add(session)
@@ -232,6 +257,7 @@ export class SessionManager {
       this.unindexBrowser(session)
       session.browserSocket = null
     }
+    session.owner = null
     if (session.idleTimer) { clearTimeout(session.idleTimer); session.idleTimer = null }
     if (onTimeout) {
       session.idleTimer = setTimeout(() => {
@@ -352,7 +378,20 @@ export class SessionManager {
     if (session) session.deviceStatus = status
   }
 
-  list(): SessionInfo[] {
+  /**
+   * @param asker      the owner key of the socket that asked, so `busy` can mean *busy for you*.
+   * @param isAlive    whether a holder's socket is answering — the same predicate occupancy uses.
+   *
+   * **`busy` has to agree with the occupancy test or the UI locks a tester out of their own session.**
+   * `browserSocket !== null` said "someone holds it", which is a different question from "you cannot have
+   * it": `QASession` renders `disabled={isBusy}`, so a tester whose socket reconnected automatically found
+   * their own device greyed out with no way to reach the takeover that would have worked. And a holder
+   * that has stopped answering keeps the card locked for everyone until the sweep notices.
+   *
+   * Passing the same `isAlive` rather than a second liveness rule is the point — two predicates that
+   * disagree would flash a device as free while a join for it is still refused.
+   */
+  list(asker: string, isAlive: (ws: WebSocket) => boolean): SessionInfo[] {
     // Group sessions by agentSocket
     const agentMap = new Map<WebSocket, Session[]>()
     for (const session of this.sessions.values()) {
@@ -380,7 +419,16 @@ export class SessionManager {
         status: s.deviceStatus,
         osVersion: s.deviceOsVersion,
         sessionId: s.id,
-        busy: s.browserSocket !== null,
+        busy:
+          s.owner !== null &&
+          s.owner !== asker &&
+          s.browserSocket !== null &&
+          // The clause that was missing, and its absence was the mirror of the failure the docstring warns
+          // about: a socket in CLOSING has not fired `close` yet, so `isAlive` is still true — the card
+          // read `busy` while a join for it would have succeeded, locking every other tester out of a
+          // device the relay was ready to hand them.
+          s.browserSocket.readyState === WebSocket.OPEN &&
+          isAlive(s.browserSocket),
       })),
     }))
   }

--- a/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
+++ b/packages/relay/src/__tests__/RelayServer.heartbeat.test.ts
@@ -20,15 +20,18 @@ const makeSock = (readyState: number = WebSocket.OPEN): MockSocket => ({
 // Internal surface poked by these tests (mirrors the `as unknown as {...}` idiom in RelayServer.test.ts).
 type HeartbeatInternals = {
   wss: WebSocketServer
-  wsAlive: WeakMap<object, boolean>
+  lastPongAt: WeakMap<object, number>
   heartbeatTimer: ReturnType<typeof setInterval> | null
   runHeartbeat: (clients?: Iterable<unknown>) => void
 }
 const internals = (server: RelayServer) => server as unknown as HeartbeatInternals
 
 const sweep = (server: RelayServer, socks: MockSocket[]) => internals(server).runHeartbeat(socks)
+/** Liveness is a pong timestamp now, not a swept flag — "dead" is "answered longer ago than the sweep
+ *  tolerates". The flag it replaced read `false` for every live socket for the length of a ping round
+ *  trip, which was harmless while it only decided termination and is not once occupancy reads it. */
 const setAlive = (server: RelayServer, sock: MockSocket, alive: boolean) =>
-  internals(server).wsAlive.set(sock, alive)
+  internals(server).lastPongAt.set(sock, alive ? Date.now() : Date.now() - 10 * 60_000)
 
 describe('RelayServer — WebSocket heartbeat (#313)', () => {
   let tmpDir: string
@@ -55,19 +58,30 @@ describe('RelayServer — WebSocket heartbeat (#313)', () => {
       await server.stop()
     })
 
-    it('terminates a socket that missed the previous pong window', () => {
-      const sock = makeSock()
-      setAlive(server, sock, true)
+    it('terminates a socket that has not answered for longer than the sweep tolerates', () => {
+      // **The clock is what decides now, not the number of sweeps.** The swept flag encoded "one interval
+      // has passed" structurally, so two back-to-back sweeps were enough; a timestamp encodes it in wall
+      // time, which is the whole point — the flag read every live socket as dead for a ping round trip,
+      // and occupancy cannot be built on a signal like that.
+      vi.useFakeTimers()
+      try {
+        const sock = makeSock()
+        setAlive(server, sock, true)
 
-      // 1st sweep: alive → mark dead, ping (probe).
-      sweep(server, [sock])
-      expect(sock.terminate).not.toHaveBeenCalled()
-      expect(sock.ping).toHaveBeenCalledTimes(1)
+        // Still inside the tolerance: probed, not terminated.
+        vi.setSystemTime(Date.now() + 30_000)
+        sweep(server, [sock])
+        expect(sock.terminate).not.toHaveBeenCalled()
+        expect(sock.ping).toHaveBeenCalledTimes(1)
 
-      // No pong arrived → still marked dead. 2nd sweep: terminate, no further ping.
-      sweep(server, [sock])
-      expect(sock.terminate).toHaveBeenCalledTimes(1)
-      expect(sock.ping).toHaveBeenCalledTimes(1)
+        // Past 1.5 intervals with no pong: terminated, and not probed again.
+        vi.setSystemTime(Date.now() + 30_000)
+        sweep(server, [sock])
+        expect(sock.terminate).toHaveBeenCalledTimes(1)
+        expect(sock.ping).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('keeps a socket that ponged between sweeps', () => {
@@ -142,7 +156,7 @@ describe('RelayServer — WebSocket heartbeat (#313)', () => {
 
       // Force the server-side socket to look dead, then run a real sweep.
       const serverWs = [...internals(server).wss.clients][0]
-      internals(server).wsAlive.set(serverWs, false)
+      internals(server).lastPongAt.set(serverWs, Date.now() - 10 * 60_000)
       internals(server).runHeartbeat()
 
       await closed // terminate() fired the close handler

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -18,8 +18,11 @@ let ownerSeq = 0
 const ownerOf = (ws: object) => {
   let key = owners.get(ws)
   if (!key) { key = `owner-${++ownerSeq}`; owners.set(ws, key) }
-  return key
+  return { key, user: key, minted: false }
 }
+
+/** A named client, for the tests that need two sockets to be one holder. */
+const asClient = (key: string) => ({ key, user: key.split(':')[0]!, minted: false })
 
 describe('SessionManager', () => {
   describe('create()', () => {
@@ -440,7 +443,7 @@ describe('SessionManager', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const holder = mockSocket()
-      sm.join(id, holder, 'tab-a', () => true)
+      sm.join(id, holder, asClient('tab-a'), () => true)
       expect(sm.list('tab-b', () => true)[0].devices[0]!.busy).toBe(true)
       expect(sm.list('tab-a', () => true)[0].devices[0]!.busy).toBe(false)
     })
@@ -450,7 +453,7 @@ describe('SessionManager', () => {
       // liveness rules that disagreed would show a device as free while a join for it was still refused.
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket(), 'tab-a', () => true)
+      sm.join(id, mockSocket(), asClient('tab-a'), () => true)
       expect(sm.list('tab-b', () => false)[0].devices[0]!.busy).toBe(false)
     })
 

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -8,6 +8,19 @@ const OPEN = 1
 const mockSocket = () => ({ readyState: OPEN } as WebSocket)
 const closedSocket = () => ({ readyState: 3 } as WebSocket)
 
+/**
+ * A distinct owner per socket, which is what an unidentified connection gets from the relay — so every
+ * pre-existing test here keeps the behaviour it was written for. Ownership by *client* is what the tests
+ * added below exercise, by passing the same key from two sockets.
+ */
+const owners = new WeakMap<object, string>()
+let ownerSeq = 0
+const ownerOf = (ws: object) => {
+  let key = owners.get(ws)
+  if (!key) { key = `owner-${++ownerSeq}`; owners.set(ws, key) }
+  return key
+}
+
 describe('SessionManager', () => {
   describe('create()', () => {
     it('returns an empty array when no devices given', () => {
@@ -182,7 +195,7 @@ describe('SessionManager', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const browserWs = mockSocket()
-      sm.join(id, browserWs)
+      sm.join(id, browserWs, ownerOf(browserWs), () => true)
       expect(sm.get(id)?.browserSocket).toBe(browserWs)
     })
 
@@ -191,15 +204,15 @@ describe('SessionManager', () => {
     // guessed a `reason`, and guessed wrong for the most common case (see the re-join tests below).
     it('reports a session that is not there', () => {
       const sm = new SessionManager()
-      expect(sm.join('bad-id', mockSocket())).toEqual({ ok: false, failure: 'not-found' })
+      expect(sm.join('bad-id', mockSocket(), ownerOf(mockSocket()), () => true)).toEqual({ ok: false, failure: 'not-found' })
     })
 
     it('reports a session another OPEN socket holds', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const busyWs = { readyState: OPEN } as WebSocket
-      sm.join(id, busyWs)
-      expect(sm.join(id, mockSocket())).toEqual({ ok: false, failure: 'held-by-another' })
+      sm.join(id, busyWs, ownerOf(busyWs), () => true)
+      expect(sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)).toEqual({ ok: false, failure: 'held-by-another' })
       // The refusal must not have moved the binding — a rejected join that stole the session would be
       // the defect this check exists to prevent, wearing a refusal's clothes.
       expect(sm.get(id)?.browserSocket).toBe(busyWs)
@@ -209,8 +222,8 @@ describe('SessionManager', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
       const owner = { readyState: OPEN } as WebSocket
-      sm.join(id, owner)
-      expect(sm.join(id, owner)).toEqual({ ok: true })
+      sm.join(id, owner, ownerOf(owner), () => true)
+      expect(sm.join(id, owner, ownerOf(owner), () => true)).toEqual({ ok: true })
       expect(sm.get(id)?.browserSocket).toBe(owner)
       // And the socket still holds it exactly once. `unindexBrowser` reads `session.browserSocket`, so a
       // re-join that ran it would drop the entry this join is re-establishing — leaving the session bound
@@ -229,8 +242,8 @@ describe('SessionManager', () => {
         { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
       ])
       const ws = { readyState: OPEN } as WebSocket
-      sm.join(a!, ws)
-      sm.join(b!, ws)
+      sm.join(a!, ws, ownerOf(ws), () => true)
+      sm.join(b!, ws, ownerOf(ws), () => true)
       expect(sm.getByBrowserSocket(ws).map((s) => s.id).sort()).toEqual([a, b].sort())
       expect(sm.get(a!)?.browserSocket).toBe(ws)
       expect(sm.get(b!)?.browserSocket).toBe(ws)
@@ -243,8 +256,8 @@ describe('SessionManager', () => {
         { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
       ])
       const ws = { readyState: OPEN } as WebSocket
-      sm.join(a!, ws)
-      sm.join(b!, ws)
+      sm.join(a!, ws, ownerOf(ws), () => true)
+      sm.join(b!, ws, ownerOf(ws), () => true)
       sm.clearBrowser(a!)
       expect(sm.getByBrowserSocket(ws).map((s) => s.id)).toEqual([b])
       sm.clearBrowser(b!)
@@ -266,8 +279,8 @@ describe('SessionManager', () => {
         { id: 'd2', name: 'Y', platform: 'ios', status: 'shutdown' },
       ])
       const ws = { readyState: OPEN } as WebSocket
-      sm.join(a!, ws)
-      sm.join(b!, ws)
+      sm.join(a!, ws, ownerOf(ws), () => true)
+      sm.join(b!, ws, ownerOf(ws), () => true)
       sm.remove(a!)
       expect(sm.getByBrowserSocket(ws).map((s) => s.id)).toEqual([b])
     })
@@ -286,7 +299,7 @@ describe('SessionManager', () => {
     it('sets browserSocket to null', () => {
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)
       sm.clearBrowser(id)
       expect(sm.get(id)?.browserSocket).toBeNull()
     })
@@ -305,7 +318,7 @@ describe('SessionManager', () => {
     it('list() has undefined resources when none reported', () => {
       const sm = new SessionManager()
       sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }], 'Mac1')
-      expect(sm.list()[0].resources).toBeUndefined()
+      expect(sm.list('asker', () => true)[0].resources).toBeUndefined()
     })
 
     it('setResources() is reflected in list()', () => {
@@ -314,7 +327,7 @@ describe('SessionManager', () => {
       sm.create(ws, [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }], 'Mac1')
       const resources = { cpuPercent: 42, memUsedMB: 8192, memTotalMB: 16384, slotsAvailable: 2, slotsTotal: 3, reportedAt: 1000 }
       sm.setResources(ws, resources)
-      expect(sm.list()[0].resources).toEqual(resources)
+      expect(sm.list('asker', () => true)[0].resources).toEqual(resources)
     })
 
     it('removeResources() clears resources from list()', () => {
@@ -323,7 +336,7 @@ describe('SessionManager', () => {
       sm.create(ws, [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }], 'Mac1')
       sm.setResources(ws, { cpuPercent: 50, memUsedMB: 4096, memTotalMB: 16384, slotsAvailable: 3, slotsTotal: 3, reportedAt: 1000 })
       sm.removeResources(ws)
-      expect(sm.list()[0].resources).toBeUndefined()
+      expect(sm.list('asker', () => true)[0].resources).toBeUndefined()
     })
 
     it('setResources() on unknown socket does not throw', () => {
@@ -338,7 +351,7 @@ describe('SessionManager', () => {
       sm.create(ws1, [{ id: 'd1', name: 'A', platform: 'ios', status: 'shutdown' }], 'Mac1')
       sm.create(ws2, [{ id: 'd2', name: 'B', platform: 'ios', status: 'shutdown' }], 'Mac2')
       sm.setResources(ws1, { cpuPercent: 10, memUsedMB: 1000, memTotalMB: 8000, slotsAvailable: 3, slotsTotal: 3, reportedAt: 1000 })
-      const listed = sm.list()
+      const listed = sm.list('asker', () => true)
       const mac1 = listed.find((g) => g.agentName === 'Mac1')!
       const mac2 = listed.find((g) => g.agentName === 'Mac2')!
       expect(mac1.resources?.cpuPercent).toBe(10)
@@ -353,7 +366,7 @@ describe('SessionManager', () => {
     it('clearBrowser() with onTimeout fires callback after idleTimeoutMs', () => {
       const sm = new SessionManager({ idleTimeoutMs: 1000 })
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)
       const onTimeout = vi.fn()
       sm.clearBrowser(id, onTimeout)
       expect(onTimeout).not.toHaveBeenCalled()
@@ -364,10 +377,10 @@ describe('SessionManager', () => {
     it('join() cancels a pending idle timer', () => {
       const sm = new SessionManager({ idleTimeoutMs: 1000 })
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)
       const onTimeout = vi.fn()
       sm.clearBrowser(id, onTimeout)
-      sm.join(id, mockSocket())          // reconnect before timeout
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)          // reconnect before timeout
       vi.advanceTimersByTime(2000)
       expect(onTimeout).not.toHaveBeenCalled()
     })
@@ -375,7 +388,7 @@ describe('SessionManager', () => {
     it('remove() cancels a pending idle timer', () => {
       const sm = new SessionManager({ idleTimeoutMs: 1000 })
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)
       const onTimeout = vi.fn()
       sm.clearBrowser(id, onTimeout)
       sm.remove(id)
@@ -386,7 +399,7 @@ describe('SessionManager', () => {
     it('clearBrowser() without onTimeout starts no timer', () => {
       const sm = new SessionManager({ idleTimeoutMs: 1000 })
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
+      sm.join(id, mockSocket(), ownerOf(mockSocket()), () => true)
       sm.clearBrowser(id)               // no callback
       expect(sm.get(id)?.idleTimer).toBeNull()
     })
@@ -395,7 +408,7 @@ describe('SessionManager', () => {
   describe('list()', () => {
     it('returns empty array when no sessions', () => {
       const sm = new SessionManager()
-      expect(sm.list()).toEqual([])
+      expect(sm.list('asker', () => true)).toEqual([])
     })
 
     it('groups devices by agent into one SessionInfo', () => {
@@ -405,7 +418,7 @@ describe('SessionManager', () => {
         { id: 'devA', name: 'iPhone A', platform: 'ios', status: 'shutdown' },
         { id: 'devB', name: 'iPhone B', platform: 'ios', status: 'shutdown' },
       ], 'MyMac')
-      const listed = sm.list()
+      const listed = sm.list('asker', () => true)
       expect(listed).toHaveLength(1)
       expect(listed[0].agentName).toBe('MyMac')
       expect(listed[0].devices).toHaveLength(2)
@@ -415,21 +428,36 @@ describe('SessionManager', () => {
       const sm = new SessionManager()
       const ws = mockSocket()
       const [idA] = sm.create(ws, [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }])
-      const listed = sm.list()
+      const listed = sm.list('asker', () => true)
       expect(listed[0].devices[0]!.sessionId).toBe(idA)
     })
 
-    it('reflects busy=true when browserSocket is set', () => {
+    it('is busy for someone else, and not for the holder', () => {
+      // `busy` used to be `browserSocket !== null` — "someone holds it", which is a different question
+      // from "you cannot have it". `QASession` renders `disabled={isBusy}`, so a tester whose socket
+      // reconnected found their own device greyed out with no way to reach the takeover that would have
+      // worked. It answers the asker's question now.
       const sm = new SessionManager()
       const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      sm.join(id, mockSocket())
-      expect(sm.list()[0].devices[0]!.busy).toBe(true)
+      const holder = mockSocket()
+      sm.join(id, holder, 'tab-a', () => true)
+      expect(sm.list('tab-b', () => true)[0].devices[0]!.busy).toBe(true)
+      expect(sm.list('tab-a', () => true)[0].devices[0]!.busy).toBe(false)
+    })
+
+    it('is not busy when the holder has stopped answering', () => {
+      // The same predicate occupancy uses, and passing it in rather than reproducing it is the point: two
+      // liveness rules that disagreed would show a device as free while a join for it was still refused.
+      const sm = new SessionManager()
+      const [id] = sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
+      sm.join(id, mockSocket(), 'tab-a', () => true)
+      expect(sm.list('tab-b', () => false)[0].devices[0]!.busy).toBe(false)
     })
 
     it('reflects busy=false when browserSocket is null', () => {
       const sm = new SessionManager()
       sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }])
-      expect(sm.list()[0].devices[0]!.busy).toBe(false)
+      expect(sm.list('asker', () => true)[0].devices[0]!.busy).toBe(false)
     })
 
   })
@@ -478,7 +506,7 @@ describe('SessionManager', () => {
     const sm = new SessionManager()
     sm.create(mockSocket(), [{ id: 'devA', name: 'A', platform: 'ios', status: 'shutdown' }], 'Mac1')
     sm.create(mockSocket(), [{ id: 'devB', name: 'B', platform: 'ios', status: 'shutdown' }], 'Mac2')
-    const listed = sm.list()
+    const listed = sm.list('asker', () => true)
     expect(listed).toHaveLength(2)
   })
 
@@ -490,7 +518,7 @@ describe('SessionManager', () => {
       const sm = new SessionManager()
       sm.create(closedSocket(), [{ id: 'devA', name: 'A', platform: 'ios', status: 'booted' }])
 
-      expect(sm.list()).toEqual([])
+      expect(sm.list('asker', () => true)).toEqual([])
     })
 
     it('lists it again once it is rebound to a live socket', () => {
@@ -502,8 +530,8 @@ describe('SessionManager', () => {
 
       sm.rebind(id!, live, dev, { agentId: 'mac-1' })
 
-      expect(sm.list()).toHaveLength(1)
-      expect(sm.list()[0]!.devices[0]!.sessionId).toBe(id)
+      expect(sm.list('asker', () => true)).toHaveLength(1)
+      expect(sm.list('asker', () => true)[0]!.devices[0]!.sessionId).toBe(id)
     })
   })
 })

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -4,8 +4,9 @@ import os from 'os'
 import path from 'path'
 import { WebSocket } from 'ws'
 import { RelayServer, IDR_REQUEST_THROTTLE_MS, ownerKeyFor } from '../RelayServer'
+import { signJwt, hashPat } from '../middleware/auth'
 import type { JoinResult } from '../SessionManager'
-import { initDb, closeDb } from '../db'
+import { initDb, closeDb, getDb } from '../db'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 import type {
   AgentRegistered, AgentsListed, DeviceShutdown, DeviceShutdownError, GenericError, SessionChrome,
@@ -58,10 +59,16 @@ describe('session ownership seam', () => {
   /** A browser socket, optionally speaking for a named client. Omitting the id is what an older build or
    *  a third-party client does, and the relay mints one per connection — so two anonymous sockets are two
    *  owners, which is exactly today's behaviour. */
-  async function browserSocket(client?: string) {
+  async function browserSocket(client?: string, userId?: number) {
     const url = new URL(`ws://localhost:${port}`)
     if (client) url.searchParams.set('client', client)
-    const ws = new WebSocket(url.toString())
+    // A cookie is the only way to give a connection a *principal* here — every socket in this file is
+    // otherwise a localhost connection with no auth, so all of them are `anon` and any rule keyed on the
+    // user is trivially satisfied. Two mutations survived on exactly that before this parameter existed.
+    const headers = userId === undefined
+      ? undefined
+      : { cookie: `tapflow_token=${signJwt({ userId, email: `u${userId}@example.test`, role: 'Admin' })}` }
+    const ws = new WebSocket(url.toString(), { headers })
     await waitForOpen(ws)
     return ws
   }
@@ -690,13 +697,27 @@ describe('session ownership seam', () => {
     // Held here because the handler's inline version was unreachable without an authenticated handshake,
     // and a mutation dropping the user id survived the entire suite. Two accounts claiming the same id is
     // the case the pairing exists for: a leaked client id must be useless to anyone else.
-    expect(ownerKeyFor(7, 'tab-a')).toBe('7:tab-a')
-    expect(ownerKeyFor(7, 'tab-a')).not.toBe(ownerKeyFor(8, 'tab-a'))
+    expect(ownerKeyFor(7, 'tab-a').key).toBe('7:tab-a')
+    expect(ownerKeyFor(7, 'tab-a').key).not.toBe(ownerKeyFor(8, 'tab-a').key)
     // No claim → a fresh identity each time, which is per-socket, which is what it replaced.
-    expect(ownerKeyFor(7, null)).not.toBe(ownerKeyFor(7, null))
-    expect(ownerKeyFor(7, '')).not.toBe(ownerKeyFor(7, ''))
+    expect(ownerKeyFor(7, null).key).not.toBe(ownerKeyFor(7, null).key)
+    expect(ownerKeyFor(7, '').key).not.toBe(ownerKeyFor(7, '').key)
     // Unauthenticated (localhost) connections still differ by their claim.
-    expect(ownerKeyFor(undefined, 'tab-a')).toBe('anon:tab-a')
+    expect(ownerKeyFor(undefined, 'tab-a').key).toBe('anon:tab-a')
+  })
+
+  it('mintedness cannot be claimed, only granted', () => {
+    // **The forgery a first version admitted.** It marked minted keys with a `minted-` prefix and had the
+    // shutdown gate recover the fact with `includes(':minted-')` — but the claim comes off the handshake
+    // query unvalidated, so `?client=minted-1` handed the caller its own exemption, and
+    // `?client=x:minted-y` did it while keeping a real user id, which let a *different* user power the
+    // device off. It is a field now, and a field cannot be spelled into existence.
+    expect(ownerKeyFor(7, 'minted-1').minted, 'a claim named like a mint is still a claim').toBe(false)
+    expect(ownerKeyFor(7, 'x:minted-y').minted).toBe(false)
+    expect(ownerKeyFor(7, null).minted, 'no claim is the only way to be minted').toBe(true)
+    expect(ownerKeyFor(7, '').minted).toBe(true)
+    // And the principal is the part before the first delimiter, whatever the claim contains.
+    expect(ownerKeyFor(7, 'x:minted-y').user).toBe('7')
   })
 
   it('a client that sends no id keeps the behaviour each gate had before it', async () => {
@@ -725,6 +746,118 @@ describe('session ownership seam', () => {
     expect(await waitForTypeOrNull(two, 'device:shutdown-error', 200)).toBeNull()
 
     agent.close(); one.close(); two.close()
+  })
+
+  it('an unidentified holder is exempt only for its own user, not across users', async () => {
+    // The exemption exists so a legacy client's own teardown works, and its own teardown is by definition
+    // the same signed-in user. Extending it further would leave one tester able to power off another's
+    // device for as long as anyone runs an older build — unchanged from before the gate existed, which is
+    // not a reason to carry it forward when the narrower rule costs one comparison.
+    //
+    // Both sockets here are unauthenticated localhost connections, so both are the `anon` principal and
+    // the exemption applies — which is what makes this the *permissive* half. Its restrictive twin is the
+    // unit assertion above: mintedness cannot be claimed, so an identified holder never reaches this path.
+    const { agent, sessionIds } = await registerAgent('owner-minted-same-user')
+    const sessionId = sessionIds[0]!
+    const legacy = await browserSocket()
+    legacy.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(legacy, 'session:joined')
+
+    const sibling = await browserSocket()
+    sibling.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    expect((await waitForType<DeviceShutdown>(agent, 'device:shutdown')).sessionId).toBe(sessionId)
+
+    agent.close(); legacy.close(); sibling.close()
+  })
+
+  it('a claim that looks minted is still a claim, and is gated', async () => {
+    // The forgery in wire form. A first version marked minted keys inside the owner string and recovered
+    // the fact with `includes(':minted-')`, so connecting as this would have handed the caller its own
+    // exemption — the claim comes off the handshake query and is never validated.
+    const { agent, sessionIds } = await registerAgent('owner-fake-mint')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('minted-1')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const stranger = await browserSocket('tab-b')
+    stranger.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType<DeviceShutdownError>(stranger, 'device:shutdown-error')
+    expect(await waitForTypeOrNull(agent, 'device:shutdown', 200)).toBeNull()
+
+    agent.close(); holder.close(); stranger.close()
+  })
+
+  it('a PAT connection gets its own principal, not `anon`', async () => {
+    // `getAuth` reads the cookie only, so a first version made every agent, `mcp-server` and
+    // `flow-runner` connection `anon:` — the whole population whose handshake URL is most likely to end
+    // up in a reverse proxy's access log, and the one the user pairing exists to protect. The handler was
+    // already resolving the PAT and discarding it.
+    const db = getDb()
+    const addUser = db.prepare("INSERT OR IGNORE INTO users (id, email, role) VALUES (?, ?, 'Admin')")
+    addUser.run(41, 'pat41@example.test')
+    addUser.run(42, 'pat42@example.test')
+    const mint = (raw: string, userId: number) =>
+      db.prepare("INSERT INTO personal_access_tokens (user_id, name, token_hash, scope) VALUES (?, ?, ?, ?)")
+        .run(userId, `t${userId}`, hashPat(raw), 'view')
+
+    const rawA = 'tflw_pat_ownerA'
+    const rawB = 'tflw_pat_ownerB'
+    mint(rawA, 41)
+    mint(rawB, 42)
+
+    // **A local connection never reaches the PAT path** — `verifyPat` is consulted only when the caller is
+    // neither local nor cookie-authenticated, so on the default server every socket here would be `anon`
+    // and this test would assert nothing. Trusting the loopback proxy is what lets `x-forwarded-for` make
+    // the connection look remote, which is the state a real PAT client is in.
+    await server.stop()
+    server = new RelayServer({ port: 0, trustedProxies: ['127.0.0.1', '::1'] })
+    await server.start()
+    port = (server.address() as { port: number }).port
+
+    const withPat = async (raw: string) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+        headers: { authorization: `Bearer ${raw}`, 'x-forwarded-for': '203.0.113.7' },
+      })
+      await waitForOpen(ws)
+      return ws
+    }
+
+    const { agent, sessionIds } = await registerAgent('owner-pat')
+    const sessionId = sessionIds[0]!
+    const holder = await withPat(rawA)
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    // A different PAT is a different principal, so it does not inherit the holder's exemption.
+    const other = await withPat(rawB)
+    other.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType<DeviceShutdownError>(other, 'device:shutdown-error')
+    expect(await waitForTypeOrNull(agent, 'device:shutdown', 200)).toBeNull()
+
+    agent.close(); holder.close(); other.close()
+  })
+
+  it('the legacy exemption does not reach across users', async () => {
+    // The holder identifies itself with nothing, so it is exempt — but only for its own principal. User 2
+    // must not inherit user 1's exemption, or one tester could power off another's device for as long as
+    // anyone is running a build that predates the `client` parameter.
+    const { agent, sessionIds } = await registerAgent('owner-cross-user')
+    const sessionId = sessionIds[0]!
+    const legacy = await browserSocket(undefined, 1)
+    legacy.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(legacy, 'session:joined')
+
+    const sameUser = await browserSocket(undefined, 1)
+    sameUser.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    expect((await waitForType<DeviceShutdown>(agent, 'device:shutdown')).sessionId).toBe(sessionId)
+
+    const otherUser = await browserSocket(undefined, 2)
+    otherUser.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType<DeviceShutdownError>(otherUser, 'device:shutdown-error')
+    expect(await waitForTypeOrNull(agent, 'device:shutdown', 200)).toBeNull()
+
+    agent.close(); legacy.close(); sameUser.close(); otherUser.close()
   })
 
   it('a client that does send an id is gated on shutdown', async () => {

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -720,6 +720,32 @@ describe('session ownership seam', () => {
     expect(ownerKeyFor(7, 'x:minted-y').user).toBe('7')
   })
 
+  it('a socket the handshake never recorded matches nothing, not even another one', () => {
+    // **The gates rest on this accessor, not on the seeding being total.** `handleConnection` records every
+    // accepted socket before a message can arrive, so nothing reaches the fallback today — but the answer it
+    // gives is what decides whether that stays a defence or becomes a dependency. A shared `'unidentified'`
+    // made any two unrecorded sockets equal, and equal is exactly what `ownsSession` tests for; equal users
+    // are what the shutdown exemption tests for. So a future path that accepted a socket without recording
+    // it would not fail closed — it would hand every such socket ownership of every other's session.
+    //
+    // Reaching in past `private` is deliberate: there is no wire that produces this state, which is the
+    // point. A test that could only drive it through a connection would be a test of the seeding instead.
+    const relay = new RelayServer({ port: 0 })
+    const reach = relay as unknown as {
+      ownerRecord(ws: object): { key: string; user: string; minted: boolean }
+      ownerOf(ws: object): string
+      userOf(ws: object): string
+    }
+    const [a, b] = [{}, {}]
+
+    expect(reach.ownerOf(a)).not.toBe(reach.ownerOf(b))
+    expect(reach.userOf(a), 'equal principals would pass the shutdown exemption').not.toBe(reach.userOf(b))
+    expect(reach.ownerRecord(a).minted, 'unrecorded is not the same as unidentified').toBe(false)
+    // Stored, not freshly minted per call — otherwise a socket would not own the session it just bound.
+    expect(reach.ownerOf(a)).toBe(reach.ownerOf(a))
+    expect(reach.ownerOf(a)).toBe(reach.ownerRecord(a).key)
+  })
+
   it('a client that sends no id keeps the behaviour each gate had before it', async () => {
     // R6, and it is **two different answers** because the two gates are different.
     //

--- a/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
+++ b/packages/relay/src/__tests__/sessionOwnershipSeam.test.ts
@@ -3,12 +3,13 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { WebSocket } from 'ws'
-import { RelayServer, IDR_REQUEST_THROTTLE_MS } from '../RelayServer'
+import { RelayServer, IDR_REQUEST_THROTTLE_MS, ownerKeyFor } from '../RelayServer'
 import type { JoinResult } from '../SessionManager'
 import { initDb, closeDb } from '../db'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 import type {
-  AgentRegistered, DeviceShutdown, DeviceShutdownError, GenericError, SessionChrome, SessionJoined,
+  AgentRegistered, AgentsListed, DeviceShutdown, DeviceShutdownError, GenericError, SessionChrome,
+  SessionJoined,
 } from '@tapflowio/protocol'
 
 // Three defects that share a subject — who holds a session — and **not** the question of who *should*.
@@ -54,8 +55,13 @@ describe('session ownership seam', () => {
     return { agent, sessionIds: reply.registeredSessions.map((s) => s.sessionId) }
   }
 
-  async function browserSocket() {
-    const ws = new WebSocket(`ws://localhost:${port}`)
+  /** A browser socket, optionally speaking for a named client. Omitting the id is what an older build or
+   *  a third-party client does, and the relay mints one per connection — so two anonymous sockets are two
+   *  owners, which is exactly today's behaviour. */
+  async function browserSocket(client?: string) {
+    const url = new URL(`ws://localhost:${port}`)
+    if (client) url.searchParams.set('client', client)
+    const ws = new WebSocket(url.toString())
     await waitForOpen(ws)
     return ws
   }
@@ -491,6 +497,253 @@ describe('session ownership seam', () => {
     agent.close()
   })
 
+  // ── #579 · #527 — the owner is a client, and occupancy is judged by liveness ──────────────────────
+
+  it('a second socket of the same client may command the session the first holds', async () => {
+    // #527. The dashboard opens four sockets per tab and the one that holds the session is not the one
+    // that sends the teardown, which is why this could not be answered with a socket.
+    const { agent, sessionIds } = await registerAgent('owner-two-sockets')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const sibling = await browserSocket('tab-a')
+    sibling.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    expect((await waitForType<DeviceShutdown>(agent, 'device:shutdown')).sessionId).toBe(sessionId)
+
+    agent.close(); holder.close(); sibling.close()
+  })
+
+  it('an unheld session stays shutdownable, so the unmount teardown survives the race', async () => {
+    // The reason the gate is "not someone else's" rather than "mine". The viewer's socket close and the
+    // teardown's `device:shutdown` travel on different connections with no ordering between them; if the
+    // close lands first the session is unheld, and an owns-it gate would refuse the teardown and leave the
+    // device booted until the idle timer. #527 named that path as the reason a gate could not be added.
+    const { agent, sessionIds } = await registerAgent('owner-unheld')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const closed = new Promise<void>((r) => holder.on('close', () => r()))
+    holder.close()
+    await closed
+
+    const teardown = await browserSocket('tab-a')
+    teardown.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    expect((await waitForType<DeviceShutdown>(agent, 'device:shutdown')).sessionId).toBe(sessionId)
+
+    agent.close(); teardown.close()
+  })
+
+  it('a live holder still refuses another client', async () => {
+    const { agent, sessionIds } = await registerAgent('owner-live-holder')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const other = await browserSocket('tab-b')
+    other.send(JSON.stringify({ type: 'session:start', sessionId }))
+    expect((await waitForType<GenericError>(other, 'error')).reason).toBe('session-busy')
+
+    agent.close(); holder.close(); other.close()
+  })
+
+  it('the same client re-joins on a new socket without waiting for the holder to be noticed', async () => {
+    // #579's ordinary shape: `useRelay` reconnects inside the same document after 2s, so the returning
+    // socket is a different socket and the same client. Before this it contended with its own predecessor.
+    const { agent, sessionIds } = await registerAgent('owner-rejoin')
+    const sessionId = sessionIds[0]!
+    const first = await browserSocket('tab-a')
+    first.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(first, 'session:joined')
+
+    // The old socket is left open and alive — the point is that being the same client is enough.
+    const second = await browserSocket('tab-a')
+    second.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(second, 'session:joined')
+
+    // Ownership moved: the new socket commands, and replies go to it.
+    second.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-1', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await waitForType(agent, 'input:touch:end')).sessionId).toBe(sessionId)
+
+    agent.close(); first.close(); second.close()
+  })
+
+  it('a holder that has stopped answering is not occupancy', async () => {
+    // #579's root: the check read `readyState`, which a sleeping laptop leaves OPEN. Liveness is the
+    // relay's own pong record, reached here the way the other private-field tests in this file reach one.
+    const { agent, sessionIds } = await registerAgent('owner-dead-holder')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const internals = server as unknown as {
+      sessions: { get(id: string): { browserSocket: object | null } | undefined }
+      lastPongAt: WeakMap<object, number>
+    }
+    const holderWs = internals.sessions.get(sessionId)!.browserSocket!
+    internals.lastPongAt.set(holderWs, Date.now() - 10 * 60_000)
+
+    const other = await browserSocket('tab-b')
+    other.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(other, 'session:joined')
+    expect(await waitForTypeOrNull<GenericError>(other, 'error', 200)).toBeNull()
+
+    agent.close(); holder.close(); other.close()
+  })
+
+  it('busy answers the asker, and agrees with occupancy about liveness', async () => {
+    const { agent, sessionIds } = await registerAgent('owner-busy')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const listOn = async (ws: WebSocket) => {
+      ws.send(JSON.stringify({ type: 'agents:list' }))
+      const listed = await waitForType<AgentsListed>(ws, 'agents:listed')
+      return listed.sessions[0]!.devices.find((d) => d.sessionId === sessionId)!.busy
+    }
+    const stranger = await browserSocket('tab-b')
+    expect(await listOn(stranger), 'another client should see it as taken').toBe(true)
+    expect(await listOn(holder), 'the holder should not be locked out of its own device').toBe(false)
+
+    // And the same liveness rule the join uses — otherwise the card flashes free while a join is refused.
+    const internals = server as unknown as { lastPongAt: WeakMap<object, number> }
+    const holderWs = (server as unknown as {
+      sessions: { get(id: string): { browserSocket: object } | undefined }
+    }).sessions.get(sessionId)!.browserSocket
+    internals.lastPongAt.set(holderWs, Date.now() - 10 * 60_000)
+    expect(await listOn(stranger), 'a holder that stopped answering does not keep the card locked').toBe(false)
+
+    agent.close(); holder.close(); stranger.close()
+  })
+
+  it('a sibling socket may issue a correlated command, which is what an owner being a client means', async () => {
+    // R2, and the assertion `mayShutDown` cannot make: `device:shutdown` has its own weaker gate, so a
+    // test using only that one passes with ownership still keyed on the socket. Measured — it did.
+    const { agent, sessionIds } = await registerAgent('owner-sibling-input')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const sibling = await browserSocket('tab-a')
+    sibling.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-sib', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await waitForType(agent, 'input:touch:end')).sessionId).toBe(sessionId)
+    expect(await waitForTypeOrNull(sibling, 'input:error', 200)).toBeNull()
+
+    // And a socket of another client is still refused by that same gate.
+    const stranger = await browserSocket('tab-b')
+    stranger.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-str', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await waitForType(stranger, 'input:error')).reason).toBe('not-session-owner')
+
+    agent.close(); holder.close(); sibling.close(); stranger.close()
+  })
+
+  it('a holder whose socket is closing is not busy, because a join for it would succeed', async () => {
+    // `busy` and occupancy have to carry **the same** conditions. A socket in CLOSING has not fired
+    // `close`, so its pong is still fresh and `isAlive` says yes — but `readyState` is not OPEN, so the
+    // join succeeds. `busy` was missing that clause, which locked every other tester out of a device the
+    // relay was ready to hand them, for as long as the close took.
+    const { agent, sessionIds } = await registerAgent('owner-busy-closing')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const stranger = await browserSocket('tab-b')
+    const isBusy = async () => {
+      stranger.send(JSON.stringify({ type: 'agents:list' }))
+      const listed = await waitForType<AgentsListed>(stranger, 'agents:listed')
+      return listed.sessions[0]!.devices.find((d) => d.sessionId === sessionId)!.busy
+    }
+    expect(await isBusy()).toBe(true)
+
+    // Force the holder's server-side socket into a non-OPEN state without letting `close` run, which is
+    // what a lost FIN looks like from the relay's side.
+    const held = (server as unknown as {
+      sessions: { get(id: string): { browserSocket: { readyState: number } } | undefined }
+    }).sessions.get(sessionId)!.browserSocket
+    const real = held.readyState
+    Object.defineProperty(held, 'readyState', { value: WebSocket.CLOSING, configurable: true })
+    try {
+      expect(await isBusy(), 'busy disagreed with the occupancy test').toBe(false)
+    } finally {
+      Object.defineProperty(held, 'readyState', { value: real, configurable: true })
+    }
+
+    agent.close(); holder.close(); stranger.close()
+  })
+
+  it('the owner key pairs the user with the claimed id', () => {
+    // Held here because the handler's inline version was unreachable without an authenticated handshake,
+    // and a mutation dropping the user id survived the entire suite. Two accounts claiming the same id is
+    // the case the pairing exists for: a leaked client id must be useless to anyone else.
+    expect(ownerKeyFor(7, 'tab-a')).toBe('7:tab-a')
+    expect(ownerKeyFor(7, 'tab-a')).not.toBe(ownerKeyFor(8, 'tab-a'))
+    // No claim → a fresh identity each time, which is per-socket, which is what it replaced.
+    expect(ownerKeyFor(7, null)).not.toBe(ownerKeyFor(7, null))
+    expect(ownerKeyFor(7, '')).not.toBe(ownerKeyFor(7, ''))
+    // Unauthenticated (localhost) connections still differ by their claim.
+    expect(ownerKeyFor(undefined, 'tab-a')).toBe('anon:tab-a')
+  })
+
+  it('a client that sends no id keeps the behaviour each gate had before it', async () => {
+    // R6, and it is **two different answers** because the two gates are different.
+    //
+    // An unidentified connection is minted an identity, so its sockets are strangers to each other —
+    // which is the ownership `ownsSession` always had, and input stays refused. But the *shutdown* gate
+    // cannot be applied to such a client at all: it would refuse that client's own teardown every time,
+    // not as a race, because its teardown socket is minted a different identity from the one holding the
+    // session. An older dashboard bundle re-attaching to an upgraded relay is exactly that shape, and
+    // gating it would leave a device booted until the idle timer on every Back press.
+    const { agent, sessionIds } = await registerAgent('owner-anonymous')
+    const sessionId = sessionIds[0]!
+    const one = await browserSocket()
+    one.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(one, 'session:joined')
+
+    const two = await browserSocket()
+    two.send(JSON.stringify({
+      type: 'input:touch:end', sessionId, requestId: 'rq-anon', payload: { x: 0.5, y: 0.5 },
+    }))
+    expect((await waitForType(two, 'input:error')).reason, 'input is still socket-shaped').toBe('not-session-owner')
+
+    two.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    expect((await waitForType<DeviceShutdown>(agent, 'device:shutdown')).sessionId).toBe(sessionId)
+    expect(await waitForTypeOrNull(two, 'device:shutdown-error', 200)).toBeNull()
+
+    agent.close(); one.close(); two.close()
+  })
+
+  it('a client that does send an id is gated on shutdown', async () => {
+    // The other side of the same rule: the gate holds between clients that say who they are. Paired with
+    // the test above so neither can be read as the whole story.
+    const { agent, sessionIds } = await registerAgent('owner-identified-gate')
+    const sessionId = sessionIds[0]!
+    const holder = await browserSocket('tab-a')
+    holder.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(holder, 'session:joined')
+
+    const stranger = await browserSocket('tab-b')
+    stranger.send(JSON.stringify({ type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' } }))
+    await waitForType<DeviceShutdownError>(stranger, 'device:shutdown-error')
+    expect(await waitForTypeOrNull(agent, 'device:shutdown', 200)).toBeNull()
+
+    agent.close(); holder.close(); stranger.close()
+  })
+
   // ── #542 — device:shutdown is answered when it cannot be dispatched ───────────────────────────────
 
   it('answers a shutdown addressed to a session that does not exist', async () => {
@@ -552,24 +805,24 @@ describe('session ownership seam', () => {
     agent.close(); browser.close()
   })
 
-  it('still forwards a shutdown from a socket that does not hold the session', async () => {
-    // #527, not this slice. `reachableTarget` deliberately omits the ownership clause, because three of
-    // the dashboard's four senders come from a socket that never joins — gating it here would break
-    // going back and the unmount teardown, the two paths that stop a device costing money. This pins the
-    // omission so that closing #527 is a decision someone makes rather than a line that drifts in.
+  it('refuses a shutdown for a session another client is holding', async () => {
+    // **This test used to assert the opposite**, and deliberately: it pinned #527's omission so that
+    // closing it would be a decision someone made rather than a line that drifted in. The decision is
+    // made — a session is owned by a client rather than a socket — so the assertion flips. Kept in place,
+    // rather than deleted and rewritten elsewhere, because the inversion is the record of the change.
     const { agent, sessionIds } = await registerAgent('seam-shutdown-nonowner')
     const sessionId = sessionIds[0]!
-    const holder = await browserSocket()
+    const holder = await browserSocket('tab-a')
     holder.send(JSON.stringify({ type: 'session:start', sessionId }))
     await waitForType(holder, 'session:joined')
 
-    const stranger = await browserSocket()
+    const stranger = await browserSocket('tab-b')
     stranger.send(JSON.stringify({
       type: 'device:shutdown', sessionId, payload: { deviceId: 'dev0' },
     }))
-    const forwarded = await waitForType<DeviceShutdown>(agent, 'device:shutdown')
-    expect(forwarded.sessionId).toBe(sessionId)
-    expect(await waitForTypeOrNull(stranger, 'device:shutdown-error', 200)).toBeNull()
+    const refusal = await waitForType<DeviceShutdownError>(stranger, 'device:shutdown-error')
+    expect(refusal.message).toMatch(/held by another client/)
+    expect(await waitForTypeOrNull(agent, 'device:shutdown', 200)).toBeNull()
 
     agent.close(); holder.close(); stranger.close()
   })

--- a/scripts/__tests__/dashboardSecureContextApis.test.mjs
+++ b/scripts/__tests__/dashboardSecureContextApis.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { sources } from './sourceFiles.mjs'
+
+// **A LAN deployment is plain HTTP, and the dashboard is the thing served over it.** That is not an edge
+// case: it is the primary manual-testing path, and the reason `pickDecoder` carries a WASM tier at all.
+// Several Web Crypto entry points are *secure-context only* — they are simply absent on `http://<mac-ip>`
+// — so calling one is a `TypeError` on the deployment this project exists for.
+//
+// Nothing else can catch it. Dev runs on `localhost`, which **is** a secure context; vitest runs in jsdom
+// and node, where these exist unconditionally. A green suite and a working dev server both agree the code
+// is fine, and the first report is a blank page from a tester on someone else's Mac.
+//
+// It has now happened twice. `lib/requestId.ts` was written the first time and says so in its own doc:
+// *"a second `randomUUID` would have looked correct in every dev environment and thrown only on the
+// deployment tapflow is for."* The second was a per-document client id in `useRelay` — a module every
+// route loads, so the failure would have been the whole dashboard rather than one socket. It was caught by
+// review. This is the check that means the third does not need to be.
+
+const root = join(import.meta.dirname, '../..')
+
+/**
+ * Secure-context-only Web Crypto surfaces, with what to use instead.
+ *
+ * `getRandomValues` is deliberately **not** here: it has no such restriction, which is what makes
+ * `newRequestId` the answer rather than a workaround.
+ */
+const FORBIDDEN = [
+  { pattern: /\bcrypto\.randomUUID\s*\(/, use: '`newRequestId()` from `lib/requestId.ts`' },
+  { pattern: /\bcrypto\.subtle\b/, use: 'a non-crypto approach, or move the work to the relay' },
+]
+
+const FILES = sources('packages/dashboard').filter((f) => !f.includes('__tests__'))
+
+/** Comments blanked, line count preserved — this file's own header names both APIs, and so does the doc
+ *  block on `requestId.ts` that exists to warn about them. A check that read prose would fail on the
+ *  warning. */
+const code = (path) =>
+  readFileSync(join(root, path), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .split('\n')
+    .map((l) => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .join('\n')
+
+describe('the dashboard bundle calls nothing that needs a secure context', () => {
+  it('the file walk found the bundle', () => {
+    // Anti-vacuity from the measurement: an empty list makes every assertion below hold for nothing, and
+    // this program's parser failures were all partial losses that left a non-empty result behind.
+    expect(FILES.length).toBeGreaterThanOrEqual(80)
+    expect(FILES.some((f) => f.endsWith('hooks/useRelay.ts'))).toBe(true)
+  })
+
+  for (const { pattern, use } of FORBIDDEN) {
+    it(`no call to ${String(pattern)}`, () => {
+      const offenders = FILES
+        .filter((f) => pattern.test(code(f)))
+        .map((f) => `${f} — secure-context only, absent over plain HTTP. Use ${use}.`)
+      expect(offenders).toEqual([])
+    })
+  }
+
+  it('the patterns match a call, and prose about it does not count as one', () => {
+    // The check's own strictness, which nothing else holds. Two independent things keep the file that
+    // *warns* about this API from being reported as breaking it, and both are load-bearing: the pattern
+    // requires a call (`(`), so a backticked mention is not one, and comments are blanked, so a
+    // commented-out call is not one either. A version missing both would fail on `requestId.ts` — the file
+    // written to prevent the failure — and the check would be deleted rather than the call.
+    const [uuid] = FORBIDDEN
+    expect(uuid.pattern.test('const id = crypto.randomUUID()')).toBe(true)
+    expect(uuid.pattern.test('`crypto.randomUUID` is not available here'), 'a mention is not a call')
+      .toBe(false)
+    expect(uuid.pattern.test(code('packages/dashboard/lib/requestId.ts')), 'the warning file is clean')
+      .toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Two defects met on the same two lines — `SessionManager.join()` and `handleSessionStart` — so this is one change rather than two. Closes #527, #579 and, as a consequence, #574.

- **#527** the relay decided who may command a session from a *socket*, but a browser tab holds four of them and the one holding the session is not the one that sends the teardown. A session is owned by `<userId>:<clientId>` now, from a `?client=` parameter at the handshake, minted per connection when absent — so there is no fallback branch and an unidentified client keeps the ownership it had.
- **#579** occupancy read `readyState`, which is not a liveness signal: a sleeping laptop holds a session for up to a minute. It reads the heartbeat's pong record instead, as a **timestamp** rather than the swept boolean — that flag called every healthy socket dead for a ping round trip, longest for the holder, whose socket also carries the video.

`device:shutdown` takes a weaker gate: refused when another client holds the session, permitted when nobody does. Not "owned by me", because the unmount teardown races its own viewer socket's close on a different connection.

Reasoning is beside the code; the release note is in `.changeset/session-owner-is-a-tab.md`.

## Checklist

- [x] Tests written and passing — 2679 across the monorepo, 24 mutations run
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a; the handshake parameter is documented in `relay/AGENTS.md` and its home in the wire contract is #581
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- Plan: `.work/2026-08-17-session-owner-is-a-tab-plan.md`
- Review: `.work/reviews/feat__session-owner-is-a-tab.md` — five channels: two design lenses that **killed the first plan**, one on the four decisions that replaced it, and two on the diff

Worth reading. The pre-PR review found `crypto.randomUUID` in the dashboard — secure-context only, and a LAN deployment is plain HTTP. `lib/requestId.ts` records that exact lesson from the first time it happened and predicts the second in writing. Because the call sat at module scope in a file every route loads, it would have been a blank page rather than a broken socket, and it was green everywhere it could be run: dev is localhost, vitest is jsdom. A static check now makes a third impossible.

It also found that the new gate would have stopped a client that sends no id from shutting down its own device — deterministically, not as a race — which is the cost #527 was filed to avoid, reintroduced by #527's fix.

Two things in this slice came from review conversation rather than a lens: that a per-document identity is not the *root* fix for #579 (the root is that `readyState` is not liveness), and that splitting the two halves would have meant fixing the same two lines twice.

Split out: #581.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions remain associated with the browser tab that opened them, preventing other connections from shutting them down.
  * Reconnecting tabs can resume sessions after network interruptions.
  * Disconnected sessions are released after approximately 45 seconds.
  * Device availability and “In use” indicators now consistently reflect active ownership.
  * Dashboard connections work reliably over non-secure HTTP contexts.

* **Documentation**
  * Updated guidance for session ownership, shutdown behavior, and connection liveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->