### PR TITLE
chore(dashboard): move lucide-react to 1.33.0

### DIFF
--- a/.changeset/soft-jars-repeat.md
+++ b/.changeset/soft-jars-repeat.md
@@ -2,6 +2,8 @@
 "@tapflowio/relay": patch
 ---
 
-The dashboard's icon set moved to lucide-react 1.x, ahead of the network control it needs an icon for.
+The dashboard's icon set moved to lucide-react 1.x, from 0.577.
 
-Nothing you interact with changes. Of the fifty icons in use, forty-nine are drawn from byte-identical path data; the book on the Docs link in the sidebar is a little taller. Bundle size is unchanged.
+Housekeeping ahead of the network control for #607, which will use `radio-off` — an icon added in lucide v1.6.0. Not a necessity: 0.577 already carries `wifi-off`, `plane`, `signal` and `antenna`, and the slash could have been drawn by hand. It is a preference for the glyph that says "no radio at all", which is what airplane mode does, and doing the bump now keeps it out of the diff that adds the control.
+
+Nothing you interact with changes. Forty-nine of the fifty icons in use are drawn from identical data; the fiftieth is the book on the sidebar's Docs link, and it has been redrawn — same book, rounder corners. All the JS the dashboard ships grows by 30 bytes.

--- a/.changeset/soft-jars-repeat.md
+++ b/.changeset/soft-jars-repeat.md
@@ -1,0 +1,7 @@
+---
+"@tapflowio/relay": patch
+---
+
+The dashboard's icon set moved to lucide-react 1.x, ahead of the network control it needs an icon for.
+
+Nothing you interact with changes. Of the fifty icons in use, forty-nine are drawn from byte-identical path data; the book on the Docs link in the sidebar is a little taller. Bundle size is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The dashboard's icon set moved to **lucide-react 1.x** from 0.577, ahead of the network control that needs an icon 0.577 does not have. Nothing you interact with changes: forty-nine of the fifty icons in use are drawn from byte-identical path data, the fiftieth is the book on the sidebar's Docs link and it is a little taller, and the bundle is the same size.
+- The dashboard's icon set moved to **lucide-react 1.x** from 0.577 — housekeeping ahead of the network control for [#607](https://github.com/jo-duchan/tapflow/issues/607), which will use an icon lucide added in v1.6.0. Nothing you interact with changes: forty-nine of the fifty icons in use are drawn from identical data, the fiftieth is the book on the sidebar's Docs link and it has been redrawn with rounder corners, and all the JS the dashboard ships grows by 30 bytes.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Full reset** now appears based on what the device agent says it can do, rather than on which platform you picked. The control was offered for every iOS device and hidden for every Android one, which was right about the agents of the day and wrong about any other combination: an agent older than the feature was still offered a toggle it has no code for, and an Android agent that gains the ability would still have had it hidden — which is the half that landed above in this same release. If you run an agent from before this release against a newer relay, the toggle is now correctly absent instead of erasing nothing — one more reason to upgrade agents and relay together, as 0.19.0 asked.
 
+### Changed
+
+- The dashboard's icon set moved to **lucide-react 1.x** from 0.577, ahead of the network control that needs an icon 0.577 does not have. Nothing you interact with changes: forty-nine of the fifty icons in use are drawn from byte-identical path data, the fiftieth is the book on the sidebar's Docs link and it is a little taller, and the bundle is the same size.
+
 ### Security
 
 - `js-yaml` moved to 3.15.1 / 4.3.1 (GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption resolving `!!omap`), and its two `pnpm.overrides` entries were retired with it. The pin listed under 0.16.0 below no longer exists: the declared ranges had admitted the patch all along, so what held the old version in place was a lockfile that never re-evaluated them, not a range that forbade it. Development dependency only — no published package carries `js-yaml`.

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@tapflowio/protocol": "workspace:*",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@hookform/resolvers": "^5.9.0",
@@ -30,6 +29,7 @@
     "@radix-ui/react-switch": "^1.3.7",
     "@radix-ui/react-tabs": "^1.1.21",
     "@radix-ui/react-tooltip": "^1.2.16",
+    "@tapflowio/protocol": "workspace:*",
     "@visx/axis": "^4.0.0",
     "@visx/curve": "^4.0.0",
     "@visx/event": "^4.0.0",
@@ -43,7 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-array": "^3.2.4",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.33.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,8 +278,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.8)
+        specifier: ^1.33.0
+        version: 1.33.0(react@19.2.8)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4146,8 +4146,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.33.0:
+    resolution: {integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -9036,7 +9036,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@19.2.8):
+  lucide-react@1.33.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## Summary

Moves `lucide-react` from `^0.577.0` to `^1.33.0` in the dashboard. No source file changes.

Housekeeping ahead of #607's network control, which will use `radio-off` — added in lucide v1.6.0. A caret on a `0.x` version opens patches only, so nothing was going to bring this in on its own. It is a preference rather than a necessity: 0.577 already carries `wifi-off`, `plane`, `signal` and `antenna`, and the slash could have been drawn by hand. Doing the bump on its own branch keeps it out of the diff that adds the control, and lets it be reverted separately if it turns out to be wrong.

Verified rather than assumed, because this crosses a major:

| | |
|---|---|
| Icons in use | 50, across 28 files |
| Resolve in 1.33 | 50/50 (`Loader2` is an alias of `LoaderCircle`, as it already was) |
| Identical `__iconNode` | 49/50 |
| The exception | `BookOpen` — redrawn, not nudged; used once, on the sidebar's Docs link |
| Bundle | `index` chunk identical, all JS assets +30 bytes — tree-shaking still drops the ~6000 unused icons |

The renderer moved too and nothing here notices: every icon is a context consumer as of 1.x, `Icon` carries `"use client"`, and the UMD build is gone. Defaults resolve to the same values, `defaultAttributes` and `mergeClasses` are byte-identical, and this is a Vite SPA with no SSR and no UMD consumer.

The review found no functional breakage and three false statements in the release note — the stated reason for the bump, "a little taller" for a full redraw, and "unchanged" for +30 bytes. All three are fixed in the second commit; the record has the detail.

## Checklist

- [x] Tests written and passing — no new tests: no source changed, and the existing dashboard suite (356) plus the root suite (387) pass
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`reviews/chore__lucide-upgrade.md` (HEAD `80f1babc5dd04c34dcc90f795168b81f761acbcd`). The control this precedes is planned in `2026-08-21-network-toggle-plan.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated dashboard icons for improved consistency and visual quality.
  * Refreshed the Docs sidebar book icon; other icons retain their existing appearance and data.
  * No interaction or functionality changes were introduced.
  * Updated the dashboard’s icon library, with a corresponding bundle-size adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->