### PR TITLE
chore: put a budget and a parent line on deferring a review finding

### DIFF
--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# PreToolUse(Bash) gate: an issue split out of other work has to name what it came from.
+#
+# **The problem this exists for is measured, not hypothetical.** One day of work on #607 produced
+# nine issues, and not one of them was reachable *from* #607 — every review finding graded `later`
+# became a sibling nobody could enumerate. Asked "is #607 finished?", the honest answer was that
+# nobody could tell, because the feature's remaining surface existed only as nine unlinked rows in a
+# tracker sorted by date. Two of those nine were closed minutes later as things that should never
+# have been filed.
+#
+# Prose mentions are not the fix and were already there: most of those nine said "raised by the
+# review of #647" somewhere in the body. GitHub builds no tree from that, and neither can a script.
+# A `Parent:` line is greppable, so the parent's checklist can be regenerated instead of maintained
+# by memory.
+#
+# Standalone issues are normal — a bug someone reports, a chore, an idea. They opt out by saying so,
+# which costs one line and makes the choice visible in the issue itself.
+#
+# Fail-open on a missing/unparseable payload, matching the other gates in this directory: this guards
+# a cooperative-but-forgetful agent, not an adversary, and failing closed would block every Bash call
+# in the session on a missing jq.
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
+
+# Command position only, the same rule pr-merge-guard.sh uses: a substring match would fire on this
+# repo's own docs, which discuss `gh issue create` by name.
+printf '%s' "$cmd" \
+  | tr '\n' ' ' \
+  | grep -qE '(^|[;&|]|\$\(|\bthen\b|\bdo\b)[[:space:]]*gh[[:space:]]+issue[[:space:]]+create' || exit 0
+
+# Either a parent, or an explicit standalone marker. `Parent: #123` / `Parent: owner/repo#123`.
+if printf '%s' "$cmd" | grep -qE 'Parent:[[:space:]]*[A-Za-z0-9_.\/-]*#[0-9]+'; then exit 0; fi
+if printf '%s' "$cmd" | grep -qF '<!-- standalone:'; then exit 0; fi
+
+cat >&2 <<'MSG'
+Blocked: this issue names no parent.
+
+An issue split out of other work needs a line of its own in the body:
+
+    Parent: #607
+
+so the work it came from can enumerate what it still owes. Prose like "raised by the review of #647"
+does not count — nothing can build a checklist from it, which is how nine issues from one day of
+work on #607 became unreachable from #607.
+
+If it genuinely stands alone — a reported bug, a chore, a new idea — say so instead:
+
+    <!-- standalone: reported by a user, not split out of anything -->
+
+And before filing at all: a finding under ~10 lines that the lens you are already running can judge
+is fixed in that PR, not deferred. AGENTS.md > "An adjacent defect is fixed here unless it needs its
+own decision".
+MSG
+exit 2

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -13,53 +13,19 @@
 # A `Parent:` line is greppable, so the parent's checklist can be regenerated instead of maintained
 # by memory.
 #
-# Standalone issues are normal — a bug someone reports, a chore, an idea. They opt out by saying so,
-# which costs one line and makes the choice visible in the issue itself.
-#
-# Fail-open on a missing/unparseable payload, matching the other gates in this directory: this guards
-# a cooperative-but-forgetful agent, not an adversary, and failing closed would block every Bash call
-# in the session on a missing jq. A `--body-file` naming a file that does not exist is not that case
-# and is left blocked — `gh` would fail on it anyway, so the verdict costs nothing either way.
+# **This file is only the prefilter.** Deciding needs the command tokenized and the body parsed, and
+# the version that tried both in shell got three rules wrong at once — `gh issue new` walked through,
+# so did an environment assignment before `gh`, `-F "issue body.md"` read a file called `issue`, and
+# a `--title` could satisfy a rule about bodies. The decision is in `scripts/issue-parent-gate.mjs`,
+# where it is tested. Node is spawned only for a command that mentions both words, which is rare.
 
 input=$(cat)
-cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 
-# Command position only, the same rule pr-merge-guard.sh uses: a substring match would fire on this
-# repo's own docs, which discuss `gh issue create` by name.
-printf '%s' "$cmd" \
-  | tr '\n' ' ' \
-  | grep -qE '(^|[;&|]|\$\(|\bthen\b|\bdo\b)[[:space:]]*gh[[:space:]]+issue[[:space:]]+create' || exit 0
+case "$input" in
+  *gh*issue*) ;;
+  *) exit 0 ;;
+esac
+[ -f scripts/issue-parent-gate.mjs ] || exit 0
 
-# The body may not be in the command at all. `--body-file` is the form this repo teaches for PRs, and
-# reading the file is the difference between a gate and a false positive on the correct usage.
-body_file=$(printf '%s' "$cmd" | sed -nE "s/.*(--body-file|-F)[[:space:]]+['\"]?([^[:space:]'\"]+).*/\2/p" | head -1)
-haystack=$cmd
-if [ -n "$body_file" ] && [ "$body_file" != "-" ] && [ -r "$body_file" ]; then
-  haystack="$cmd
-$(cat "$body_file")"
-fi
-
-# Either a parent, or an explicit standalone marker. `Parent: #123` / `Parent: owner/repo#123`.
-if printf '%s' "$haystack" | grep -qE 'Parent:[[:space:]]*[A-Za-z0-9_.\/-]*#[0-9]+'; then exit 0; fi
-if printf '%s' "$haystack" | grep -qF '<!-- standalone:'; then exit 0; fi
-
-cat >&2 <<'MSG'
-Blocked: this issue names no parent.
-
-An issue split out of other work needs a line of its own in the body:
-
-    Parent: #607
-
-so the work it came from can enumerate what it still owes. Prose like "raised by the review of #647"
-does not count — nothing can build a checklist from it, which is how nine issues from one day of
-work on #607 became unreachable from #607.
-
-If it genuinely stands alone — a reported bug, a chore, a new idea — say so instead:
-
-    <!-- standalone: reported by a user, not split out of anything -->
-
-And before filing at all: a finding under ~10 lines that the lens you are already running can judge
-is fixed in that PR, not deferred. AGENTS.md > "An adjacent defect is fixed here unless it needs its
-own decision".
-MSG
-exit 2
+printf '%s' "$input" | node scripts/issue-parent-gate.mjs

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -18,7 +18,8 @@
 #
 # Fail-open on a missing/unparseable payload, matching the other gates in this directory: this guards
 # a cooperative-but-forgetful agent, not an adversary, and failing closed would block every Bash call
-# in the session on a missing jq.
+# in the session on a missing jq. A `--body-file` naming a file that does not exist is not that case
+# and is left blocked — `gh` would fail on it anyway, so the verdict costs nothing either way.
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
@@ -29,9 +30,18 @@ printf '%s' "$cmd" \
   | tr '\n' ' ' \
   | grep -qE '(^|[;&|]|\$\(|\bthen\b|\bdo\b)[[:space:]]*gh[[:space:]]+issue[[:space:]]+create' || exit 0
 
+# The body may not be in the command at all. `--body-file` is the form this repo teaches for PRs, and
+# reading the file is the difference between a gate and a false positive on the correct usage.
+body_file=$(printf '%s' "$cmd" | sed -nE "s/.*(--body-file|-F)[[:space:]]+['\"]?([^[:space:]'\"]+).*/\2/p" | head -1)
+haystack=$cmd
+if [ -n "$body_file" ] && [ "$body_file" != "-" ] && [ -r "$body_file" ]; then
+  haystack="$cmd
+$(cat "$body_file")"
+fi
+
 # Either a parent, or an explicit standalone marker. `Parent: #123` / `Parent: owner/repo#123`.
-if printf '%s' "$cmd" | grep -qE 'Parent:[[:space:]]*[A-Za-z0-9_.\/-]*#[0-9]+'; then exit 0; fi
-if printf '%s' "$cmd" | grep -qF '<!-- standalone:'; then exit 0; fi
+if printf '%s' "$haystack" | grep -qE 'Parent:[[:space:]]*[A-Za-z0-9_.\/-]*#[0-9]+'; then exit 0; fi
+if printf '%s' "$haystack" | grep -qF '<!-- standalone:'; then exit 0; fi
 
 cat >&2 <<'MSG'
 Blocked: this issue names no parent.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/adversarial-review-gate.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/issue-parent-gate.sh\""
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,34 @@ Splitting is still right when it is right — `#508`'s relay type drift genuinel
 The rule is that it must be a decision with a reason, and the reason may not be "it was in a
 different file".
 
+#### A reviewer's `later` is an input, not a verdict — and deferring has a budget
+
+The rule above was written for a session choosing its own deferrals. Once the findings arrive from
+review channels, the choosing is quietly delegated: a reviewer writes `later`, and it becomes an
+issue because that is what the column said.
+
+**Measured on one day of work on #607: nine issues, from three PRs.** That is not bad luck, it is
+arithmetic — two or three channels per PR, a cap of four or five findings each, and a `later` rate of
+about a third. Two of the nine were closed within the hour as things that should never have been
+filed, and one of them (`#673`, a missing `timeout`) was a few lines in a file the running lens was
+already reading, which the section above says is fixed in place.
+
+Three things keep it honest, and none of them is remembering harder:
+
+- **Re-grade every `later` yourself.** Severity was already being re-graded; disposition was not.
+  Hold each one against the same two questions: under ~10 lines, and judgable by the lens already
+  running? Then it is fixed here, whatever the column says.
+- **Give the reviewer a `later` budget** — at most two per channel, each justified against that rule.
+  A cap on findings with no cap on deferrals makes deferring free, and free is what it was.
+- **Every split-out issue names its parent**, on a line of its own: `Parent: #607`. Prose like "raised
+  by the review of #647" is not it — nothing can build a checklist from a mention, which is how the
+  nine above became unreachable from the issue they all came from. `.claude/hooks/issue-parent-gate.sh`
+  blocks an issue that carries neither a `Parent:` line nor an explicit
+  `<!-- standalone: reason -->`.
+
+And the parent keeps a checklist. Asked whether #607 was finished, nobody could answer — the feature's
+remaining surface existed only as unlinked rows in a tracker sorted by date.
+
 ### Design Principles (SOLID — priority subset)
 
 - **OCP**: New platforms and features are added without modifying existing code — platforms register via `AgentRegistry.register()` only; relay and dashboard code stay unchanged.

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -179,8 +179,17 @@ What made the 4m30s pair cheap was structural, not stylistic. Each prompt carrie
 4. **The commands not to run**, by name.
 5. **A findings cap and a time budget.**
 6. **A required "checked and cleared" list**, so coverage is visible when nothing is found.
-7. **A now/later column on every finding — and for every `later`, the reason plus a one-line issue
-   title and body.** Without the column the split falls to whoever holds the diff, who is the person
+7. **A now/later column on every finding, a `later` budget of two per channel — and for every
+   `later`, the reason plus a one-line issue title and body.**
+
+   The budget is the part that was missing, and its absence is measured: capping findings while
+   leaving deferrals free produced nine issues from three PRs in a day. Ask the reviewer to justify
+   each `later` against the ten-line rule, and **re-grade every one of them yourself** — the column is
+   the reviewer's opinion about work it is not doing.
+
+   Every issue that does get filed names its parent on a line of its own (`Parent: #607`), which is
+   what lets the work it came from enumerate what it still owes.
+ Without the column the split falls to whoever holds the diff, who is the person
    least able to see what deferring costs, and the answer defaults to "later" because that is what
    keeps the diff small. Without the issue text, "later" costs a sentence while filing costs a task,
    and the cheaper one wins — which is how six deferrals came to live in a single conversation. The

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -12,7 +12,7 @@ import { spawnSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { judge, tokenize, issueCreateInvocations, bodyFileArg, hasParent, hasStandalone } from '../lib/issue-parent.mjs'
+import { judge, tokenize, issueCreateInvocations, bodyFileArg, hasParent, hasStandalone, heredocs } from '../lib/issue-parent.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const PARENT = 'Parent: #607'
@@ -55,6 +55,22 @@ describe('which commands are issue creations', () => {
   }
 })
 
+describe('an invocation ends where the command does', () => {
+  it('does not borrow a later command\'s flags', () => {
+    // `words.slice(j)` ran to the end of the token list, so `echo`'s `--body` counted as the issue's
+    // and an invocation with no body at all was allowed.
+    expect(verdict('gh issue create --web && echo --body "Parent: #607"').blocked).toBe(true)
+    expect(verdict('gh issue create --web ; cat "Parent: #607"').blocked).toBe(true)
+  })
+
+  it('still judges each invocation in a chain on its own body', () => {
+    const both = 'gh issue create --body "Parent: #607" && gh issue create --body "Parent: #608"'
+    expect(verdict(both).blocked).toBe(false)
+    const second = 'gh issue create --body "Parent: #607" && gh issue create --body "a bug"'
+    expect(verdict(second).blocked, 'the second one names nothing').toBe(true)
+  })
+})
+
 describe('where the body comes from', () => {
   it('reads a quoted --body-file path whole', () => {
     // `-F "issue body.md"` used to be cut at the first space and read a file called `issue`, so a
@@ -84,6 +100,20 @@ describe('where the body comes from', () => {
   it('reads a heredoc, whose body exists only in the command', () => {
     expect(verdict(`gh issue create --body-file - <<EOF\n${PARENT}\nEOF`).blocked).toBe(false)
     expect(verdict('gh issue create --body-file - <<EOF\nnothing\nEOF').blocked).toBe(true)
+    expect(verdict(`gh issue create --body-file - <<'EOF'\n${PARENT}\nEOF`).blocked, 'quoted delimiter').toBe(false)
+  })
+
+  it('reads the payload rather than the command around it', () => {
+    // The title bypass again, one case over: `body = cmd` let a `Parent:` line in a title-side
+    // heredoc satisfy a check about the body.
+    const cmd = `gh issue create --title "$(cat <<T\n${PARENT}\nT\n)" --body-file - <<B\nno parent here\nB`
+    expect(heredocs(cmd), 'both payloads, in order').toEqual([PARENT, 'no parent here'])
+    expect(verdict(cmd).blocked).toBe(true)
+  })
+
+  it('blocks rather than guessing when a command carries several heredocs', () => {
+    // Picking one would be a guess, and the wrong guess is the permissive one.
+    expect(verdict(`gh issue create --body-file - <<A\n${PARENT}\nA\ncat <<B\nx\nB`).blocked).toBe(true)
   })
 })
 
@@ -91,6 +121,14 @@ describe('what counts as naming a parent', () => {
   it('takes the line on its own, with or without an owner/repo prefix', () => {
     expect(hasParent(`intro\n\n${PARENT}\n`)).toBe(true)
     expect(hasParent('Parent: jo-duchan/tapflow#607')).toBe(true)
+  })
+
+  it('refuses a half-written cross-repository reference', () => {
+    // The prefix used to be any run of the characters an owner/repo contains, so neither of these
+    // was a reference and both switched the gate off.
+    expect(hasParent('Parent: owner#607')).toBe(false)
+    expect(hasParent('Parent: /#607')).toBe(false)
+    expect(hasParent('Parent: owner/#607')).toBe(false)
   })
 
   const NOT_A_PARENT = {

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -1,0 +1,168 @@
+// The gate that makes a split-out issue name what it came from.
+//
+// **Every case below was a bypass in the shell version this replaces**, which is the reason the file
+// exists: the first draft matched strings in the whole command and its own review record admitted it
+// was untested. Three of its four rules were wrong in the same way, and none of them was visible
+// without running it.
+//
+// The last describe spawns the real hook rather than the library, because a correct decision reached
+// through a prefilter that never calls it is not a gate.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { judge, tokenize, issueCreateInvocations, bodyFileArg, hasParent, hasStandalone } from '../lib/issue-parent.mjs'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const PARENT = 'Parent: #607'
+
+/** `judge` with no filesystem: every body is supplied inline. */
+const verdict = (cmd, files = {}) => judge(cmd, (p) => {
+  if (!(p in files)) throw new Error('ENOENT')
+  return files[p]
+})
+
+describe('which commands are issue creations', () => {
+  const CREATES = {
+    'the plain form': 'gh issue create --title x --body "Parent: #607"',
+    'the undocumented `new` alias, which gh accepts': 'gh issue new --body "Parent: #607"',
+    'behind an environment assignment': 'GH_REPO=o/r gh issue create --body "Parent: #607"',
+    'behind two of them': 'A=1 GH_REPO=o/r gh issue create --body "Parent: #607"',
+    'behind env(1)': 'env GH_REPO=o/r gh issue create --body "Parent: #607"',
+    'after a separator': 'git status && gh issue create --body "Parent: #607"',
+    'inside a subshell': '( gh issue create --body "Parent: #607" )',
+  }
+  for (const [name, cmd] of Object.entries(CREATES)) {
+    it(`sees ${name}`, () => {
+      expect(issueCreateInvocations(cmd)).toHaveLength(1)
+    })
+  }
+
+  const NOT_CREATES = {
+    'listing issues': 'gh issue list --state open',
+    'viewing one': 'gh issue view 607 --json body',
+    'a PR, not an issue': 'gh pr create --body-file /tmp/x.md',
+    'the words inside an argument': 'echo "run gh issue create to file one"',
+    'the words in a grep pattern': "grep -rn 'gh issue create' docs/",
+  }
+  for (const [name, cmd] of Object.entries(NOT_CREATES)) {
+    it(`ignores ${name}`, () => {
+      // Asserting a present count of zero rather than "nothing happened": these run through the same
+      // tokenizer, so a broken tokenizer cannot pass this by returning early.
+      expect(issueCreateInvocations(cmd)).toEqual([])
+    })
+  }
+})
+
+describe('where the body comes from', () => {
+  it('reads a quoted --body-file path whole', () => {
+    // `-F "issue body.md"` used to be cut at the first space and read a file called `issue`, so a
+    // correctly-filed issue was refused for a line its body already had.
+    expect(bodyFileArg(tokenize('gh issue create -F "issue body.md"'))).toBe('issue body.md')
+    expect(bodyFileArg(tokenize("gh issue create --body-file 'my issue.md'"))).toBe('my issue.md')
+    expect(bodyFileArg(tokenize('gh issue create --body-file=body.md'))).toBe('body.md')
+  })
+
+  it('allows a body file that carries the line, and blocks one that does not', () => {
+    const cmd = 'gh issue create -F "issue body.md"'
+    expect(verdict(cmd, { 'issue body.md': `${PARENT}\n\ntext\n` }).blocked).toBe(false)
+    expect(verdict(cmd, { 'issue body.md': 'raised by the review of #647\n' }).blocked).toBe(true)
+  })
+
+  it('does not let a --title stand in for the body', () => {
+    // The whole command used to be the haystack, so the gate could be satisfied by text that never
+    // reached the issue.
+    expect(verdict('gh issue create --title "Parent: #607" --body "a bug"').blocked).toBe(true)
+  })
+
+  it('blocks when no body can be read at all', () => {
+    expect(verdict('gh issue create --title x').blocked).toBe(true)
+    expect(verdict('gh issue create --body-file /nope.md').blocked).toBe(true)
+  })
+
+  it('reads a heredoc, whose body exists only in the command', () => {
+    expect(verdict(`gh issue create --body-file - <<EOF\n${PARENT}\nEOF`).blocked).toBe(false)
+    expect(verdict('gh issue create --body-file - <<EOF\nnothing\nEOF').blocked).toBe(true)
+  })
+})
+
+describe('what counts as naming a parent', () => {
+  it('takes the line on its own, with or without an owner/repo prefix', () => {
+    expect(hasParent(`intro\n\n${PARENT}\n`)).toBe(true)
+    expect(hasParent('Parent: jo-duchan/tapflow#607')).toBe(true)
+  })
+
+  const NOT_A_PARENT = {
+    'prose that mentions the issue': 'Raised by the review of #647.',
+    'the words mid-sentence': 'Its Parent: #607 is where this came from.',
+    'inside a fenced block': `Write it like this:\n\n\`\`\`\n${PARENT}\n\`\`\`\n`,
+    'inside a tilde fence': `Write it like this:\n\n~~~\n${PARENT}\n~~~\n`,
+    'inside an indented block': `Write it like this:\n\n    ${PARENT}\n`,
+    'quoted inline': `Put \`${PARENT}\` in the body.`,
+    'no number': 'Parent: #',
+  }
+  for (const [name, body] of Object.entries(NOT_A_PARENT)) {
+    it(`refuses: ${name}`, () => {
+      expect(hasParent(body)).toBe(false)
+    })
+  }
+
+  // The exact shape AGENTS.md prints. If this ever counted, documenting the convention would satisfy
+  // the gate for whoever documents it — the failure `changesetReason.test.mjs` already names.
+  it('refuses the snippet as AGENTS.md prints it', () => {
+    expect(hasParent('Every split-out issue names its parent, on a line of its own: `Parent: #607`.')).toBe(false)
+  })
+})
+
+describe('what counts as standing alone', () => {
+  it('takes a marker with a reason', () => {
+    expect(hasStandalone('<!-- standalone: reported by a user -->')).toBe(true)
+  })
+
+  it('refuses one with no reason, which is the marker without the decision', () => {
+    expect(hasStandalone('<!-- standalone: -->')).toBe(false)
+    expect(hasStandalone('<!-- standalone:  -->')).toBe(false)
+  })
+
+  it('refuses an unterminated marker', () => {
+    expect(hasStandalone('<!-- standalone: forgot the close')).toBe(false)
+  })
+
+  it('refuses one quoted in a fenced block', () => {
+    expect(hasStandalone('Say:\n\n```\n<!-- standalone: a reason -->\n```\n')).toBe(false)
+  })
+})
+
+describe('the hook itself, spawned', () => {
+  const run = (cmd) => spawnSync('bash', [path.join(REPO, '.claude/hooks/issue-parent-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd } }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  it('blocks a bare issue and says what to add', () => {
+    const r = run('gh issue create --title x --body "a bug"')
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/Parent: #607/)
+  })
+
+  it('allows one that names its parent', () => {
+    expect(run(`gh issue create --title x --body "${PARENT}"`).status).toBe(0)
+  })
+
+  it('allows an unrelated command without paying for node', () => {
+    // The prefilter's job. `git status` never reaches the decision, which is why it can afford to be
+    // a node process.
+    expect(run('git status --short').status).toBe(0)
+  })
+
+  it('fails open on a payload it cannot parse', () => {
+    const r = spawnSync('bash', [path.join(REPO, '.claude/hooks/issue-parent-gate.sh')], {
+      input: 'not json at all, gh issue create',
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status, 'a malformed payload would block every Bash call in the session').toBe(0)
+  })
+})

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -20,6 +20,7 @@ import {
   prodReachableNames,
   prodVersionChanges,
 } from './prod-reach.mjs'
+import { proseLines } from './lib/prose-lines.mjs'
 
 // Inverted on purpose: everything under `packages/` ships unless named here. Listing what
 // ships instead left a NEW published package invisible to the gate — the case that most needs
@@ -272,43 +273,6 @@ function shipsBetween(file, before, after) {
  *
  * Exported for the tests.
  */
-/**
- * The lines of a markdown body that are actually prose: no fenced block, no indented block, and
- * — with `skipFrontmatter` — nothing inside the leading `---` delimiters.
- *
- * Shared on purpose. Both markers below are switches that turn a gate OFF, so a body that merely
- * QUOTES one must not trip it; every doc in this repo prints both verbatim. `extractReason` had
- * this guard and `parseBackfills` was written without it, which is exactly the kind of drift a
- * second copy invites.
- */
-function* proseLines(body, { skipFrontmatter = false } = {}) {
-  const lines = body.split(/\r?\n/)
-  let i = 0
-  if (skipFrontmatter && lines[0]?.trim() === '---') {
-    i = 1
-    while (i < lines.length && lines[i].trim() !== '---') i++
-    i++                                            // step past the closing delimiter
-  }
-  let fence = null
-  for (; i < lines.length; i++) {
-    const raw = lines[i]
-    const line = raw.trim()
-    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(raw)
-    if (fence) {
-      if (marker && marker[1][0] === fence.char && marker[1].length >= fence.length && !marker[2].trim()) {
-        fence = null
-      }
-      continue
-    }
-    if (marker && (marker[1][0] === '~' || !marker[2].includes('`'))) {
-      fence = { char: marker[1][0], length: marker[1].length }
-      continue
-    }
-    if (/^ {4,}|^\t/.test(raw)) continue           // indented code block
-    yield { raw, line }
-  }
-}
-
 export function extractReason(body) {
   for (const { line } of proseLines(body)) {
     const m = line.match(/^<!--\s*no-changeset:\s*(.*?)\s*-->$/)

--- a/scripts/issue-parent-gate.mjs
+++ b/scripts/issue-parent-gate.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// The decision half of `.claude/hooks/issue-parent-gate.sh`. Reads the PreToolUse payload on stdin,
+// exits 0 to allow and 2 to block. Kept out of the shell because the rules are parsing rules and the
+// shell version got three of them wrong — see `scripts/lib/issue-parent.mjs`.
+import { judge } from './lib/issue-parent.mjs'
+
+const MESSAGE = `Blocked: this issue names no parent.
+
+An issue split out of other work needs a line of its own in the body:
+
+    Parent: #607
+
+so the work it came from can enumerate what it still owes. Prose like "raised by the review of #647"
+does not count — nothing can build a checklist from it, which is how nine issues from one day of
+work on #607 became unreachable from #607.
+
+If it genuinely stands alone — a reported bug, a chore, a new idea — say so instead, with a reason:
+
+    <!-- standalone: reported by a user, not split out of anything -->
+
+And before filing at all: a finding under ~10 lines that the lens you are already running can judge
+is fixed in that PR, not deferred. AGENTS.md > "An adjacent defect is fixed here unless it needs its
+own decision".`
+
+let raw = ''
+process.stdin.setEncoding('utf8')
+for await (const chunk of process.stdin) raw += chunk
+
+// Fail open on anything unparseable, matching the other gates in this directory: this guards a
+// cooperative-but-forgetful agent, not an adversary, and a gate that dies noisily on a malformed
+// payload would block every Bash call in the session.
+let cmd
+try { cmd = JSON.parse(raw)?.tool_input?.command ?? '' } catch { process.exit(0) }
+if (typeof cmd !== 'string' || !cmd) process.exit(0)
+
+let verdict
+try { verdict = judge(cmd) } catch { process.exit(0) }
+if (!verdict.blocked) process.exit(0)
+process.stderr.write(`${MESSAGE}\n`)
+process.exit(2)

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -84,7 +84,12 @@ export function issueCreateInvocations(cmd) {
     let j = i
     while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
     if (words[j] === 'gh' && words[j + 1] === 'issue' && (words[j + 2] === 'create' || words[j + 2] === 'new')) {
-      found.push(words.slice(j))
+      // **Stop at the next separator.** Running to the end of the token list meant a later command's
+      // flags counted as this one's: `gh issue create --web && echo --body "Parent: #607"` was
+      // allowed, because `bodyArg` found `echo`'s argument.
+      let end = j
+      while (end < words.length && !SEPARATOR.has(words[end])) end++
+      found.push(words.slice(j, end))
     }
     atStart = false
   }
@@ -121,7 +126,9 @@ export function bodyArg(words) {
  */
 export function hasParent(body) {
   for (const { line } of proseLines(body, { skipFrontmatter: true })) {
-    if (/^Parent:\s*[A-Za-z0-9_.\/-]*#\d+\s*$/.test(line)) return true
+    // The optional prefix is one whole `owner/repo`, not any run of the characters that appear in
+    // one — `Parent: owner#607` and `Parent: /#607` are neither form and both switched the gate off.
+    if (/^Parent:\s*(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+\s*$/.test(line)) return true
   }
   return false
 }
@@ -134,6 +141,34 @@ export function hasStandalone(body) {
     if (m && m[1]) return true
   }
   return false
+}
+
+/**
+ * Every heredoc payload in a command, in order.
+ *
+ * Enough for `--body-file -`, which is the only reason this exists: `<<EOF`, `<<'EOF'`, `<<"EOF"`
+ * and `<<-EOF`, terminated by a line that is the delimiter alone. The caller blocks when a command
+ * carries more than one, because picking is guessing.
+ */
+export function heredocs(cmd) {
+  const lines = cmd.split(/\r?\n/)
+  const out = []
+  for (let i = 0; i < lines.length; i++) {
+    const m = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/.exec(lines[i])
+    if (!m) continue
+    const [, dash, , delim] = m
+    const body = []
+    let j = i + 1
+    for (; j < lines.length; j++) {
+      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
+      if (candidate === delim) break
+      body.push(lines[j])
+    }
+    if (j >= lines.length) continue          // never terminated: not a payload anyone can read
+    out.push(body.join('\n'))
+    i = j
+  }
+  return out
 }
 
 /**
@@ -154,9 +189,14 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
       try { body = readFile(file) } catch { body = null }
     }
     if (body === null) body = bodyArg(words)
-    // A heredoc reaches `--body-file -`; its text is in the command and nowhere else, so that one
-    // case reads the command rather than losing the body entirely.
-    if (body === null && file === '-') body = cmd
+    // A heredoc reaches `--body-file -`; its text is in the command and nowhere else. Reading the
+    // whole command for it was the title bypass again one case over — a `Parent:` line in a
+    // title-side heredoc satisfied a check about the body — so the payload is extracted, and an
+    // ambiguous command is blocked rather than guessed at.
+    if (body === null && file === '-') {
+      const docs = heredocs(cmd)
+      body = docs.length === 1 ? docs[0] : null
+    }
 
     if (body === null) return { blocked: true, detail: 'no body could be read from the command' }
     if (!hasParent(body) && !hasStandalone(body)) return { blocked: true, detail: 'the body names no parent' }

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,0 +1,165 @@
+import fs from 'node:fs'
+import { proseLines } from './prose-lines.mjs'
+
+/**
+ * Does an issue split out of other work name what it came from?
+ *
+ * **The decision lives here rather than in the hook's shell**, because the first version was shell
+ * and three of its four rules were wrong in the same way: they matched text anywhere in the command
+ * instead of parsing anything. `gh issue new` — an undocumented alias that works — went straight
+ * through, so did `GH_REPO=o/r gh issue create`, `-F "issue body.md"` read the file `issue`, and
+ * `Parent: #607` in a `--title` satisfied a gate about bodies.
+ *
+ * It also means this repo stops keeping a third, weaker copy of "which lines of a markdown body
+ * count". `check-changeset.mjs` already had `proseLines`, whose own comment warns that a second copy
+ * is how the guard drifts. Both markers here are switches that turn a gate **off**, so a body that
+ * merely quotes one must not trip it — the same rule, now shared rather than re-derived.
+ */
+
+/**
+ * Split a shell command into words the way the shell would, enough for this job: single quotes are
+ * literal, double quotes group, a backslash escapes the next character.
+ *
+ * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and the
+ * caller treats an unresolvable body as "no parent found" — which fails toward blocking, which for a
+ * cooperative agent costs one line and for a wrong guess costs nothing.
+ */
+export function tokenize(cmd) {
+  const out = []
+  let cur = ''
+  let started = false
+  let quote = null
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]
+    if (quote === "'") {
+      if (c === "'") quote = null
+      else cur += c
+      continue
+    }
+    if (quote === '"') {
+      if (c === '"') quote = null
+      else if (c === '\\' && i + 1 < cmd.length && '"\\$`'.includes(cmd[i + 1])) cur += cmd[++i]
+      else cur += c
+      continue
+    }
+    if (c === "'" || c === '"') { quote = c; started = true; continue }
+    if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue }
+    if (/\s/.test(c)) {
+      if (started || cur) out.push(cur)
+      cur = ''
+      started = false
+      continue
+    }
+    cur += c
+    started = true
+  }
+  if (started || cur) out.push(cur)
+  return out
+}
+
+/** `FOO=bar`, the form that let `GH_REPO=o/r gh issue create` past a matcher anchored on `gh`. */
+const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+/** Wrappers that keep the next word in command position. */
+const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time'])
+
+/** Separators after which a new command begins. */
+const SEPARATOR = new Set([';', '&&', '||', '|', '&', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
+
+/**
+ * Every `gh issue create` (or `new`) in the command, as the token slice that starts at `gh`.
+ *
+ * Command position is tracked rather than pattern-matched, so this repo's own docs — which print
+ * `gh issue create` inside prose and inside `echo` — do not trip it, while the wrapped and prefixed
+ * forms do.
+ */
+export function issueCreateInvocations(cmd) {
+  const words = tokenize(cmd)
+  const found = []
+  let atStart = true
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (SEPARATOR.has(w)) { atStart = true; continue }
+    if (!atStart) continue
+    let j = i
+    while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
+    if (words[j] === 'gh' && words[j + 1] === 'issue' && (words[j + 2] === 'create' || words[j + 2] === 'new')) {
+      found.push(words.slice(j))
+    }
+    atStart = false
+  }
+  return found
+}
+
+/** The `--body-file` / `-F` argument, quoting resolved. `-` means stdin, which is not a path. */
+export function bodyFileArg(words) {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === '--body-file' || words[i] === '-F') return words[i + 1] ?? null
+    const eq = /^--body-file=(.*)$/.exec(words[i])
+    if (eq) return eq[1]
+  }
+  return null
+}
+
+/** The `--body` / `-b` argument, quoting resolved. */
+export function bodyArg(words) {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === '--body' || words[i] === '-b') return words[i + 1] ?? null
+    const eq = /^--body=(.*)$/.exec(words[i])
+    if (eq) return eq[1]
+  }
+  return null
+}
+
+/**
+ * `Parent: #607` on a line of its own.
+ *
+ * Anchored, because the point of the rule is that a checklist can be regenerated from it. Prose that
+ * happens to contain the words — "raised by the review of #647" was the measured case — is exactly
+ * what the gate exists to reject, and an unanchored match accepted a sentence with `Parent:` in the
+ * middle of it just as readily.
+ */
+export function hasParent(body) {
+  for (const { line } of proseLines(body, { skipFrontmatter: true })) {
+    if (/^Parent:\s*[A-Za-z0-9_.\/-]*#\d+\s*$/.test(line)) return true
+  }
+  return false
+}
+
+/** `<!-- standalone: reason -->`, and the reason has to say something. An empty one is the marker
+ *  without the part that makes it a decision. */
+export function hasStandalone(body) {
+  for (const { line } of proseLines(body, { skipFrontmatter: true })) {
+    const m = /^<!--\s*standalone:\s*(.*?)\s*-->$/.exec(line)
+    if (m && m[1]) return true
+  }
+  return false
+}
+
+/**
+ * @param {string} cmd the Bash command the tool was asked to run
+ * @param {(p: string) => string} [readFile] injected for the tests
+ * @returns {{ blocked: boolean, detail?: string }}
+ */
+export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
+  const invocations = issueCreateInvocations(cmd)
+  if (invocations.length === 0) return { blocked: false }
+
+  for (const words of invocations) {
+    // **Only the body is consulted.** `haystack = the whole command` let a `--title` satisfy a rule
+    // about bodies, which is the gate agreeing with itself rather than with the issue.
+    let body = null
+    const file = bodyFileArg(words)
+    if (file && file !== '-') {
+      try { body = readFile(file) } catch { body = null }
+    }
+    if (body === null) body = bodyArg(words)
+    // A heredoc reaches `--body-file -`; its text is in the command and nowhere else, so that one
+    // case reads the command rather than losing the body entirely.
+    if (body === null && file === '-') body = cmd
+
+    if (body === null) return { blocked: true, detail: 'no body could be read from the command' }
+    if (!hasParent(body) && !hasStandalone(body)) return { blocked: true, detail: 'the body names no parent' }
+  }
+  return { blocked: false }
+}

--- a/scripts/lib/prose-lines.mjs
+++ b/scripts/lib/prose-lines.mjs
@@ -1,0 +1,36 @@
+/**
+ * The lines of a markdown body that are actually prose: no fenced block, no indented block, and
+ * — with `skipFrontmatter` — nothing inside the leading `---` delimiters.
+ *
+ * Shared on purpose. Both markers below are switches that turn a gate OFF, so a body that merely
+ * QUOTES one must not trip it; every doc in this repo prints both verbatim. `extractReason` had
+ * this guard and `parseBackfills` was written without it, which is exactly the kind of drift a
+ * second copy invites.
+ */
+export function* proseLines(body, { skipFrontmatter = false } = {}) {
+  const lines = body.split(/\r?\n/)
+  let i = 0
+  if (skipFrontmatter && lines[0]?.trim() === '---') {
+    i = 1
+    while (i < lines.length && lines[i].trim() !== '---') i++
+    i++                                            // step past the closing delimiter
+  }
+  let fence = null
+  for (; i < lines.length; i++) {
+    const raw = lines[i]
+    const line = raw.trim()
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(raw)
+    if (fence) {
+      if (marker && marker[1][0] === fence.char && marker[1].length >= fence.length && !marker[2].trim()) {
+        fence = null
+      }
+      continue
+    }
+    if (marker && (marker[1][0] === '~' || !marker[2].includes('`'))) {
+      fence = { char: marker[1][0], length: marker[1].length }
+      continue
+    }
+    if (/^ {4,}|^\t/.test(raw)) continue           // indented code block
+    yield { raw, line }
+  }
+}


### PR DESCRIPTION
## Summary

Nine issues in one day, from three PRs on one feature (#607). That is arithmetic rather than
accident: two or three review channels per PR, a cap of four or five findings each, and a `later`
rate of about a third — a cap on findings with no cap on deferrals. Two of the nine were closed
within the hour as things that should never have been filed, and none of them named the issue they
came from, so "is #607 finished?" had no answer.

Three changes, none of which is remembering harder:

- `AGENTS.md` — a reviewer's now/later is an input, not a verdict. Every `later` is re-graded against
  the existing ten-line rule.
- `contributing/adversarial-review.md` — the reviewer prompt carries a `later` budget of two per
  channel, each justified against that rule.
- `.claude/hooks/issue-parent-gate.sh` — `gh issue create` needs a `Parent: #N` line or an explicit
  `<!-- standalone: reason -->`. A prose mention is not enough: nothing can build a checklist from it.

## Checklist

- [ ] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first
- [x] No sensitive info (tokens, paths, credentials)

Tests: unchecked on purpose. The hook has none — the ten-row decision table in the review record was
run by hand, like the other hooks in that directory. Named there rather than implied.

## Related `.work/` docs

`.work/reviews/chore__deferral-gate.md`. **No independent channel reviewed this**, and the record
says so rather than implying one did. Self-verification did find one real false positive first:
`gh issue create --body-file` puts the body outside the command string, so a correctly-filed issue
was blocked by a message about a line its body already had.

<!-- no-changeset: repo process and tooling only, no published source -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for issue creation to ensure each issue includes a parent issue reference or an explicit standalone marker.
  * Issue creation is blocked with guidance when required information is missing.
  * Validation supports common command formats and issue bodies supplied through files or heredocs.

* **Documentation**
  * Updated contribution and review guidance to limit deferred findings, require justifications, and include parent references for related issues.

* **Tests**
  * Added comprehensive coverage for validation, command handling, and bypass prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->