### PR TITLE
test(dashboard): cover reset mode across agent changes

### DIFF
--- a/packages/dashboard/src/__tests__/QASession.reset.test.tsx
+++ b/packages/dashboard/src/__tests__/QASession.reset.test.tsx
@@ -69,6 +69,15 @@ const ANDROID_AGENTS: SessionInfo[] = [{
   capabilities: ['clipboard'],
   devices: [device('dev-a', 'Pixel 7', 'android')],
 }]
+const MIXED_CAPABILITY_AGENTS: SessionInfo[] = [
+  ...AGENTS,
+  {
+    agentName: 'legacy-mac',
+    platform: 'ios',
+    capabilities: ['clipboard'],
+    devices: [device('dev-c', 'iPhone 14')],
+  },
+]
 
 /** The breadcrumb is rendered by the layout, outside QASession — and once a session is open it is
  *  the only way back to the Mac list, which is the path this issue is about. */
@@ -171,6 +180,18 @@ describe('QASession — Full reset applies to exactly one pick (#439)', () => {
 
     await user.click(screen.getByText('Pixel 7'))
     expect(viewerMounts).toEqual([{ deviceId: 'dev-a', resetMode: 'app-only' }])
+  })
+
+  it('does not carry an armed full reset to an agent that lacks the capability', async () => {
+    const user = userEvent.setup()
+    await openDeviceList(user, MIXED_CAPABILITY_AGENTS)
+
+    await user.click(screen.getByRole('switch'))
+    await user.click(screen.getByRole('button', { name: '← All Macs' }))
+    await user.click(screen.getByText('legacy-mac'))
+    await user.click(screen.getByText('iPhone 14'))
+
+    expect(viewerMounts).toEqual([{ deviceId: 'dev-c', resetMode: 'app-only' }])
   })
 
   it('mounts a fresh viewer per pick — the per-mount reset guard depends on it', async () => {

--- a/packages/dashboard/src/__tests__/QASession.reset.test.tsx
+++ b/packages/dashboard/src/__tests__/QASession.reset.test.tsx
@@ -178,6 +178,8 @@ describe('QASession — Full reset applies to exactly one pick (#439)', () => {
 
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 
+    // This only pins Android's default mount; the armed capability guard is covered by the
+    // mixed-agent case below.
     await user.click(screen.getByText('Pixel 7'))
     expect(viewerMounts).toEqual([{ deviceId: 'dev-a', resetMode: 'app-only' }])
   })


### PR DESCRIPTION
## Summary

Adds dashboard integration coverage for Full reset across an agent change.

The test arms Full reset on a capable Mac, returns to the Mac list without selecting a device, then selects an agent without `full-reset`. It verifies the viewer receives `resetMode: 'app-only'`, preventing an armed destructive reset from carrying across agents.

<!-- no-changeset: test-only coverage for #608 -->
closes #608 
## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first — not applicable
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/2026-08-27-dashboard-reset-integration-608-plan.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a device without full-reset support now automatically limits an armed reset to an app-only reset.
  * Prevents unsupported full resets from being initiated.
  * Improves reset handling across devices with different reset capabilities, helping ensure that only supported reset options are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->