### PR TITLE
chore: add scripts test command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ gates went on: `AgentRegistry.test.ts` declared `implements DeviceAgent` while m
 sites naming a type violated.
 
 ### Test Hygiene
-Tests run through `pnpm --filter <pkg> test`, never `npx vitest` — not even from inside the package directory, and not for a single file. npm rewrites the root `package.json` on its way through and collapses `pnpm.overrides` to `pnpm: {}`, leaving `pnpm-lock.yaml` rewritten beside it, and it reports none of that. Reviewing #474 cost exactly this: one `npx vitest` on one test file, and the entire override block was gone with only `git status` to say so. `git checkout HEAD -- package.json pnpm-lock.yaml` puts both back — check `git diff` on them first if you were editing either on purpose, since that discards everything uncommitted in both.
+Tests run through `pnpm --filter <pkg> test`; use `pnpm test:scripts` for the root scripts suite. Never use `npx vitest` — not even from inside the package directory, and not for a single file. npm rewrites the root `package.json` on its way through and collapses `pnpm.overrides` to `pnpm: {}`, leaving `pnpm-lock.yaml` rewritten beside it, and it reports none of that. Reviewing #474 cost exactly this: one `npx vitest` on one test file, and the entire override block was gone with only `git status` to say so. `git checkout HEAD -- package.json pnpm-lock.yaml` puts both back — check `git diff` on them first if you were editing either on purpose, since that discards everything uncommitted in both.
 
 After running tests (especially repeated or looped runs), always check for zombie vitest processes and kill them:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,12 @@ All packages:
 pnpm test
 ```
 
+Repository scripts suite (cross-package static checks):
+
+```sh
+pnpm test:scripts
+```
+
 A specific package:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "pnpm --filter @tapflowio/protocol build && pnpm --filter @tapflowio/agent-core build && pnpm --filter @tapflowio/dashboard build && pnpm --filter @tapflowio/flow-runner build && pnpm --filter @tapflowio/relay build && pnpm --filter @tapflowio/ios-agent build && pnpm --filter @tapflowio/android-agent build && pnpm --filter tapflow build && pnpm --filter @tapflowio/mcp-server build",
-    "test": "vitest run --config scripts/vitest.config.mjs && pnpm -r test --if-present",
+    "test": "pnpm test:scripts && pnpm -r test --if-present",
+    "test:scripts": "vitest run --config scripts/vitest.config.mjs",
     "lint": "eslint scripts && pnpm -r --if-present lint",
     "typecheck": "tsc -b && pnpm -r --if-present typecheck",
     "prepare": "lefthook install || true",

--- a/scripts/vitest.config.mjs
+++ b/scripts/vitest.config.mjs
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'path'
 
 // Deliberately NOT at the repo root. A config file there is inherited by every package that has
 // none of its own — all of them do — and they then run with this `include` and find no tests.
-// Invoked explicitly: `vitest run --config scripts/vitest.config.mjs`.
+// Invoked explicitly: `pnpm test:scripts`.
 //
 // `root` is resolved from this file, not from the cwd: vitest resolves a relative `root` against
 // the working directory, so '..' pointed one level above the repo.


### PR DESCRIPTION
## Summary

Adds `pnpm test:scripts` as the documented entry point for the root scripts suite.
The root `test` command now delegates to it, preserving the existing command and test order.

I also checked the per-package targeted test command mentioned in #616. `pnpm --filter <pkg> test <path>` forwards a single test-file path to Vitest for package-level test scripts, so this PR only addresses the missing root scripts-suite affordance.

<!-- no-changeset: root test-script configuration only -->
## Checklist

- [ ] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs
- `.work/reviews/feature__scripts-test-suite-616.md` — independent adversarial review, no findings.
<!-- Name the plan/review file, if any -->


Closes #616
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance with instructions for running the repository’s scripts suite.
  * Clarified the recommended commands for package-level and cross-package tests.

* **Chores**
  * Improved the default test workflow to run scripts checks before package tests.
  * Updated test configuration guidance to reflect the standard scripts-suite command.

Closes `#616`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->