### PR TITLE
fix(scripts): read the changelog:internal marker the way the other two markers are read

### DIFF
--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -87,6 +87,7 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
     'mixed-fence.md': cs('"@tapflowio/relay": patch') + '\n```md\n~~~\n<!-- changelog: internal -->\n~~~\n```\n',
     'after-fence.md': cs('"@tapflowio/protocol": patch') + '\n```md\nexample\n```\n<!-- changelog: internal -->\n',
     'indented-fence.md': cs('"@tapflowio/protocol": patch') + '\n    ```md\n<!-- changelog: internal -->\n    ```\n',
+    'indented-marker.md': `${cs('"@tapflowio/protocol": patch')}\n  <!-- changelog: internal -->  \n`,
   })[f]
 
   it('owes one for a plain changeset', () => {
@@ -113,6 +114,9 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
   })
   it('is released by an unindented marker between four-space-indented fence-like lines', () => {
     expect(changelogEntryOwed(['indented-fence.md'], read)).toEqual([])
+  })
+  it('is released by the marker even with leading/trailing spaces', () => {
+    expect(changelogEntryOwed(['indented-marker.md'], read)).toEqual([])
   })
 })
 

--- a/scripts/__tests__/changesetGateAccuracy.test.mjs
+++ b/scripts/__tests__/changesetGateAccuracy.test.mjs
@@ -88,6 +88,7 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
     'after-fence.md': cs('"@tapflowio/protocol": patch') + '\n```md\nexample\n```\n<!-- changelog: internal -->\n',
     'indented-fence.md': cs('"@tapflowio/protocol": patch') + '\n    ```md\n<!-- changelog: internal -->\n    ```\n',
     'indented-marker.md': `${cs('"@tapflowio/protocol": patch')}\n  <!-- changelog: internal -->  \n`,
+    'indented-code-marker.md': `${cs('"@tapflowio/protocol": patch')}\nThe gate takes an opt-out:\n\n    <!-- changelog: internal -->\n`,
   })[f]
 
   it('owes one for a plain changeset', () => {
@@ -117,6 +118,13 @@ describe('a changeset that owes the root CHANGELOG an entry', () => {
   })
   it('is released by the marker even with leading/trailing spaces', () => {
     expect(changelogEntryOwed(['indented-marker.md'], read)).toEqual([])
+  })
+  // The trim widened what counts as a marker, so what still must NOT count is worth pinning:
+  // four spaces makes an indented code block -- someone quoting the syntax -- and `proseLines`
+  // is now the only thing between that and a silent opt-out, since the match itself no longer
+  // sees the indentation.
+  it('is not released by a marker inside a four-space-indented code block', () => {
+    expect(changelogEntryOwed(['indented-code-marker.md'], read)).toEqual(['indented-code-marker.md'])
   })
 })
 

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -403,8 +403,8 @@ export function ignoredOnlyChangesets(files, ignored, read) {
  */
 export function changelogEntryOwed(files, read) {
   return files.filter((f) => {
-    for (const { raw } of proseLines(read(f), { skipFrontmatter: true })) {
-      if (/^<!--\s*changelog:\s*internal\b.*-->$/.test(raw)) return false
+    for (const { line } of proseLines(read(f), { skipFrontmatter: true })) {
+      if (/^<!--\s*changelog:\s*internal\b.*-->$/.test(line)) return false
     }
     return true
   })


### PR DESCRIPTION
This finishes #604.

`proseLines` already filters out lines where a marker could be quoted (such as fenced code blocks, four-space-indented blocks, and tab-indented blocks) before yielding lines. Consequently, parsing `raw` inside `changelogEntryOwed` was redundant, and differed from the sibling markers (`no-changeset` and `Backfills:`) which already read the trimmed `line`.

This change updates the `changelog:internal` marker to align with the other two markers by matching on the trimmed `line`.

Note: This trim deliberately widens the opt-out behavior to include markers indented by 1 to 3 spaces (e.g. inside a list-item continuation line), bringing parity with the other two parser consumers. Added unit tests to pin the behavior (confirming that 1-3 spaces are accepted, but four spaces representing an indented code block are not released).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changelog opt-out markers are now recognized when surrounded by permitted whitespace.
  * Markers inside indented code blocks no longer incorrectly bypass the changelog-entry requirement.

* **Tests**
  * Added coverage for whitespace-tolerant markers.
  * Added coverage confirming that markers in four-space-indented code blocks are treated as code rather than opt-out instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->