### PR TITLE
fix(dashboard): gate Full reset on the agent capability, not the platform

### DIFF
--- a/.changeset/gentle-jars-shave.md
+++ b/.changeset/gentle-jars-shave.md
@@ -1,0 +1,14 @@
+---
+"@tapflowio/protocol": minor
+"@tapflowio/agent-core": minor
+"@tapflowio/relay": minor
+"@tapflowio/ios-agent": minor
+---
+
+Gate the dashboard's Full reset toggle on an agent capability instead of the platform string.
+
+`AgentCapability` gains `full-reset`, `IOSAgent` advertises it, and `SessionInfo` now carries the
+agent's capabilities so the viewer can gate while picking a device — before any session exists to
+join. The old `os !== 'android'` check said "Android cannot" when it meant "this agent did not say
+it can", and got both directions wrong: an iOS agent too old to implement Full reset was still
+offered the toggle, and an Android agent that implements it later would still have it hidden.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Full reset** now appears based on what the device agent says it can do, rather than on which platform you picked. The control was offered for every iOS device and hidden for every Android one, which was right about today's agents and wrong about any other combination: an agent older than the feature was still offered a toggle it has no code for, and an Android agent that gains the ability later would still have had it hidden. If you run an agent from before this release against a newer relay, the toggle is now correctly absent instead of erasing nothing — one more reason to upgrade agents and relay together, as 0.19.0 asked. Android still does not implement Full reset ([#447](https://github.com/jo-duchan/tapflow/issues/447)); this is what lets it appear the moment it does, with no dashboard change.
+
 ### Security
 
 - `js-yaml` moved to 3.15.1 / 4.3.1 (GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption resolving `!!omap`), and its two `pnpm.overrides` entries were retired with it. The pin listed under 0.16.0 below no longer exists: the declared ranges had admitted the patch all along, so what held the old version in place was a lockfile that never re-evaluated them, not a range that forbade it. Development dependency only — no published package carries `js-yaml`.

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -36,7 +36,10 @@ export interface Device {
 // on a merely-slow agent, and a lost keystroke on an old one).
 // The dashboard cannot import from here (it has no agent-core dependency), so this stays a
 // plain string list on the wire rather than a helper nobody on the reading side can call.
-export type AgentCapability = 'clipboard'
+// `full-reset`: the agent honours `device:boot`'s `resetMode: 'full-erase'` by wiping the device
+// before booting it. iOS does (`simctl erase`); Android does not yet (#447), and says so by not
+// listing it rather than by being named in a platform check on the viewer.
+export type AgentCapability = 'clipboard' | 'full-reset'
 
 
 // ── Clipboard bridge shared contract ────────────────────────────────────────

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -49,6 +49,10 @@ import { EmulatorVideo } from './emulator/EmulatorVideo.js'
 const logger = createLogger('android-agent')
 
 // Typed so a typo cannot ship silently — the viewer gates the whole clipboard bridge on this.
+// `full-reset` is deliberately absent: `handleDeviceBoot` does not read `resetMode`, and
+// `-wipe-data` is not passed to the emulator (#447). Listing it would make the viewer offer a
+// toggle that disarms having erased nothing, which reads as "done". Add it in the same change
+// that implements the wipe, not before.
 const AGENT_CAPABILITIES: AgentCapability[] = ['clipboard']
 
 // Parse H.264 SPS NAL unit to extract frame dimensions.

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -1722,6 +1722,25 @@ describe('AndroidAgent', () => {
         expect((joined as unknown as { capabilities: string[] }).capabilities).toContain('clipboard')
       })
 
+      // #447: `handleDeviceBoot` does not read `resetMode` and the emulator is never launched with
+      // `-wipe-data`, so advertising `full-reset` would put a toggle on screen that erases nothing
+      // and then disarms itself, which reads as "done" — the bug that issue exists for.
+      //
+      // Asserting an absence is usually the weak shape this repo warns about, but not here: the
+      // mutation is adding the string to `AGENT_CAPABILITIES`, and that fails this line. It is the
+      // only thing standing between a one-word edit and a control that lies. Delete it in the same
+      // change that implements the wipe.
+      it('does not advertise full-reset, because nothing here honours it yet', async () => {
+        browser = new WebSocket(`ws://localhost:${port}`)
+        await waitForOpen(browser)
+        browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+        const joined = await waitForType(browser, 'session:joined')
+        const caps = (joined as unknown as { capabilities: string[] }).capabilities
+        // Paired with a positive so this cannot pass by the capability list being empty/absent.
+        expect(caps).toContain('clipboard')
+        expect(caps).not.toContain('full-reset')
+      })
+
       it('clipboard:read returns the guest clipboard as clipboard:data', async () => {
         grpcClipboardText = '한글 テスト 🎉\nline2'
         await bootDevice()

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -131,6 +131,7 @@ import type { ScrcpyControl } from '../scrcpy/ScrcpyControl'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
 import type { AdbRunner } from '../adb'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type { SessionJoined } from '@tapflowio/protocol'
 
 // Test-only view of a per-device state entry (the real DeviceState is not exported).
 interface TestState {
@@ -1718,8 +1719,8 @@ describe('AndroidAgent', () => {
         browser = new WebSocket(`ws://localhost:${port}`)
         await waitForOpen(browser)
         browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-        const joined = await waitForType(browser, 'session:joined')
-        expect((joined as unknown as { capabilities: string[] }).capabilities).toContain('clipboard')
+        const joined = await waitForType<SessionJoined>(browser, 'session:joined')
+        expect(joined.capabilities).toContain('clipboard')
       })
 
       // #447: `handleDeviceBoot` does not read `resetMode` and the emulator is never launched with
@@ -1734,8 +1735,8 @@ describe('AndroidAgent', () => {
         browser = new WebSocket(`ws://localhost:${port}`)
         await waitForOpen(browser)
         browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-        const joined = await waitForType(browser, 'session:joined')
-        const caps = (joined as unknown as { capabilities: string[] }).capabilities
+        const joined = await waitForType<SessionJoined>(browser, 'session:joined')
+        const caps = joined.capabilities
         // Paired with a positive so this cannot pass by the capability list being empty/absent.
         expect(caps).toContain('clipboard')
         expect(caps).not.toContain('full-reset')

--- a/packages/dashboard/hooks/useDeviceSelector.ts
+++ b/packages/dashboard/hooks/useDeviceSelector.ts
@@ -13,16 +13,25 @@ export function useDeviceSelector(
   // which mode it was launched under.
   const [appliedResetMode, setAppliedResetMode] = useState<'app-only' | 'full-erase'>('app-only')
 
-  /** Only iOS acts on Full reset today (#447). */
-  const fullResetSupported = os !== 'android'
+  /** Whether the agent holding this device honours `resetMode: 'full-erase'`.
+   *
+   *  This was `os !== 'android'`, which says "Android cannot" when what it means is "this agent did
+   *  not say it can" — and the two differ in both directions (#447). An iOS agent too old to
+   *  implement Full reset still reports `platform: 'ios'`, so the platform check offered a control
+   *  that agent has no code for; and the day AndroidAgent implements `-wipe-data` it would still
+   *  hide it. Gating on what the agent advertised is right on both counts, and needs no dashboard
+   *  change when the second one lands.
+   *
+   *  No session picked yet means nothing known yet, so the control stays hidden. */
+  const fullResetSupported = selectedSession?.capabilities?.includes('full-reset') ?? false
 
   /** Full reset is a one-shot intent — "erase the next device I pick" — not a setting that stays
    *  on. Leaving a session is a conditional re-render, not an unmount, so without this the toggle
    *  survives back-to-the-list and silently erases the *next* device too (#439). */
   const consumeResetMode = useCallback(() => {
-    // Android ignores resetMode outright — AndroidAgent never reads it (#447). Applying it there
-    // would disarm the toggle having erased nothing, which reads as "done"; the UI disables the
-    // switch for the same reason, and this keeps the two from drifting apart.
+    // Applying a mode the agent does not honour would disarm the toggle having erased nothing,
+    // which reads as "done"; the UI hides the switch for the same reason, and this keeps the two
+    // from drifting apart.
     setAppliedResetMode(fullResetSupported ? resetMode : 'app-only')
     setResetMode('app-only')
   }, [resetMode, fullResetSupported])

--- a/packages/dashboard/hooks/useDeviceSelector.ts
+++ b/packages/dashboard/hooks/useDeviceSelector.ts
@@ -23,7 +23,7 @@ export function useDeviceSelector(
    *  change when the second one lands.
    *
    *  No session picked yet means nothing known yet, so the control stays hidden. */
-  const fullResetSupported = selectedSession?.capabilities?.includes('full-reset') ?? false
+  const fullResetSupported = selectedSession?.capabilities.includes('full-reset') ?? false
 
   /** Full reset is a one-shot intent — "erase the next device I pick" — not a setting that stays
    *  on. Leaving a session is a conditional re-render, not an unmount, so without this the toggle

--- a/packages/dashboard/src/__tests__/QASession.reset.test.tsx
+++ b/packages/dashboard/src/__tests__/QASession.reset.test.tsx
@@ -53,14 +53,18 @@ const { QASession } = await import('../pages/QASession')
 const device = (id: string, name: string, platform = 'ios') => ({
   id, name, platform, status: 'shutdown', osVersion: 'iOS 18.3', sessionId: 'sess-1', busy: false,
 })
+// `capabilities` is what gates the toggle now, not `platform` (#447). These mirror what each agent
+// actually registers: `IOSAgent` lists `full-reset`, `AndroidAgent` does not yet.
 const AGENTS: SessionInfo[] = [{
   agentName: 'studio-mac',
   platform: 'ios',
+  capabilities: ['clipboard', 'full-reset'],
   devices: [device('dev-a', 'iPhone 15'), device('dev-b', 'iPhone SE')],
 }]
 const ANDROID_AGENTS: SessionInfo[] = [{
   agentName: 'studio-mac',
   platform: 'android',
+  capabilities: ['clipboard'],
   devices: [device('dev-a', 'Pixel 7', 'android')],
 }]
 

--- a/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
+++ b/packages/dashboard/src/__tests__/SessionList.shutdownRefused.test.tsx
@@ -29,6 +29,7 @@ const { SessionList } = await import('@/components/SessionList')
 
 const SESSIONS: SessionInfo[] = [{
   agentName: 'mac-1',
+  capabilities: [],
   devices: [{
     id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted',
     sessionId: 's1', busy: false,
@@ -37,6 +38,7 @@ const SESSIONS: SessionInfo[] = [{
 
 const TWO_DEVICES: SessionInfo[] = [{
   agentName: 'mac-1',
+  capabilities: [],
   devices: [
     { id: 'dev-1', name: 'iPhone 15', platform: 'ios', status: 'booted', sessionId: 's1', busy: false },
     { id: 'dev-2', name: 'iPhone 14', platform: 'ios', status: 'booted', sessionId: 's2', busy: false },

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -21,6 +21,9 @@ let capturedOnMessage: (msg: BrowserInbound) => void = () => {}
 
 const makeSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
   agentName: 'test-mac',
+  // An agent that advertises nothing. `capabilities` is required on the wire, so `[]` — not an
+  // absent key — is how the relay reports one that predates a capability (#447).
+  capabilities: [],
   devices: [],
   ...overrides,
 })
@@ -211,7 +214,7 @@ describe('useDeviceSelector', () => {
     makeDevice({ id: 'd3', name: 'iPhone 15', osVersion: 'iOS 17', platform: 'ios' }),
   ]
   /** Advertises nothing, which is what an agent that predates a capability sends (#447). */
-  const session: SessionInfo = { agentName: 'mac', devices }
+  const session: SessionInfo = { agentName: 'mac', capabilities: [], devices }
   const withCaps = (capabilities: string[]): SessionInfo => ({ ...session, capabilities })
 
   it('filters devices by osVersion when set', () => {
@@ -236,7 +239,7 @@ describe('useDeviceSelector', () => {
       makeDevice({ osVersion: 'Android 15', platform: 'android' }),
       makeDevice({ osVersion: 'Android 14', platform: 'android' }),
     ]
-    const sess: SessionInfo = { agentName: 'mac', devices: mixedDevices }
+    const sess: SessionInfo = { agentName: 'mac', capabilities: [], devices: mixedDevices }
     const { result } = renderHook(() => useDeviceSelector(sess, 'android'))
 
     expect(result.current.osVersions).toEqual(['Android 15', 'Android 14', 'Android 13'])
@@ -310,6 +313,35 @@ describe('useDeviceSelector', () => {
     it('is not supported before an agent is selected', () => {
       const { result } = renderHook(() => useDeviceSelector(undefined, 'ios'))
       expect(result.current.fullResetSupported).toBe(false)
+    })
+
+    // What `AndroidAgent` actually registers today. Named on its own because the shapes around it
+    // are `[]` and `['clipboard','full-reset']`, and a guard written as "has any capability at all"
+    // passes both of those — this is the case that tells membership from non-emptiness.
+    it('is not supported for an agent that advertises other capabilities but not this one', () => {
+      const { result } = renderHook(() => useDeviceSelector(withCaps(['clipboard']), 'android'))
+      expect(result.current.fullResetSupported).toBe(false)
+    })
+
+    // The gate used to read `os`, which cannot change while the page lives, so `consumeResetMode`'s
+    // dependency on it never had to be right. It reads the picked agent now, and that *does* change
+    // under a live hook: leaving a session is a conditional re-render, not an unmount (#439), and
+    // going back to the Mac list without picking a device leaves the toggle armed.
+    //
+    // Without `fullResetSupported` in the callback's deps this test fails and every other one here
+    // still passes — they each render against a single fixed session, so the stale closure never
+    // gets a chance to be wrong.
+    it('re-reads the guard when the picked agent changes, so an armed toggle cannot cross over', () => {
+      const { result, rerender } = renderHook(
+        ({ s }: { s: SessionInfo }) => useDeviceSelector(s, 'ios'),
+        { initialProps: { s: withCaps(['full-reset']) } },
+      )
+
+      act(() => result.current.setResetMode('full-erase'))
+      rerender({ s: withCaps(['clipboard']) })      // different Mac, no device picked in between
+      act(() => result.current.consumeResetMode())
+
+      expect(result.current.appliedResetMode).toBe('app-only')
     })
   })
 })

--- a/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
+++ b/packages/dashboard/src/__tests__/useQASessionHooks.test.tsx
@@ -210,7 +210,9 @@ describe('useDeviceSelector', () => {
     makeDevice({ id: 'd2', name: 'Pixel 6', osVersion: 'Android 13', platform: 'android' }),
     makeDevice({ id: 'd3', name: 'iPhone 15', osVersion: 'iOS 17', platform: 'ios' }),
   ]
+  /** Advertises nothing, which is what an agent that predates a capability sends (#447). */
   const session: SessionInfo = { agentName: 'mac', devices }
+  const withCaps = (capabilities: string[]): SessionInfo => ({ ...session, capabilities })
 
   it('filters devices by osVersion when set', () => {
     const { result } = renderHook(() => useDeviceSelector(session, 'android'))
@@ -244,7 +246,7 @@ describe('useDeviceSelector', () => {
   // survive back-to-the-list and erase the next device the tester picked.
   describe('resetMode is a one-shot intent', () => {
     it('hands the armed mode to the viewer and disarms the toggle when a device is picked', () => {
-      const { result } = renderHook(() => useDeviceSelector(session, 'ios'))
+      const { result } = renderHook(() => useDeviceSelector(withCaps(['full-reset']), 'ios'))
 
       act(() => result.current.setResetMode('full-erase'))
       act(() => result.current.consumeResetMode())
@@ -254,7 +256,7 @@ describe('useDeviceSelector', () => {
     })
 
     it('does not re-arm on the next pick', () => {
-      const { result } = renderHook(() => useDeviceSelector(session, 'ios'))
+      const { result } = renderHook(() => useDeviceSelector(withCaps(['full-reset']), 'ios'))
 
       act(() => result.current.setResetMode('full-erase'))
       act(() => result.current.consumeResetMode())
@@ -264,10 +266,12 @@ describe('useDeviceSelector', () => {
       expect(result.current.resetMode).toBe('app-only')
     })
 
-    // #447: AndroidAgent never reads resetMode. Arming it there would disarm the toggle having
-    // erased nothing — a stronger promise than before, kept even less.
-    it('never applies full-erase on Android, where nothing acts on it', () => {
-      const { result } = renderHook(() => useDeviceSelector(session, 'android'))
+    // #447: arming a mode nothing acts on would disarm the toggle having erased nothing — a
+    // stronger promise than before, kept even less.
+    // `'ios'` on purpose: the platform is no longer what decides this, so the test that proves the
+    // mode is not applied has to be one the old platform check would have got wrong.
+    it('never applies full-erase when the agent does not advertise it', () => {
+      const { result } = renderHook(() => useDeviceSelector(session, 'ios'))
 
       expect(result.current.fullResetSupported).toBe(false)
 
@@ -275,6 +279,37 @@ describe('useDeviceSelector', () => {
       act(() => result.current.consumeResetMode())
 
       expect(result.current.appliedResetMode).toBe('app-only')
+    })
+  })
+
+  // #447: this used to be `os !== 'android'`, which says "Android cannot" when what it means is
+  // "this agent did not say it can". The two differ in both directions, and each direction is a
+  // bug the platform string cannot express.
+  describe('Full reset is gated on the capability, not the platform', () => {
+    it('is supported when the agent advertises full-reset', () => {
+      const { result } = renderHook(() => useDeviceSelector(withCaps(['clipboard', 'full-reset']), 'ios'))
+      expect(result.current.fullResetSupported).toBe(true)
+    })
+
+    // The direction the OS string got wrong first: an agent too old to implement Full reset still
+    // reports `platform: 'ios'`, so the viewer offered a control that agent has no code for.
+    it('is not supported on iOS when the agent is too old to advertise it', () => {
+      const { result } = renderHook(() => useDeviceSelector(withCaps([]), 'ios'))
+      expect(result.current.fullResetSupported).toBe(false)
+    })
+
+    // And the other direction, which is what unblocks the rest of #447: the moment AndroidAgent
+    // implements `-wipe-data` and advertises it, the toggle appears with no dashboard change.
+    it('is supported on Android once that agent advertises it', () => {
+      const { result } = renderHook(() => useDeviceSelector(withCaps(['full-reset']), 'android'))
+      expect(result.current.fullResetSupported).toBe(true)
+    })
+
+    // Nothing picked yet means nothing known yet. Hiding the control is the safe answer; showing it
+    // would arm a one-shot intent against an agent we have not heard from.
+    it('is not supported before an agent is selected', () => {
+      const { result } = renderHook(() => useDeviceSelector(undefined, 'ios'))
+      expect(result.current.fullResetSupported).toBe(false)
     })
   })
 })

--- a/packages/ios-agent/src/IOSAgent.ts
+++ b/packages/ios-agent/src/IOSAgent.ts
@@ -15,7 +15,9 @@ import type {
 const logger = createLogger('ios-agent')
 
 // Typed so a typo cannot ship silently — the viewer gates the whole clipboard bridge on this.
-const AGENT_CAPABILITIES: AgentCapability[] = ['clipboard']
+// `full-reset` is honoured in `handleDeviceBoot`, which shuts a running device down before
+// `simctl erase` (which refuses anything but a shut-down device) and boots it again.
+const AGENT_CAPABILITIES: AgentCapability[] = ['clipboard', 'full-reset']
 
 // Human prose for each reason. Not in `@tapflowio/protocol`: that package's main entry must stay
 // runtime-free so it erases under `import type` and never reaches the dashboard bundle — a lookup

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -100,6 +100,7 @@ import { launchAudioHelper } from '@tapflowio/audiotap-helper'
 import { SimctlWrapper } from '../SimctlWrapper'
 import { TouchHelper } from '../TouchHelper'
 import { barrier, waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+import type { SessionJoined } from '@tapflowio/protocol'
 const MockTouchHelper = vi.mocked(TouchHelper)
 const MockAudioStreamer = vi.mocked(AudioCaptureStreamer)
 const mockLaunchAudioHelper = vi.mocked(launchAudioHelper)
@@ -2837,8 +2838,8 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-      const joined = await waitForType(browser, 'session:joined')
-      expect((joined as unknown as { capabilities: string[] }).capabilities).toContain('clipboard')
+      const joined = await waitForType<SessionJoined>(browser, 'session:joined')
+      expect(joined.capabilities).toContain('clipboard')
 
       agent.disconnect(); browser.close()
     })
@@ -2853,8 +2854,8 @@ describe('IOSAgent', () => {
       const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
       await agent.connect(`ws://localhost:${port}`)
       browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
-      const joined = await waitForType(browser, 'session:joined')
-      expect((joined as unknown as { capabilities: string[] }).capabilities).toContain('full-reset')
+      const joined = await waitForType<SessionJoined>(browser, 'session:joined')
+      expect(joined.capabilities).toContain('full-reset')
 
       agent.disconnect(); browser.close()
     })

--- a/packages/ios-agent/src/__tests__/IOSAgent.test.ts
+++ b/packages/ios-agent/src/__tests__/IOSAgent.test.ts
@@ -2843,6 +2843,22 @@ describe('IOSAgent', () => {
       agent.disconnect(); browser.close()
     })
 
+    // The same argument the clipboard case above makes, for the capability that replaced the
+    // viewer's `os !== 'android'` check (#447): the agent's array is now the *only* switch behind
+    // Full reset, so dropping `'full-reset'` from it removes the control with nothing else in any
+    // suite to notice — the relay and dashboard tests all use hand-written capability fixtures.
+    it('advertises the full-reset capability all the way to the viewer', async () => {
+      const browser = new WebSocket(`ws://localhost:${port}`)
+      await waitForOpen(browser)
+      const agent = new IOSAgent({ intervalMs: 50 }, mockSimctl(true))
+      await agent.connect(`ws://localhost:${port}`)
+      browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+      const joined = await waitForType(browser, 'session:joined')
+      expect((joined as unknown as { capabilities: string[] }).capabilities).toContain('full-reset')
+
+      agent.disconnect(); browser.close()
+    })
+
     it('clipboard:read returns the simulator pasteboard as clipboard:data', async () => {
       const simctl = mockSimctl(true)
       ;(simctl.getPasteboard as ReturnType<typeof vi.fn>).mockResolvedValue('한글 テスト 🎉\nline2')

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -97,11 +97,15 @@ export interface SessionInfo {
    *
    *  It rides the listing as well as `session:joined` because the viewer has to gate controls
    *  **while picking a device**, which happens before any session exists to join — Full reset
-   *  (#447) is armed on the picker, not inside the session. Optional only for a relay that
-   *  predates the field; `SessionManager.list()` always emits an array, and `[]` means "advertises
-   *  nothing", which is what makes an old agent hide the control rather than offer one it cannot
-   *  honour. */
-  capabilities?: string[]
+   *  (#447) is armed on the picker, not inside the session.
+   *
+   *  **Required, like every other producer field.** There is one producer (`SessionManager.list()`)
+   *  and it always emits an array, so no relay can send the listing without it — and none ever
+   *  will, because the dashboard ships inside the relay package (`files: [public]`) and cannot skew
+   *  from it. An agent that predates the capability is expressed by `[]`, not by the key being
+   *  absent; the door already defaults it that way (`validate/index.ts`). Optional here would
+   *  describe a frame nobody sends and hand every consumer a `?.` to carry for good. */
+  capabilities: string[]
   devices: DeviceSummary[]
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -93,6 +93,15 @@ export interface SessionInfo {
   agentName?: string
   platform?: string
   resources?: AgentResources
+  /** What this agent implements, mirroring `AgentRegister.capabilities`.
+   *
+   *  It rides the listing as well as `session:joined` because the viewer has to gate controls
+   *  **while picking a device**, which happens before any session exists to join — Full reset
+   *  (#447) is armed on the picker, not inside the session. Optional only for a relay that
+   *  predates the field; `SessionManager.list()` always emits an array, and `[]` means "advertises
+   *  nothing", which is what makes an old agent hide the control rather than offer one it cannot
+   *  honour. */
+  capabilities?: string[]
   devices: DeviceSummary[]
 }
 

--- a/packages/relay/src/SessionManager.ts
+++ b/packages/relay/src/SessionManager.ts
@@ -429,6 +429,10 @@ export class SessionManager {
       agentName: group[0].agentName,
       platform: group[0].agentPlatform,
       resources: this.agentResources.get(group[0].agentSocket),
+      // `?? []` rather than passing the absence through: an agent that predates the field means
+      // "advertises nothing", and the viewer gates on membership. Leaving it undefined would make
+      // every consumer repeat the same fallback, and one of them would forget.
+      capabilities: group[0].agentCapabilities ?? [],
       devices: group.map((s) => ({
         id: s.deviceId,
         name: s.deviceName,

--- a/packages/relay/src/__tests__/SessionManager.test.ts
+++ b/packages/relay/src/__tests__/SessionManager.test.ts
@@ -435,6 +435,27 @@ describe('SessionManager', () => {
       expect(listed[0].devices[0]!.sessionId).toBe(idA)
     })
 
+    // #447: the viewer has to gate Full reset *while picking a device*, which is before any
+    // `session:joined` exists — so `capabilities` has to ride the listing, not only the join.
+    it('carries the agent capabilities so the picker can gate on them', () => {
+      const sm = new SessionManager()
+      sm.create(
+        mockSocket(),
+        [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }],
+        'MyMac', 'ios', undefined, ['clipboard', 'full-reset'],
+      )
+      expect(sm.list('asker', () => true)[0].capabilities).toEqual(['clipboard', 'full-reset'])
+    })
+
+    // An agent that predates the field registers without it. `[]` — "advertises nothing" — is the
+    // answer that makes the viewer hide the control, which is the whole point of gating on a
+    // capability rather than on the platform string: an old iOS agent cannot do Full reset either.
+    it('reports an agent that advertised nothing as empty, not undefined', () => {
+      const sm = new SessionManager()
+      sm.create(mockSocket(), [{ id: 'd1', name: 'X', platform: 'ios', status: 'shutdown' }], 'MyMac')
+      expect(sm.list('asker', () => true)[0].capabilities).toEqual([])
+    })
+
     it('is busy for someone else, and not for the holder', () => {
       // `busy` used to be `browserSocket !== null` — "someone holds it", which is a different question
       // from "you cannot have it". `QASession` renders `disabled={isBusy}`, so a tester whose socket

--- a/scripts/__tests__/protocolPayloadTypes.test.mjs
+++ b/scripts/__tests__/protocolPayloadTypes.test.mjs
@@ -152,9 +152,10 @@ const ALLOWED = new Set([
   // shape instead of by name — and the cost is worth paying, since name matching missed two of five
   // copies of one shape when this work was planned.
   'agent-core:UIElementFrame',
-  // `AgentSession` in mcp-server and flow-runner is `SessionInfo` minus `resources` — a narrower view
-  // for a client that does not read them, not a copy. Its field set differs so it never matches;
-  // listed so the next reader knows it was considered rather than missed.
+  // `AgentSession` in mcp-server and flow-runner is `SessionInfo` minus `resources` and
+  // `capabilities` — a narrower view for a client that reads neither, not a copy. Its field set
+  // differs so it never matches; listed so the next reader knows it was considered rather than
+  // missed.
 ])
 
 describe('wire payload types are declared once, in @tapflowio/protocol', () => {
@@ -169,7 +170,7 @@ describe('wire payload types are declared once, in @tapflowio/protocol', () => {
     expect(count('ChromeData')).toBe(11)
     expect(count('ChromeButton')).toBe(13)
     expect(count('DeviceSummary')).toBe(7)
-    expect(count('SessionInfo')).toBe(4)
+    expect(count('SessionInfo')).toBe(5)
   })
 
   it('guards the payload shapes by name, so a shape cannot silently leave', () => {


### PR DESCRIPTION
## Summary

`fullResetSupported` was `os !== 'android'`, which says "Android cannot" when what it means is "this agent did not say it can". Both directions were wrong: an iOS agent too old to implement Full reset still reports `platform: 'ios'`, so the viewer offered a control it has no code for; and the day `AndroidAgent` implements `-wipe-data` the toggle would still be hidden.

`AgentCapability` gains `full-reset`, `IOSAgent` advertises it, and `SessionInfo` carries the agent's capabilities — the toggle is armed **while picking a device**, before any session exists to join, so `session:joined` is too late for this one.

This is **item 3 of #447 only**. The other two (`AndroidAgent` reading `resetMode`, `buildEmulatorArgs` passing `-wipe-data`) need a real emulator and follow separately; the issue itself notes item 3 is worth doing even if they slip. It also gives the dashboard its first capability-gated control — the wire carried `capabilities` end to end already, but nothing consumed it.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/feature__full-reset-capability.md` — two-channel adversarial review (contract + test integrity), 6 findings, 4 fixed here and 2 split out as #608 and #609. Two were blockers: a field-count pin that would have failed CI in the scripts suite before any package ran, and the producing side of the whole feature having no test at all — dropping `full-reset` from `AGENT_CAPABILITIES` removed the toggle for good with 1800+ tests green. Every new assertion was mutation-checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full device reset is now available only for sessions whose agent supports it.
  * iOS sessions advertise full-reset support; Android sessions do not.
  * Session listings now include agent capabilities.

* **Bug Fixes**
  * Prevented unsupported reset modes from being applied when switching devices or selecting sessions without full-reset support.

* **Tests**
  * Added coverage for capability-based reset availability and session capability reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->