### PR TITLE
fix(cli): use resolved TLS host in agent instructions

### DIFF
--- a/.changeset/brisk-agents-connect.md
+++ b/.changeset/brisk-agents-connect.md
@@ -1,0 +1,5 @@
+---
+"tapflow": patch
+---
+
+TLS startup instructions now use the certificate-resolved hostname for remote agent connections instead of leaving a misleading host placeholder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **TLS startup instructions now use the certificate-resolved hostname for remote agent connections** ([#627](https://github.com/jo-duchan/tapflow/issues/627)).
+- **TLS startup instructions now use the certificate-resolved hostname for remote agent connections** ([#627](https://github.com/jo-duchan/tapflow/issues/627)). HTTP and local fallback paths intentionally retain the host placeholder because an agent running on another Mac must not be directed to `localhost`.
 
 ## [0.20.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TLS startup instructions now use the certificate-resolved hostname for remote agent connections** ([#627](https://github.com/jo-duchan/tapflow/issues/627)).
+
 ## [0.20.0] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -27,6 +27,14 @@ import { RatholeTunnel } from '../../lib/rathole-tunnel.js'
 import { TailscaleTunnel } from '../../lib/tailscale-tunnel.js'
 import { cmdRelayStart } from '../../commands/relay-start.js'
 
+function agentConnectLine(output: string[]): string {
+  const start = output.findIndex((entry) => entry.includes('tapflow agent start --relay'))
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = output.findIndex((entry, index) => index >= start && entry.includes('--token <agent-PAT>'))
+  expect(end).toBeGreaterThanOrEqual(start)
+  return output.slice(start, end + 1).join(' ')
+}
+
 describe('cmdRelayStart', () => {
   let output: string[]
   let exitSpy: MockInstance
@@ -115,6 +123,42 @@ describe('cmdRelayStart', () => {
 
     expect(resolveRelayDisplayHost).toHaveBeenCalledWith(config.tls, 'CERT', expect.any(Function))
     expect(output.join('\n')).toContain('https://relay.example.com:4000')
+  })
+
+  it('TLS agent-connect 안내에 인증서 host를 사용', async () => {
+    vi.mocked(config).tls = { mode: 'import-cert', certPath: '/cert.pem', keyPath: '/key.pem' }
+    vi.mocked(createCertProvider).mockReturnValue({
+      ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
+    } as never)
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue('relay.example.com')
+
+    await cmdRelayStart({ port: 4321 })
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('wss://relay.example.com:4321')
+    expect(line).not.toContain('<host>')
+  })
+
+  it('HTTP agent-connect 안내는 host placeholder를 유지', async () => {
+    await cmdRelayStart({})
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('ws://<host>:4000')
+    expect(line).not.toContain('ws://localhost:4000')
+  })
+
+  it('TLS host가 localhost로 fallback되면 agent-connect 안내는 placeholder를 유지', async () => {
+    vi.mocked(config).tls = { mode: 'import-cert', certPath: '/cert.pem', keyPath: '/key.pem' }
+    vi.mocked(createCertProvider).mockReturnValue({
+      ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
+    } as never)
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue('localhost')
+
+    await cmdRelayStart({})
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('wss://<host>:4000')
+    expect(line).not.toContain('wss://localhost:4000')
   })
 
   it('Connect Mac agents 안내에 --token PAT와 발급처가 포함됨', async () => {

--- a/packages/cli/src/__tests__/commands/relay-start.test.ts
+++ b/packages/cli/src/__tests__/commands/relay-start.test.ts
@@ -147,18 +147,18 @@ describe('cmdRelayStart', () => {
     expect(line).not.toContain('ws://localhost:4000')
   })
 
-  it('TLS host가 localhost로 fallback되면 agent-connect 안내는 placeholder를 유지', async () => {
+  it.each(['localhost', 'Localhost'])('TLS host가 %s로 fallback되면 agent-connect 안내는 placeholder를 유지', async (displayHost) => {
     vi.mocked(config).tls = { mode: 'import-cert', certPath: '/cert.pem', keyPath: '/key.pem' }
     vi.mocked(createCertProvider).mockReturnValue({
       ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
     } as never)
-    vi.mocked(resolveRelayDisplayHost).mockReturnValue('localhost')
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue(displayHost)
 
     await cmdRelayStart({})
 
     const line = agentConnectLine(output)
     expect(line).toContain('wss://<host>:4000')
-    expect(line).not.toContain('wss://localhost:4000')
+    expect(line).not.toContain(`wss://${displayHost}:4000`)
   })
 
   it('Connect Mac agents 안내에 --token PAT와 발급처가 포함됨', async () => {

--- a/packages/cli/src/__tests__/commands/start.test.ts
+++ b/packages/cli/src/__tests__/commands/start.test.ts
@@ -32,6 +32,14 @@ import { cmdStart } from '../../commands/start.js'
 
 const mockExecSync = vi.mocked(execSync)
 
+function agentConnectLine(output: string[]): string {
+  const start = output.findIndex((entry) => entry.includes('tapflow agent start --relay'))
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = output.findIndex((entry, index) => index >= start && entry.includes('--token <agent-PAT>'))
+  expect(end).toBeGreaterThanOrEqual(start)
+  return output.slice(start, end + 1).join(' ')
+}
+
 function testHasAdb(): boolean {
   try {
     return String(mockExecSync('which adb', { encoding: 'utf8', stdio: 'pipe' })).trim().length > 0
@@ -122,6 +130,64 @@ describe('cmdStart', () => {
 
     expect(resolveRelayDisplayHost).toHaveBeenCalledWith(config.tls, 'CERT', expect.any(Function))
     expect(output.join('\n')).toContain('https://relay.example.com:4000')
+  })
+
+  it('TLS relay-only agent-connect 안내에 인증서 host를 사용', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockExecSync.mockImplementation((cmd) => {
+      if ((cmd as string) === 'which adb') throw new Error('not found')
+      return ''
+    })
+    vi.mocked(config).tls = { mode: 'import-cert', certPath: '/cert.pem', keyPath: '/key.pem' }
+    vi.mocked(createCertProvider).mockReturnValue({
+      ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
+    } as never)
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue('relay.example.com')
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
+
+    await cmdStart({})
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('wss://relay.example.com:4000')
+    expect(line).not.toContain('<this-ip>')
+  })
+
+  it('HTTP relay-only agent-connect 안내는 host placeholder를 유지', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockExecSync.mockImplementation((cmd) => {
+      if ((cmd as string) === 'which adb') throw new Error('not found')
+      return ''
+    })
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
+
+    await cmdStart({})
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('ws://<this-ip>:4000')
+    expect(line).not.toContain('ws://localhost:4000')
+  })
+
+  it('TLS host가 localhost로 fallback되면 relay-only agent-connect 안내는 placeholder를 유지', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    mockExecSync.mockImplementation((cmd) => {
+      if ((cmd as string) === 'which adb') throw new Error('not found')
+      return ''
+    })
+    vi.mocked(config).tls = { mode: 'import-cert', certPath: '/cert.pem', keyPath: '/key.pem' }
+    vi.mocked(createCertProvider).mockReturnValue({
+      ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
+    } as never)
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue('localhost')
+    const output: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
+
+    await cmdStart({})
+
+    const line = agentConnectLine(output)
+    expect(line).toContain('wss://<this-ip>:4000')
+    expect(line).not.toContain('wss://localhost:4000')
   })
 
   it('macOS + adb 있으면 iOS와 Android 모두 연결', async () => {

--- a/packages/cli/src/__tests__/commands/start.test.ts
+++ b/packages/cli/src/__tests__/commands/start.test.ts
@@ -169,7 +169,7 @@ describe('cmdStart', () => {
     expect(line).not.toContain('ws://localhost:4000')
   })
 
-  it('TLS host가 localhost로 fallback되면 relay-only agent-connect 안내는 placeholder를 유지', async () => {
+  it.each(['localhost', 'Localhost'])('TLS host가 %s로 fallback되면 relay-only agent-connect 안내는 placeholder를 유지', async (displayHost) => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     mockExecSync.mockImplementation((cmd) => {
       if ((cmd as string) === 'which adb') throw new Error('not found')
@@ -179,7 +179,7 @@ describe('cmdStart', () => {
     vi.mocked(createCertProvider).mockReturnValue({
       ensureCert: vi.fn().mockResolvedValue({ cert: 'CERT', key: 'KEY' }),
     } as never)
-    vi.mocked(resolveRelayDisplayHost).mockReturnValue('localhost')
+    vi.mocked(resolveRelayDisplayHost).mockReturnValue(displayHost)
     const output: string[] = []
     vi.spyOn(console, 'log').mockImplementation((...args) => output.push(args.join(' ')))
 
@@ -187,7 +187,7 @@ describe('cmdStart', () => {
 
     const line = agentConnectLine(output)
     expect(line).toContain('wss://<this-ip>:4000')
-    expect(line).not.toContain('wss://localhost:4000')
+    expect(line).not.toContain(`wss://${displayHost}:4000`)
   })
 
   it('macOS + adb 있으면 iOS와 Android 모두 연결', async () => {

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -41,6 +41,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const httpScheme = tls ? 'https' : 'http'
   const wsScheme = tls ? 'wss' : 'ws'
+  const agentConnectHost = tls && displayHost !== 'localhost' ? displayHost : '<host>'
 
   const proxyWarning = proxyWithoutPublicUrlWarning(config)
   if (proxyWarning) warn(proxyWarning)
@@ -72,7 +73,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   banner('success', 'TAPFLOW RELAY READY', [
     `Relay  : ${httpScheme}://${displayHost}:${port}`,
     ...(publicUrl ? [`Public : ${publicUrl}`] : []),
-    `Connect Mac agents:  tapflow agent start --relay ${wsScheme}://<host>:${port} --token <agent-PAT>`,
+    `Connect Mac agents:  tapflow agent start --relay ${wsScheme}://${agentConnectHost}:${port} --token <agent-PAT>`,
     `  Issue an 'agent'-scope token in the dashboard (Settings → Tokens).`,
     'Press Ctrl+C to stop.',
   ])

--- a/packages/cli/src/commands/relay-start.ts
+++ b/packages/cli/src/commands/relay-start.ts
@@ -41,7 +41,7 @@ export async function cmdRelayStart(opts: RelayStartOptions): Promise<void> {
   }
   const httpScheme = tls ? 'https' : 'http'
   const wsScheme = tls ? 'wss' : 'ws'
-  const agentConnectHost = tls && displayHost !== 'localhost' ? displayHost : '<host>'
+  const agentConnectHost = tls && displayHost.toLowerCase() !== 'localhost' ? displayHost : '<host>'
 
   const proxyWarning = proxyWithoutPublicUrlWarning(config)
   if (proxyWarning) warn(proxyWarning)

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -58,7 +58,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
   }
   const httpScheme = tls ? 'https' : 'http'
   const wsScheme = tls ? 'wss' : 'ws'
-  const agentConnectHost = tls && displayHost !== 'localhost' ? displayHost : '<this-ip>'
+  const agentConnectHost = tls && displayHost.toLowerCase() !== 'localhost' ? displayHost : '<this-ip>'
   // The co-located agent connects over localhost; the agent accepts the domain cert there (see isLocalhostWss).
   const relayUrl = `${wsScheme}://localhost:${RELAY_PORT}`
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -58,6 +58,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
   }
   const httpScheme = tls ? 'https' : 'http'
   const wsScheme = tls ? 'wss' : 'ws'
+  const agentConnectHost = tls && displayHost !== 'localhost' ? displayHost : '<this-ip>'
   // The co-located agent connects over localhost; the agent accepts the domain cert there (see isLocalhostWss).
   const relayUrl = `${wsScheme}://localhost:${RELAY_PORT}`
 
@@ -83,7 +84,7 @@ export async function cmdStart(opts: StartOptions): Promise<void> {
       `Relay  : ${httpScheme}://${displayHost}:${RELAY_PORT}`,
       ...(publicUrl ? [`Public : ${publicUrl}`] : []),
       'No agent environment detected — running relay only.',
-      `Connect a Mac agent:  tapflow agent start --relay ${wsScheme}://<this-ip>:${RELAY_PORT} --token <agent-PAT>`,
+      `Connect a Mac agent:  tapflow agent start --relay ${wsScheme}://${agentConnectHost}:${RELAY_PORT} --token <agent-PAT>`,
       `  Issue an 'agent'-scope token in the dashboard (Settings → Tokens).`,
       'Press Ctrl+C to stop.',
     ])


### PR DESCRIPTION
## Summary

Use the resolved certificate hostname in remote-agent connection instructions when TLS has a concrete non-localhost identity. Both `tapflow start` and `tapflow relay start` keep their existing placeholders for HTTP and TLS localhost-fallback cases, so a remote Mac is never instructed to connect to `localhost`.

Focused start/relay command tests pass, along with typecheck, lint, changeset checks, and pre-commit. The full CLI suite on Windows reports 277 passed with 25 pre-existing platform-specific failures.

Closes #627

## Checklist

* [x] Tests written and passing
* [x] No `any`
* [x] Interface changes land in `agent-core` first — not applicable; no interface changes
* [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

* `.work/2026-08-28-agent-connect-host-plan.md`
* `.work/reviews/fix__627-agent-connect-host.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated TLS startup instructions to show the certificate-resolved hostname for remote agent connections.
  - Preserved placeholder host guidance for HTTP connections and local TLS setups.
  - Corrected connection hints in both standard and relay-only startup flows.
  - Improved hostname handling regardless of capitalization.

- **Documentation**
  - Added the fix to the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->