### PR TITLE
feat(protocol): add the network on/off wire contract and agent capability

### DIFF
--- a/.changeset/olive-moons-listen.md
+++ b/.changeset/olive-moons-listen.md
@@ -19,3 +19,8 @@ carries that as `available` plus a closed `reason`. A single boolean was tried a
 capability gating the control, `available: false` would have been unreachable, and the state it
 describes — conditioned but no longer steerable — would have hidden the only control that could undo
 it.
+
+`offline` reports the **device**, not the request: one taken offline and then left unsteerable is
+still offline, and saying otherwise would render "online" over a device whose app reaches nothing.
+The payload shape and its reason set live in `@tapflowio/protocol` and are re-exported by
+`agent-core`, the rule that package already follows for `ClipboardErrorPayload`.

--- a/.changeset/olive-moons-listen.md
+++ b/.changeset/olive-moons-listen.md
@@ -1,0 +1,21 @@
+---
+"@tapflowio/protocol": minor
+"@tapflowio/agent-core": minor
+"@tapflowio/relay": minor
+---
+
+Add the wire contract for taking a device under test off the network (#607): `network:set` from the
+viewer, `network:state` and `network:error` back, and a `NetworkControlCapability` beside
+`DeviceAgent` for the agents that implement it.
+
+No agent implements it yet and no control renders it — this is the contract, landing before the
+platforms so each one has something to build against.
+
+**`network-control` in `capabilities` claims less than the other two entries do.** `clipboard` and
+`full-reset` are settled facts about an agent's own code, but that string is sent once at
+`agent:register`, before any device is booted or app launched — so it can only mean "this agent has
+the code". Whether the mechanism actually takes is per device and per app, and `network:state`
+carries that as `available` plus a closed `reason`. A single boolean was tried and rejected: with the
+capability gating the control, `available: false` would have been unreachable, and the state it
+describes — conditioned but no longer steerable — would have hidden the only control that could undo
+it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Groundwork for taking a device off the network** ([#607](https://github.com/jo-duchan/tapflow/issues/607)). Nothing is visible yet: this release carries the messages the viewer and the agents will speak, so the two platforms can be built against a contract rather than against each other. A self-hoster has nothing to do about it.
 - **Full reset now works on Android.** The toggle wipes the emulator's user data before booting it, the counterpart to erasing a simulator on iOS — so a tester can start from a first-launch state without touching Android Studio. Because the wipe can only be applied while the emulator starts, one that is already running is stopped and started again, which is what iOS does for the same reason; expect the extra boot. If it will not stop — or if tapflow cannot see well enough to tell — the boot fails and says so rather than quietly handing you a device that was never wiped. `-no-snapshot` was already passed on every boot and is **not** this: it skips the saved snapshot and keeps user data, so nothing was being wiped before ([#447](https://github.com/jo-duchan/tapflow/issues/447)).
 
 ### Fixed

--- a/packages/agent-core/src/NetworkControlCapability.ts
+++ b/packages/agent-core/src/NetworkControlCapability.ts
@@ -1,0 +1,43 @@
+import type { DeviceAgent } from './DeviceAgent.js'
+
+// Optional network-control capability (take the device under test off the network and back), kept
+// OUT of the core DeviceAgent interface (ISP): the mechanism is platform-asymmetric and opt-in, so
+// only agents that can do it implement it. Consumers must feature-detect with hasNetworkControl().
+// Same shape as AudioStreamCapability, and for the same reason.
+
+/** Why control is not available on this device right now. Mirrors the wire's
+ *  `NetworkUnavailableReason` — the dashboard cannot import from this package, so the closed set
+ *  lives in `@tapflowio/protocol` and this is the agent-side name for it. */
+export type NetworkUnavailable = 'hooks-not-installed' | 'not-armed' | 'unsupported-device'
+
+export interface NetworkState {
+  offline: boolean
+  /**
+   * Whether tapflow can actually steer this device's network **right now**.
+   *
+   * Deliberately not the same question as the `network-control` capability. That string is sent
+   * once in `agent:register`, before any device is booted or app launched, so it can only ever
+   * claim "this agent has the code". Whether the mechanism took is per device and per app — an
+   * injection that did not land, an emulator image too old for the command — and that is this.
+   */
+  available: boolean
+  /** Set when `available` is false, and only then. */
+  reason?: NetworkUnavailable
+}
+
+export interface NetworkControlCapability {
+  /** Take the device off the network, or put it back. Returns the state that resulted, which may
+   *  report `available: false` — asking for something the device cannot do is an answer, not an
+   *  error. */
+  setNetworkOffline(offline: boolean): Promise<NetworkState>
+  /** The current state, for the unsolicited report a session gets on `device:ready` and after a
+   *  boot re-arms whatever the platform needs armed. */
+  networkState(): Promise<NetworkState>
+}
+
+export function hasNetworkControl(
+  agent: DeviceAgent,
+): agent is DeviceAgent & NetworkControlCapability {
+  const a = agent as Partial<NetworkControlCapability>
+  return typeof a.setNetworkOffline === 'function' && typeof a.networkState === 'function'
+}

--- a/packages/agent-core/src/NetworkControlCapability.ts
+++ b/packages/agent-core/src/NetworkControlCapability.ts
@@ -1,3 +1,4 @@
+import type { NetworkStatePayload, NetworkUnavailableReason } from '@tapflowio/protocol'
 import type { DeviceAgent } from './DeviceAgent.js'
 
 // Optional network-control capability (take the device under test off the network and back), kept
@@ -5,34 +6,24 @@ import type { DeviceAgent } from './DeviceAgent.js'
 // only agents that can do it implement it. Consumers must feature-detect with hasNetworkControl().
 // Same shape as AudioStreamCapability, and for the same reason.
 
-/** Why control is not available on this device right now. Mirrors the wire's
- *  `NetworkUnavailableReason` — the dashboard cannot import from this package, so the closed set
- *  lives in `@tapflowio/protocol` and this is the agent-side name for it. */
-export type NetworkUnavailable = 'hooks-not-installed' | 'not-armed' | 'unsupported-device'
-
-export interface NetworkState {
-  offline: boolean
-  /**
-   * Whether tapflow can actually steer this device's network **right now**.
-   *
-   * Deliberately not the same question as the `network-control` capability. That string is sent
-   * once in `agent:register`, before any device is booted or app launched, so it can only ever
-   * claim "this agent has the code". Whether the mechanism took is per device and per app — an
-   * injection that did not land, an emulator image too old for the command — and that is this.
-   */
-  available: boolean
-  /** Set when `available` is false, and only then. */
-  reason?: NetworkUnavailable
-}
+// The state shape and its reason set are **wire** types, so `@tapflowio/protocol` owns them and this
+// re-exports rather than re-declares — the rule `types.ts` states for `ClipboardErrorPayload` and the
+// five beside it. A second copy here would drift the moment a reason is added: nothing would fail,
+// and an agent typed against this package simply could not return the new value.
+//
+// `NetworkState` is deliberately **not** the name used here. Protocol exports that as the *message*;
+// taking it for the payload would put two different types under one name across two packages an
+// agent imports in the same file.
+export type { NetworkStatePayload, NetworkUnavailableReason }
 
 export interface NetworkControlCapability {
   /** Take the device off the network, or put it back. Returns the state that resulted, which may
    *  report `available: false` — asking for something the device cannot do is an answer, not an
    *  error. */
-  setNetworkOffline(offline: boolean): Promise<NetworkState>
+  setNetworkOffline(offline: boolean): Promise<NetworkStatePayload>
   /** The current state, for the unsolicited report a session gets on `device:ready` and after a
    *  boot re-arms whatever the platform needs armed. */
-  networkState(): Promise<NetworkState>
+  networkState(): Promise<NetworkStatePayload>
 }
 
 export function hasNetworkControl(

--- a/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
+++ b/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
@@ -106,7 +106,11 @@ describe('NetworkControlCapability', () => {
     expect(hasNetworkControl(agent)).toBe(true)
 
     const state = await agent.setNetworkOffline(true)
+    // Narrowing on `available` is how a consumer reaches `reason` at all — the payload is a union,
+    // so an unavailable state without one cannot be constructed and an available state with one
+    // cannot either. This is the consumer shape the viewer will use.
     expect(state.available).toBe(false)
+    if (state.available) throw new Error('expected an unavailable state')
     expect(state.reason).toBe('hooks-not-installed')
     // `false` because the device really is on the network — not as a stand-in for "the request did
     // not land". The test below is the one that pins which of those two `offline` means.

--- a/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
+++ b/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { hasNetworkControl } from '../NetworkControlCapability'
+import type { NetworkControlCapability, NetworkState } from '../NetworkControlCapability'
+import type { DeviceAgent } from '../DeviceAgent'
+import type { Device, UIElement } from '../types'
+
+// An agent that implements DeviceAgent and nothing optional — the shape every platform can meet.
+class PlainAgent implements DeviceAgent {
+  listDevices(): Promise<Device[]> { return Promise.resolve([]) }
+  boot(_deviceId: string): Promise<void> { return Promise.resolve() }
+  shutdown(_deviceId: string): Promise<void> { return Promise.resolve() }
+  installApp(_path: string): Promise<void> { return Promise.resolve() }
+  launchApp(_bundleId: string): Promise<void> { return Promise.resolve() }
+  screenshot(): Promise<Buffer> { return Promise.resolve(Buffer.alloc(0)) }
+  stream(): ReadableStream<Buffer> { return new ReadableStream() }
+  touchStart(_x: number, _y: number): void {}
+  touchMove(_x: number, _y: number): Promise<void> { return Promise.resolve() }
+  touchEnd(): Promise<void> { return Promise.resolve() }
+  openUrl(_url: string): Promise<void> { return Promise.resolve() }
+  queryUITree(): Promise<UIElement[]> { return Promise.resolve([]) }
+}
+
+class NetworkAgent extends PlainAgent implements NetworkControlCapability {
+  private offline = false
+  setNetworkOffline(offline: boolean): Promise<NetworkState> {
+    this.offline = offline
+    return Promise.resolve({ offline, available: true })
+  }
+  networkState(): Promise<NetworkState> {
+    return Promise.resolve({ offline: this.offline, available: true })
+  }
+}
+
+/** Implements the feature but cannot run it on this device — the case the capability string cannot
+ *  express, because it is announced once per agent and this is per device. */
+class UnavailableNetworkAgent extends PlainAgent implements NetworkControlCapability {
+  setNetworkOffline(_offline: boolean): Promise<NetworkState> {
+    return Promise.resolve({ offline: false, available: false, reason: 'hooks-not-installed' })
+  }
+  networkState(): Promise<NetworkState> {
+    return Promise.resolve({ offline: false, available: false, reason: 'hooks-not-installed' })
+  }
+}
+
+describe('NetworkControlCapability', () => {
+  it('hasNetworkControl is false for an agent without it', () => {
+    expect(hasNetworkControl(new PlainAgent())).toBe(false)
+  })
+
+  it('hasNetworkControl is true for an agent that implements both methods', () => {
+    expect(hasNetworkControl(new NetworkAgent())).toBe(true)
+  })
+
+  // Both members, not either — a half-implemented agent would satisfy a one-sided check and then
+  // throw at the call site the viewer already enabled a control for.
+  it('is false when only one of the two methods is present', () => {
+    const halves = [
+      Object.assign(new PlainAgent(), { setNetworkOffline: () => Promise.resolve({ offline: true, available: true }) }),
+      Object.assign(new PlainAgent(), { networkState: () => Promise.resolve({ offline: true, available: true }) }),
+    ]
+    for (const half of halves) expect(hasNetworkControl(half as DeviceAgent)).toBe(false)
+  })
+
+  it('round-trips the offline flag', async () => {
+    const agent = new NetworkAgent()
+    expect((await agent.networkState()).offline).toBe(false)
+    expect((await agent.setNetworkOffline(true)).offline).toBe(true)
+    expect((await agent.networkState()).offline).toBe(true)
+    expect((await agent.setNetworkOffline(false)).offline).toBe(false)
+  })
+
+  // The distinction the whole two-layer design rests on: an agent can implement this and still be
+  // unable to do it here. `hasNetworkControl` answers the first question and must not be read as
+  // answering the second — that is what `available` is for.
+  it('an agent that cannot run it on this device still has the capability', async () => {
+    const agent = new UnavailableNetworkAgent()
+    expect(hasNetworkControl(agent)).toBe(true)
+
+    const state = await agent.setNetworkOffline(true)
+    expect(state.available).toBe(false)
+    expect(state.reason).toBe('hooks-not-installed')
+    // And it did not pretend the request landed.
+    expect(state.offline).toBe(false)
+  })
+})

--- a/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
+++ b/packages/agent-core/src/__tests__/NetworkControlCapability.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { hasNetworkControl } from '../NetworkControlCapability'
-import type { NetworkControlCapability, NetworkState } from '../NetworkControlCapability'
+import type { NetworkControlCapability, NetworkStatePayload } from '../NetworkControlCapability'
 import type { DeviceAgent } from '../DeviceAgent'
 import type { Device, UIElement } from '../types'
 
@@ -22,23 +22,38 @@ class PlainAgent implements DeviceAgent {
 
 class NetworkAgent extends PlainAgent implements NetworkControlCapability {
   private offline = false
-  setNetworkOffline(offline: boolean): Promise<NetworkState> {
+  setNetworkOffline(offline: boolean): Promise<NetworkStatePayload> {
     this.offline = offline
     return Promise.resolve({ offline, available: true })
   }
-  networkState(): Promise<NetworkState> {
+  networkState(): Promise<NetworkStatePayload> {
     return Promise.resolve({ offline: this.offline, available: true })
   }
 }
 
 /** Implements the feature but cannot run it on this device — the case the capability string cannot
- *  express, because it is announced once per agent and this is per device. */
+ *  express, because it is announced once per agent and this is per device.
+ *
+ *  **It still reports the device's real state.** This one was never taken offline, so `offline` is
+ *  false because that is true, not because the request failed — see `UnsteerableOfflineAgent`
+ *  below for the half that distinction exists for. */
 class UnavailableNetworkAgent extends PlainAgent implements NetworkControlCapability {
-  setNetworkOffline(_offline: boolean): Promise<NetworkState> {
+  setNetworkOffline(_offline: boolean): Promise<NetworkStatePayload> {
     return Promise.resolve({ offline: false, available: false, reason: 'hooks-not-installed' })
   }
-  networkState(): Promise<NetworkState> {
+  networkState(): Promise<NetworkStatePayload> {
     return Promise.resolve({ offline: false, available: false, reason: 'hooks-not-installed' })
+  }
+}
+
+/** Taken offline, then the injection was lost — the app relaunched, or a re-arm did not happen. The
+ *  device is **still off the network** and tapflow can no longer put it back. */
+class UnsteerableOfflineAgent extends PlainAgent implements NetworkControlCapability {
+  setNetworkOffline(_offline: boolean): Promise<NetworkStatePayload> {
+    return Promise.resolve({ offline: true, available: false, reason: 'not-armed' })
+  }
+  networkState(): Promise<NetworkStatePayload> {
+    return Promise.resolve({ offline: true, available: false, reason: 'not-armed' })
   }
 }
 
@@ -61,7 +76,19 @@ describe('NetworkControlCapability', () => {
     for (const half of halves) expect(hasNetworkControl(half as DeviceAgent)).toBe(false)
   })
 
-  it('round-trips the offline flag', async () => {
+  // **`typeof … === 'function'`, not merely present.** With both keys there but not callable, a
+  // presence check passes and the viewer enables a control whose first use throws. The two halves
+  // above cannot catch that — each is missing a key, so the *other* operand answers false whichever
+  // way the check is written.
+  it('is false for an object carrying both names as non-callable values', () => {
+    const impostor = Object.assign(new PlainAgent(), { setNetworkOffline: true, networkState: 'yes' })
+    expect(hasNetworkControl(impostor as unknown as DeviceAgent)).toBe(false)
+  })
+
+  // Pins the **fixture**, not production: `NetworkAgent` is defined in this file and no code from
+  // `NetworkControlCapability.ts` is on this path. It earns its place by keeping the double honest
+  // — a fixture that drifts from the interface is how a suite proves something about nothing.
+  it('the double round-trips the offline flag, as the interface requires', async () => {
     const agent = new NetworkAgent()
     expect((await agent.networkState()).offline).toBe(false)
     expect((await agent.setNetworkOffline(true)).offline).toBe(true)
@@ -73,13 +100,26 @@ describe('NetworkControlCapability', () => {
   // unable to do it here. `hasNetworkControl` answers the first question and must not be read as
   // answering the second — that is what `available` is for.
   it('an agent that cannot run it on this device still has the capability', async () => {
+    // Only the first assertion below reaches production; the rest pin the double. Both matter, and
+    // the comment is here so a reader does not take the block for coverage it is not.
     const agent = new UnavailableNetworkAgent()
     expect(hasNetworkControl(agent)).toBe(true)
 
     const state = await agent.setNetworkOffline(true)
     expect(state.available).toBe(false)
     expect(state.reason).toBe('hooks-not-installed')
-    // And it did not pretend the request landed.
+    // `false` because the device really is on the network — not as a stand-in for "the request did
+    // not land". The test below is the one that pins which of those two `offline` means.
     expect(state.offline).toBe(false)
+  })
+
+  // **`offline` describes the device, never the request.** A device taken offline and then left
+  // unsteerable is still offline, and reporting `false` there would render "online" over a device
+  // whose app can reach nothing — after which every bug filed goes to the app under test. There is
+  // no third value on the wire for "unknown", so a producer that uses `offline` as a placeholder
+  // has no way to say what is true.
+  it('reports a device that is offline and no longer steerable as offline', async () => {
+    const state = await new UnsteerableOfflineAgent().networkState()
+    expect(state).toEqual({ offline: true, available: false, reason: 'not-armed' })
   })
 })

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -35,6 +35,12 @@ export type {
   AudioSampleFormat,
   AudioChannels,
 } from './AudioStreamCapability.js'
+export { hasNetworkControl } from './NetworkControlCapability.js'
+export type {
+  NetworkControlCapability,
+  NetworkState,
+  NetworkUnavailable,
+} from './NetworkControlCapability.js'
 export { createKeyedSerialQueue } from './utils/serialQueue.js'
 export { AgentRegistry } from './AgentRegistry.js'
 export type { AgentConnectOpts } from './AgentRegistry.js'

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -38,8 +38,8 @@ export type {
 export { hasNetworkControl } from './NetworkControlCapability.js'
 export type {
   NetworkControlCapability,
-  NetworkState,
-  NetworkUnavailable,
+  NetworkStatePayload,
+  NetworkUnavailableReason,
 } from './NetworkControlCapability.js'
 export { createKeyedSerialQueue } from './utils/serialQueue.js'
 export { AgentRegistry } from './AgentRegistry.js'

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -37,9 +37,17 @@ export interface Device {
 // The dashboard cannot import from here (it has no agent-core dependency), so this stays a
 // plain string list on the wire rather than a helper nobody on the reading side can call.
 // `full-reset`: the agent honours `device:boot`'s `resetMode: 'full-erase'` by wiping the device
-// before booting it. iOS does (`simctl erase`); Android does not yet (#447), and says so by not
-// listing it rather than by being named in a platform check on the viewer.
-export type AgentCapability = 'clipboard' | 'full-reset'
+// before booting it. Both platforms do as of #447 — iOS with `simctl erase`, Android with
+// `-wipe-data` — and an agent that does not says so by not listing it rather than by being named in
+// a platform check on the viewer.
+//
+// `network-control`: the agent implements `network:set` (#607). **This one claims less than the
+// other two do.** They are settled facts about the agent's own code; whether the network mechanism
+// actually takes is per device and per app — an injection that did not land, an emulator image too
+// old for the command — and this string is sent once at `agent:register`, before any device is
+// booted. So it means "this agent has the code", and `network:state.available` carries the rest.
+// Reading it as a promise that the toggle will work is the mistake this comment exists to prevent.
+export type AgentCapability = 'clipboard' | 'full-reset' | 'network-control'
 
 
 // ── Clipboard bridge shared contract ────────────────────────────────────────

--- a/packages/dashboard/lib/inboundDisposition.ts
+++ b/packages/dashboard/lib/inboundDisposition.ts
@@ -54,6 +54,11 @@ export const INBOUND_DISPOSITION = {
   'clipboard:data': { at: 'DeviceViewer, useClipboardBridge' },
   'clipboard:error': { at: 'DeviceViewer, useClipboardBridge' },
   'clipboard:write-done': { at: 'DeviceViewer, useClipboardBridge' },
+  // The viewer is the only consumer that acts on these — it owns the control. **No handler exists
+  // yet**: the protocol lands before the UI (#607, plan step 2 of 5), and this file is written so
+  // that gap is a stated fact rather than an absent branch nobody can tell from an oversight.
+  'network:state': { ignored: 'No handler yet — the control lands in a later slice of #607.' },
+  'network:error': { ignored: 'No handler yet — the control lands in a later slice of #607.' },
   'device:boot-error': { at: 'DeviceViewer, SessionList' },
   'device:booting': { at: 'DeviceViewer' },
   'device:ready': { at: 'DeviceViewer, SessionList' },

--- a/packages/flow-runner/src/inboundDisposition.ts
+++ b/packages/flow-runner/src/inboundDisposition.ts
@@ -72,6 +72,11 @@ export const INBOUND_DISPOSITION = {
     ignored: 'Same as `clipboard:data` — no clipboard step exists, so a confirmation here answers nothing a flow '
       + 'asked for.',
   },
+  'network:state': {
+    ignored: 'No network step exists. A flow that took its own device offline would be asserting against a '
+      + 'device it can no longer drive, and the step after it could not report why it failed.',
+  },
+  'network:error': { ignored: 'Same as `network:state` — nothing here sends a `network:set`.' },
   'keyboard:toggled': {
     ignored: 'Nothing here sends `input:keyboard:toggle`. `inputText` drives a paste handshake and does not '
       + 'depend on the on-screen keyboard\'s visibility.',

--- a/packages/mcp-server/src/inboundDisposition.ts
+++ b/packages/mcp-server/src/inboundDisposition.ts
@@ -85,6 +85,11 @@ export const INBOUND_DISPOSITION = {
     ignored: 'Same as `clipboard:data` — this package sends no `clipboard:write`, so a confirmation here answers '
       + 'nothing it asked for.',
   },
+  'network:state': {
+    ignored: 'No network tool here. Taking a device off the network is a manual-testing control a person '
+      + 'arms while watching the screen; an agent driving a flow has no use for a device it cannot reach.',
+  },
+  'network:error': { ignored: 'Same as `network:state` — nothing in this package sends a `network:set`.' },
   'keyboard:toggled': {
     ignored: 'Nothing here sends `input:keyboard:toggle`. It reports the on-screen keyboard\'s visibility, '
       + 'which is a viewer concern — this client has no surface to reflect it on.',

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -44,7 +44,7 @@ The cost of a broad name is ambiguity about what belongs — answered by the two
   - **`SchemaExact` ties each schema to its interface**, and refuses `z.custom<T>()` and a
     `const s: z.ZodType<T>` annotation by kind, because both produce `T` with no `any` for `IsAny` to
     catch and would compare `T` with itself.
-  - **The envelope is judged before the payload**, so a payload failure on one of the twelve correlated
+  - **The envelope is judged before the payload**, so a payload failure on one of the thirteen correlated
     browser requests comes back as `bad-payload` carrying the address and the correlator — which is what
     lets the relay answer it instead of dropping it. `ANSWERABLE` is that set; keeping it equal to the
     correlated request set is `scripts/__tests__/correlatedRequestsGated.test.mjs`'s job, because
@@ -406,7 +406,7 @@ verify `session.agentSocket === ws` before resolving, and these two do not.
 
 ## Browser-inbound messages are split by producer, and one union is shared
 
-A browser receives 29 message types. They come from two producers, and the difference matters to the
+A browser receives 31 message types. They come from two producers, and the difference matters to the
 **relay**, not to the consumer:
 
 - **`RelayToBrowser`** — the relay builds these itself, so `sendTo(socket, msg: RelayOutbound)` holds

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -544,6 +544,60 @@ export interface ClipboardError extends SessionScoped {
   payload?: ClipboardErrorPayload
 }
 
+/**
+ * Why network control is not available on this device right now.
+ *
+ * A closed set for the same reason `InputErrorReason` is one: **a member exists per thing a
+ * consumer must do differently**, not per internal state an agent can be in. Each of these makes a
+ * different sentence on screen, which is what a single `available: boolean` could not do — and a
+ * machine field nobody branches on is the shape this package forbids by name (#492).
+ */
+export type NetworkUnavailableReason =
+  /** The hooks were delivered but did not take. The agent proved this by trying, not by assuming. */
+  | 'hooks-not-installed'
+  /** Nothing was delivered for this boot — a re-arm that did not happen, or a device booted outside
+   *  tapflow. Distinct from the above because the answer is to reboot the device, not to give up. */
+  | 'not-armed'
+  /** This device cannot do it at all: an Android image whose `cmd connectivity` predates the API.
+   *  Unlike the other two, retrying anything will not change it. */
+  | 'unsupported-device'
+
+/**
+ * What the device's network is doing, and whether tapflow can steer it.
+ *
+ * **Answers `network:set`, and is also sent unsolicited** — on `device:ready`, when a boot re-arms
+ * the injection, and when a session's condition is cleared. So `requestId` is optional, and absent
+ * means *this frame is not the answer to a request* — never "an old agent" (see
+ * 「Lifecycle correlation」 in AGENTS.md for what that optionality costs and who pays it).
+ *
+ * `available` is separate from the `network-control` capability on purpose. The capability is
+ * announced once at `agent:register`, before any device is booted or app launched, so it can only
+ * ever mean "this agent has the code". Whether the hooks actually took is per device and per app,
+ * and this is where that lives.
+ */
+export interface NetworkState {
+  type: 'network:state'
+  /** Inline rather than `extends SessionScoped`: that base is the **failure** family — every member
+   *  of it carries a `message` and `protocolMessageNames` enforces that. This one reports state, not
+   *  a failure, so it names its session the way `clipboard:data` does. */
+  sessionId: string
+  requestId?: string
+  payload: {
+    offline: boolean
+    available: boolean
+    /** Set when `available` is false, and only then. */
+    reason?: NetworkUnavailableReason
+  }
+}
+
+/** A `network:set` that could not be dispatched or that the device refused. Relay-or-agent, because
+ *  the relay answers one it cannot deliver rather than letting the viewer's control sit armed. */
+export interface NetworkError extends SessionScoped {
+  type: 'network:error'
+  message: string
+  requestId: string
+}
+
 export type RelayOrAgentToBrowser =
   | SessionChrome
   | SessionDeviceInfo
@@ -559,6 +613,7 @@ export type RelayOrAgentToBrowser =
   // `mcp-server` and `flow-runner` key on the `input:type-*` pair and ignore an `input:error` entirely,
   // which is why widening `TERMINAL_INPUT_TYPES` was never the fix for it.
   | InputTypeError
+  | NetworkError
   | ClipboardError
 
 export interface AgentsListed {
@@ -823,6 +878,7 @@ export type AgentToBrowser =
   | InputTypeDone
   | KeyboardToggled
   | ClipboardData
+  | NetworkState
   | ClipboardWriteDone
 
 /** Everything a browser socket can receive, whoever produced it. This is what a viewer's message
@@ -1082,6 +1138,20 @@ export type ClipboardRequest =
   | ClipboardRead
   | ClipboardWrite
 
+/**
+ * Take the device under test off the network, or put it back (#607).
+ *
+ * `requestId` is **required**, like the clipboard pair: every producer is a viewer acting on a
+ * control, so an id is always available, and requiring it makes a missing one a compile error
+ * rather than a reply the viewer drops.
+ */
+export interface NetworkSet {
+  type: 'network:set'
+  sessionId: string
+  requestId: string
+  payload: { offline: boolean }
+}
+
 
 export interface AgentsList {
   type: 'agents:list'
@@ -1279,4 +1349,5 @@ export type BrowserToRelay =
   | InputRotate
   | InputKeyboardToggle
   | ClipboardRequest
+  | NetworkSet
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -575,32 +575,45 @@ export type NetworkUnavailableReason =
  * ever mean "this agent has the code". Whether the hooks actually took is per device and per app,
  * and this is where that lives.
  */
-/**
- * What a device's network is doing and whether tapflow can steer it.
- *
- * **Named rather than inline** so `agent-core` can re-export it instead of declaring a second copy
- * — the rule `types.ts` already follows for `ClipboardErrorPayload` — and so
- * `scripts/__tests__/protocolPayloadTypes.test.mjs` can see it. An inline payload is invisible to
- * that check, which is how the first draft of this shipped two declarations of one shape.
- */
-export interface NetworkStatePayload {
+/** The device is off the network right now, or is not, and tapflow can still change that. */
+export interface NetworkSteerable {
   /**
    * Whether the device is off the network **right now**, as far as the agent can tell.
    *
-   * **This describes the device, not the request.** When `available` is false it still reports what
-   * is true: a device taken offline and then left unsteerable — the app relaunched, a re-arm that
-   * did not happen — is *still offline*, and saying `false` there would render "online" over a
-   * device whose app can reach nothing, sending every bug filed after it to the app under test.
-   * Report the state, never a placeholder for "the request did not land".
+   * **This describes the device, not the request.** A device taken offline and then left
+   * unsteerable is *still offline* — see `NetworkNotSteerable`, which carries the same field for
+   * that reason. Reporting `false` as a stand-in for "the request did not land" would render
+   * "online" over a device whose app can reach nothing, sending every bug filed after it to the app
+   * under test.
    */
   offline: boolean
-  /** Whether tapflow can still change `offline`. Separate from the `network-control` capability:
-   *  that is announced once per agent and means "this agent has the code", while this is per device
-   *  and per app. */
-  available: boolean
-  /** Set when `available` is false, and only then. */
-  reason?: NetworkUnavailableReason
+  available: true
 }
+
+/** Whatever the device's network is doing, tapflow can no longer change it — and this is why. */
+export interface NetworkNotSteerable {
+  /** Still the device's real state. See `NetworkSteerable.offline`. */
+  offline: boolean
+  available: false
+  /** **Required here, and absent from the steerable member.** Written as prose first — "set when
+   *  `available` is false, and only then" — which a single interface could not enforce: it admitted
+   *  both `{ available: false }` with nothing to show a tester and `{ available: true, reason }`.
+   *  Each value makes a different sentence on screen, so an unavailable state with no reason is a
+   *  control that says it does not work and cannot say why. */
+  reason: NetworkUnavailableReason
+}
+
+/**
+ * What a device's network is doing and whether tapflow can steer it.
+ *
+ * **Two named members rather than one interface with an optional field**, so the invariant is the
+ * compiler's rather than a comment's. **And named rather than inline** so `agent-core` can
+ * re-export instead of declaring a second copy — the rule `types.ts` already follows for
+ * `ClipboardErrorPayload` — and so `scripts/__tests__/protocolPayloadTypes.test.mjs` can see the
+ * shapes. That check reads named declarations; an inline payload is invisible to it, and so is a
+ * union alias whose members are anonymous.
+ */
+export type NetworkStatePayload = NetworkSteerable | NetworkNotSteerable
 
 export interface NetworkState {
   type: 'network:state'

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -575,6 +575,33 @@ export type NetworkUnavailableReason =
  * ever mean "this agent has the code". Whether the hooks actually took is per device and per app,
  * and this is where that lives.
  */
+/**
+ * What a device's network is doing and whether tapflow can steer it.
+ *
+ * **Named rather than inline** so `agent-core` can re-export it instead of declaring a second copy
+ * — the rule `types.ts` already follows for `ClipboardErrorPayload` — and so
+ * `scripts/__tests__/protocolPayloadTypes.test.mjs` can see it. An inline payload is invisible to
+ * that check, which is how the first draft of this shipped two declarations of one shape.
+ */
+export interface NetworkStatePayload {
+  /**
+   * Whether the device is off the network **right now**, as far as the agent can tell.
+   *
+   * **This describes the device, not the request.** When `available` is false it still reports what
+   * is true: a device taken offline and then left unsteerable — the app relaunched, a re-arm that
+   * did not happen — is *still offline*, and saying `false` there would render "online" over a
+   * device whose app can reach nothing, sending every bug filed after it to the app under test.
+   * Report the state, never a placeholder for "the request did not land".
+   */
+  offline: boolean
+  /** Whether tapflow can still change `offline`. Separate from the `network-control` capability:
+   *  that is announced once per agent and means "this agent has the code", while this is per device
+   *  and per app. */
+  available: boolean
+  /** Set when `available` is false, and only then. */
+  reason?: NetworkUnavailableReason
+}
+
 export interface NetworkState {
   type: 'network:state'
   /** Inline rather than `extends SessionScoped`: that base is the **failure** family — every member
@@ -582,12 +609,7 @@ export interface NetworkState {
    *  a failure, so it names its session the way `clipboard:data` does. */
   sessionId: string
   requestId?: string
-  payload: {
-    offline: boolean
-    available: boolean
-    /** Set when `available` is false, and only then. */
-    reason?: NetworkUnavailableReason
-  }
+  payload: NetworkStatePayload
 }
 
 /** A `network:set` that could not be dispatched or that the device refused. Relay-or-agent, because

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -11,6 +11,7 @@ import type {
   AppClearState, AppClearStateDone, AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent,
   AppInstallToRelay, AppLaunchDone, AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound,
   BrowserToRelay, ClipboardData, ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone,
+  NetworkError, NetworkSet, NetworkState,
   DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone,
   DeviceShutdownError, GenericError,
   InputButton, InputDone, InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove,
@@ -136,6 +137,9 @@ export const _AppLaunchToAgent: AppLaunchToAgent['type'] = 'app:launch'
 export const _AppLaunchToRelay: AppLaunchToRelay['type'] = 'app:launch'
 export const _ClipboardData: ClipboardData['type'] = 'clipboard:data'
 export const _ClipboardError: ClipboardError['type'] = 'clipboard:error'
+export const _NetworkSet: NetworkSet['type'] = 'network:set'
+export const _NetworkState: NetworkState['type'] = 'network:state'
+export const _NetworkError: NetworkError['type'] = 'network:error'
 export const _ClipboardRead: ClipboardRead['type'] = 'clipboard:read'
 export const _ClipboardWrite: ClipboardWrite['type'] = 'clipboard:write'
 export const _ClipboardWriteDone: ClipboardWriteDone['type'] = 'clipboard:write-done'

--- a/packages/protocol/src/typeAssertions.ts
+++ b/packages/protocol/src/typeAssertions.ts
@@ -11,7 +11,7 @@ import type {
   AppClearState, AppClearStateDone, AppClearStateError, AppInstallDone, AppInstallError, AppInstallToAgent,
   AppInstallToRelay, AppLaunchDone, AppLaunchError, AppLaunchToAgent, AppLaunchToRelay, BrowserInbound,
   BrowserToRelay, ClipboardData, ClipboardError, ClipboardRead, ClipboardWrite, ClipboardWriteDone,
-  NetworkError, NetworkSet, NetworkState,
+  NetworkError, NetworkSet, NetworkState, NetworkStatePayload,
   DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown, DeviceShutdownDone,
   DeviceShutdownError, GenericError,
   InputButton, InputDone, InputError, InputKey, InputKeyboardToggle, InputPinchEnd, InputPinchMove,
@@ -140,6 +140,16 @@ export const _ClipboardError: ClipboardError['type'] = 'clipboard:error'
 export const _NetworkSet: NetworkSet['type'] = 'network:set'
 export const _NetworkState: NetworkState['type'] = 'network:state'
 export const _NetworkError: NetworkError['type'] = 'network:error'
+
+// `available` and `reason` travel together or not at all, and these two are what say so — the rule
+// began as prose on a single interface, which admitted both of the frames below. An unavailable
+// state with nothing to show a tester is a control that says it does not work and cannot say why.
+// @ts-expect-error - an unavailable state must name a reason
+export const _networkUnavailableNeedsReason: NetworkStatePayload = { offline: true, available: false }
+// One line, deliberately: `@ts-expect-error` covers the line after it, and a declaration wrapped
+// onto a continuation puts the error out of its reach — which reads as the assertion passing.
+// @ts-expect-error - a steerable state must not carry one
+export const _networkAvailableRefusesReason: NetworkStatePayload = { offline: true, available: true, reason: 'not-armed' }
 export const _ClipboardRead: ClipboardRead['type'] = 'clipboard:read'
 export const _ClipboardWrite: ClipboardWrite['type'] = 'clipboard:write'
 export const _ClipboardWriteDone: ClipboardWriteDone['type'] = 'clipboard:write-done'

--- a/packages/protocol/src/validate/index.ts
+++ b/packages/protocol/src/validate/index.ts
@@ -56,6 +56,7 @@ import type {
   AgentRegister, AgentResourceReport, AgentsList, AppClearState, AppClearStateDone,
   AppClearStateError, AppInstallDone, AppInstallError, AppInstallToRelay, AppLaunchDone,
   AppLaunchError, AppLaunchToRelay, ClipboardData, ClipboardError, ClipboardRead, ClipboardWrite,
+  NetworkError, NetworkSet, NetworkState,
   ClipboardWriteDone, DeviceBoot, DeviceBootError, DeviceBooting, DeviceReady, DeviceShutdown,
   DeviceShutdownDone, InputButton, InputDone, InputError, InputKey, InputKeyboardToggle,
   InputPinchEnd, InputPinchMove, InputPinchStart, InputRotate, InputTouchEnd, InputTouchMove,
@@ -175,6 +176,15 @@ const BROWSER_INBOUND = {
     type: z.literal('clipboard:write'), sessionId, requestId,
     payload: z.object({ text: z.string(), pasteAfter: z.boolean().optional() }),
   }),
+  // `payload` required, and `offline` required inside it: this command has exactly one thing to say
+  // and a frame that omits it is not "toggle" — nothing on the wire carries the current state, so
+  // there would be nothing to toggle *from*. A malformed one is answered rather than dropped
+  // (`ANSWERABLE` below), because the viewer's control would otherwise sit armed on a device that
+  // never heard the request.
+  'network:set': z.object({
+    type: z.literal('network:set'), sessionId, requestId,
+    payload: z.object({ offline: z.boolean() }),
+  }),
 } as const
 
 // ── agent → relay ────────────────────────────────────────────────────────────
@@ -278,6 +288,11 @@ const AGENT_FORWARDED = {
   'clipboard:data': envC('clipboard:data'),
   'clipboard:write-done': envC('clipboard:write-done'),
   'clipboard:error': envC('clipboard:error'),
+  // `envCo`, not `envC`: this one answers `network:set` **and** arrives unsolicited — on
+  // `device:ready`, on a boot that re-arms the injection, and when a session's condition is cleared.
+  // Absent means "not the answer to a request", never "an old agent".
+  'network:state': envCo('network:state'),
+  'network:error': envC('network:error'),
 } as const
 
 const AGENT_INBOUND = { ...AGENT_CONSUMED, ...AGENT_FORWARDED } as const
@@ -322,6 +337,7 @@ const ANSWERABLE = {
   'input:type': envC('input:type'),
   'clipboard:read': envC('clipboard:read'),
   'clipboard:write': envC('clipboard:write'),
+  'network:set': envC('network:set'),
 } as const
 
 export type AnswerableType = keyof typeof ANSWERABLE
@@ -540,3 +556,5 @@ type _KeyboardToggled = Assert<E<'keyboard:toggled', KeyboardToggled>>
 type _ClipboardData = Assert<E<'clipboard:data', ClipboardData>>
 type _ClipboardWriteDone = Assert<E<'clipboard:write-done', ClipboardWriteDone>>
 type _ClipboardError = Assert<E<'clipboard:error', ClipboardError>>
+type _NetworkState = Assert<E<'network:state', NetworkState>>
+type _NetworkError = Assert<E<'network:error', NetworkError>>

--- a/packages/protocol/src/validate/index.ts
+++ b/packages/protocol/src/validate/index.ts
@@ -524,6 +524,7 @@ type _InputRotate = Assert<V<'input:rotate', InputRotate>>
 type _InputKeyboardToggle = Assert<V<'input:keyboard:toggle', InputKeyboardToggle>>
 type _ClipboardRead = Assert<V<'clipboard:read', ClipboardRead>>
 type _ClipboardWrite = Assert<V<'clipboard:write', ClipboardWrite>>
+type _NetworkSet = Assert<V<'network:set', NetworkSet>>
 
 type _AgentRegister = Assert<V<'agent:register', AgentRegister>>
 type _AgentResources = Assert<V<'agent:resources', AgentResourceReport>>

--- a/packages/relay/AGENTS.md
+++ b/packages/relay/AGENTS.md
@@ -49,7 +49,7 @@ iOS build format: `.app.zip` **or** `.tar.gz`/`.tgz` (EAS `eas build` simulator 
   on the input pair. Without it this door would have converted an answered failure into silence: a
   malformed `open-url` used to reach the agent, whose guard answered, and `IOSAgent.ts` names this
   validation as what takes that over. The cost is worst on the inputs, because `awaitInputAck` reports
-  silence from a never-acked session as **success** (#457). The twelve answerable requests,
+  silence from a never-acked session as **success** (#457). The thirteen answerable requests,
   `ANSWERABLE` in the protocol and the replies in `refuseMalformed` are held to one derived set by
   `scripts/__tests__/correlatedRequestsGated.test.mjs`.
 

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -990,6 +990,11 @@ export class RelayServer {
       // Bound to the session's own agent socket, unlike the replies above: this payload
       // lands on the viewer's host OS clipboard, so a second agent (another Mac on the
       // same relay) must not be able to address someone else's session.
+      // Bound to the session's own agent socket for the same reason clipboard is: this reply says
+      // whether a **specific tester's** device is on the network, and a second agent must not be
+      // able to tell that tester's viewer something about it.
+      case 'network:state':
+      case 'network:error':
       case 'clipboard:data':
       case 'clipboard:write-done':
       case 'clipboard:error': {
@@ -1200,6 +1205,21 @@ export class RelayServer {
         } else if (ws.readyState === WebSocket.OPEN) {
           this.sendTo(ws, {
             type: 'clipboard:error', sessionId: msg.sessionId, requestId: msg.requestId, message: clip.message,
+          })
+        }
+        break
+      }
+      // Ownership is not decoration here: taking a device off the network is the most disruptive
+      // thing a non-holder could do to someone else's session short of shutting it down, and unlike
+      // a shutdown it leaves the device *looking* fine. `dispatchTarget` rather than the weaker
+      // `reachableTarget` `device:shutdown` uses — there is no teardown race to accommodate.
+      case 'network:set': {
+        const net = this.dispatchTarget(ws, msg.sessionId)
+        if (net.ok) {
+          net.session.agentSocket.send(JSON.stringify(msg))
+        } else if (ws.readyState === WebSocket.OPEN) {
+          this.sendTo(ws, {
+            type: 'network:error', sessionId: msg.sessionId, requestId: msg.requestId, message: net.message,
           })
         }
         break
@@ -1793,6 +1813,7 @@ export class RelayServer {
         this.sendTo(ws, { type: 'input:type-error', sessionId, requestId, message, reason: 'malformed' }); break
       case 'clipboard:read':
       case 'clipboard:write': this.sendTo(ws, { type: 'clipboard:error', sessionId, requestId, message }); break
+      case 'network:set':     this.sendTo(ws, { type: 'network:error', sessionId, requestId, message }); break
       // The four remaining acked inputs. A `default` rather than four labels because the union is
       // closed and exhaustive: adding a thirteenth answerable request without a case here would land
       // it on `input:error`, which `answerableRequestsAnswered` is what stops.

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -754,7 +754,7 @@ export class RelayServer {
    */
   private settleRole(ws: WebSocket, inbound: ParseResult): boolean {
     // Every reason that carries a type, which is all of them but the two that have none to carry.
-    // Missing `bad-payload` here returned `false` before the caller could answer, so the twelve
+    // Missing `bad-payload` here returned `false` before the caller could answer, so the thirteen
     // answerable requests were classified correctly and then dropped anyway — the regression this
     // whole path exists to prevent, reintroduced one line above it.
     const type = inbound.ok ? inbound.msg.type
@@ -1815,7 +1815,7 @@ export class RelayServer {
       case 'clipboard:write': this.sendTo(ws, { type: 'clipboard:error', sessionId, requestId, message }); break
       case 'network:set':     this.sendTo(ws, { type: 'network:error', sessionId, requestId, message }); break
       // The four remaining acked inputs. A `default` rather than four labels because the union is
-      // closed and exhaustive: adding a thirteenth answerable request without a case here would land
+      // closed and exhaustive: adding a fourteenth answerable request without a case here would land
       // it on `input:error`, which `answerableRequestsAnswered` is what stops.
       default:
         this.sendTo(ws, { type: 'input:error', sessionId, requestId, message, reason: 'malformed' })

--- a/packages/relay/src/__tests__/networkControl.test.ts
+++ b/packages/relay/src/__tests__/networkControl.test.ts
@@ -8,7 +8,7 @@ import { initDb, closeDb } from '../db'
 import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
 
 import type {
-  AgentRegistered, BrowserToRelay, NetworkError, NetworkSet, NetworkState, RelayToAgent,
+  AgentRegistered, BrowserInbound, BrowserToRelay, NetworkError, NetworkSet, NetworkState, RelayToAgent,
   SessionJoined,
 } from '@tapflowio/protocol'
 
@@ -80,6 +80,10 @@ describe('network control relay routing (#607)', () => {
       payload: { offline: true, available: true },
     }))
     const state = await waitForType<NetworkState>(browser, 'network:state')
+    // `waitForType` matches on `type` alone, so without this the address is unasserted — and
+    // `DeviceViewer` drops any frame whose `sessionId` is not its own, which turns a wrong address
+    // into a control that sits armed forever with nothing on screen to say why.
+    expect(state.sessionId).toBe(sessionId)
     expect(state.requestId).toBe('rq-2')
     expect(state.payload).toEqual({ offline: true, available: true })
 
@@ -95,6 +99,7 @@ describe('network control relay routing (#607)', () => {
       payload: { offline: false, available: false, reason: 'hooks-not-installed' },
     }))
     const state = await waitForType<NetworkState>(browser, 'network:state')
+    expect(state.sessionId).toBe(sessionId)
     expect(state.requestId).toBeUndefined()
     expect(state.payload.reason).toBe('hooks-not-installed')
 
@@ -112,11 +117,53 @@ describe('network control relay routing (#607)', () => {
     intruder.send(JSON.stringify(setMsg(sessionId, 'rq-3', true)))
 
     const err = await waitForType<NetworkError>(intruder, 'network:error')
+    expect(err.sessionId).toBe(sessionId)
     expect(err.requestId).toBe('rq-3')
+    // `message` carries the diagnosis `dispatchTarget` picked — stale session id, dead Mac, or in
+    // use by someone else. An empty one ships a toast that says nothing.
+    expect(err.message.length).toBeGreaterThan(0)
     // And the agent never saw it — refused at the door, not after delivery.
     expect(await waitForTypeOrNull(agent, 'network:set', 300)).toBeNull()
 
     agent.close(); browser.close(); intruder.close()
+  })
+
+  // The mirror of the test above, on the direction the gate in `RelayServer` actually buys. Without
+  // it, moving these two labels into the ungated forward block two lines up leaves **every** relay
+  // test green and the static routing guard green with them — that guard reads `case` labels and
+  // cannot see which block they sit in. A second agent could then tell a stranger's viewer their
+  // device is offline, or that it is fine when it is not.
+  it('another agent cannot push network:state into someone else\'s session', async () => {
+    const { agent, browser, sessionId } = await setup()
+
+    const rogue = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(rogue)
+    rogue.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: 'net-2',
+      devices: [{ id: 'rogue-1', name: 'Rogue', platform: 'ios', status: 'booted' }],
+    }))
+    await waitForType(rogue, 'agent:registered')
+
+    const got: BrowserInbound[] = []
+    browser.on('message', (d) => got.push(JSON.parse(d.toString()) as BrowserInbound))
+
+    rogue.send(JSON.stringify({
+      type: 'network:state', sessionId, payload: { offline: true, available: true },
+    }))
+    rogue.send(JSON.stringify({
+      type: 'network:error', sessionId, requestId: 'spoof', message: 'ATTACKER',
+    }))
+    await new Promise((r) => setTimeout(r, 200))
+    expect(got.filter((m) => m.type === 'network:state' || m.type === 'network:error')).toEqual([])
+
+    // Paired with a positive, so this cannot pass by the forward being broken for everyone.
+    agent.send(JSON.stringify({
+      type: 'network:state', sessionId, payload: { offline: false, available: true },
+    }))
+    const mine = await waitForType<NetworkState>(browser, 'network:state')
+    expect(mine.payload.offline).toBe(false)
+
+    agent.close(); browser.close(); rogue.close()
   })
 
   // The refusal has to arrive in the shape this request's own waiter reads. An `input:error` here
@@ -128,7 +175,9 @@ describe('network control relay routing (#607)', () => {
     }))
 
     const err = await waitForType<NetworkError>(browser, 'network:error')
+    expect(err.sessionId).toBe(sessionId)
     expect(err.requestId).toBe('rq-4')
+    expect(err.message.length).toBeGreaterThan(0)
     expect(await waitForTypeOrNull(agent, 'network:set', 300)).toBeNull()
 
     agent.close(); browser.close()
@@ -148,6 +197,21 @@ describe('network control relay routing (#607)', () => {
     }))
     const state = await waitForType<NetworkState>(browser, 'network:state')
     expect(state.payload).toEqual({ offline: false, available: false, reason: 'not-armed' })
+
+    agent.close(); browser.close()
+  })
+
+  // The combination the wire has to be able to carry: still offline, no longer steerable. If a
+  // producer used `offline` as a placeholder for "the request did not land" this frame could not be
+  // expressed, and the viewer would show "online" over a device whose app reaches nothing.
+  it('carries offline:true together with available:false', async () => {
+    const { agent, browser, sessionId } = await setup()
+    agent.send(JSON.stringify({
+      type: 'network:state', sessionId,
+      payload: { offline: true, available: false, reason: 'not-armed' },
+    }))
+    const state = await waitForType<NetworkState>(browser, 'network:state')
+    expect(state.payload).toEqual({ offline: true, available: false, reason: 'not-armed' })
 
     agent.close(); browser.close()
   })

--- a/packages/relay/src/__tests__/networkControl.test.ts
+++ b/packages/relay/src/__tests__/networkControl.test.ts
@@ -101,6 +101,9 @@ describe('network control relay routing (#607)', () => {
     const state = await waitForType<NetworkState>(browser, 'network:state')
     expect(state.sessionId).toBe(sessionId)
     expect(state.requestId).toBeUndefined()
+    // The payload is a union, so `reason` is only reachable after narrowing — which is the shape
+    // every consumer will use, and the reason an unavailable frame cannot arrive without one.
+    if (state.payload.available) throw new Error('expected an unavailable state')
     expect(state.payload.reason).toBe('hooks-not-installed')
 
     agent.close(); browser.close()

--- a/packages/relay/src/__tests__/networkControl.test.ts
+++ b/packages/relay/src/__tests__/networkControl.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { RelayServer } from '../RelayServer'
+import { initDb, closeDb } from '../db'
+import { waitForOpen, waitForType, waitForTypeOrNull } from '@tapflowio/test-utils'
+
+import type {
+  AgentRegistered, BrowserToRelay, NetworkError, NetworkSet, NetworkState, RelayToAgent,
+  SessionJoined,
+} from '@tapflowio/protocol'
+
+/** What an agent socket receives: what the relay originates, plus browser commands it forwards
+ *  verbatim. Same note as `clipboard.test.ts` — the protocol has no single union for it (#557). */
+type AgentSocketInbound = RelayToAgent | BrowserToRelay
+
+describe('network control relay routing (#607)', () => {
+  let server: RelayServer
+  let port: number
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-network-test-'))
+    initDb(path.join(tmpDir, 'test.db'))
+  })
+
+  afterAll(() => {
+    closeDb()
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  beforeEach(async () => {
+    server = new RelayServer({ port: 0 })
+    await server.start()
+    port = (server.address() as { port: number }).port
+  })
+
+  afterEach(async () => { await server.stop() })
+
+  async function setup(capabilities: string[] = ['network-control']) {
+    const agent = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(agent)
+    agent.send(JSON.stringify({
+      type: 'agent:register', platform: 'ios', agentName: 'net-1', capabilities,
+      devices: [{ id: 'dev-1', name: 'iPhone', platform: 'ios', status: 'booted' }],
+    }))
+    const reply = await waitForType<AgentRegistered>(agent, 'agent:registered')
+    const sessionId = reply.registeredSessions[0]!.sessionId
+
+    const browser = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(browser)
+    browser.send(JSON.stringify({ type: 'session:start', sessionId }))
+    await waitForType(browser, 'session:joined')
+    return { agent, browser, sessionId }
+  }
+
+  const setMsg = (sessionId: string, requestId: string, offline: boolean): NetworkSet =>
+    ({ type: 'network:set', sessionId, requestId, payload: { offline } })
+
+  it('forwards network:set to the agent with its correlator intact', async () => {
+    const { agent, browser, sessionId } = await setup()
+    browser.send(JSON.stringify(setMsg(sessionId, 'rq-1', true)))
+
+    const got = await waitForType<AgentSocketInbound & NetworkSet>(agent, 'network:set')
+    expect(got.requestId).toBe('rq-1')
+    expect(got.payload).toEqual({ offline: true })
+
+    agent.close(); browser.close()
+  })
+
+  it('routes network:state back to the browser, echoing the requestId', async () => {
+    const { agent, browser, sessionId } = await setup()
+    browser.send(JSON.stringify(setMsg(sessionId, 'rq-2', true)))
+    await waitForType(agent, 'network:set')
+
+    agent.send(JSON.stringify({
+      type: 'network:state', sessionId, requestId: 'rq-2',
+      payload: { offline: true, available: true },
+    }))
+    const state = await waitForType<NetworkState>(browser, 'network:state')
+    expect(state.requestId).toBe('rq-2')
+    expect(state.payload).toEqual({ offline: true, available: true })
+
+    agent.close(); browser.close()
+  })
+
+  // The unsolicited half. `requestId` absent means "not the answer to a request", and the relay
+  // must forward it rather than treating a missing correlator as a malformed frame.
+  it('routes an unsolicited network:state, with no correlator at all', async () => {
+    const { agent, browser, sessionId } = await setup()
+    agent.send(JSON.stringify({
+      type: 'network:state', sessionId,
+      payload: { offline: false, available: false, reason: 'hooks-not-installed' },
+    }))
+    const state = await waitForType<NetworkState>(browser, 'network:state')
+    expect(state.requestId).toBeUndefined()
+    expect(state.payload.reason).toBe('hooks-not-installed')
+
+    agent.close(); browser.close()
+  })
+
+  // Taking a device off the network is the most disruptive thing a non-holder could do to someone
+  // else's session short of shutting it down — and unlike a shutdown it leaves the device looking
+  // fine, so the tester has no reason to suspect anyone else.
+  it('refuses a network:set from a client that does not hold the session', async () => {
+    const { agent, browser, sessionId } = await setup()
+
+    const intruder = new WebSocket(`ws://localhost:${port}?client=someone-else`)
+    await waitForOpen(intruder)
+    intruder.send(JSON.stringify(setMsg(sessionId, 'rq-3', true)))
+
+    const err = await waitForType<NetworkError>(intruder, 'network:error')
+    expect(err.requestId).toBe('rq-3')
+    // And the agent never saw it — refused at the door, not after delivery.
+    expect(await waitForTypeOrNull(agent, 'network:set', 300)).toBeNull()
+
+    agent.close(); browser.close(); intruder.close()
+  })
+
+  // The refusal has to arrive in the shape this request's own waiter reads. An `input:error` here
+  // would be a non-answer the caller waits out — the defect `refuseMalformed` exists to prevent.
+  it('answers a malformed network:set with network:error, not silence', async () => {
+    const { agent, browser, sessionId } = await setup()
+    browser.send(JSON.stringify({
+      type: 'network:set', sessionId, requestId: 'rq-4', payload: {},   // `offline` missing
+    }))
+
+    const err = await waitForType<NetworkError>(browser, 'network:error')
+    expect(err.requestId).toBe('rq-4')
+    expect(await waitForTypeOrNull(agent, 'network:set', 300)).toBeNull()
+
+    agent.close(); browser.close()
+  })
+
+  // `network-control` says the agent has the code; it does not say the toggle will work. The relay
+  // has no business judging that, and an agent that answers `available: false` is answering, not
+  // failing — so this must route like any other reply.
+  it('routes an available:false answer through unchanged', async () => {
+    const { agent, browser, sessionId } = await setup()
+    browser.send(JSON.stringify(setMsg(sessionId, 'rq-5', true)))
+    await waitForType(agent, 'network:set')
+
+    agent.send(JSON.stringify({
+      type: 'network:state', sessionId, requestId: 'rq-5',
+      payload: { offline: false, available: false, reason: 'not-armed' },
+    }))
+    const state = await waitForType<NetworkState>(browser, 'network:state')
+    expect(state.payload).toEqual({ offline: false, available: false, reason: 'not-armed' })
+
+    agent.close(); browser.close()
+  })
+
+  // The capability rides the join so the viewer knows whether to render the control at all, the
+  // same hop `clipboard` and `full-reset` use. What it does **not** tell the viewer is whether the
+  // toggle will work — that is `network:state.available`, and the two answer different questions.
+  it('echoes network-control on session:joined, alongside the others', async () => {
+    const { agent, browser, sessionId } = await setup(['clipboard', 'network-control'])
+    browser.close()
+
+    const b2 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(b2)
+    b2.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const joined = await waitForType<SessionJoined>(b2, 'session:joined')
+    expect(joined.capabilities).toEqual(['clipboard', 'network-control'])
+
+    agent.close(); b2.close()
+  })
+
+  // An agent that has no network code says so by omission, and the relay does not invent one.
+  it('does not invent the capability for an agent that never claimed it', async () => {
+    const { agent, browser, sessionId } = await setup(['clipboard'])
+    browser.close()
+
+    const b2 = new WebSocket(`ws://localhost:${port}`)
+    await waitForOpen(b2)
+    b2.send(JSON.stringify({ type: 'session:start', sessionId }))
+    const joined = await waitForType<SessionJoined>(b2, 'session:joined')
+    expect(joined.capabilities).not.toContain('network-control')
+    // Paired with a positive so this cannot pass by the list being empty.
+    expect(joined.capabilities).toContain('clipboard')
+
+    agent.close(); b2.close()
+  })
+})

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -170,7 +170,7 @@ describe('browser-inbound routing matches the protocol union', () => {
   // empty set. L2 shipped exactly that mistake in the other direction — a lazy regex truncated a
   // nested literal to 6 of 11 fields and the by-name assertion passed anyway.
   it('the parser reached every forward site', () => {
-    expect(forwarded.size).toBe(22)
+    expect(forwarded.size).toBe(24)
     const sends = (relaySrc.match(/browserSocket\.send\(JSON\.stringify\(raw\)\)/g) ?? []).length
     expect(sends).toBe(8) // 6 single-label blocks + the 13-label block + the clipboard block
   })
@@ -209,7 +209,7 @@ describe('browser-inbound routing matches the protocol union', () => {
 
   it('RelayOrAgentToBrowser is shared by both directions rather than copied', () => {
     const shared = unionMembers(protocolSrc, 'RelayOrAgentToBrowser')
-    expect(shared.size).toBe(11)
+    expect(shared.size).toBe(12)
     for (const name of ['RelayToBrowser', 'AgentToBrowser']) {
       expect(protocolSrc).toContain(`export type ${name} =\n  | RelayOrAgentToBrowser`)
     }

--- a/scripts/__tests__/browserInboundRouting.test.mjs
+++ b/scripts/__tests__/browserInboundRouting.test.mjs
@@ -172,7 +172,7 @@ describe('browser-inbound routing matches the protocol union', () => {
   it('the parser reached every forward site', () => {
     expect(forwarded.size).toBe(24)
     const sends = (relaySrc.match(/browserSocket\.send\(JSON\.stringify\(raw\)\)/g) ?? []).length
-    expect(sends).toBe(8) // 6 single-label blocks + the 13-label block + the clipboard block
+    expect(sends).toBe(8) // 6 single-label blocks + the 13-label block + the owner-gated block
   })
 
   // The other half of the rule above, and the one a count cannot see: a forward that switched back to
@@ -191,7 +191,8 @@ describe('browser-inbound routing matches the protocol union', () => {
   //
   // What survives is the property underneath, which nothing states. A forward resolves the session from
   // the message and sends to *that session's* browser without checking that the sender is that session's
-  // agent — `clipboard:*` is the deliberate exception, bound to `session.agentSocket` with the reason
+  // agent — `clipboard:*` and `network:*` are the deliberate exceptions, bound to `session.agentSocket`
+  // with the reason
   // beside it. The door is what makes that safe, and it is safe only while the two sets are disjoint: a
   // literal that is **both** browser-sendable and browser-forwardable passes the role gate and is then
   // injected into another tester's viewer, which acts on it.
@@ -201,7 +202,7 @@ describe('browser-inbound routing matches the protocol union', () => {
   // a divergence a compile error. So this reads the union the door is held to, not a second copy of it.
   it('no literal is both browser-sendable and browser-forwardable', () => {
     const sendable = unionMembers(protocolSrc, 'BrowserToRelay')
-    // Anti-vacuity on both operands. `forwarded` is pinned at 22 above; this one has no other pin, and an
+    // Anti-vacuity on both operands. `forwarded` is pinned above; this one has no other pin, and an
     // empty set would make the intersection empty for the wrong reason.
     expect(sendable.size).toBeGreaterThanOrEqual(20)
     expect([...forwarded].filter((t) => sendable.has(t)).sort()).toEqual([])

--- a/scripts/__tests__/clientInboundDisposition.test.mjs
+++ b/scripts/__tests__/clientInboundDisposition.test.mjs
@@ -115,7 +115,7 @@ describe('both clients declare what they do with every browser-inbound message',
       it('parsed every entry — 29, the browser-inbound surface', () => {
         // The compiler already refuses a missing key, so this is the parser's honesty check rather than
         // the coverage one. Pinned from the measurement: 29 as of #542, which added `device:shutdown-error`.
-        expect(table.size).toBe(29)
+        expect(table.size).toBe(31)
       })
 
       it('every entry is exactly one of settles / does / ignored', () => {

--- a/scripts/__tests__/correlatedRequestsGated.test.mjs
+++ b/scripts/__tests__/correlatedRequestsGated.test.mjs
@@ -198,6 +198,7 @@ const EXPECTED_REPLY = {
   'input:type': 'input:type-error',
   'clipboard:read': 'clipboard:error',
   'clipboard:write': 'clipboard:error',
+  'network:set': 'network:error',
   'input:touch:end': 'input:error',
   'input:pinch:end': 'input:error',
   'input:key': 'input:error',

--- a/scripts/__tests__/inboundDisposition.test.mjs
+++ b/scripts/__tests__/inboundDisposition.test.mjs
@@ -65,7 +65,7 @@ describe('inbound disposition', () => {
     // The compiler already refuses a missing key, so this is not the coverage assertion; it is the
     // parser's own honesty check. Without it the two assertions below pass on an empty map.
     // 29 as of #542: `device:shutdown-error` gave the shutdown pair the failure member it lacked.
-    expect(table_entries.size).toBe(29)
+    expect(table_entries.size).toBe(31)
   })
 
   it('every entry is exactly one of at / ignored', () => {
@@ -142,7 +142,7 @@ describe('inbound disposition', () => {
     expect(thin).toEqual([])
   })
 
-  it('the six ignored messages are the ones the measurement found', () => {
+  it('the ignored messages are the ones a decision put there', () => {
     // Pinned so that "handled" quietly becoming "ignored" is a decision someone makes here, in a diff,
     // rather than a branch that got deleted. Growing this list is allowed; doing it silently is not.
     const ignored = [...table_entries].filter(([, v]) => /\bignored:/.test(v)).map(([t]) => t).sort()
@@ -152,6 +152,11 @@ describe('inbound disposition', () => {
       'input:done',
       'input:type-done',
       'input:type-error',
+      // Not a decision to leave these unhandled — the protocol for #607 lands a slice before the
+      // control that reads them, and this file exists so "no branch yet" cannot be told apart from
+      // "no branch ever" by anything but a written reason. They become `at:` with the viewer.
+      'network:error',
+      'network:state',
       'session:deviceInfo',
     ])
   })

--- a/scripts/__tests__/protocolMessageNames.test.mjs
+++ b/scripts/__tests__/protocolMessageNames.test.mjs
@@ -170,7 +170,7 @@ describe('protocol message interfaces', () => {
     // `InputKey`, which was already named and is a message like any other. L4a added the seven agent→relay
     // messages, the last direction that had none. 66 is `DeviceShutdownError`, #542 — the shutdown pair had
     // no failure member, so an undeliverable shutdown had nothing to be answered with.
-    expect(messages.size).toBe(66)
+    expect(messages.size).toBe(69)
     // `InputKey` predates L1 and has always been named; it must be in here too.
     expect(messages.has('InputKey')).toBe(true)
   })
@@ -281,7 +281,7 @@ describe('protocol message interfaces', () => {
       if (base !== 'SessionScoped') offenders.push(`${name} ('${literal}')`)
     }
     expect(offenders).toEqual([])
-    expect([...messages].filter(([, m]) => m.extends === 'SessionScoped')).toHaveLength(10)
+    expect([...messages].filter(([, m]) => m.extends === 'SessionScoped')).toHaveLength(11)
     // `error` is the ninth, as of L5d. Pinned by name rather than only by the count, because the count alone
     // would be satisfied by any new member and this is the one whose membership was argued.
     expect(messages.get('GenericError')).toMatchObject({ literal: 'error', extends: 'SessionScoped' })


### PR DESCRIPTION
## Summary

The wire contract for taking a device under test off the network (#607): `network:set` from the viewer, `network:state` and `network:error` back, and a `NetworkControlCapability` beside `DeviceAgent`. **No agent implements it and no control renders it** — the contract lands first so both platforms build against it rather than against each other.

`network-control` in `capabilities` claims less than `clipboard` and `full-reset` do. Those are settled facts about an agent's own code; this string is sent once at `agent:register`, before any device is booted or app launched, so it can only mean "this agent has the code". Whether the mechanism takes is per device and per app, and `network:state` carries that as `available` plus a closed `reason`.

Step 2 of 5 in `.work/2026-08-20-network-control-plan.md`. Android is next.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/feature__network-control-protocol.md` — a **design** review before any code (four findings, all reflected in the plan first), then a two-channel review of the diff: eight findings, seven fixed here and one split out as #614.

The one worth naming: the agent-side ownership gate on `network:state` existed, with a comment explaining it, and **nothing executed it** — moving those two labels into the ungated block left all 675 relay tests green *and* the static routing guard green, because that guard reads `case` labels and cannot see which block they sit in. `clipboard.test.ts` has had this test since the bridge was written; this now has its twin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protocol support for taking devices offline, restoring connectivity, and querying network state.
  - Added network-control capability detection and unavailable-state reporting.
  - Added relay routing for network-control requests, state updates, and errors.

- **Documentation**
  - Updated release notes and protocol documentation for network control.

- **Tests**
  - Added coverage for capability detection, validation, routing, authorization, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->