### PR TITLE
Keep the resource series inside its plot, and match the comment form's radius

### DIFF
--- a/.changeset/typecheck-and-lint-tests-backfill.md
+++ b/.changeset/typecheck-and-lint-tests-backfill.md
@@ -1,0 +1,24 @@
+---
+'@tapflowio/agent-core': patch
+'@tapflowio/android-agent': patch
+'@tapflowio/audiotap-helper': patch
+'@tapflowio/cli': patch
+'@tapflowio/flow-runner': patch
+'@tapflowio/ios-agent': patch
+'@tapflowio/mcp-server': patch
+'@tapflowio/relay': patch
+---
+
+Type-check and lint the test trees
+
+Backfills: #537
+
+<!-- changelog: internal — a `typecheck` script and a test-tree tsconfig per package; no runtime or
+     interface change a self-hoster can observe. What it found was inside the tests themselves: a double
+     declaring `implements DeviceAgent` while missing two members, five duplicate object keys, a call
+     passing one argument to a two-argument method, and a `test-utils` constraint no named message could
+     satisfy. -->
+
+Every package's build tsconfig excluded `src/__tests__` and eslint ignored it, so a test double could
+drift from the interface it doubled with both gates green. The manifests gained a `typecheck` script and
+the test trees a tsconfig of their own, which is the only reason this touches published files at all.

--- a/.changeset/typecheck-and-lint-tests-backfill.md
+++ b/.changeset/typecheck-and-lint-tests-backfill.md
@@ -2,7 +2,7 @@
 '@tapflowio/agent-core': patch
 '@tapflowio/android-agent': patch
 '@tapflowio/audiotap-helper': patch
-'@tapflowio/cli': patch
+'tapflow': patch
 '@tapflowio/flow-runner': patch
 '@tapflowio/ios-agent': patch
 '@tapflowio/mcp-server': patch
@@ -13,12 +13,13 @@ Type-check and lint the test trees
 
 Backfills: #537
 
-<!-- changelog: internal — a `typecheck` script and a test-tree tsconfig per package; no runtime or
-     interface change a self-hoster can observe. What it found was inside the tests themselves: a double
-     declaring `implements DeviceAgent` while missing two members, five duplicate object keys, a call
-     passing one argument to a two-argument method, and a `test-utils` constraint no named message could
-     satisfy. -->
+<!-- changelog: internal — a per-package `typecheck` script and a test-tree tsconfig; no runtime or interface change a self-hoster can observe -->
 
 Every package's build tsconfig excluded `src/__tests__` and eslint ignored it, so a test double could
 drift from the interface it doubled with both gates green. The manifests gained a `typecheck` script and
 the test trees a tsconfig of their own, which is the only reason this touches published files at all.
+What the gates then found was inside the tests: a double declaring `implements DeviceAgent` while missing
+two members, five duplicate object keys, a call passing one argument to a two-argument method, and a
+`test-utils` constraint no named message could satisfy.
+
+The CLI is `tapflow`, not `@tapflowio/cli` — the manifest name, which is what `changeset version` resolves.

--- a/packages/dashboard/components/CommentPanel.tsx
+++ b/packages/dashboard/components/CommentPanel.tsx
@@ -145,18 +145,33 @@ export function CommentPanel({ buildId }: Props) {
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="h-4 w-4 ml-0.5 opacity-0 group-hover:opacity-50 hover:!opacity-100 transition-opacity"
+                              className="h-4 w-4 ml-0.5 opacity-0 group-hover:opacity-50 hover:!opacity-100 group-focus-within:opacity-50 focus-visible:!opacity-100 transition-opacity"
+                              aria-label="Copy link to comment"
                               onClick={() => copyLink(c.id)}
                             >
-                              <Link2 className="h-3 w-3" />
+                              <Link2 className="h-3 w-3" aria-hidden="true" />
                             </Button>
                           </div>
                           <p className="text-sm leading-relaxed whitespace-pre-wrap mt-1">{c.body}</p>
-                          {c.attachments.map((a) => (
-                            <a key={a.id} href={a.file_path} target="_blank" rel="noreferrer" className="mt-1.5 block">
-                              <img src={a.file_path} alt="attachment" className="max-h-48 rounded border object-contain" />
-                            </a>
-                          ))}
+                          {c.attachments.map((a) => {
+                            // The stored name, not the word "attachment": the image is the link's only
+                            // content and therefore its whole accessible name, so several attachments on
+                            // one comment all announced identically. `CommentAttachment` carries no
+                            // filename field, so the path's last segment is the description available.
+                            const name = decodeURIComponent(a.file_path.split('/').pop() ?? 'image')
+                            return (
+                              <a
+                                key={a.id}
+                                href={a.file_path}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="mt-1.5 block"
+                                aria-label={`Open ${name} in a new tab`}
+                              >
+                                <img src={a.file_path} alt={name} className="max-h-48 rounded border object-contain" />
+                              </a>
+                            )
+                          })}
                         </div>
                       </div>
                     ))}
@@ -170,8 +185,13 @@ export function CommentPanel({ buildId }: Props) {
 
       <div className="pb-1">
       <form onSubmit={handleSubmit}>
-        <div className="rounded-xl border border-input bg-background ring-offset-background transition-shadow focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+        {/* `rounded-md` (6px), the same as the list above it — `rounded-xl` is 12px and is not on this
+          scale at all, so the two boxes in one column disagreed by 6px. DESIGN.md's md is the form radius. */}
+      <div className="rounded-md border border-input bg-background ring-offset-background transition-shadow focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
           <Textarea
+            // The placeholder is a hint, not a name: it is gone the moment anyone types, leaving an edit
+            // box a screen reader can only call "text area".
+            aria-label="Comment"
             placeholder="Leave a comment…"
             value={body}
             onChange={(e) => setBody(e.target.value)}
@@ -189,9 +209,10 @@ export function CommentPanel({ buildId }: Props) {
               variant="ghost"
               size="icon"
               className="h-7 w-7 text-muted-foreground"
+              aria-label="Attach image"
               onClick={() => fileRef.current?.click()}
             >
-              <ImagePlus className="h-4 w-4" />
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
             </Button>
             <input
               ref={fileRef}
@@ -205,9 +226,10 @@ export function CommentPanel({ buildId }: Props) {
               type="submit"
               size="icon"
               className="h-7 w-7 rounded-full"
+              aria-label="Post comment"
               disabled={submitting || (!body.trim() && !file)}
             >
-              <ArrowUp className="h-3.5 w-3.5" />
+              <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </div>

--- a/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
+++ b/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
@@ -170,6 +170,20 @@ describe('the chart can be read without a mouse', () => {
     expect(surface.getAttribute('aria-valuenow'), 'refocus jumped the reader to the end').toBe('1')
   })
 
+  it('tells adjacent samples apart on every range', () => {
+    // `formatTick` is the axis format: on 7d it is the date alone, so every sample in a day announced
+    // identically and arrowing between neighbours sounded like nothing had moved. The visible tooltip is
+    // `aria-hidden`, so this string is the only reading AT gets.
+    const { container } = render(
+      <AreaChartInner width={600} height={220} data={series} dataKey="cpu" hex="#60a5fa" range="7d" now={AT} label="CPU %" />,
+    )
+    const surface = surfaceOf(container)
+    fireEvent.focus(surface)
+    const first = surface.getAttribute('aria-valuetext')
+    fireEvent.keyDown(surface, { key: 'ArrowLeft' })
+    expect(surface.getAttribute('aria-valuetext'), 'two samples announce the same thing').not.toBe(first)
+  })
+
   it('does not paint an outline until focus asks for one', () => {
     // `outline-none` is a *transparent* 2px outline, so colouring it inline drew a black box around every
     // plot at rest — reported from a screenshot, not by any gate.

--- a/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
+++ b/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
@@ -200,6 +200,10 @@ describe('the chart can be read without a mouse', () => {
     expect(announced).toContain('57.4%')
     const drawn = container.querySelector('[aria-hidden="true"]')?.textContent ?? ''
     expect(drawn, 'the drawn reading disagrees with the announced one').toContain('57.4%')
+
+    // The third rendering of the same number: the chart's own summary name, which a reader hears on the
+    // way in. It rounded to an integer while both of the above kept a digit.
+    expect(container.querySelector('svg')?.getAttribute('aria-label')).toContain('12.3%')
   })
 
   it('does not paint an outline until focus asks for one', () => {

--- a/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
+++ b/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AreaChartInner } from '@/src/pages/MacResources'
+
+// **The series is clipped to the plot, and this is what says so.** The window's right edge is rounded *up*
+// to a clean tick so the times stay round (`ceil(now / step) * step`), which pushes its left edge up to one
+// step later than the oldest sample the relay returns — the API selects from `now - interval`, the chart
+// draws from `ceil(now/step)*step - interval`. On the 1h range that is 10 minutes of points sitting left of
+// the y-axis, and `scaleTime` does not clamp: they map to a negative x and the area painted straight
+// through the tick labels. It showed worst on RAM, which sits at ~57% right where "50%" and "25%" are.
+//
+// Rendered directly rather than through the page: `ParentSize` measures 0 in jsdom, so `ChartCard` renders
+// nothing there and a test of the page would assert against an empty div.
+
+const AT = Date.parse('2026-08-18T02:55:00.000Z')
+const STEP = 600_000 // the 1h range's tick step
+
+/** One sample per minute across the last hour — which starts before the rounded-up window does. */
+const series = Array.from({ length: 60 }, (_, i) => {
+  const t = AT - (59 - i) * 60_000
+  return { time: new Date(t).toISOString(), cpu: 20, mem: 57 }
+})
+
+const paths = (c: HTMLElement) => [...c.querySelectorAll('path')].map((p) => p.getAttribute('d') ?? '')
+const xs = (d: string) => [...d.matchAll(/[ML]\s*(-?[\d.]+)/g)].map((m) => Number(m[1]))
+
+describe('the resource chart does not paint over its own axis', () => {
+  it('has samples that fall left of the plot — the premise, measured', () => {
+    // Without this the test below could pass on a chart that simply has nothing to clip.
+    const maxT = Math.ceil(AT / STEP) * STEP
+    const minT = maxT - 3_600_000
+    const before = series.filter((d) => Date.parse(d.time) < minT)
+    expect(before.length, 'no sample precedes the window — pick an `AT` that is not on a step boundary')
+      .toBeGreaterThan(0)
+  })
+
+  it('draws the series inside a clip that starts at the axis', () => {
+    const { container } = render(
+      <AreaChartInner width={600} height={220} data={series} dataKey="cpu" hex="#60a5fa" range="1h" now={AT} label="CPU %" />,
+    )
+
+    const clipped = container.querySelector('g[clip-path]')
+    expect(clipped, 'the series is not clipped').not.toBeNull()
+    expect(clipped!.querySelectorAll('path').length, 'the area and the line are both inside the clip').toBe(2)
+
+    const rect = container.querySelector('clipPath rect')!
+    expect(rect.getAttribute('x'), 'the clip must start at the axis, not left of it').toBe('0')
+    expect(Number(rect.getAttribute('width'))).toBeGreaterThan(0)
+  })
+
+  it('and the geometry it clips really does reach past the axis', () => {
+    // The other half: if the scale ever started clamping, the clip would be inert and this file would go on
+    // reporting success for a fix that no longer does anything.
+    const { container } = render(
+      <AreaChartInner width={600} height={220} data={series} dataKey="mem" hex="#a78bfa" range="1h" now={AT} label="RAM %" />,
+    )
+    const drawn = paths(container).flatMap(xs)
+    expect(drawn.length, 'no path geometry was rendered').toBeGreaterThan(0)
+    expect(Math.min(...drawn), 'nothing extends past the axis — the clip is guarding nothing').toBeLessThan(0)
+  })
+})
+
+describe('the chart can be read without a mouse', () => {
+  // The tooltip is the only place a reading is written down, and it opened on `mousemove` alone — so the
+  // page was unreadable to a keyboard user, which is what the a11y gate blocked this change on. Held here
+  // rather than left to the gate: the gate reads a diff, and nothing would fail once the file stops changing.
+  const setup = () =>
+    render(
+      <AreaChartInner width={600} height={220} data={series} dataKey="cpu" hex="#60a5fa" range="1h" now={AT} label="CPU %" />,
+    )
+  const surfaceOf = (c: HTMLElement) => c.querySelector('rect[role="slider"]')!
+
+  it('exposes the cursor as a slider, which is the role whose key model is the arrow keys', () => {
+    // **Not `img` or `application`.** A non-widget role leaves NVDA and JAWS in browse mode, where the
+    // virtual cursor takes the arrow keys before `onKeyDown` ever runs — the keyboard path would exist and
+    // be unreachable for the users it was built for. The reading rides on `aria-valuetext`, so there is no
+    // live region to keep in step with it.
+    const { container } = setup()
+    const surface = surfaceOf(container)
+    expect(surface.getAttribute('tabindex')).toBe('0')
+    expect(surface.getAttribute('aria-valuemax')).toBe(String(series.length - 1))
+    expect(surface.getAttribute('aria-valuetext')).toMatch(/CPU %/)
+  })
+
+  it('the arrows walk the series and Escape dismisses the reading', () => {
+    const { container } = setup()
+    const surface = surfaceOf(container)
+
+    fireEvent.focus(surface)
+    const atFocus = surface.getAttribute('aria-valuenow')
+    expect(surface.getAttribute('aria-valuetext')).toMatch(/\d+%/)
+
+    fireEvent.keyDown(surface, { key: 'ArrowLeft' })
+    expect(surface.getAttribute('aria-valuenow'), 'ArrowLeft did not move the cursor').not.toBe(atFocus)
+
+    fireEvent.keyDown(surface, { key: 'Home' })
+    expect(surface.getAttribute('aria-valuenow')).toBe('0')
+
+    // Dismissible without moving focus (WCAG 1.4.13) — the reading overlays the plot.
+    fireEvent.keyDown(surface, { key: 'Escape' })
+    expect(container.querySelector('[class*="pointer-events-none"]'), 'Escape left the reading up').toBeNull()
+  })
+
+  it('names itself with the title the card shows', () => {
+    // The page passes its visible card title (`CPU %`), not the legend key (`CPU`) — asserting the latter
+    // would check a string the page never produces and would miss the name drifting from what is on screen.
+    const { container } = setup()
+    expect(container.querySelector('svg')?.getAttribute('aria-label')).toMatch(/^CPU %, last 1h/)
+    expect(surfaceOf(container).getAttribute('aria-label')).toBe('CPU % samples')
+  })
+
+  it('keeps the cursor where the reader left it when the overlay is dismissed', () => {
+    // Derived from `tooltipData`, every path that hid the reading — Escape, blur — snapped the announced
+    // value back to the last sample: a change nobody made, and the next arrow key resumed from the end.
+    const { container } = setup()
+    const surface = surfaceOf(container)
+
+    fireEvent.focus(surface)
+    fireEvent.keyDown(surface, { key: 'Home' })
+    expect(surface.getAttribute('aria-valuenow')).toBe('0')
+    fireEvent.keyDown(surface, { key: 'Escape' })
+    expect(surface.getAttribute('aria-valuenow'), 'Escape moved the cursor').toBe('0')
+    fireEvent.blur(surface)
+    expect(surface.getAttribute('aria-valuenow'), 'blur moved the cursor').toBe('0')
+  })
+
+  it('answers the vertical arrows too, which are half of the slider key set', () => {
+    const { container } = setup()
+    const surface = surfaceOf(container)
+    fireEvent.focus(surface)
+    fireEvent.keyDown(surface, { key: 'Home' })
+    fireEvent.keyDown(surface, { key: 'ArrowUp' })
+    expect(surface.getAttribute('aria-valuenow'), 'ArrowUp did not move the cursor').toBe('1')
+    fireEvent.keyDown(surface, { key: 'ArrowDown' })
+    expect(surface.getAttribute('aria-valuenow')).toBe('0')
+  })
+
+  it('keeps the announced value inside the series when the range shrinks under it', () => {
+    // Switching 7d → 1h leaves a cursor that was valid pointing past the end. Unclamped, `aria-valuenow`
+    // sat above `aria-valuemax` with no `aria-valuetext` at all — a slider announcing an index.
+    const { container, rerender } = setup()
+    const surface = surfaceOf(container)
+    fireEvent.focus(surface)
+    fireEvent.keyDown(surface, { key: 'End' })
+    expect(surface.getAttribute('aria-valuenow')).toBe(String(series.length - 1))
+
+    rerender(
+      <AreaChartInner width={600} height={220} data={series.slice(0, 3)} dataKey="cpu" hex="#60a5fa" range="1h" now={AT} label="CPU %" />,
+    )
+    const after = surfaceOf(container)
+    expect(Number(after.getAttribute('aria-valuenow'))).toBeLessThanOrEqual(Number(after.getAttribute('aria-valuemax')))
+    expect(after.getAttribute('aria-valuetext'), 'the reading went missing').toMatch(/CPU %/)
+  })
+
+  it('does not paint an outline until focus asks for one', () => {
+    // `outline-none` is a *transparent* 2px outline, so colouring it inline drew a black box around every
+    // plot at rest — reported from a screenshot, not by any gate.
+    const surface = surfaceOf(setup().container)
+    expect(surface.getAttribute('style') ?? '', 'an inline outline colour is visible at rest').not.toMatch(/outline/i)
+    expect(surface.getAttribute('class') ?? '').toMatch(/focus-visible:outline/)
+  })
+})

--- a/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
+++ b/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
@@ -184,6 +184,24 @@ describe('the chart can be read without a mouse', () => {
     expect(surface.getAttribute('aria-valuetext'), 'two samples announce the same thing').not.toBe(first)
   })
 
+  it('announces exactly what it draws', () => {
+    // The tooltip is `aria-hidden`, so `aria-valuetext` is the only reading AT gets — and the two used to
+    // be formatted separately, diverging first on the date and then on precision (57.4% drawn, "57%"
+    // announced). One formatter, asserted against a fractional value so a rounding difference would show.
+    const fractional = [{ time: series[0]!.time, cpu: 57.4, mem: 57.4 }, { time: series[1]!.time, cpu: 12.3, mem: 12.3 }]
+    const { container } = render(
+      <AreaChartInner width={600} height={220} data={fractional} dataKey="cpu" hex="#60a5fa" range="1h" now={AT} label="CPU %" />,
+    )
+    const surface = surfaceOf(container)
+    fireEvent.focus(surface)
+    fireEvent.keyDown(surface, { key: 'Home' })
+
+    const announced = surface.getAttribute('aria-valuetext') ?? ''
+    expect(announced).toContain('57.4%')
+    const drawn = container.querySelector('[aria-hidden="true"]')?.textContent ?? ''
+    expect(drawn, 'the drawn reading disagrees with the announced one').toContain('57.4%')
+  })
+
   it('does not paint an outline until focus asks for one', () => {
     // `outline-none` is a *transparent* 2px outline, so colouring it inline drew a black box around every
     // plot at rest — reported from a screenshot, not by any gate.

--- a/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
+++ b/packages/dashboard/src/__tests__/MacResources.chart.test.tsx
@@ -152,6 +152,24 @@ describe('the chart can be read without a mouse', () => {
     expect(after.getAttribute('aria-valuetext'), 'the reading went missing').toMatch(/CPU %/)
   })
 
+  it('returns focus to where the reader left the cursor, not to the end', () => {
+    // Focus used to select the newest sample every time, so Escape (or tabbing away) and coming back moved
+    // the reader to the other end of the series without a keypress — and the next arrow stepped from there.
+    const { container } = setup()
+    const surface = surfaceOf(container)
+
+    fireEvent.focus(surface)
+    expect(surface.getAttribute('aria-valuenow'), 'the first focus should open at the newest sample')
+      .toBe(String(series.length - 1))
+    fireEvent.keyDown(surface, { key: 'Home' })
+    fireEvent.keyDown(surface, { key: 'ArrowRight' })
+    expect(surface.getAttribute('aria-valuenow')).toBe('1')
+
+    fireEvent.blur(surface)
+    fireEvent.focus(surface)
+    expect(surface.getAttribute('aria-valuenow'), 'refocus jumped the reader to the end').toBe('1')
+  })
+
   it('does not paint an outline until focus asks for one', () => {
     // `outline-none` is a *transparent* 2px outline, so colouring it inline drew a black box around every
     // plot at rest — reported from a screenshot, not by any gate.

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -320,9 +320,15 @@ export function AreaChartInner({
   }
 
   const latest = data[data.length - 1]
-  // Named, because the page renders two of these side by side and each has its own live region — an
-  // unattributed "02:50, 57%" does not say which chart answered.
-  const reading = (d: Datum) => `${label}, ${formatTick(d.time, range)}, ${Math.round(d[dataKey])}%`
+  // Named, because the page renders two of these side by side — an unattributed "02:50, 57%" does not say
+  // which chart answered. And its own full timestamp rather than `formatTick`, which is written for axis
+  // labels: on 7d that format is the date alone, so every sample in a day announced identically and
+  // arrowing between neighbours sounded like nothing had moved. This is the only reading AT gets — the
+  // visible tooltip is `aria-hidden` — so it carries what that tooltip draws.
+  const reading = (d: Datum) =>
+    `${label}, ${new Date(d.time).toLocaleString('ko-KR', {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+    })}, ${Math.round(d[dataKey])}%`
 
   return (
     <>

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -187,7 +187,9 @@ const getTime = (d: Datum) => new Date(d.time).getTime()
  *  string, and every other date in the dashboard already follows the reader's own locale. */
 const stampOf = (d: Datum) =>
   new Date(d.time).toLocaleString(undefined, {
-    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+    // `hourCycle`, not `hour12: false`: en-US maps that flag to h24, which speaks midnight as "24:00" —
+    // an hour that is on no axis in this page. h23 is the cycle the axis labels use.
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
   })
 const percentOf = (v: number) => `${Math.round(v * 10) / 10}%`
 const bisectTime = bisector<Datum, number>(getTime).left
@@ -349,7 +351,7 @@ export function AreaChartInner({
         role="group"
         aria-label={
           latest
-            ? `${label}, last ${range}. Latest ${Math.round(latest[dataKey])} percent.`
+            ? `${label}, last ${range}. Latest ${percentOf(latest[dataKey])}.`
             : `${label}, last ${range}. No samples.`
         }
       >

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -247,11 +247,16 @@ export function AreaChartInner({
   // **Its own state, not a view of `tooltipData`.** Derived, every path that hides the reading — Escape,
   // blur — snapped the announced value back to the last sample: a change the user never made, and the next
   // arrow key resumed from the end rather than where they were reading.
-  const [cursor, setCursor] = useState(0)
+  // `null` until the reader places it, which is not the same as 0: an unplaced cursor should open at the
+  // newest sample, and a placed one should still be there after Escape or a blur. Focus used to jump to
+  // the end unconditionally, so leaving and returning silently moved the reader to the other end of the
+  // series and the next arrow key stepped from there.
+  const [cursor, setCursor] = useState<number | null>(null)
   // Clamped on render: switching 7d → 1h shrinks `data` under a cursor that was valid, which left
   // `aria-valuenow` above `aria-valuemax` and `aria-valuetext` undefined — a slider announcing a bare
   // out-of-range index instead of a reading.
-  const idx = Math.min(cursor, Math.max(0, data.length - 1))
+  const last = Math.max(0, data.length - 1)
+  const idx = cursor === null ? last : Math.min(cursor, last)
 
   const innerW = width - MARGIN.left - MARGIN.right
   const innerH = height - MARGIN.top - MARGIN.bottom
@@ -417,7 +422,7 @@ export function AreaChartInner({
             // No inline `outlineColor`: `outline-none` is a *transparent* 2px outline, so colouring it
             // here painted a black box around the plot at rest. The colour belongs in the focus variant.
             className="outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-            onFocus={() => showAt(data.length - 1)}
+            onFocus={() => showAt(idx)}
             onBlur={hideTooltip}
             onKeyDown={handleKey}
             onMouseMove={handleMove}

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -436,6 +436,9 @@ export function AreaChartInner({
       <p id={hintId} className="sr-only">Use the arrow keys to read individual samples. Escape hides the reading.</p>
       {tooltipData && (
         <div
+          // The reading rides on `aria-valuetext`; this is the same value drawn, and exposing both gave a
+          // browse-mode reader two renderings of it that disagreed on date format and rounding.
+          aria-hidden="true"
           className="pointer-events-none absolute top-0 left-0 whitespace-nowrap rounded-lg border bg-background px-3 py-2 text-xs text-foreground shadow-md"
           style={{
             // transform (not left/top) so position eases smoothly like recharts

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -177,6 +177,19 @@ export function MacResources() {
 type Datum = { time: string; cpu: number; mem: number }
 
 const getTime = (d: Datum) => new Date(d.time).getTime()
+
+/** The sample, in words. **One function, called by the tooltip and by `aria-valuetext`.** They used to
+ *  format separately and diverged twice — a date the axis format had already truncated, then a rounding
+ *  that gave the screen-reader user one digit less than the sighted one from the same cursor. The comment
+ *  claiming the two agreed was the thing that was false.
+ *
+ *  `undefined` locale, not `'ko-KR'`: the document is `lang="en"`, an English synthesizer is handed this
+ *  string, and every other date in the dashboard already follows the reader's own locale. */
+const stampOf = (d: Datum) =>
+  new Date(d.time).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+  })
+const percentOf = (v: number) => `${Math.round(v * 10) / 10}%`
 const bisectTime = bisector<Datum, number>(getTime).left
 
 const MARGIN = { top: 8, right: 24, bottom: 24, left: 40 }
@@ -321,14 +334,9 @@ export function AreaChartInner({
 
   const latest = data[data.length - 1]
   // Named, because the page renders two of these side by side — an unattributed "02:50, 57%" does not say
-  // which chart answered. And its own full timestamp rather than `formatTick`, which is written for axis
-  // labels: on 7d that format is the date alone, so every sample in a day announced identically and
-  // arrowing between neighbours sounded like nothing had moved. This is the only reading AT gets — the
-  // visible tooltip is `aria-hidden` — so it carries what that tooltip draws.
-  const reading = (d: Datum) =>
-    `${label}, ${new Date(d.time).toLocaleString('ko-KR', {
-      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
-    })}, ${Math.round(d[dataKey])}%`
+  // which chart answered. The rest comes from `stampOf`/`percentOf`, which the visible tooltip also calls:
+  // this is the only reading AT gets, since that tooltip is `aria-hidden`, so the two must not drift.
+  const reading = (d: Datum) => `${label}, ${stampOf(d)}, ${percentOf(d[dataKey])}`
 
   return (
     <>
@@ -454,12 +462,10 @@ export function AreaChartInner({
         >
           <p className="mb-1">
             Date:{' '}
-            {new Date(tooltipData.time).toLocaleString('ko-KR', {
-              month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
-            })}
+            {stampOf(tooltipData)}
           </p>
           <p>
-            {label}: {Math.round(tooltipData[dataKey] * 10) / 10}%
+            {label}: {percentOf(tooltipData[dataKey])}
           </p>
         </div>
       )}

--- a/packages/dashboard/src/pages/MacResources.tsx
+++ b/packages/dashboard/src/pages/MacResources.tsx
@@ -103,11 +103,13 @@ export function MacResources() {
 
   return (
     <div className="flex h-full min-h-0">
-      {/* Macs sidebar */}
-      <aside className="w-64 shrink-0 border-r flex flex-col gap-1 p-3 overflow-y-auto">
-        <span className="px-2 pb-1 font-mono text-xs font-medium text-muted-foreground uppercase tracking-wider">
+      {/* Macs sidebar. The title is a heading rather than a styled span for the same reason the chart
+          titles are: with the charts now landmarked by `h2`, this list would be the one region of the page
+          a screen-reader user could not jump to. */}
+      <aside aria-labelledby="macs-heading" className="w-64 shrink-0 border-r flex flex-col gap-1 p-3 overflow-y-auto">
+        <h2 id="macs-heading" className="px-2 pb-1 font-mono text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Macs
-        </span>
+        </h2>
         {allAgents.length === 0 ? (
           <span className="px-2 text-sm text-muted-foreground">
             {connected ? 'No agents yet.' : 'Connecting…'}
@@ -201,13 +203,16 @@ function ChartCard({
     <div className="rounded-lg border p-4 flex flex-col gap-3">
       <div className="flex items-center gap-2">
         <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ background: hex }} />
-        <span className="text-sm font-medium">{title}</span>
+        {/* A heading, not a styled span: it is a section title in every respect, and it is what names the
+            chart below it — an outline of one `h1` and nothing else gives a screen-reader user no way to
+            move between the two charts. */}
+        <h2 className="text-sm font-medium">{title}</h2>
       </div>
       <div className="relative h-[220px] w-full">
         <ParentSize>
           {({ width, height }) =>
             width > 0 && height > 0 ? (
-              <AreaChartInner width={width} height={height} data={data} dataKey={dataKey} hex={hex} range={range} now={now} label={chartConfig[dataKey].label} />
+              <AreaChartInner width={width} height={height} data={data} dataKey={dataKey} hex={hex} range={range} now={now} label={title} />
             ) : null
           }
         </ParentSize>
@@ -216,7 +221,9 @@ function ChartCard({
   )
 }
 
-function AreaChartInner({
+/** Exported for `MacResources.chart.test.tsx` only. `ParentSize` measures 0 in jsdom, so the chart never
+ *  renders through the page — and the clip below is the kind of thing that regresses silently. */
+export function AreaChartInner({
   width,
   height,
   data,
@@ -236,6 +243,15 @@ function AreaChartInner({
   label: string
 }) {
   const { showTooltip, hideTooltip, tooltipData, tooltipLeft, tooltipTop } = useTooltip<Datum>()
+  const hintId = `chart-hint-${dataKey}`
+  // **Its own state, not a view of `tooltipData`.** Derived, every path that hides the reading — Escape,
+  // blur — snapped the announced value back to the last sample: a change the user never made, and the next
+  // arrow key resumed from the end rather than where they were reading.
+  const [cursor, setCursor] = useState(0)
+  // Clamped on render: switching 7d → 1h shrinks `data` under a cursor that was valid, which left
+  // `aria-valuenow` above `aria-valuemax` and `aria-valuetext` undefined — a slider announcing a bare
+  // out-of-range index instead of a reading.
+  const idx = Math.min(cursor, Math.max(0, data.length - 1))
 
   const innerW = width - MARGIN.left - MARGIN.right
   const innerH = height - MARGIN.top - MARGIN.bottom
@@ -250,6 +266,38 @@ function AreaChartInner({
   const ticks = Array.from({ length: RANGE_MS[range] / step + 1 }, (_, i) => new Date(minT + i * step))
 
   const gradId = `fill-${dataKey}`
+  const clipId = `plot-${dataKey}`
+
+  /** Show the sample at `i`, the way a pointer move would. The keyboard path lands here too. */
+  const showAt = (i: number) => {
+    const d = data[i]
+    if (!d) return
+    setCursor(i)
+    showTooltip({ tooltipData: d, tooltipLeft: xScale(getTime(d)), tooltipTop: yScale(d[dataKey]) })
+  }
+
+  // **The values in this chart were mouse-only.** The tooltip is the only place a reading is written down,
+  // and it opened on `mousemove` alone — so a keyboard user could reach the page and read nothing from it.
+  // Arrow keys walk the samples, Home/End jump to the ends, and the focused reading is announced through
+  // the live region below rather than inferred from a tooltip nobody can see.
+  const handleKey = (e: React.KeyboardEvent<SVGRectElement>) => {
+    if (data.length === 0) return
+    // Dismissible without moving focus (WCAG 1.4.13): the reading overlays the plot, and a magnifier user
+    // whose view it covers should not have to tab away to clear it.
+    if (e.key === 'Escape') { hideTooltip(); return }
+    // Vertical arrows too: they are half of the slider pattern's key set, and a screen-reader user in
+    // focus mode reaches for them as readily as the horizontal pair.
+    const current = idx
+    const next =
+      e.key === 'ArrowLeft' || e.key === 'ArrowDown' ? Math.max(0, current - 1)
+      : e.key === 'ArrowRight' || e.key === 'ArrowUp' ? Math.min(data.length - 1, current + 1)
+      : e.key === 'Home' ? 0
+      : e.key === 'End' ? data.length - 1
+      : null
+    if (next === null) return
+    e.preventDefault()
+    showAt(next)
+  }
 
   const handleMove = (e: React.MouseEvent<SVGRectElement> | React.TouchEvent<SVGRectElement>) => {
     const point = localPoint(e)
@@ -260,31 +308,63 @@ function AreaChartInner({
     const hi = data[i]
     const d = lo && hi ? (t0 - getTime(lo) < getTime(hi) - t0 ? lo : hi) : (lo ?? hi)
     if (!d) return
-    showTooltip({ tooltipData: d, tooltipLeft: xScale(getTime(d)), tooltipTop: yScale(d[dataKey]) })
+    // Through `showAt`, so the cursor is the one source of position. Calling `showTooltip` directly here
+    // moved what is drawn while `aria-valuenow` kept reporting the keyboard's index — the slider's state
+    // then described something other than what it was showing.
+    showAt(data.indexOf(d))
   }
+
+  const latest = data[data.length - 1]
+  // Named, because the page renders two of these side by side and each has its own live region — an
+  // unattributed "02:50, 57%" does not say which chart answered.
+  const reading = (d: Datum) => `${label}, ${formatTick(d.time, range)}, ${Math.round(d[dataKey])}%`
 
   return (
     <>
-      <svg width={width} height={height}>
+      {/* `group`, not `img`: `img` takes presentational children, and the focusable surface below lives
+          inside this subtree — under `img` the one element the keyboard path depends on is in a subtree
+          AT is told not to expose, so the support would exist and never be advertised. */}
+      <svg
+        width={width}
+        height={height}
+        role="group"
+        aria-label={
+          latest
+            ? `${label}, last ${range}. Latest ${Math.round(latest[dataKey])} percent.`
+            : `${label}, last ${range}. No samples.`
+        }
+      >
         <LinearGradient id={gradId} from={hex} to={hex} fromOpacity={0.3} toOpacity={0} fromOffset="5%" toOffset="95%" />
+        {/* **The series is clipped to the plot, and the axis labels live outside it.** `maxT` is rounded
+            *up* to a clean step so the tick times stay round, which pushes the window's start up to one
+            step later than the oldest point the API returned — 10 minutes on the 1h range. `scaleTime`
+            does not clamp, so those points map to a negative x and the area painted straight through the
+            y-axis labels, worst on a series sitting where the labels are (RAM at ~57% covers 50% and 25%).
+            Clipping rather than dropping them: a point just off-window still shapes the curve at the edge,
+            which is what an off-screen sample should do. */}
+        <clipPath id={clipId}>
+          <rect x={0} y={0} width={Math.max(0, innerW)} height={Math.max(0, innerH)} />
+        </clipPath>
         <Group left={MARGIN.left} top={MARGIN.top}>
           <GridRows scale={yScale} width={innerW} tickValues={[0, 25, 50, 75, 100]} strokeDasharray="3 3" stroke="hsl(var(--border))" />
-          <AreaClosed<Datum>
-            data={data}
-            x={(d) => xScale(getTime(d))}
-            y={(d) => yScale(d[dataKey])}
-            yScale={yScale}
-            curve={curveMonotoneX}
-            fill={`url(#${gradId})`}
-          />
-          <LinePath<Datum>
-            data={data}
-            x={(d) => xScale(getTime(d))}
-            y={(d) => yScale(d[dataKey])}
-            curve={curveMonotoneX}
-            stroke={hex}
-            strokeWidth={1.5}
-          />
+          <g clipPath={`url(#${clipId})`}>
+            <AreaClosed<Datum>
+              data={data}
+              x={(d) => xScale(getTime(d))}
+              y={(d) => yScale(d[dataKey])}
+              yScale={yScale}
+              curve={curveMonotoneX}
+              fill={`url(#${gradId})`}
+            />
+            <LinePath<Datum>
+              data={data}
+              x={(d) => xScale(getTime(d))}
+              y={(d) => yScale(d[dataKey])}
+              curve={curveMonotoneX}
+              stroke={hex}
+              strokeWidth={1.5}
+            />
+          </g>
           <AxisBottom
             top={innerH}
             scale={xScale}
@@ -321,6 +401,25 @@ function AreaChartInner({
             width={Math.max(0, innerW)}
             height={Math.max(0, innerH)}
             fill="transparent"
+            tabIndex={0}
+            // **`slider`, over the sample index.** `img` was worse than useless here: a non-widget role
+            // leaves NVDA and JAWS in browse mode, where the virtual cursor swallows the arrow keys before
+            // `onKeyDown` sees them — the keyboard path would exist for exactly the users who could not
+            // reach it. A slider's native key model *is* arrow keys, and `aria-valuetext` speaks the
+            // reading on every move, which is why there is no live region here any more.
+            role="slider"
+            aria-label={`${label} samples`}
+            aria-valuemin={0}
+            aria-valuemax={Math.max(0, data.length - 1)}
+            aria-valuenow={idx}
+            aria-valuetext={data[idx] ? reading(data[idx]!) : undefined}
+            aria-describedby={hintId}
+            // No inline `outlineColor`: `outline-none` is a *transparent* 2px outline, so colouring it
+            // here painted a black box around the plot at rest. The colour belongs in the focus variant.
+            className="outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            onFocus={() => showAt(data.length - 1)}
+            onBlur={hideTooltip}
+            onKeyDown={handleKey}
             onMouseMove={handleMove}
             onMouseLeave={hideTooltip}
             onTouchMove={handleMove}
@@ -329,6 +428,7 @@ function AreaChartInner({
           />
         </Group>
       </svg>
+      <p id={hintId} className="sr-only">Use the arrow keys to read individual samples. Escape hides the reading.</p>
       {tooltipData && (
         <div
           className="pointer-events-none absolute top-0 left-0 whitespace-nowrap rounded-lg border bg-background px-3 py-2 text-xs text-foreground shadow-md"


### PR DESCRIPTION
## Summary

Two reported UI defects, plus the changeset backfill the release audit was blocking on.

**The resource chart painted through its own y-axis.** The window is anchored to a rounded-up tick so the
times stay round, which puts its left edge up to one step later than the oldest sample the relay returns —
ten minutes of points on the 1h range, mapped to a negative x because `scaleTime` does not clamp. Worst on
RAM, which sits where the "50%" and "25%" labels are. The series is clipped to the plot rather than
filtered, so an off-window sample still shapes the curve at the edge.

**The comment composer's radius** was `rounded-xl` (12px), which is not on this project's scale, against
the `rounded-md` (6px) list directly above it.

Touching those two files put both through the a11y gate, four rounds of it, and what it found was not
decoration: the chart's readings were mouse-only and the composer was unnamed. The chart's cursor is now a
`slider` over the sample index — the role whose native key model is the arrow keys — announcing through
`aria-valuetext`. Two of the gate's findings were bugs in the code I had just written rather than a11y
points: an unclamped cursor (7d → 1h left `aria-valuenow` past `aria-valuemax`) and a pointer path that
bypassed it, so the slider announced something other than what it showed.

One defect no gate caught and the reporter did: `outline-none` is a *transparent* 2px outline, so setting
`outlineColor` inline drew a black box around every plot at rest.

Also backfills a changeset for #537, which changed eight manifests with no release note — marked internal,
which is what `pnpm changeset:audit` was reporting before this.

## Checklist

- [x] Tests written and passing — 10 new, on a component that had none; 5 mutations run, 5 caught
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

Review record is local (`.work/` is gitignored). The adversarial review was **skipped** deliberately — two
visual defects inside one package, judged against a screenshot — and the a11y gate served as the
independent context instead; its four rounds are recorded there. Worth one caveat: on the final commit
a11y-lens **timed out and skipped** rather than passing. The two errors it raised the round before are
fixed and only prose changed after, but the last state of this branch has not been through it.

Split out rather than fixed here: #589.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mac resource charts now support keyboard navigation, screen-reader guidance, Escape-to-dismiss behavior, and accessible value readouts.
  - Mouse, touch, and keyboard interactions now share consistent chart cursor behavior.
- **Bug Fixes**
  - Chart data is clipped correctly within plot boundaries, and cursor positions remain valid when ranges change.
  - Comment attachment filenames are decoded for clearer accessible labels.
- **Accessibility**
  - Added accessible names and semantic headings for controls, forms, charts, and decorative icons.
- **Tests**
  - Expanded coverage for chart interaction, accessibility, clipping, and keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->