### PR TITLE
test(scripts): guard dashboard capability consumers

### DIFF
--- a/scripts/__tests__/agentCapabilityConsumers.test.mjs
+++ b/scripts/__tests__/agentCapabilityConsumers.test.mjs
@@ -14,7 +14,7 @@ function withoutComments(text) {
 }
 
 function stringLiterals(text) {
-  return [...text.matchAll(/'([^']+)'/g)].map((match) => match[1])
+  return [...text.matchAll(/(['"])([^\r\n]*?)\1/g)].map((match) => match[2])
 }
 
 function agentCapabilities(text) {
@@ -23,14 +23,18 @@ function agentCapabilities(text) {
   return new Set(stringLiterals(match[1]))
 }
 
+const capabilityCheck = /\b(?:agentCapabilities|(?:\w+\??\.)?capabilities)\??\.includes\(\s*(['"])([^\r\n]*?)\1\s*\)/g
+
+function capabilityChecks(text) {
+  return [...withoutComments(text).matchAll(capabilityCheck)].map((match) => match[2])
+}
+
 function dashboardCapabilityConsumers() {
   const consumers = []
-  const capabilityCheck = /\b(?:agentCapabilities|(?:\w+\??\.)?capabilities)\??\.includes\(\s*'([^']+)'\s*\)/g
 
   for (const file of sources('packages/dashboard')) {
-    const source = withoutComments(readFileSync(join(root, file), 'utf8'))
-    for (const match of source.matchAll(capabilityCheck)) {
-      consumers.push({ file, capability: match[1] })
+    for (const capability of capabilityChecks(readFileSync(join(root, file), 'utf8'))) {
+      consumers.push({ file, capability })
     }
   }
 
@@ -38,6 +42,14 @@ function dashboardCapabilityConsumers() {
 }
 
 describe('dashboard capability consumers', () => {
+  it('reports undeclared double-quoted capability checks', () => {
+    const declared = agentCapabilities(agentCore)
+    const consumers = capabilityChecks('agentCapabilities.includes("full-erase")')
+
+    expect(consumers).toEqual(['full-erase'])
+    expect(consumers.filter((capability) => !declared.has(capability))).toEqual(['full-erase'])
+  })
+
   it('only checks capabilities AgentCapability declares', () => {
     const declared = agentCapabilities(agentCore)
     const consumers = dashboardCapabilityConsumers()

--- a/scripts/__tests__/agentCapabilityConsumers.test.mjs
+++ b/scripts/__tests__/agentCapabilityConsumers.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { sources } from './sourceFiles.mjs'
+
+const root = join(import.meta.dirname, '../..')
+const agentCore = readFileSync(join(root, 'packages/agent-core/src/types.ts'), 'utf8')
+
+function withoutComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+    .replace(/\s*\/\/.*$/gm, '')
+}
+
+function stringLiterals(text) {
+  return [...text.matchAll(/'([^']+)'/g)].map((match) => match[1])
+}
+
+function agentCapabilities(text) {
+  const match = withoutComments(text).match(/export type AgentCapability\s*=\s*([\s\S]*?)(?=\n\s*\n)/)
+  expect(match, 'AgentCapability union did not parse').not.toBeNull()
+  return new Set(stringLiterals(match[1]))
+}
+
+function dashboardCapabilityConsumers() {
+  const consumers = []
+  const capabilityCheck = /\b(?:agentCapabilities|(?:\w+\??\.)?capabilities)\??\.includes\(\s*'([^']+)'\s*\)/g
+
+  for (const file of sources('packages/dashboard')) {
+    const source = withoutComments(readFileSync(join(root, file), 'utf8'))
+    for (const match of source.matchAll(capabilityCheck)) {
+      consumers.push({ file, capability: match[1] })
+    }
+  }
+
+  return consumers
+}
+
+describe('dashboard capability consumers', () => {
+  it('only checks capabilities AgentCapability declares', () => {
+    const declared = agentCapabilities(agentCore)
+    const consumers = dashboardCapabilityConsumers()
+
+    // An empty list proves no consumer was scanned, not that consumers agree. The cardinality also
+    // catches a narrower matcher that loses one of the current selector/viewer forms.
+    expect(consumers).toHaveLength(3)
+
+    const unknown = consumers.filter(({ capability }) => !declared.has(capability))
+    expect(unknown).toEqual([])
+  })
+})

--- a/scripts/__tests__/agentCapabilityConsumers.test.mjs
+++ b/scripts/__tests__/agentCapabilityConsumers.test.mjs
@@ -23,6 +23,8 @@ function agentCapabilities(text) {
   return new Set(stringLiterals(match[1]))
 }
 
+// This spelling floor only sees direct literal checks: aliases, constants, and template literals are
+// deliberately outside its scope, so it is not a whole-program capability-consumer fence.
 const capabilityCheck = /\b(?:agentCapabilities|(?:\w+\??\.)?capabilities)\??\.includes\(\s*(['"])([^\r\n]*?)\1\s*\)/g
 
 function capabilityChecks(text) {
@@ -44,10 +46,10 @@ function dashboardCapabilityConsumers() {
 describe('dashboard capability consumers', () => {
   it('reports undeclared double-quoted capability checks', () => {
     const declared = agentCapabilities(agentCore)
-    const consumers = capabilityChecks('agentCapabilities.includes("full-erase")')
+    const consumers = capabilityChecks('agentCapabilities.includes("undeclared-capability")')
 
-    expect(consumers).toEqual(['full-erase'])
-    expect(consumers.filter((capability) => !declared.has(capability))).toEqual(['full-erase'])
+    expect(consumers).toEqual(['undeclared-capability'])
+    expect(consumers.filter((capability) => !declared.has(capability))).toEqual(['undeclared-capability'])
   })
 
   it('only checks capabilities AgentCapability declares', () => {


### PR DESCRIPTION
## Summary

Adds a source-based guard for dashboard capability checks.

The guard reads `AgentCapability` from agent-core and verifies that every dashboard `capabilities.includes(...)` / `agentCapabilities.includes(...)` literal is declared by that producer contract. This catches a renamed capability such as `full-reset` drifting to `full-erase`.

closes #609 
## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first — not applicable
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/2026-08-27-agent-capability-consumers-609-plan.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced automated validation for dashboard capability checks using both single- and double-quoted values.
  * Added coverage to detect undeclared capabilities consistently across supported formats.
  * Continued verifying that dashboard consumers reference only declared agent capabilities and that the expected number of consumers remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->