### PR TITLE
fix(scripts): ignore changelog markers in code fences

### DIFF
--- a/scripts/__tests__/auditBackfills.test.mjs
+++ b/scripts/__tests__/auditBackfills.test.mjs
@@ -62,4 +62,15 @@ describe('parseBackfills', () => {
   it('allows prose after the references on the same line', () => {
     expect(parseBackfills(body('Backfills: #413 — the shortcuts never worked before it'))).toEqual([413])
   })
+
+  it.each([
+    ['a shorter fence nested inside a longer one', '````md', '```md', 'Backfills: #413', '```', '````', 'Backfills: #414'],
+    ['a closing fence with an info string', '```md', '``` not-a-close', 'Backfills: #413', '```', 'Backfills: #414'],
+  ])('ignores a reference inside %s and resumes after it', (_name, ...lines) => {
+    expect(parseBackfills(body(...lines))).toEqual([414])
+  })
+
+  it('reads an unindented reference between four-space-indented fence-like lines', () => {
+    expect(parseBackfills(body('    ```md', 'Backfills: #413', '    ```'))).toEqual([413])
+  })
 })

--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -81,6 +81,11 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
     'internal.md': `${cs('"@tapflowio/protocol": patch')}\n<!-- changelog: internal — protocol typing, nothing observable -->\n`,
     'no-reason.md': `${cs('"@tapflowio/protocol": patch')}\n<!-- changelog: internal -->\n`,
     'mentions-it.md': `${cs('"@tapflowio/relay": patch')}\n\nSee the changelog: internal notes are not a marker.\n`,
+    'backtick-fence.md': cs('"@tapflowio/relay": patch') + '\n```md\n<!-- changelog: internal -->\n```\n',
+    'tilde-fence.md': `${cs('"@tapflowio/relay": patch')}\n~~~md\n<!-- changelog: internal -->\n~~~\n`,
+    'long-backtick-fence.md': cs('"@tapflowio/relay": patch') + '\n````md\n```md\n<!-- changelog: internal -->\n```\n````\n',
+    'mixed-fence.md': cs('"@tapflowio/relay": patch') + '\n```md\n~~~\n<!-- changelog: internal -->\n~~~\n```\n',
+    'after-fence.md': cs('"@tapflowio/protocol": patch') + '\n```md\nexample\n```\n<!-- changelog: internal -->\n',
   })[f]
 
   it('owes one for a plain changeset', () => {
@@ -98,6 +103,12 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
   // an opt-out -- the shape this repo has been bitten by twice, where a comment was read as a value.
   it('is not released by prose that merely says the words', () => {
     expect(changelogEntryOwed(['mentions-it.md'], read)).toEqual(['mentions-it.md'])
+  })
+  it.each(['backtick-fence.md', 'tilde-fence.md', 'long-backtick-fence.md', 'mixed-fence.md'])('is not released by a marker inside %s', (file) => {
+    expect(changelogEntryOwed([file], read)).toEqual([file])
+  })
+  it('is released by a marker after a closed fence', () => {
+    expect(changelogEntryOwed(['after-fence.md'], read)).toEqual([])
   })
 })
 

--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -86,6 +86,7 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
     'long-backtick-fence.md': cs('"@tapflowio/relay": patch') + '\n````md\n```md\n<!-- changelog: internal -->\n```\n````\n',
     'mixed-fence.md': cs('"@tapflowio/relay": patch') + '\n```md\n~~~\n<!-- changelog: internal -->\n~~~\n```\n',
     'after-fence.md': cs('"@tapflowio/protocol": patch') + '\n```md\nexample\n```\n<!-- changelog: internal -->\n',
+    'indented-fence.md': cs('"@tapflowio/protocol": patch') + '\n    ```md\n<!-- changelog: internal -->\n    ```\n',
   })[f]
 
   it('owes one for a plain changeset', () => {
@@ -109,6 +110,9 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
   })
   it('is released by a marker after a closed fence', () => {
     expect(changelogEntryOwed(['after-fence.md'], read)).toEqual([])
+  })
+  it('is released by an unindented marker between four-space-indented fence-like lines', () => {
+    expect(changelogEntryOwed(['indented-fence.md'], read)).toEqual([])
   })
 })
 

--- a/scripts/__tests__/changesetReason.test.mjs
+++ b/scripts/__tests__/changesetReason.test.mjs
@@ -64,6 +64,14 @@ describe('extractReason — refuses anything that is not one', () => {
     const body = '```js`\n```\n<!-- no-changeset: reason -->\n```\n'
     expect(extractReason(body)).toBe('')
   })
+
+  it('opens a tilde fence even when its info string contains a backtick', () => {
+    // The other half of the clause above: CommonMark forbids a backtick in a backtick fence's
+    // info string and permits one in a tilde fence's. Refusing to open here would leave the
+    // marker below unquoted, which is #560's leak arriving from the other side.
+    const body = '~~~js`\n<!-- no-changeset: reason -->\n~~~\n'
+    expect(extractReason(body)).toBe('')
+  })
 })
 
 describe('extractReason — follows CommonMark indentation', () => {

--- a/scripts/__tests__/changesetReason.test.mjs
+++ b/scripts/__tests__/changesetReason.test.mjs
@@ -59,6 +59,11 @@ describe('extractReason — refuses anything that is not one', () => {
   ])('ignores a marker inside %s and resumes after it', (_name, body) => {
     expect(extractReason(body)).toBe('real')
   })
+
+  it('does not open a backtick fence when its info string contains a backtick', () => {
+    const body = '```js`\n```\n<!-- no-changeset: reason -->\n```\n'
+    expect(extractReason(body)).toBe('')
+  })
 })
 
 describe('extractReason — follows CommonMark indentation', () => {

--- a/scripts/__tests__/changesetReason.test.mjs
+++ b/scripts/__tests__/changesetReason.test.mjs
@@ -52,4 +52,18 @@ describe('extractReason — refuses anything that is not one', () => {
     ].join('\n')
     expect(extractReason(body)).toBe('')
   })
+
+  it.each([
+    ['a shorter fence nested inside a longer one', '````md\n```md\n<!-- no-changeset: reason -->\n```\n````\n<!-- no-changeset: real -->\n'],
+    ['a closing fence with an info string', '```md\n``` not-a-close\n<!-- no-changeset: reason -->\n```\n<!-- no-changeset: real -->\n'],
+  ])('ignores a marker inside %s and resumes after it', (_name, body) => {
+    expect(extractReason(body)).toBe('real')
+  })
+})
+
+describe('extractReason — follows CommonMark indentation', () => {
+  it('reads an unindented marker between four-space-indented fence-like lines', () => {
+    const body = '    ```md\n<!-- no-changeset: reason -->\n    ```\n'
+    expect(extractReason(body)).toBe('reason')
+  })
 })

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -289,12 +289,21 @@ function* proseLines(body, { skipFrontmatter = false } = {}) {
     while (i < lines.length && lines[i].trim() !== '---') i++
     i++                                            // step past the closing delimiter
   }
-  let fenced = false
+  let fence = null
   for (; i < lines.length; i++) {
     const raw = lines[i]
     const line = raw.trim()
-    if (/^(```|~~~)/.test(line)) { fenced = !fenced; continue }
-    if (fenced) continue
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(raw)
+    if (fence) {
+      if (marker && marker[1][0] === fence.char && marker[1].length >= fence.length && !marker[2].trim()) {
+        fence = null
+      }
+      continue
+    }
+    if (marker && (marker[1][0] === '~' || !marker[2].includes('`'))) {
+      fence = { char: marker[1][0], length: marker[1].length }
+      continue
+    }
     if (/^ {4,}|^\t/.test(raw)) continue           // indented code block
     yield { raw, line }
   }
@@ -380,8 +389,7 @@ export function ignoredOnlyChangesets(files, ignored, read) {
  *
  *     <!-- changelog: internal — protocol typing, nothing a user can observe -->
  *
- * The reason is required for the same purpose it is required on `no-changeset`: skipping is a decision
- * somebody wrote down, not something that happens by forgetting.
+ * The marker itself records the decision; prose after `internal` is optional.
  *
  * **What this covers, stated rather than implied:** a branch that touches a changeset — added, amended or
  * renamed — and ships published source. It does **not** cover a branch with no changeset (its
@@ -394,7 +402,12 @@ export function ignoredOnlyChangesets(files, ignored, read) {
  * can need it for one of them.
  */
 export function changelogEntryOwed(files, read) {
-  return files.filter((f) => !/^<!--\s*changelog:\s*internal\b.*-->$/m.test(read(f)))
+  return files.filter((f) => {
+    for (const { raw } of proseLines(read(f), { skipFrontmatter: true })) {
+      if (/^<!--\s*changelog:\s*internal\b.*-->$/.test(raw)) return false
+    }
+    return true
+  })
 }
 
 function main() {


### PR DESCRIPTION
## Summary

- Ignore `changelog: internal` markers inside fenced code blocks.
- Track fence characters and lengths so nested examples do not close the outer fence early.
- Cover backtick, tilde, nested, mixed, and post-fence cases.
- The shared parser also prevents quoted markers in nested fences from bypassing the `no-changeset` and `Backfills:` gates.

Closes #560

<!-- no-changeset: changeset gate tooling only; no shipped package behavior changes -->

## Validation

- Focused Vitest suites: 61 tests passed
- `pnpm lint`
- `pnpm typecheck`

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/2026-08-20-changeset-fenced-marker-plan.md`
- `.work/reviews/feature__changeset-fenced-marker.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog marker handling so markers inside Markdown code blocks are ignored.
  * Added support for backtick and tilde fences with varying lengths, indentation, and nested fence-like content.
  * Correctly handles closing fences with additional text and resumes scanning afterward.
  * Markers outside code blocks continue to release the required changelog entry.
  * Clarified that explanatory text following the internal marker is optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->