### PR TITLE
docs(readme): stop repeating the hero's own claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@
     &nbsp;·&nbsp;
     <strong>2-line setup</strong>
     &nbsp;·&nbsp;
-    <strong>Self-hosted · Free · MIT</strong>
+    <strong>MIT</strong>
   </p>
 
   <p>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
-    <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js ≥ 22" /></a>
     <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
     <a href="https://github.com/jo-duchan/tapflow/releases"><img src="https://img.shields.io/github/v/release/jo-duchan/tapflow?include_prereleases&sort=semver" alt="Latest release" /></a>
     <a href="https://github.com/jo-duchan/tapflow/commits/main"><img src="https://img.shields.io/github/last-commit/jo-duchan/tapflow" alt="Last commit" /></a>
-    <a href="ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-v0.x→v1.0-blueviolet" alt="Roadmap" /></a>
   </p>
 
   <p>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,16 +13,13 @@
     &nbsp;·&nbsp;
     <strong>2-line setup</strong>
     &nbsp;·&nbsp;
-    <strong>Self-hosted · Free · MIT</strong>
+    <strong>MIT</strong>
   </p>
 
   <p>
-    <a href="https://github.com/jo-duchan/tapflow/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
-    <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js ≥ 22" /></a>
     <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
     <a href="https://github.com/jo-duchan/tapflow/releases"><img src="https://img.shields.io/github/v/release/jo-duchan/tapflow?include_prereleases&sort=semver" alt="Latest release" /></a>
     <a href="https://github.com/jo-duchan/tapflow/commits/main"><img src="https://img.shields.io/github/last-commit/jo-duchan/tapflow" alt="Last commit" /></a>
-    <a href="https://github.com/jo-duchan/tapflow/blob/main/ROADMAP.md"><img src="https://img.shields.io/badge/roadmap-v0.x→v1.0-blueviolet" alt="Roadmap" /></a>
   </p>
 
   <p>


### PR DESCRIPTION
## Summary

The hero tagline stated **Self-hosted** a third time — the headline and the paragraph above it had already made that claim — and **MIT** a second time, duplicating the License badge. What only that line says is `No WebDriverAgent` and `2-line setup`, and the repetition was taking half its width.

Three badges go with it: `License` duplicated the tagline, `roadmap` duplicated the v0.x callout under the video, and `node >=22` is a lossy copy of the `## Requirements` table, which separates the relay (any OS) from the agents (macOS). Six badges also stack vertically for logged-out visitors on github.com ([primer/brand#1426](https://github.com/primer/brand/issues/1426)) — every reader arriving from a shared link — so `MIT` stays in the tagline rather than the badge, because text renders either way.

`packages/cli/README.md` carries the same hero for the npm page and gets the same edit.

```diff
- No WebDriverAgent · 2-line setup · Self-hosted · Free · MIT
+ No WebDriverAgent · 2-line setup · MIT

- [License MIT] [node >=22] [platform macOS agent] [release] [last commit] [roadmap]
+ [platform macOS agent] [release] [last commit]
```

## Checklist

- [ ] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/docs__readme-hero-dedupe.md` — adversarial review skipped (docs-only); per-badge reasoning, verification that nothing became unreachable, and one item left alone are recorded there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined README badge sections.
  * Separated the MIT license badge from platform, release, and commit badges.
  * Removed outdated Node.js, license, roadmap, and combined descriptor badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->