### PR TITLE
feat(android-agent): honour Full reset by launching the emulator with -wipe-data

### DIFF
--- a/.changeset/olive-parrots-repeat.md
+++ b/.changeset/olive-parrots-repeat.md
@@ -11,10 +11,13 @@ emulator that is already running is stopped and relaunched, the same answer iOS 
 erase` refusing a booted device.
 
 Whether one is running is asked of the process rather than of adb, since adb reports an emulator that
-is still coming up as shut down and a second emulator on the same AVD would race its lock file. That
-probe distinguishes "nothing is running" from "the lookup could not run", and only the first permits a
-launch. If the emulator will not exit, or cannot be observed at all, the boot fails with an error: a relaunch that loses the lock exits
-unseen, and the surviving emulator is what the agent would then find and report ready — a Full reset
-that never happened, announced as complete.
+is still coming up as shut down, and a second emulator on the same AVD would race its lock file. With
+nothing running the launch is immediate; a running one is stopped first and launches once its process
+is confirmed gone.
+
+The probe holds both of those apart from a third state — the lookup could not run — which launches
+nothing at all. Neither does an emulator that will not exit. Proceeding in either case would report a
+Full reset that never happened: the relaunch loses the lock and exits unseen, and the survivor is what
+the agent finds and announces ready.
 
 The agent advertises the `full-reset` capability now, which is what puts the toggle on screen.

--- a/.changeset/olive-parrots-repeat.md
+++ b/.changeset/olive-parrots-repeat.md
@@ -11,8 +11,9 @@ emulator that is already running is stopped and relaunched, the same answer iOS 
 erase` refusing a booted device.
 
 Whether one is running is asked of the process rather than of adb, since adb reports an emulator that
-is still coming up as shut down and a second emulator on the same AVD would race its lock file. If it
-will not exit, the boot fails with an error instead of launching: a relaunch that loses the lock exits
+is still coming up as shut down and a second emulator on the same AVD would race its lock file. That
+probe distinguishes "nothing is running" from "the lookup could not run", and only the first permits a
+launch. If the emulator will not exit, or cannot be observed at all, the boot fails with an error: a relaunch that loses the lock exits
 unseen, and the surviving emulator is what the agent would then find and report ready — a Full reset
 that never happened, announced as complete.
 

--- a/.changeset/olive-parrots-repeat.md
+++ b/.changeset/olive-parrots-repeat.md
@@ -8,5 +8,12 @@ Honour Full reset on Android: `handleDeviceBoot` reads `resetMode`, and the emul
 `-no-snapshot` was already there and is not this — it is a cold boot, which skips the snapshot and
 keeps `userdata`, so nothing wiped anything before. Because `-wipe-data` only applies at launch, an
 emulator that is already running is stopped and relaunched, the same answer iOS gives for `simctl
-erase` refusing a booted device. The agent advertises the `full-reset` capability now, which is what
-puts the toggle on screen.
+erase` refusing a booted device.
+
+Whether one is running is asked of the process rather than of adb, since adb reports an emulator that
+is still coming up as shut down and a second emulator on the same AVD would race its lock file. If it
+will not exit, the boot fails with an error instead of launching: a relaunch that loses the lock exits
+unseen, and the surviving emulator is what the agent would then find and report ready — a Full reset
+that never happened, announced as complete.
+
+The agent advertises the `full-reset` capability now, which is what puts the toggle on screen.

--- a/.changeset/olive-parrots-repeat.md
+++ b/.changeset/olive-parrots-repeat.md
@@ -1,0 +1,12 @@
+---
+"@tapflowio/android-agent": minor
+---
+
+Honour Full reset on Android: `handleDeviceBoot` reads `resetMode`, and the emulator is launched with
+`-wipe-data`.
+
+`-no-snapshot` was already there and is not this — it is a cold boot, which skips the snapshot and
+keeps `userdata`, so nothing wiped anything before. Because `-wipe-data` only applies at launch, an
+emulator that is already running is stopped and relaunched, the same answer iOS gives for `simctl
+erase` refusing a booted device. The agent advertises the `full-reset` capability now, which is what
+puts the toggle on screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. If it will not stop, the boot fails and says so rather than quietly handing you a device that was never wiped. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
+- **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. If it will not stop — or if tapflow cannot see well enough to tell — the boot fails and says so rather than quietly handing you a device that was never wiped. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
+- **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. If it will not stop, the boot fails and says so rather than quietly handing you a device that was never wiped. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
+
 ### Fixed
 
-- **Full reset** now appears based on what the device agent says it can do, rather than on which platform you picked. The control was offered for every iOS device and hidden for every Android one, which was right about today's agents and wrong about any other combination: an agent older than the feature was still offered a toggle it has no code for, and an Android agent that gains the ability later would still have had it hidden. If you run an agent from before this release against a newer relay, the toggle is now correctly absent instead of erasing nothing — one more reason to upgrade agents and relay together, as 0.19.0 asked. Android still does not implement Full reset ([#447](https://github.com/jo-duchan/tapflow/issues/447)); this is what lets it appear the moment it does, with no dashboard change.
+- **Full reset** now appears based on what the device agent says it can do, rather than on which platform you picked. The control was offered for every iOS device and hidden for every Android one, which was right about the agents of the day and wrong about any other combination: an agent older than the feature was still offered a toggle it has no code for, and an Android agent that gains the ability would still have had it hidden — which is the half that landed above in this same release. If you run an agent from before this release against a newer relay, the toggle is now correctly absent instead of erasing nothing — one more reason to upgrade agents and relay together, as 0.19.0 asked.
 
 ### Security
 

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -48,12 +48,10 @@ import { EmulatorVideo } from './emulator/EmulatorVideo.js'
 
 const logger = createLogger('android-agent')
 
-// Typed so a typo cannot ship silently — the viewer gates the whole clipboard bridge on this.
-// `full-reset` is deliberately absent: `handleDeviceBoot` does not read `resetMode`, and
-// `-wipe-data` is not passed to the emulator (#447). Listing it would make the viewer offer a
-// toggle that disarms having erased nothing, which reads as "done". Add it in the same change
-// that implements the wipe, not before.
-const AGENT_CAPABILITIES: AgentCapability[] = ['clipboard']
+// Typed so a typo cannot ship silently — the viewer gates the whole clipboard bridge on this, and
+// since #447 the Full reset toggle too. `full-reset` is honoured in `handleDeviceBoot`, which stops
+// an already-running emulator and relaunches it with `-wipe-data`.
+const AGENT_CAPABILITIES: AgentCapability[] = ['clipboard', 'full-reset']
 
 // Parse H.264 SPS NAL unit to extract frame dimensions.
 // scrcpy sends a new SPS (inside an IDR keyframe) whenever the capture size changes —
@@ -930,7 +928,7 @@ export class AndroidAgent implements DeviceAgent {
   // `requestId` is a parameter, never a field on `state`: `bootSeq` exists because two boots overlap,
   // and a correlator hoisted onto shared state would answer the first request with the second's id.
   // Optional because the relay's idle timer boots nothing — but every *browser* boot carries one.
-  private async handleDeviceBoot(sessionId: string, avdId: string, tier?: { secureContext: boolean; external: boolean }, requestId?: string): Promise<void> {
+  private async handleDeviceBoot(sessionId: string, avdId: string, fullErase = false, tier?: { secureContext: boolean; external: boolean }, requestId?: string): Promise<void> {
     const state = this.deviceStates.get(sessionId)
     // Split, because the two halves are not the same kind of nothing. No open control channel means the
     // answer itself has nowhere to go, so this is the one abandonment that stays silent — and the caller
@@ -963,12 +961,37 @@ export class AndroidAgent implements DeviceAgent {
       const target = devices.find((d) => d.id === avdId)
       if (!target) throw new PlatformError(`Device not found: ${avdId}`)
 
-      if (target.status !== 'booted') {
+      if (fullErase && target.status === 'booted') {
+        // `-wipe-data` is a **launch** argument, so an emulator that is already up cannot honour it
+        // where it stands — the mirror of `simctl erase` refusing a booted device (#439). A device
+        // survives agent restarts and sessions that ended without a clean shutdown, so "this
+        // session's first boot, device already running" is reachable; iOS answers it by restarting
+        // and so does this, or the toggle would refuse exactly the device a tester just armed it for.
+        const serial = this.adb.getSerial(avdId)
+        if (serial) {
+          await this.adb.shutdown(serial).catch((e: unknown) => {
+            // Best effort, as on the shutdown path: the emulator may already be going down. The
+            // wait below is what decides whether we may launch, not this call's success.
+            logger.warn('emu kill before wipe failed (already gone?):', (e as Error).message)
+          })
+          this.adb.clearSerial(avdId)
+          await this.launcher.waitForExit(avdName)
+        }
+        // The kill and the wait are both awaits, so a newer boot may have overtaken us. Without
+        // this the superseded boot goes on to wipe a device the tester has since re-picked with the
+        // toggle off — the erase-with-no-click #439 exists to prevent, on the platform where it
+        // would be silent.
+        if (seq !== state.bootSeq) { this.abandonBoot(state, seq, sessionId, requestId); return }
+      }
+
+      // `|| fullErase`: the branch above left the device down on purpose, and the reading in
+      // `target` predates it.
+      if (target.status !== 'booted' || fullErase) {
         // One unique gRPC port per emulator (undefined when forced to scrcpy → no `-grpc`).
         const grpcPort = this.forceScrcpy() ? undefined : await this.pickFreeGrpcPort()
         state.grpcPort = grpcPort ?? null
         try {
-          this.launcher.launch(avdName, grpcPort, { audio: this.audioEnabled() })
+          this.launcher.launch(avdName, grpcPort, { audio: this.audioEnabled(), wipeData: fullErase })
           const serial = await this.launcher.findSerial(avdName)
           if (seq !== state.bootSeq) { this.abandonBoot(state, seq, sessionId, requestId); return }
           await this.launcher.waitForBoot(serial)
@@ -1123,8 +1146,8 @@ export class AndroidAgent implements DeviceAgent {
   private handleRelayMessage(msg: { type: string; sessionId: string; requestId?: string; payload?: unknown }): void {
     switch (msg.type) {
       case 'device:boot': {
-        const { deviceId, secureContext, external } = msg.payload as { deviceId: string; secureContext?: boolean; external?: boolean }
-        this.handleDeviceBoot(msg.sessionId, deviceId, { secureContext: !!secureContext, external: !!external }, msg.requestId)
+        const { deviceId, resetMode, secureContext, external } = msg.payload as { deviceId: string; resetMode?: 'app-only' | 'full-erase'; secureContext?: boolean; external?: boolean }
+        this.handleDeviceBoot(msg.sessionId, deviceId, resetMode === 'full-erase', { secureContext: !!secureContext, external: !!external }, msg.requestId)
           .catch((e) => logger.error('handleDeviceBoot failed:', e))
         break
       }

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -36,7 +36,7 @@ import {
 } from '@tapflowio/agent-core/utils'
 import { execFileSync } from 'child_process'
 import { AdbWrapper } from './AdbWrapper.js'
-import { EmulatorLauncher, findEmulatorPid, stopEmulatorProcess } from './EmulatorLauncher.js'
+import { EmulatorLauncher, findEmulatorPid, probeEmulator, stopEmulatorProcess } from './EmulatorLauncher.js'
 import { ensureHelperApp, launchMuteOnlyTap, isAudioSupported } from '@tapflowio/audiotap-helper'
 import { AndroidTouchHelper } from './AndroidTouchHelper.js'
 import { parseUiAutomatorDump } from './uiTree.js'
@@ -973,7 +973,17 @@ export class AndroidAgent implements DeviceAgent {
       // same AVD and race its lock file. iOS widened the same condition for the same reason and
       // says so at `IOSAgent.ts` (`!== 'shutdown'`, not `=== 'booted'`); this is that widening,
       // expressed against the only thing Android's two-valued status cannot tell us.
-      if (fullErase && findEmulatorPid(avdName) !== null) {
+      // `probeEmulator`, not `findEmulatorPid`: the latter reports "could not look" as "not
+      // running", and here that difference is a wiped device versus a lie about one. An
+      // unconfirmable probe fails the boot before anything destructive happens.
+      const emulator = fullErase ? probeEmulator(avdName) : { state: 'gone' as const }
+      if (emulator.state === 'unknown') {
+        throw new PlatformError(
+          `Could not tell whether emulator "${avdName}" was already running (process lookup ` +
+          'unavailable), so Full reset was not attempted.',
+        )
+      }
+      if (emulator.state === 'running') {
         const serial = this.adb.getSerial(avdId)
         if (serial) {
           await this.adb.shutdown(serial).catch((e: unknown) => {

--- a/packages/android-agent/src/AndroidAgent.ts
+++ b/packages/android-agent/src/AndroidAgent.ts
@@ -36,7 +36,7 @@ import {
 } from '@tapflowio/agent-core/utils'
 import { execFileSync } from 'child_process'
 import { AdbWrapper } from './AdbWrapper.js'
-import { EmulatorLauncher, findEmulatorPid } from './EmulatorLauncher.js'
+import { EmulatorLauncher, findEmulatorPid, stopEmulatorProcess } from './EmulatorLauncher.js'
 import { ensureHelperApp, launchMuteOnlyTap, isAudioSupported } from '@tapflowio/audiotap-helper'
 import { AndroidTouchHelper } from './AndroidTouchHelper.js'
 import { parseUiAutomatorDump } from './uiTree.js'
@@ -961,12 +961,19 @@ export class AndroidAgent implements DeviceAgent {
       const target = devices.find((d) => d.id === avdId)
       if (!target) throw new PlatformError(`Device not found: ${avdId}`)
 
-      if (fullErase && target.status === 'booted') {
-        // `-wipe-data` is a **launch** argument, so an emulator that is already up cannot honour it
-        // where it stands — the mirror of `simctl erase` refusing a booted device (#439). A device
-        // survives agent restarts and sessions that ended without a clean shutdown, so "this
-        // session's first boot, device already running" is reachable; iOS answers it by restarting
-        // and so does this, or the toggle would refuse exactly the device a tester just armed it for.
+      // `-wipe-data` is a **launch** argument, so an emulator that is already up cannot honour it
+      // where it stands — the mirror of `simctl erase` refusing a booted device (#439). A device
+      // survives agent restarts and sessions that ended without a clean shutdown, so "this
+      // session's first boot, device already running" is reachable; iOS answers it by restarting
+      // and so does this, or the toggle would refuse exactly the device a tester just armed it for.
+      //
+      // **Asked of the process, not of `target.status`.** That status is `Boolean(serial)` — it
+      // says adb can *see* the emulator, which an emulator that is still coming up, or one whose
+      // adb server restarted, is not. Skipping the stop there would put a second emulator on the
+      // same AVD and race its lock file. iOS widened the same condition for the same reason and
+      // says so at `IOSAgent.ts` (`!== 'shutdown'`, not `=== 'booted'`); this is that widening,
+      // expressed against the only thing Android's two-valued status cannot tell us.
+      if (fullErase && findEmulatorPid(avdName) !== null) {
         const serial = this.adb.getSerial(avdId)
         if (serial) {
           await this.adb.shutdown(serial).catch((e: unknown) => {
@@ -975,9 +982,15 @@ export class AndroidAgent implements DeviceAgent {
             logger.warn('emu kill before wipe failed (already gone?):', (e as Error).message)
           })
           this.adb.clearSerial(avdId)
-          await this.launcher.waitForExit(avdName)
+        } else {
+          // Live process, no console to ask. Safe here and only here — the data a hard stop could
+          // damage is about to be wiped.
+          stopEmulatorProcess(avdName)
         }
-        // The kill and the wait are both awaits, so a newer boot may have overtaken us. Without
+        // Throws if it is still up at the deadline, which the outer catch turns into
+        // `device:boot-error`. Launching anyway would report a Full reset that never happened.
+        await this.launcher.waitForExit(avdName)
+        // The stop and the wait are both awaits, so a newer boot may have overtaken us. Without
         // this the superseded boot goes on to wipe a device the tester has since re-picked with the
         // toggle off — the erase-with-no-click #439 exists to prevent, on the platform where it
         // would be silent.
@@ -990,6 +1003,10 @@ export class AndroidAgent implements DeviceAgent {
         // One unique gRPC port per emulator (undefined when forced to scrcpy → no `-grpc`).
         const grpcPort = this.forceScrcpy() ? undefined : await this.pickFreeGrpcPort()
         state.grpcPort = grpcPort ?? null
+        // The port probe is an await, and the launch below is destructive now that it can carry
+        // `-wipe-data`. A `device:shutdown` landing in that gap used to reach a harmless relaunch;
+        // it would now bring the device back *erased* seconds after the tester asked for it to stop.
+        if (seq !== state.bootSeq) { this.abandonBoot(state, seq, sessionId, requestId); return }
         try {
           this.launcher.launch(avdName, grpcPort, { audio: this.audioEnabled(), wipeData: fullErase })
           const serial = await this.launcher.findSerial(avdName)

--- a/packages/android-agent/src/EmulatorLauncher.ts
+++ b/packages/android-agent/src/EmulatorLauncher.ts
@@ -44,24 +44,38 @@ export type EmulatorProbe = { state: 'running'; pid: number } | { state: 'gone' 
  * Ask whether a qemu process is holding this AVD, keeping "no" and "cannot tell" apart.
  *
  * The qemu process embeds `-avd <name>` in its command line. `pgrep` reports "no match" by exiting
- * non-zero, which is an answer; a `pgrep` that cannot run reports nothing at all, which is not.
+ * **1**, which is an answer; a `pgrep` that cannot run, or that fails for its own reasons, reports
+ * nothing usable at all, which is not.
  */
 export function probeEmulator(avdName: string): EmulatorProbe {
   // `spawnSync` rather than `execFileSync`, which is the same call plus a throw: the two outcomes
   // this has to separate arrive as `status` and `error`, and turning both into one exception only
-  // to reconstruct the difference from its properties loses information on the way — a caller can
-  // rethrow, a wrapper can swallow, and the result is the collapse this function exists to undo.
-  // Escape regex metacharacters so an AVD name like "Pixel.7" can't alter the pgrep -f pattern.
+  // to reconstruct the difference from its properties loses information on the way.
+  //
+  // The pattern matches the **whole** `-avd` argument. Without the boundaries, `Pixel` matches a
+  // running `-avd Pixel_8` (verified with `pgrep -f`), which for the audio tap meant muting the
+  // wrong emulator and here would mean sending SIGTERM to it. POSIX character classes rather than
+  // `\b`, because `pgrep -f` matches with an extended regex and word boundaries are not portable
+  // there. Metacharacters in the name are escaped so an AVD like "Pixel.7" cannot alter the pattern.
   const esc = avdName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const r = spawnSync('pgrep', ['-f', `qemu-system.*-avd ${esc}`], { encoding: 'utf8' })
+  const r = spawnSync(
+    'pgrep',
+    ['-f', `qemu-system.*[[:space:]]-avd[[:space:]]${esc}([[:space:]]|$)`],
+    { encoding: 'utf8' },
+  )
 
-  // pgrep could not be run at all — absent, not executable. Not the same as finding nothing.
+  // Could not run pgrep at all — absent, not executable. Not the same as finding nothing.
   if (r.error || r.status === null) return { state: 'unknown' }
-  // pgrep's own "no match" is an answer: it looked, and there is nothing.
-  if (r.status !== 0) return { state: 'gone' }
+  // **Only exit 1 is pgrep saying it looked and found nothing.** 2 is a syntax error and 3 is a
+  // fatal one; reading either as "gone" would let a wipe relaunch past an emulator still holding
+  // the AVD, which is the failure this whole probe exists to prevent.
+  if (r.status === 1) return { state: 'gone' }
+  if (r.status !== 0) return { state: 'unknown' }
 
+  // Exit 0 means it matched something, so unparseable output is "cannot tell", never "nothing".
+  // `> 0` and not merely finite: `process.kill(0, …)` signals the caller's whole process group.
   const pid = parseInt((r.stdout ?? '').trim().split('\n')[0] ?? '', 10)
-  return Number.isFinite(pid) ? { state: 'running', pid } : { state: 'gone' }
+  return Number.isInteger(pid) && pid > 0 ? { state: 'running', pid } : { state: 'unknown' }
 }
 
 /**

--- a/packages/android-agent/src/EmulatorLauncher.ts
+++ b/packages/android-agent/src/EmulatorLauncher.ts
@@ -26,6 +26,10 @@ function getEmulatorPath(): string {
 export interface EmulatorLaunchOpts {
   // Opt-in audio output; default off keeps `-no-audio` so the video-only path is unchanged.
   audio?: boolean
+  // Full reset (#447) — wipe `userdata` before booting, the counterpart to iOS's `simctl erase`.
+  // `-no-snapshot` below is **not** this: it is a cold boot, which skips the snapshot and keeps
+  // userdata, so nothing here erased anything until this flag existed.
+  wipeData?: boolean
 }
 
 /**
@@ -49,6 +53,7 @@ export function buildEmulatorArgs(avdName: string, grpcPort?: number, opts?: Emu
   const args = ['-avd', avdName]
   if (!opts?.audio) args.push('-no-audio')
   args.push('-no-snapshot', '-no-window', '-gpu', 'host')
+  if (opts?.wipeData) args.push('-wipe-data')
   if (grpcPort !== undefined) args.push('-grpc', String(grpcPort))
   return args
 }
@@ -100,6 +105,33 @@ export class EmulatorLauncher {
    *  normally (#549), and the two numbers live in different packages. A caller may still pass its own —
    *  which the check cannot see, and says so. */
   static readonly BOOT_READY_TIMEOUT_MS = 120_000
+
+  /** How long to wait for a stopped emulator's qemu process to actually exit. */
+  static readonly EXIT_TIMEOUT_MS = 30_000
+
+  /**
+   * Wait until no qemu process is holding this AVD.
+   *
+   * `adb emu kill` returns as soon as the emulator console accepts it, and the process dies some
+   * time after — so a relaunch issued immediately races the AVD directory's lock file, and the
+   * loser starts against a directory another process still owns. Only Full reset (#447) needs
+   * this, because it is the one path that stops an emulator in order to start it again.
+   *
+   * **Returns rather than throws on timeout.** The caller's next move is the launch either way:
+   * refusing to boot because a process we asked to die is taking its time would turn a slow
+   * shutdown into a failed session, while proceeding gives the emulator its own chance to report
+   * a lock it cannot take. `findEmulatorPid` also answers `null` when `pgrep` is unavailable, so
+   * on a host where it cannot look this is a no-op by construction — which is the same shape the
+   * audio tap already relies on.
+   */
+  async waitForExit(avdName: string, timeoutMs = EmulatorLauncher.EXIT_TIMEOUT_MS): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (findEmulatorPid(avdName) === null) return
+      await new Promise((r) => setTimeout(r, 200))
+    }
+    logger.warn(`emulator "${avdName}" still running ${timeoutMs / 1000}s after kill — launching anyway`)
+  }
 
   async waitForBoot(serial: string, timeoutMs = EmulatorLauncher.BOOT_READY_TIMEOUT_MS): Promise<void> {
     const adb = getAdbPath()

--- a/packages/android-agent/src/EmulatorLauncher.ts
+++ b/packages/android-agent/src/EmulatorLauncher.ts
@@ -48,6 +48,34 @@ export function findEmulatorPid(avdName: string): number | null {
   } catch { return null }
 }
 
+/**
+ * Ask this AVD's emulator process to stop, without going through adb.
+ *
+ * `adb emu kill` is the graceful route and the one to prefer — but it needs a serial, and a serial
+ * only exists once `adb devices` reports the emulator as `device`. An emulator that is still coming
+ * up, or one whose adb server was restarted underneath it, has a live process and no serial, and
+ * that is exactly the state Full reset must be able to clear (#447): a second emulator on the same
+ * AVD would race the lock file.
+ *
+ * Only ever called on the wipe path, which is what makes SIGTERM acceptable — the user data this
+ * could corrupt is being discarded in the next breath. Do not reach for this on an ordinary
+ * shutdown, where a clean console stop is worth waiting for.
+ *
+ * Returns whether a process was signalled; `false` means there was nothing to stop.
+ */
+export function stopEmulatorProcess(avdName: string): boolean {
+  const pid = findEmulatorPid(avdName)
+  if (pid === null) return false
+  try {
+    process.kill(pid, 'SIGTERM')
+    return true
+  } catch {
+    // Already gone between the lookup and the signal, or not ours to signal. `waitForExit` is what
+    // decides whether the AVD is actually free, so a failure here is not the answer to that.
+    return false
+  }
+}
+
 /** Build the emulator CLI args. Pure + exported so the `-no-audio` gating is unit-testable. */
 export function buildEmulatorArgs(avdName: string, grpcPort?: number, opts?: EmulatorLaunchOpts): string[] {
   const args = ['-avd', avdName]
@@ -113,24 +141,33 @@ export class EmulatorLauncher {
    * Wait until no qemu process is holding this AVD.
    *
    * `adb emu kill` returns as soon as the emulator console accepts it, and the process dies some
-   * time after — so a relaunch issued immediately races the AVD directory's lock file, and the
-   * loser starts against a directory another process still owns. Only Full reset (#447) needs
-   * this, because it is the one path that stops an emulator in order to start it again.
+   * time after — so a relaunch issued immediately races the AVD directory's lock file. Only Full
+   * reset (#447) needs this, because it is the one path that stops an emulator to start it again.
    *
-   * **Returns rather than throws on timeout.** The caller's next move is the launch either way:
-   * refusing to boot because a process we asked to die is taking its time would turn a slow
-   * shutdown into a failed session, while proceeding gives the emulator its own chance to report
-   * a lock it cannot take. `findEmulatorPid` also answers `null` when `pgrep` is unavailable, so
-   * on a host where it cannot look this is a no-op by construction — which is the same shape the
-   * audio tap already relies on.
+   * **Throws on timeout, and that is the whole point.** Proceeding to launch looks like the
+   * forgiving choice and is the dangerous one: the second emulator loses the lock and exits, and
+   * nothing here notices — `launch` spawns `detached` with `stdio: 'ignore'` and reads no exit
+   * code, while `findSerial` scans `adb devices` for **any** emulator answering to this AVD name,
+   * so it returns the survivor. `waitForBoot` then passes instantly against a device that is
+   * already up, and the session reports Full reset complete on a device that was never wiped.
+   * A failed boot the tester can see beats a silent lie about erasing their data.
+   *
+   * `findEmulatorPid` answers `null` when `pgrep` finds nothing **and** when it cannot run at all,
+   * so on a host without `pgrep` this returns immediately rather than blocking a boot — the same
+   * shape the audio tap relies on, and the reason this is a wait rather than a proof.
    */
   async waitForExit(avdName: string, timeoutMs = EmulatorLauncher.EXIT_TIMEOUT_MS): Promise<void> {
     const deadline = Date.now() + timeoutMs
-    while (Date.now() < deadline) {
+    for (;;) {
       if (findEmulatorPid(avdName) === null) return
+      if (Date.now() >= deadline) {
+        throw new PlatformError(
+          `Emulator "${avdName}" was still running ${timeoutMs / 1000}s after being asked to stop, ` +
+          'so it could not be wiped and relaunched.',
+        )
+      }
       await new Promise((r) => setTimeout(r, 200))
     }
-    logger.warn(`emulator "${avdName}" still running ${timeoutMs / 1000}s after kill — launching anyway`)
   }
 
   async waitForBoot(serial: string, timeoutMs = EmulatorLauncher.BOOT_READY_TIMEOUT_MS): Promise<void> {

--- a/packages/android-agent/src/EmulatorLauncher.ts
+++ b/packages/android-agent/src/EmulatorLauncher.ts
@@ -1,4 +1,4 @@
-import { execFile, execFileSync, spawn } from 'child_process'
+import { execFile, spawn, spawnSync } from 'child_process'
 import { promisify } from 'util'
 import { createLogger, PlatformError, ValidationError } from '@tapflowio/agent-core'
 
@@ -32,20 +32,50 @@ export interface EmulatorLaunchOpts {
   wipeData?: boolean
 }
 
+/** What a `pgrep` for this AVD's qemu process could establish.
+ *
+ *  `'unknown'` is the member that matters and the one a boolean cannot hold: `pgrep` exits 1 when
+ *  it finds nothing, and fails to run at all when it is absent — and those are opposite facts.
+ *  Collapsing them reads "I could not look" as "nothing is there", which is safe for the audio tap
+ *  (it just does not mute) and unsafe for Full reset (it wipes nothing and says it did). */
+export type EmulatorProbe = { state: 'running'; pid: number } | { state: 'gone' } | { state: 'unknown' }
+
 /**
- * Find the running emulator's qemu PID by AVD name — the qemu process embeds `-avd <name>` in its
- * command line. Used to point the macOS mute-only audio tap at the emulator's host process so its
- * audio doesn't leak to the agent Mac's speakers (#341). Returns null when not found (not running yet,
- * or `pgrep` unavailable / exits 1 with no match). macOS only in practice; harmless elsewhere.
+ * Ask whether a qemu process is holding this AVD, keeping "no" and "cannot tell" apart.
+ *
+ * The qemu process embeds `-avd <name>` in its command line. `pgrep` reports "no match" by exiting
+ * non-zero, which is an answer; a `pgrep` that cannot run reports nothing at all, which is not.
+ */
+export function probeEmulator(avdName: string): EmulatorProbe {
+  // `spawnSync` rather than `execFileSync`, which is the same call plus a throw: the two outcomes
+  // this has to separate arrive as `status` and `error`, and turning both into one exception only
+  // to reconstruct the difference from its properties loses information on the way — a caller can
+  // rethrow, a wrapper can swallow, and the result is the collapse this function exists to undo.
+  // Escape regex metacharacters so an AVD name like "Pixel.7" can't alter the pgrep -f pattern.
+  const esc = avdName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const r = spawnSync('pgrep', ['-f', `qemu-system.*-avd ${esc}`], { encoding: 'utf8' })
+
+  // pgrep could not be run at all — absent, not executable. Not the same as finding nothing.
+  if (r.error || r.status === null) return { state: 'unknown' }
+  // pgrep's own "no match" is an answer: it looked, and there is nothing.
+  if (r.status !== 0) return { state: 'gone' }
+
+  const pid = parseInt((r.stdout ?? '').trim().split('\n')[0] ?? '', 10)
+  return Number.isFinite(pid) ? { state: 'running', pid } : { state: 'gone' }
+}
+
+/**
+ * The running emulator's qemu PID, or null. Used to point the macOS mute-only audio tap at the
+ * emulator's host process so its audio doesn't leak to the agent Mac's speakers (#341).
+ *
+ * **Deliberately still collapses `unknown` into null.** That caller's worst case is that it does
+ * not mute, so "could not look" and "not running" really are the same answer there. A caller for
+ * which they differ must use `probeEmulator` — see `waitForExit`, where the difference is a wiped
+ * device versus a lie about one.
  */
 export function findEmulatorPid(avdName: string): number | null {
-  try {
-    // Escape regex metacharacters so an AVD name like "Pixel.7" can't alter the pgrep -f pattern.
-    const esc = avdName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const out = execFileSync('pgrep', ['-f', `qemu-system.*-avd ${esc}`], { encoding: 'utf8' })
-    const pid = parseInt(out.trim().split('\n')[0] ?? '', 10)
-    return Number.isFinite(pid) ? pid : null
-  } catch { return null }
+  const probe = probeEmulator(avdName)
+  return probe.state === 'running' ? probe.pid : null
 }
 
 /**
@@ -152,14 +182,24 @@ export class EmulatorLauncher {
    * already up, and the session reports Full reset complete on a device that was never wiped.
    * A failed boot the tester can see beats a silent lie about erasing their data.
    *
-   * `findEmulatorPid` answers `null` when `pgrep` finds nothing **and** when it cannot run at all,
-   * so on a host without `pgrep` this returns immediately rather than blocking a boot — the same
-   * shape the audio tap relies on, and the reason this is a wait rather than a proof.
+   * **A probe that cannot look is a failure too**, not a pass. `pgrep` answers "no match" and
+   * "I am not installed" through the same thrown error, and reading the second as the first is the
+   * same lie by a different door: it returns at once, the launch races a lock that may still be
+   * held, and the survivor is reported as a completed wipe. `probeEmulator` keeps them apart and
+   * this refuses the one it cannot confirm. `findEmulatorPid` still collapses them for the audio
+   * tap, where the worst case is silence rather than a false result.
    */
   async waitForExit(avdName: string, timeoutMs = EmulatorLauncher.EXIT_TIMEOUT_MS): Promise<void> {
     const deadline = Date.now() + timeoutMs
     for (;;) {
-      if (findEmulatorPid(avdName) === null) return
+      const probe = probeEmulator(avdName)
+      if (probe.state === 'gone') return
+      if (probe.state === 'unknown') {
+        throw new PlatformError(
+          `Could not tell whether emulator "${avdName}" had stopped (process lookup unavailable), ` +
+          'so it was not relaunched — a wipe that cannot be confirmed would be reported as done.',
+        )
+      }
       if (Date.now() >= deadline) {
         throw new PlatformError(
           `Emulator "${avdName}" was still running ${timeoutMs / 1000}s after being asked to stop, ` +

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -58,6 +58,7 @@ vi.mock('../EmulatorLauncher', () => ({
     launch: vi.fn(),
     findSerial: vi.fn().mockResolvedValue('emulator-5554'),
     waitForBoot: vi.fn().mockResolvedValue(undefined),
+    waitForExit: vi.fn().mockResolvedValue(undefined),
   }) }),
   findEmulatorPid: vi.fn(() => null),
 }))
@@ -285,6 +286,126 @@ describe('AndroidAgent', () => {
 
       agent.disconnect()
       browser.close()
+    })
+
+    // ── #447: Full reset — `-wipe-data`, the counterpart to iOS's `simctl erase` ──────────────
+
+    describe('resetMode: full-erase', () => {
+      /** The launcher this agent built, so the flags it was actually launched with can be read. */
+      function launchArgs(agent: AndroidAgent) {
+        const l = (agent as unknown as { launcher: { launch: ReturnType<typeof vi.fn> } }).launcher
+        return l.launch.mock.calls
+      }
+
+      /** What the emulator will actually be told, not how the caller spelled it. `wipeData` absent
+       *  and `wipeData: false` produce the same command line (`buildEmulatorArgs` reads it as
+       *  falsy), so asserting the key's presence would fail a refactor that is behaviourally
+       *  identical — and pass none that is not. */
+      function wipedOnFirstLaunch(agent: AndroidAgent): boolean {
+        const opts = launchArgs(agent)[0]?.[2] as { wipeData?: boolean } | undefined
+        return opts?.wipeData ?? false
+      }
+
+      async function boot(agent: AndroidAgent, resetMode?: 'app-only' | 'full-erase') {
+        const browser = new WebSocket(`ws://localhost:${port}`)
+        await waitForOpen(browser)
+        browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
+        await waitForType(browser, 'session:joined')
+        browser.send(JSON.stringify({
+          type: 'device:boot',
+          requestId: 'rq-wipe',
+          sessionId: agent.sessionId,
+          payload: { deviceId: 'avd:Pixel_8_API_34', ...(resetMode ? { resetMode } : {}) },
+        }))
+        await waitForType(browser, 'device:ready')
+        return browser
+      }
+
+      it('launches with wipeData when the toggle was armed', async () => {
+        const agent = new AndroidAgent({}, mockAdb(false))
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'full-erase')
+
+        expect(wipedOnFirstLaunch(agent)).toBe(true)
+
+        agent.disconnect(); browser.close()
+      })
+
+      // The control. Without it the assertion above passes on an implementation that wipes every
+      // boot, which is the worse of the two failures — it erases devices nobody asked it to.
+      it('does not wipe an ordinary boot', async () => {
+        const agent = new AndroidAgent({}, mockAdb(false))
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent)
+
+        expect(wipedOnFirstLaunch(agent)).toBe(false)
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('passes app-only through as no wipe', async () => {
+        const agent = new AndroidAgent({}, mockAdb(false))
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'app-only')
+
+        expect(wipedOnFirstLaunch(agent)).toBe(false)
+
+        agent.disconnect(); browser.close()
+      })
+
+      // `-wipe-data` is a **launch** argument, so an emulator that is already up cannot honour it
+      // where it stands — the mirror of `simctl erase` refusing a booted device (#439). It survives
+      // agent restarts and sessions that ended without a clean shutdown, so "already running" is
+      // reachable on a session's first boot. iOS answers this by restarting; so does this.
+      it('stops an already-running emulator first, then relaunches it wiped', async () => {
+        const adb = mockAdb(true)
+        const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'full-erase')
+
+        expect(shutdown).toHaveBeenCalledWith('emulator-5554')
+        expect(wipedOnFirstLaunch(agent)).toBe(true)
+
+        agent.disconnect(); browser.close()
+      })
+
+      // Relaunching before the old qemu process is gone races the AVD's lock file, and the emulator
+      // that loses starts against a directory another process still owns. Nothing in `emu kill`
+      // waits — it returns as soon as the console accepts it.
+      it('waits for the old process to exit before relaunching', async () => {
+        const adb = mockAdb(true)
+        vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+
+        const l = (agent as unknown as {
+          launcher: { waitForExit: ReturnType<typeof vi.fn>; launch: ReturnType<typeof vi.fn> }
+        }).launcher
+        const order: string[] = []
+        l.waitForExit.mockImplementation(async () => { order.push('waited') })
+        l.launch.mockImplementation(() => { order.push('launched') })
+
+        const browser = await boot(agent, 'full-erase')
+
+        expect(order).toEqual(['waited', 'launched'])
+
+        agent.disconnect(); browser.close()
+      })
+
+      // An emulator that is already down has nothing to stop, and issuing `emu kill` at a serial
+      // the map no longer holds would be an adb call against nothing.
+      it('does not try to stop an emulator that is already down', async () => {
+        const adb = mockAdb(false)
+        const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'full-erase')
+
+        expect(shutdown).not.toHaveBeenCalled()
+
+        agent.disconnect(); browser.close()
+      })
     })
 
     // ── #526: a boot the agent stops running is answered, not abandoned ───────────────────────
@@ -1723,23 +1844,15 @@ describe('AndroidAgent', () => {
         expect(joined.capabilities).toContain('clipboard')
       })
 
-      // #447: `handleDeviceBoot` does not read `resetMode` and the emulator is never launched with
-      // `-wipe-data`, so advertising `full-reset` would put a toggle on screen that erases nothing
-      // and then disarms itself, which reads as "done" — the bug that issue exists for.
-      //
-      // Asserting an absence is usually the weak shape this repo warns about, but not here: the
-      // mutation is adding the string to `AGENT_CAPABILITIES`, and that fails this line. It is the
-      // only thing standing between a one-word edit and a control that lies. Delete it in the same
-      // change that implements the wipe.
-      it('does not advertise full-reset, because nothing here honours it yet', async () => {
+      // #447: the toggle is gated on this, not on the platform string — so the capability and the
+      // `-wipe-data` launch flag have to arrive together. Advertising it without the flag puts a
+      // control on screen that erases nothing and then disarms, which reads as "done".
+      it('advertises the full-reset capability all the way to the viewer', async () => {
         browser = new WebSocket(`ws://localhost:${port}`)
         await waitForOpen(browser)
         browser.send(JSON.stringify({ type: 'session:start', sessionId: agent.sessionId }))
         const joined = await waitForType<SessionJoined>(browser, 'session:joined')
-        const caps = joined.capabilities
-        // Paired with a positive so this cannot pass by the capability list being empty/absent.
-        expect(caps).toContain('clipboard')
-        expect(caps).not.toContain('full-reset')
+        expect(joined.capabilities).toContain('full-reset')
       })
 
       it('clipboard:read returns the guest clipboard as clipboard:data', async () => {

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -61,6 +61,7 @@ vi.mock('../EmulatorLauncher', () => ({
     waitForExit: vi.fn().mockResolvedValue(undefined),
   }) }),
   findEmulatorPid: vi.fn(() => null),
+  stopEmulatorProcess: vi.fn(() => true),
 }))
 // Shared macOS host-mute helper (#341). Off by default in tests (isAudioSupported → false → no-op);
 // the host-mute test overrides these to assert the mute tap launches.
@@ -126,7 +127,7 @@ import { AdbWrapper } from '../AdbWrapper'
 import { ScrcpySession } from '../scrcpy/ScrcpySession'
 import { EmulatorVideo } from '../emulator/EmulatorVideo'
 import { EmulatorGrpcClient } from '../emulator/EmulatorGrpcClient'
-import { findEmulatorPid } from '../EmulatorLauncher'
+import { findEmulatorPid, stopEmulatorProcess } from '../EmulatorLauncher'
 import { isAudioSupported, launchMuteOnlyTap } from '@tapflowio/audiotap-helper'
 import type { ScrcpyControl } from '../scrcpy/ScrcpyControl'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
@@ -291,10 +292,14 @@ describe('AndroidAgent', () => {
     // ── #447: Full reset — `-wipe-data`, the counterpart to iOS's `simctl erase` ──────────────
 
     describe('resetMode: full-erase', () => {
-      /** The launcher this agent built, so the flags it was actually launched with can be read. */
-      function launchArgs(agent: AndroidAgent) {
-        const l = (agent as unknown as { launcher: { launch: ReturnType<typeof vi.fn> } }).launcher
-        return l.launch.mock.calls
+      /** The launcher this agent built, so the flags it was launched with can be read. */
+      function launcherOf(agent: AndroidAgent) {
+        return (agent as unknown as {
+          launcher: {
+            launch: ReturnType<typeof vi.fn>
+            waitForExit: ReturnType<typeof vi.fn>
+          }
+        }).launcher
       }
 
       /** What the emulator will actually be told, not how the caller spelled it. `wipeData` absent
@@ -302,7 +307,7 @@ describe('AndroidAgent', () => {
        *  falsy), so asserting the key's presence would fail a refactor that is behaviourally
        *  identical — and pass none that is not. */
       function wipedOnFirstLaunch(agent: AndroidAgent): boolean {
-        const opts = launchArgs(agent)[0]?.[2] as { wipeData?: boolean } | undefined
+        const opts = launcherOf(agent).launch.mock.calls[0]?.[2] as { wipeData?: boolean } | undefined
         return opts?.wipeData ?? false
       }
 
@@ -317,14 +322,26 @@ describe('AndroidAgent', () => {
           sessionId: agent.sessionId,
           payload: { deviceId: 'avd:Pixel_8_API_34', ...(resetMode ? { resetMode } : {}) },
         }))
-        await waitForType(browser, 'device:ready')
         return browser
       }
+
+      // The suite's default is "no emulator process". Each test states which world it is in, because
+      // the stop branch is gated on the process rather than on adb's view of it.
+      //
+      // Both are module-level `vi.fn()`s shared by every test in the file, so the call history has
+      // to be cleared as well as the return value — a `not.toHaveBeenCalled()` reading a previous
+      // test's call is a failure that points at the wrong test.
+      beforeEach(() => {
+        vi.mocked(findEmulatorPid).mockReturnValue(null)
+        vi.mocked(stopEmulatorProcess).mockClear()
+      })
+      afterEach(() => vi.mocked(findEmulatorPid).mockReturnValue(null))
 
       it('launches with wipeData when the toggle was armed', async () => {
         const agent = new AndroidAgent({}, mockAdb(false))
         await agent.connect(`ws://localhost:${port}`)
         const browser = await boot(agent, 'full-erase')
+        await waitForType(browser, 'device:ready')
 
         expect(wipedOnFirstLaunch(agent)).toBe(true)
 
@@ -337,6 +354,7 @@ describe('AndroidAgent', () => {
         const agent = new AndroidAgent({}, mockAdb(false))
         await agent.connect(`ws://localhost:${port}`)
         const browser = await boot(agent)
+        await waitForType(browser, 'device:ready')
 
         expect(wipedOnFirstLaunch(agent)).toBe(false)
 
@@ -347,22 +365,21 @@ describe('AndroidAgent', () => {
         const agent = new AndroidAgent({}, mockAdb(false))
         await agent.connect(`ws://localhost:${port}`)
         const browser = await boot(agent, 'app-only')
+        await waitForType(browser, 'device:ready')
 
         expect(wipedOnFirstLaunch(agent)).toBe(false)
 
         agent.disconnect(); browser.close()
       })
 
-      // `-wipe-data` is a **launch** argument, so an emulator that is already up cannot honour it
-      // where it stands — the mirror of `simctl erase` refusing a booted device (#439). It survives
-      // agent restarts and sessions that ended without a clean shutdown, so "already running" is
-      // reachable on a session's first boot. iOS answers this by restarting; so does this.
       it('stops an already-running emulator first, then relaunches it wiped', async () => {
+        vi.mocked(findEmulatorPid).mockReturnValue(4321)
         const adb = mockAdb(true)
         const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
         await agent.connect(`ws://localhost:${port}`)
         const browser = await boot(agent, 'full-erase')
+        await waitForType(browser, 'device:ready')
 
         expect(shutdown).toHaveBeenCalledWith('emulator-5554')
         expect(wipedOnFirstLaunch(agent)).toBe(true)
@@ -370,39 +387,100 @@ describe('AndroidAgent', () => {
         agent.disconnect(); browser.close()
       })
 
-      // Relaunching before the old qemu process is gone races the AVD's lock file, and the emulator
-      // that loses starts against a directory another process still owns. Nothing in `emu kill`
-      // waits — it returns as soon as the console accepts it.
-      it('waits for the old process to exit before relaunching', async () => {
+      // The mirror of the test above, and the one that keeps the `fullErase &&` in the condition
+      // honest: an ordinary boot must not touch a running emulator, or every tester loses the
+      // device they were using to a cold boot nobody asked for.
+      it('leaves a running emulator alone on an ordinary boot', async () => {
+        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        const adb = mockAdb(true)
+        const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent)
+        await waitForType(browser, 'device:ready')
+
+        expect(shutdown).not.toHaveBeenCalled()
+        // Paired with the launch, so this cannot pass by the boot having failed before reaching it.
+        expect(launcherOf(agent).launch).not.toHaveBeenCalled()
+
+        agent.disconnect(); browser.close()
+      })
+
+      // Relaunching before the old qemu process is gone races the AVD's lock file. Nothing in
+      // `emu kill` waits — it returns as soon as the console accepts it.
+      it('waits for the old process to exit before relaunching, naming the AVD not the device id', async () => {
+        vi.mocked(findEmulatorPid).mockReturnValue(4321)
         const adb = mockAdb(true)
         vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
         await agent.connect(`ws://localhost:${port}`)
 
-        const l = (agent as unknown as {
-          launcher: { waitForExit: ReturnType<typeof vi.fn>; launch: ReturnType<typeof vi.fn> }
-        }).launcher
+        const l = launcherOf(agent)
         const order: string[] = []
         l.waitForExit.mockImplementation(async () => { order.push('waited') })
         l.launch.mockImplementation(() => { order.push('launched') })
 
         const browser = await boot(agent, 'full-erase')
+        await waitForType(browser, 'device:ready')
 
         expect(order).toEqual(['waited', 'launched'])
+        // `avd:Pixel_8_API_34` is three lines away in the same block and would make `pgrep` match
+        // nothing, so the wait would return at once and buy nothing at all.
+        expect(l.waitForExit).toHaveBeenCalledWith('Pixel_8_API_34')
 
         agent.disconnect(); browser.close()
       })
 
-      // An emulator that is already down has nothing to stop, and issuing `emu kill` at a serial
-      // the map no longer holds would be an adb call against nothing.
-      it('does not try to stop an emulator that is already down', async () => {
+      // A live process adb cannot see — still coming up, or its adb server restarted. There is no
+      // console to ask, and skipping the stop would put a second emulator on the same AVD.
+      it('stops a live emulator that adb cannot see, without a serial', async () => {
+        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        const adb = mockAdb(false)          // no serial: adb reports nothing booted
+        const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'full-erase')
+        await waitForType(browser, 'device:ready')
+
+        expect(shutdown).not.toHaveBeenCalled()          // no console to send it to
+        expect(vi.mocked(stopEmulatorProcess)).toHaveBeenCalledWith('Pixel_8_API_34')
+        expect(launcherOf(agent).waitForExit).toHaveBeenCalledWith('Pixel_8_API_34')
+
+        agent.disconnect(); browser.close()
+      })
+
+      it('does not try to stop an emulator that is not running', async () => {
         const adb = mockAdb(false)
         const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
         await agent.connect(`ws://localhost:${port}`)
         const browser = await boot(agent, 'full-erase')
+        await waitForType(browser, 'device:ready')
 
         expect(shutdown).not.toHaveBeenCalled()
+        expect(vi.mocked(stopEmulatorProcess)).not.toHaveBeenCalled()
+        expect(launcherOf(agent).waitForExit).not.toHaveBeenCalled()
+
+        agent.disconnect(); browser.close()
+      })
+
+      // The blocker this review found: proceeding to launch after a failed stop reports a Full
+      // reset that never happened, because `findSerial` scans `adb devices` for any emulator
+      // answering to this AVD and returns the survivor, and `waitForBoot` passes instantly on a
+      // device that is already up. The boot has to fail where the tester can see it.
+      it('fails the boot rather than launching when the old emulator will not exit', async () => {
+        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        const adb = mockAdb(true)
+        vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
+        const agent = new AndroidAgent({}, adb)
+        await agent.connect(`ws://localhost:${port}`)
+        launcherOf(agent).waitForExit.mockRejectedValue(new Error('still running after 30s'))
+
+        const browser = await boot(agent, 'full-erase')
+        const err = await waitForType(browser, 'device:boot-error')
+
+        expect(err['requestId']).toBe('rq-wipe')
+        expect(launcherOf(agent).launch).not.toHaveBeenCalled()
 
         agent.disconnect(); browser.close()
       })

--- a/packages/android-agent/src/__tests__/AndroidAgent.test.ts
+++ b/packages/android-agent/src/__tests__/AndroidAgent.test.ts
@@ -61,6 +61,9 @@ vi.mock('../EmulatorLauncher', () => ({
     waitForExit: vi.fn().mockResolvedValue(undefined),
   }) }),
   findEmulatorPid: vi.fn(() => null),
+  // The boot path probes rather than asking for a pid, because it has to tell "not running" from
+  // "could not look" (#447 review). Default: nothing running, and we could see that.
+  probeEmulator: vi.fn(() => ({ state: 'gone' as const })),
   stopEmulatorProcess: vi.fn(() => true),
 }))
 // Shared macOS host-mute helper (#341). Off by default in tests (isAudioSupported → false → no-op);
@@ -127,7 +130,7 @@ import { AdbWrapper } from '../AdbWrapper'
 import { ScrcpySession } from '../scrcpy/ScrcpySession'
 import { EmulatorVideo } from '../emulator/EmulatorVideo'
 import { EmulatorGrpcClient } from '../emulator/EmulatorGrpcClient'
-import { findEmulatorPid, stopEmulatorProcess } from '../EmulatorLauncher'
+import { findEmulatorPid, probeEmulator, stopEmulatorProcess } from '../EmulatorLauncher'
 import { isAudioSupported, launchMuteOnlyTap } from '@tapflowio/audiotap-helper'
 import type { ScrcpyControl } from '../scrcpy/ScrcpyControl'
 import type { ScrcpyFrame } from '../scrcpy/ScrcpyVideo'
@@ -332,10 +335,10 @@ describe('AndroidAgent', () => {
       // to be cleared as well as the return value — a `not.toHaveBeenCalled()` reading a previous
       // test's call is a failure that points at the wrong test.
       beforeEach(() => {
-        vi.mocked(findEmulatorPid).mockReturnValue(null)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'gone' })
         vi.mocked(stopEmulatorProcess).mockClear()
       })
-      afterEach(() => vi.mocked(findEmulatorPid).mockReturnValue(null))
+      afterEach(() => vi.mocked(probeEmulator).mockReturnValue({ state: 'gone' }))
 
       it('launches with wipeData when the toggle was armed', async () => {
         const agent = new AndroidAgent({}, mockAdb(false))
@@ -373,7 +376,7 @@ describe('AndroidAgent', () => {
       })
 
       it('stops an already-running emulator first, then relaunches it wiped', async () => {
-        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'running', pid: 4321 })
         const adb = mockAdb(true)
         const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
@@ -391,7 +394,7 @@ describe('AndroidAgent', () => {
       // honest: an ordinary boot must not touch a running emulator, or every tester loses the
       // device they were using to a cold boot nobody asked for.
       it('leaves a running emulator alone on an ordinary boot', async () => {
-        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'running', pid: 4321 })
         const adb = mockAdb(true)
         const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
@@ -409,7 +412,7 @@ describe('AndroidAgent', () => {
       // Relaunching before the old qemu process is gone races the AVD's lock file. Nothing in
       // `emu kill` waits — it returns as soon as the console accepts it.
       it('waits for the old process to exit before relaunching, naming the AVD not the device id', async () => {
-        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'running', pid: 4321 })
         const adb = mockAdb(true)
         vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
@@ -434,7 +437,7 @@ describe('AndroidAgent', () => {
       // A live process adb cannot see — still coming up, or its adb server restarted. There is no
       // console to ask, and skipping the stop would put a second emulator on the same AVD.
       it('stops a live emulator that adb cannot see, without a serial', async () => {
-        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'running', pid: 4321 })
         const adb = mockAdb(false)          // no serial: adb reports nothing booted
         const shutdown = vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)
@@ -464,12 +467,42 @@ describe('AndroidAgent', () => {
         agent.disconnect(); browser.close()
       })
 
+      // `pgrep` answers "no match" and "I am not installed" through the same thrown error, so a
+      // probe that cannot look must not read as "nothing is running" — that lands on the same
+      // silent false success as launching after a failed stop, by a different door.
+      it('fails the boot when it cannot tell whether an emulator is running', async () => {
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'unknown' })
+        const agent = new AndroidAgent({}, mockAdb(false))
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent, 'full-erase')
+        const err = await waitForType(browser, 'device:boot-error')
+
+        expect(err['requestId']).toBe('rq-wipe')
+        expect(launcherOf(agent).launch).not.toHaveBeenCalled()
+
+        agent.disconnect(); browser.close()
+      })
+
+      // The same probe failure must not touch an ordinary boot — it never asks, and a host without
+      // `pgrep` has to keep booting devices normally.
+      it('does not consult the probe on an ordinary boot', async () => {
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'unknown' })
+        const agent = new AndroidAgent({}, mockAdb(false))
+        await agent.connect(`ws://localhost:${port}`)
+        const browser = await boot(agent)
+        await waitForType(browser, 'device:ready')
+
+        expect(launcherOf(agent).launch).toHaveBeenCalled()
+
+        agent.disconnect(); browser.close()
+      })
+
       // The blocker this review found: proceeding to launch after a failed stop reports a Full
       // reset that never happened, because `findSerial` scans `adb devices` for any emulator
       // answering to this AVD and returns the survivor, and `waitForBoot` passes instantly on a
       // device that is already up. The boot has to fail where the tester can see it.
       it('fails the boot rather than launching when the old emulator will not exit', async () => {
-        vi.mocked(findEmulatorPid).mockReturnValue(4321)
+        vi.mocked(probeEmulator).mockReturnValue({ state: 'running', pid: 4321 })
         const adb = mockAdb(true)
         vi.spyOn(adb, 'shutdown').mockResolvedValue(undefined)
         const agent = new AndroidAgent({}, adb)

--- a/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
@@ -7,11 +7,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
   execFile: vi.fn(),
-  execFileSync: vi.fn(() => ''),
+  // `probeEmulator` reads `status` and `error` off the result rather than catching a throw, which
+  // is also what makes both of its outcomes reachable from a test — this runner reports an error
+  // thrown inside `mockImplementation` as a failure even when production code swallows it.
+  spawnSync: vi.fn(() => ({ status: 1, stdout: '', error: undefined })),
 }))
 
-import { spawn, execFileSync } from 'child_process'
-import { buildEmulatorArgs, EmulatorLauncher, findEmulatorPid, stopEmulatorProcess } from '../EmulatorLauncher'
+import { spawn, spawnSync } from 'child_process'
+import { buildEmulatorArgs, EmulatorLauncher, findEmulatorPid, probeEmulator, stopEmulatorProcess } from '../EmulatorLauncher'
 
 describe('buildEmulatorArgs', () => {
   it('includes -no-audio by default (audio off — video path unchanged)', () => {
@@ -88,7 +91,7 @@ describe('EmulatorLauncher.launch', () => {
 })
 
 describe('waitForExit', () => {
-  beforeEach(() => vi.mocked(execFileSync).mockReset())
+  beforeEach(() => vi.mocked(spawnSync).mockReset())
   afterEach(() => vi.useRealTimers())
 
   /** `findEmulatorPid` parses `pgrep` stdout; no match parses to NaN, which it reports as null.
@@ -97,9 +100,10 @@ describe('waitForExit', () => {
   const NONE = ''
   const pgrepReturns = (...results: string[]) => {
     let i = 0
-    vi.mocked(execFileSync).mockImplementation(
-      () => results[Math.min(i++, results.length - 1)]!,
-    )
+    vi.mocked(spawnSync).mockImplementation(() => {
+      const out = results[Math.min(i++, results.length - 1)]!
+      return { status: out ? 0 : 1, stdout: out, error: undefined } as never
+    })
   }
 
   it('returns as soon as no process holds the AVD', async () => {
@@ -112,7 +116,15 @@ describe('waitForExit', () => {
   it('keeps waiting while a process is still there, then returns when it goes', async () => {
     pgrepReturns('4321\n', '4321\n', NONE)
     await expect(new EmulatorLauncher().waitForExit('Pixel', 5_000)).resolves.toBeUndefined()
-    expect(vi.mocked(execFileSync).mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect(vi.mocked(spawnSync).mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  // A probe that cannot look is not a confirmed exit. Returning here would let the caller launch
+  // against a lock that may still be held, and nothing downstream tells that from a real wipe.
+  it('throws when the process lookup itself is unavailable', async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: null, stdout: '', error: new Error('ENOENT') } as never)
+    await expect(new EmulatorLauncher().waitForExit('Pixel', 5_000))
+      .rejects.toThrow(/process lookup unavailable/)
   })
 
   // Throwing is the whole contract. Returning here would let the caller launch a second emulator
@@ -126,10 +138,10 @@ describe('waitForExit', () => {
 })
 
 describe('stopEmulatorProcess', () => {
-  beforeEach(() => vi.mocked(execFileSync).mockReset())
+  beforeEach(() => vi.mocked(spawnSync).mockReset())
 
   it('signals the pid it found', () => {
-    vi.mocked(execFileSync).mockReturnValue('4321\n')
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: '4321\n', error: undefined } as never)
     const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
     expect(stopEmulatorProcess('Pixel')).toBe(true)
     expect(kill).toHaveBeenCalledWith(4321, 'SIGTERM')
@@ -137,7 +149,7 @@ describe('stopEmulatorProcess', () => {
   })
 
   it('reports false when nothing is running, without signalling', () => {
-    vi.mocked(execFileSync).mockReturnValue('')
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stdout: '', error: undefined } as never)
     const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
     expect(stopEmulatorProcess('Pixel')).toBe(false)
     expect(kill).not.toHaveBeenCalled()
@@ -146,28 +158,49 @@ describe('stopEmulatorProcess', () => {
 
   // A pid that died between the lookup and the signal is not a failure to stop it.
   it('reports false rather than throwing when the signal is refused', () => {
-    vi.mocked(execFileSync).mockReturnValue('4321\n')
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: '4321\n', error: undefined } as never)
     const kill = vi.spyOn(process, 'kill').mockImplementation(() => { throw new Error('ESRCH') })
     expect(stopEmulatorProcess('Pixel')).toBe(false)
     kill.mockRestore()
   })
 })
 
-describe('findEmulatorPid', () => {
-  beforeEach(() => vi.mocked(execFileSync).mockReset())
+describe('probeEmulator', () => {
+  beforeEach(() => vi.mocked(spawnSync).mockReset())
 
-  // `pgrep` exiting non-zero (no match, or not installed) reaches the same `return null` as the
-  // empty-output case above, and that outcome is what every caller depends on — it is why
-  // `waitForExit` is safe to call on a host that cannot look. **Not covered directly**: an error
-  // thrown from inside `vi.fn().mockImplementation` is reported as a test failure by this runner
-  // even when the production `catch` swallows it (verified — `expect(...).not.toThrow()` passes and
-  // the error is still raised alongside it), so the exit-1 branch cannot be exercised here without
-  // asserting on the harness instead of the code.
+  it('reads pgrep exit 1 as "gone", because that is pgrep saying it looked', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stdout: '', error: undefined } as never)
+    expect(probeEmulator('Pixel')).toEqual({ state: 'gone' })
+  })
+
+  it('reads a failure to run pgrep as "unknown", not as "gone"', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: null, stdout: '', error: new Error('ENOENT') } as never)
+    expect(probeEmulator('Pixel')).toEqual({ state: 'unknown' })
+  })
+
+  it('reports the pid it found', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: '4321\n', error: undefined } as never)
+    expect(probeEmulator('Pixel')).toEqual({ state: 'running', pid: 4321 })
+  })
+})
+
+describe('findEmulatorPid', () => {
+  beforeEach(() => vi.mocked(spawnSync).mockReset())
+
+  // Both non-running probe states collapse to `null` here on purpose — the audio tap's worst case
+  // is that it does not mute. The `probeEmulator` describe above is where they are told apart, and
+  // `waitForExit` is the caller for which the difference is a wiped device or a lie about one.
+  it('answers null whether the emulator is gone or the lookup was unavailable', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stdout: '', error: undefined } as never)
+    expect(findEmulatorPid('Pixel')).toBeNull()
+    vi.mocked(spawnSync).mockReturnValue({ status: null, stdout: '', error: new Error('ENOENT') } as never)
+    expect(findEmulatorPid('Pixel')).toBeNull()
+  })
 
   it('escapes regex metacharacters in the AVD name', () => {
-    vi.mocked(execFileSync).mockReturnValue('1\n')
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: '1\n', error: undefined } as never)
     findEmulatorPid('Pixel.7')
-    const pattern = (vi.mocked(execFileSync).mock.calls[0]?.[1] as string[])[1]
+    const pattern = (vi.mocked(spawnSync).mock.calls[0]?.[1] as string[])[1]
     expect(pattern).toContain('Pixel\\.7')
   })
 })

--- a/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
@@ -178,6 +178,40 @@ describe('probeEmulator', () => {
     expect(probeEmulator('Pixel')).toEqual({ state: 'unknown' })
   })
 
+  // pgrep exits 2 on a syntax error and 3 on a fatal one. Neither means it looked and found
+  // nothing, and reading them that way lets a wipe relaunch past a live emulator.
+  it('reads any other non-zero status as "unknown", not as "gone"', () => {
+    for (const status of [2, 3]) {
+      vi.mocked(spawnSync).mockReturnValue({ status, stdout: '', error: undefined } as never)
+      expect(probeEmulator('Pixel')).toEqual({ state: 'unknown' })
+    }
+  })
+
+  // Exit 0 means pgrep matched something, so output it cannot parse is "cannot tell".
+  it('reads a match it cannot parse as "unknown"', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: 'not-a-pid\n', error: undefined } as never)
+    expect(probeEmulator('Pixel')).toEqual({ state: 'unknown' })
+  })
+
+  // `process.kill(0, …)` signals the caller's own process group, so a zero here is not a pid we
+  // may act on — `Number.isFinite` alone would have let it through.
+  it('refuses a non-positive pid rather than reporting it as running', () => {
+    for (const stdout of ['0\n', '-1\n']) {
+      vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout, error: undefined } as never)
+      expect(probeEmulator('Pixel')).toEqual({ state: 'unknown' })
+    }
+  })
+
+  // Verified against a real `pgrep -f`: the unbounded pattern matched a running `-avd Pixel_8`
+  // when asked about `Pixel`, which for the audio tap muted the wrong emulator and here would
+  // SIGTERM it.
+  it('matches the whole -avd argument, so one AVD name cannot be a prefix of another', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stdout: '', error: undefined } as never)
+    probeEmulator('Pixel')
+    const pattern = (vi.mocked(spawnSync).mock.calls[0]?.[1] as string[])[1]!
+    expect(pattern).toContain('[[:space:]]-avd[[:space:]]Pixel([[:space:]]|$)')
+  })
+
   it('reports the pid it found', () => {
     vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: '4321\n', error: undefined } as never)
     expect(probeEmulator('Pixel')).toEqual({ state: 'running', pid: 4321 })

--- a/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
@@ -23,4 +23,28 @@ describe('buildEmulatorArgs', () => {
   it('explicit audio:false keeps -no-audio (parity with default)', () => {
     expect(buildEmulatorArgs('Pixel', 8554, { audio: false })).toContain('-no-audio')
   })
+
+  // #447: the counterpart to iOS's `simctl erase`. `-no-snapshot` above is a **cold boot** — it skips
+  // the snapshot and keeps `userdata`, so nothing here wiped anything before this flag.
+  describe('wipeData', () => {
+    it('adds -wipe-data, leaving every other arg where it was', () => {
+      const args = buildEmulatorArgs('Pixel', 8554, { wipeData: true })
+      expect(args).toEqual(
+        ['-avd', 'Pixel', '-no-audio', '-no-snapshot', '-no-window', '-gpu', 'host', '-wipe-data', '-grpc', '8554'],
+      )
+    })
+
+    it('is absent by default, so an ordinary boot keeps userdata', () => {
+      expect(buildEmulatorArgs('Pixel', 8554)).not.toContain('-wipe-data')
+      expect(buildEmulatorArgs('Pixel', 8554, { wipeData: false })).not.toContain('-wipe-data')
+    })
+
+    // The two options are independent knobs and a session can arm both — asserted because the
+    // obvious implementation (one `if/else` over `opts`) passes each of the tests above alone.
+    it('composes with audio rather than replacing it', () => {
+      const args = buildEmulatorArgs('Pixel', 8554, { wipeData: true, audio: true })
+      expect(args).toContain('-wipe-data')
+      expect(args).not.toContain('-no-audio')
+    })
+  })
 })

--- a/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
+++ b/packages/android-agent/src/__tests__/EmulatorLauncher.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import { buildEmulatorArgs } from '../EmulatorLauncher'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// `launch` spawns and `findEmulatorPid` pgreps; both go through child_process, and both are
+// **production code no test reached before** — the seam between `buildEmulatorArgs` and the process
+// that receives its argv had nothing covering it, so dropping `opts` from the call inside `launch`
+// left the whole suite green while killing `-wipe-data` (#447) and `-no-audio` (#341) together.
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+  execFile: vi.fn(),
+  execFileSync: vi.fn(() => ''),
+}))
+
+import { spawn, execFileSync } from 'child_process'
+import { buildEmulatorArgs, EmulatorLauncher, findEmulatorPid, stopEmulatorProcess } from '../EmulatorLauncher'
 
 describe('buildEmulatorArgs', () => {
   it('includes -no-audio by default (audio off — video path unchanged)', () => {
@@ -46,5 +58,116 @@ describe('buildEmulatorArgs', () => {
       expect(args).toContain('-wipe-data')
       expect(args).not.toContain('-no-audio')
     })
+  })
+})
+
+describe('EmulatorLauncher.launch', () => {
+  beforeEach(() => vi.mocked(spawn).mockClear())
+
+  /** The argv the emulator process is actually given. */
+  function argvOf(): string[] {
+    return vi.mocked(spawn).mock.calls[0]?.[1] as string[]
+  }
+
+  it('hands buildEmulatorArgs output to the spawned process, options included', () => {
+    new EmulatorLauncher().launch('Pixel', 8554, { wipeData: true })
+    expect(argvOf()).toEqual(buildEmulatorArgs('Pixel', 8554, { wipeData: true }))
+    expect(argvOf()).toContain('-wipe-data')
+  })
+
+  // Named separately from the case above because they fail to different mutations: dropping `opts`
+  // from the `buildEmulatorArgs` call inside `launch` kills both flags at once, and each of these
+  // is the only assertion in the package that would say so for its own flag.
+  it('still gates audio through the same call', () => {
+    new EmulatorLauncher().launch('Pixel', 8554)
+    expect(argvOf()).toContain('-no-audio')
+    vi.mocked(spawn).mockClear()
+    new EmulatorLauncher().launch('Pixel', 8554, { audio: true })
+    expect(argvOf()).not.toContain('-no-audio')
+  })
+})
+
+describe('waitForExit', () => {
+  beforeEach(() => vi.mocked(execFileSync).mockReset())
+  afterEach(() => vi.useRealTimers())
+
+  /** `findEmulatorPid` parses `pgrep` stdout; no match parses to NaN, which it reports as null.
+   *  (`pgrep` also exits 1 on no match — that path is the function's own `catch`, covered by the
+   *  `findEmulatorPid` describe below rather than by re-throwing through every wait test.) */
+  const NONE = ''
+  const pgrepReturns = (...results: string[]) => {
+    let i = 0
+    vi.mocked(execFileSync).mockImplementation(
+      () => results[Math.min(i++, results.length - 1)]!,
+    )
+  }
+
+  it('returns as soon as no process holds the AVD', async () => {
+    pgrepReturns(NONE)
+    await expect(new EmulatorLauncher().waitForExit('Pixel', 1_000)).resolves.toBeUndefined()
+  })
+
+  // The direction matters more than the wait: inverted, this returns while the emulator is alive
+  // and hands the relaunch the lock race it exists to prevent.
+  it('keeps waiting while a process is still there, then returns when it goes', async () => {
+    pgrepReturns('4321\n', '4321\n', NONE)
+    await expect(new EmulatorLauncher().waitForExit('Pixel', 5_000)).resolves.toBeUndefined()
+    expect(vi.mocked(execFileSync).mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  // Throwing is the whole contract. Returning here would let the caller launch a second emulator
+  // on a locked AVD, and nothing downstream can tell that apart from a successful wipe — `launch`
+  // reads no exit code and `findSerial` would return the survivor's serial.
+  it('throws when the emulator outlives the deadline, naming the AVD', async () => {
+    pgrepReturns('4321\n')
+    await expect(new EmulatorLauncher().waitForExit('Pixel', 300))
+      .rejects.toThrow(/Pixel/)
+  })
+})
+
+describe('stopEmulatorProcess', () => {
+  beforeEach(() => vi.mocked(execFileSync).mockReset())
+
+  it('signals the pid it found', () => {
+    vi.mocked(execFileSync).mockReturnValue('4321\n')
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    expect(stopEmulatorProcess('Pixel')).toBe(true)
+    expect(kill).toHaveBeenCalledWith(4321, 'SIGTERM')
+    kill.mockRestore()
+  })
+
+  it('reports false when nothing is running, without signalling', () => {
+    vi.mocked(execFileSync).mockReturnValue('')
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    expect(stopEmulatorProcess('Pixel')).toBe(false)
+    expect(kill).not.toHaveBeenCalled()
+    kill.mockRestore()
+  })
+
+  // A pid that died between the lookup and the signal is not a failure to stop it.
+  it('reports false rather than throwing when the signal is refused', () => {
+    vi.mocked(execFileSync).mockReturnValue('4321\n')
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => { throw new Error('ESRCH') })
+    expect(stopEmulatorProcess('Pixel')).toBe(false)
+    kill.mockRestore()
+  })
+})
+
+describe('findEmulatorPid', () => {
+  beforeEach(() => vi.mocked(execFileSync).mockReset())
+
+  // `pgrep` exiting non-zero (no match, or not installed) reaches the same `return null` as the
+  // empty-output case above, and that outcome is what every caller depends on — it is why
+  // `waitForExit` is safe to call on a host that cannot look. **Not covered directly**: an error
+  // thrown from inside `vi.fn().mockImplementation` is reported as a test failure by this runner
+  // even when the production `catch` swallows it (verified — `expect(...).not.toThrow()` passes and
+  // the error is still raised alongside it), so the exit-1 branch cannot be exercised here without
+  // asserting on the harness instead of the code.
+
+  it('escapes regex metacharacters in the AVD name', () => {
+    vi.mocked(execFileSync).mockReturnValue('1\n')
+    findEmulatorPid('Pixel.7')
+    const pattern = (vi.mocked(execFileSync).mock.calls[0]?.[1] as string[])[1]
+    expect(pattern).toContain('Pixel\\.7')
   })
 })

--- a/packages/dashboard/hooks/useDeviceSelector.ts
+++ b/packages/dashboard/hooks/useDeviceSelector.ts
@@ -18,9 +18,9 @@ export function useDeviceSelector(
    *  This was `os !== 'android'`, which says "Android cannot" when what it means is "this agent did
    *  not say it can" — and the two differ in both directions (#447). An iOS agent too old to
    *  implement Full reset still reports `platform: 'ios'`, so the platform check offered a control
-   *  that agent has no code for; and the day AndroidAgent implements `-wipe-data` it would still
-   *  hide it. Gating on what the agent advertised is right on both counts, and needs no dashboard
-   *  change when the second one lands.
+   *  that agent has no code for; and `AndroidAgent` implements `-wipe-data` now, which the platform
+   *  check would still be hiding. That second half landed without touching this file, which is the
+   *  argument for gating this way rather than a prediction about it.
    *
    *  No session picked yet means nothing known yet, so the control stays hidden. */
   const fullResetSupported = selectedSession?.capabilities.includes('full-reset') ?? false

--- a/packages/dashboard/src/__tests__/QASession.reset.test.tsx
+++ b/packages/dashboard/src/__tests__/QASession.reset.test.tsx
@@ -53,8 +53,10 @@ const { QASession } = await import('../pages/QASession')
 const device = (id: string, name: string, platform = 'ios') => ({
   id, name, platform, status: 'shutdown', osVersion: 'iOS 18.3', sessionId: 'sess-1', busy: false,
 })
-// `capabilities` is what gates the toggle now, not `platform` (#447). These mirror what each agent
-// actually registers: `IOSAgent` lists `full-reset`, `AndroidAgent` does not yet.
+// `capabilities` is what gates the toggle now, not `platform` (#447). Both shipped agents advertise
+// `full-reset` as of the Android wipe; `ANDROID_AGENTS` keeps a list without it on purpose — it is
+// no longer a portrait of AndroidAgent but of **any** agent that does not implement the feature,
+// which is what the gate is actually written against and what the tests below need.
 const AGENTS: SessionInfo[] = [{
   agentName: 'studio-mac',
   platform: 'ios',


### PR DESCRIPTION
## Summary

`handleDeviceBoot` took no reset parameter and `resetMode` appeared nowhere in the package, so an armed Full reset booted exactly as if it were off. It reads it now and launches the emulator with `-wipe-data`. `-no-snapshot` was already on every launch and is **not** this — it is a cold boot, which keeps `userdata`.

Because `-wipe-data` applies at launch only, an emulator that is already running is stopped and relaunched, which is the answer iOS gives for `simctl erase` refusing a booted device. Two things make that safe: whether one is running is asked of the **process** (`findEmulatorPid`) rather than of adb, whose `booted` only means "adb can see it"; and if it will not exit, the boot **fails** instead of launching — a second emulator loses the AVD lock and exits unseen, after which `findSerial` returns the survivor and the session would report a Full reset that never happened.

Closes #447 (item 3 landed in #610).

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/feature__android-full-reset.md` — two-channel adversarial review (boot-path concurrency + test integrity), 6 findings, 5 fixed here and 1 split out as #611. One was a blocker: proceeding after a failed stop reports a wipe that never happened, and nothing downstream can tell the difference. Three seams had no test at all, each with a one-line mutation that survived the whole suite — dropping `opts` inside `launch` (killing `-wipe-data` and `-no-audio` together), emptying or inverting `waitForExit`, and passing it `avdId` instead of `avdName`. All five now fail.

No emulator was available, so nothing here is verified against a real device — the launcher is mocked and the assertions are about the argv it is handed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-reset support for Android emulators, allowing user data to be wiped during restart.
  * Running emulators are safely stopped before a full reset and relaunched with cleared data.
  * Reset controls now appear only when supported by the connected agent.

* **Bug Fixes**
  * Boot now reports a failure if an emulator cannot be stopped or its state cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->