### PR TITLE
chore(release): verify a publish by polling the registry, not by asking npm view

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -187,7 +187,10 @@ model: claude-opus-4-8
     missing=""; stale=""
     while read -r name ver; do
       [ -n "$name" ] || continue
-      doc=$(curl -sf "https://registry.npmjs.org/$(printf '%s' "$name" | sed 's|/|%2f|')") \
+      # `--max-time`, because a stalled request has no limit of its own and the deadline is only
+    # checked between rounds — one hung connection and the poll never reaches it again. A timeout
+    # is just this round failing for that package; the next round retries it.
+    doc=$(curl -sf --max-time 30 "https://registry.npmjs.org/$(printf '%s' "$name" | sed 's|/|%2f|')") \
         || { missing="$missing $name@$ver(no document)"; continue; }
       got=$(printf '%s' "$doc" | python3 -c 'import json,sys
   d = json.load(sys.stdin); v = sys.argv[1]
@@ -208,7 +211,10 @@ model: claude-opus-4-8
       exit 1
     fi
     echo "[$(date +%H:%M:%S)] waiting:$missing$stale"
-    sleep 30
+    # Never sleep past the deadline: with a short PUBLISH_TIMEOUT a fixed sleep is what decides
+    # when the check gives up, instead of the deadline doing it.
+    nap=$(( deadline - $(date +%s) )); [ "$nap" -gt 30 ] && nap=30
+    sleep "$nap"
   done
   ```
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -153,4 +153,77 @@ model: claude-opus-4-8
 - `git push origin vX.Y.Z`
 - 워크플로우가 처리하는 것: `pnpm build` → `changeset publish`(공개 패키지 전부, 단일 경로) → GitHub Release 생성. changesets publish는 위상 정렬 없이 동시 발행하므로, 신규 패키지가 있으면 위 7번의 seed publish 전제를 반드시 지킨다.
 - npm 인증은 **GitHub OIDC(trusted publishing)** 로 동작한다 — NPM_TOKEN 등 별도 토큰이 필요 없다.
-- 발행 확인: Actions의 Release 워크플로우 `success`, `npm view tapflow version`, GitHub Releases 페이지.
+- **발행 확인은 폴링이고, 레지스트리를 직접 읽는다.** v0.20.0에서 예전 확인 셋이 **전부 참이면서 릴리즈는
+  설치 불가**였다. 워크플로우 로그는 9개 전부 `published successfully`라고 말했고, 그 시점에 둘은 13분 뒤에야
+  나타났다 — 로그는 npm API가 받아들였다는 뜻이지 레지스트리가 서빙한다는 뜻이 아니다. `npm view`는 CDN 캐시를
+  읽어, `ios-agent`가 레지스트리 문서에 이미 들어간 뒤에도 `0.19.0`을 돌려줬다. GitHub Releases 페이지는 npm에
+  대해 아무 말도 하지 않는다. 게다가 `tapflow` 하나만 봤다 — 9개 중 1개고, 그게 가장 느린 축이었던 건 운이다.
+
+  측정된 반영 시차: 7개 즉시, `ios-agent` 약 1분, `tapflow`·`relay` **약 13분**. 늦은 셋이 가장 큰
+  것들이다 — `relay`는 빌드된 대시보드를, `ios-agent`는 notarized 시스템 확장을 품는다.
+
+  ```sh
+  set -o pipefail
+  # 최신 태그를 버전 순으로 고른다. `git describe`는 HEAD 기준으로 답하므로, 다른 세션이
+  # 낡은 브랜치를 체크아웃해 두었으면 직전 릴리즈를 고르고 조용히 그것을 검증한다.
+  tag=${1:-$(git tag -l 'v*' --sort=-v:refname | head -1)}
+  deadline=$(( $(date +%s) + ${PUBLISH_TIMEOUT:-1200} ))
+
+  # 이름과 기대 버전을 태그에서 읽는다. 작업 트리가 릴리즈 커밋에 있으리란 보장이 없고
+  # (다른 세션이 브랜치를 바꿔둘 수 있다), 릴리즈에 버전선이 하나라는 보장도 없다 —
+  # v0.20.0에서 audiotap-helper는 0.3.1이었다.
+  want=$(git ls-tree -r --name-only "$tag" -- packages 2>/dev/null \
+    | grep -E '^packages/[^/]+/package\.json$' \
+    | while read -r f; do
+        git show "$tag:$f" | python3 -c 'import json,sys
+  d = json.load(sys.stdin)
+  if not d.get("private"): print(d["name"], d["version"])'
+      done)
+  n=$(printf '%s' "$want" | grep -c .)
+  [ "$n" -ge 2 ] || { echo "found $n published package(s) at $tag — refusing to report on that"; exit 1; }
+  echo "verifying $n packages from $tag"
+
+  while :; do
+    missing=""; stale=""
+    while read -r name ver; do
+      [ -n "$name" ] || continue
+      doc=$(curl -sf "https://registry.npmjs.org/$(printf '%s' "$name" | sed 's|/|%2f|')") \
+        || { missing="$missing $name@$ver(no document)"; continue; }
+      got=$(printf '%s' "$doc" | python3 -c 'import json,sys
+  d = json.load(sys.stdin); v = sys.argv[1]
+  print(("ok" if d.get("dist-tags",{}).get("latest") == v else "latest=" + str(d.get("dist-tags",{}).get("latest"))) if v in d.get("versions",{}) else "absent")' "$ver") \
+        || { missing="$missing $name@$ver(unreadable)"; continue; }
+      case "$got" in
+        ok) ;;
+        absent) missing="$missing $name@$ver" ;;
+        *)     stale="$stale $name@$ver($got)" ;;
+      esac
+    done <<EOF
+  $want
+  EOF
+    [ -n "$missing$stale" ] || { echo "all $n packages published, and latest points at them"; break; }
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      [ -n "$missing" ] && echo "DEADLINE — never appeared:$missing"
+      [ -n "$stale" ] && echo "DEADLINE — published but latest points elsewhere:$stale (checking the wrong tag?)"
+      exit 1
+    fi
+    echo "[$(date +%H:%M:%S)] waiting:$missing$stale"
+    sleep 30
+  done
+  ```
+
+  세 가지를 일부러 이렇게 했다:
+
+  - **`versions`에 있는 것과 `dist-tags.latest`가 그것을 가리키는 것은 다르다.** `npm install tapflow`는
+    latest를 가져가므로 둘 다 본다. 메시지도 둘을 나눈다 — `absent`는 아직 안 올라온 것이고,
+    `latest=…`는 올라왔는데 latest가 딴 데를 가리키는 것이라 **엉뚱한 태그를 검증 중**이라는 뜻일 때가 많다.
+  - **기대 버전은 작업 트리가 아니라 태그에서 읽는다.** 다른 세션이 낡은 브랜치를 체크아웃해 둘 수 있다. 이걸
+    짜면서 실제로 그 상태였고, 트리에서 읽던 판은 `0.19.0`을 기대하며 영원히 기다렸다. 그리고 릴리즈에
+    버전선이 하나라는 보장이 없다 — v0.20.0에서 `audiotap-helper`는 `0.3.1`이었으므로 버전은 패키지마다
+    자기 매니페스트에서 읽는다.
+  - **태그는 버전 순으로 고르지, `git describe`로 고르지 않는다.** `describe`는 HEAD 기준으로 답한다.
+    같은 낡은 브랜치에서 그것이 `v0.19.0`을 골랐고, 검사는 직전 릴리즈를 조용히 검증할 뻔했다.
+
+  일부러 깨뜨려 재봤다: 없는 태그 → 바닥 판정으로 exit 1, 낡은 태그 → `latest points elsewhere`로 exit 1,
+  없는 패키지 → `no document`, 발행된 적 없는 버전 → `absent`. 정상 실행은 `all 9 packages published,
+  and latest points at them`으로 exit 0.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -190,7 +190,16 @@ model: claude-opus-4-8
       # `--max-time`, because a stalled request has no limit of its own and the deadline is only
     # checked between rounds — one hung connection and the poll never reaches it again. A timeout
     # is just this round failing for that package; the next round retries it.
-    doc=$(curl -sf --max-time 30 "https://registry.npmjs.org/$(printf '%s' "$name" | sed 's|/|%2f|')") \
+    #
+    # Bounded by what is left rather than a flat 30s: nine stalled packages at 30s each is a
+    # 270-second round, and the deadline cannot govern a round it is only consulted after. When
+    # nothing is left, the package is recorded as unchecked rather than skipped — skipping it
+    # silently would let a round end with an empty pending list and announce success for packages
+    # no request was ever made about.
+    left=$(( deadline - $(date +%s) ))
+    if [ "$left" -le 0 ]; then missing="$missing $name@$ver(unchecked, deadline)"; continue; fi
+    [ "$left" -gt 30 ] && left=30
+    doc=$(curl -sf --max-time "$left" "https://registry.npmjs.org/$(printf '%s' "$name" | sed 's|/|%2f|')") \
         || { missing="$missing $name@$ver(no document)"; continue; }
       got=$(printf '%s' "$doc" | python3 -c 'import json,sys
   d = json.load(sys.stdin); v = sys.argv[1]


### PR DESCRIPTION
## Summary

`/release` step 11 confirmed a publish with three things that were **all true during v0.20.0 while two packages were not installable**: the workflow log (which reports what npm's API accepted — `tapflow` and `@tapflowio/relay` appeared ~13 minutes later), `npm view` (which reads a CDN cache, and returned `0.19.0` for `ios-agent` after the registry document already carried `0.20.0`), and the Releases page (which says nothing about npm). Only `tapflow` was checked, one of nine; that it was among the slowest was luck.

Replaced with a poll that reads `registry.npmjs.org` directly and holds every published package to two conditions — the version exists, and `latest` points at it. `npm install` takes `latest`, so both matter, and they are reported apart: `absent` means not up yet, `latest=…` usually means the wrong tag is being verified.

Two defects surfaced while writing it, both caught by the check's own message and both the same class as the one it exists for — deriving from what is at hand rather than from what is being released. Expectations now come from the tag rather than the working tree, and the tag is chosen by version order rather than `git describe`, which answers relative to HEAD. Versions are read per package, since a release need not have one version line — `audiotap-helper` was `0.3.1` in v0.20.0.

Verified by breaking it four ways rather than by reading it; the table is in the review record, and the snippet was extracted verbatim from the committed markdown and run.

## Checklist

- [x] Tests written and passing — docs-only; the snippet was executed against four induced failures and the normal path
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/chore__release-publish-verification.md` — review skipped (docs-only), with the four break tests, the two defects found while writing it, and the v0.20.0 measurements behind the change.

<!-- no-changeset: no published source changed — `pnpm changeset:check` reports "No published source changed" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification by checking the package registry directly.
  * Selects the latest version tag reliably and validates published package names and versions.
  * Detects missing, outdated, or stale package releases.
  * Retries verification within defined time limits and distinguishes unpublished releases from delayed updates.
  * Provides more detailed error information when publication verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->