### PR TITLE
fix(hooks): read the review gate's branch from the checkout the session is in

### DIFF
--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -23,9 +23,15 @@ printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:s
 # record for that unrelated branch, referencing its own HEAD, satisfied the gate.
 #
 # Asked of git rather than tested with `[ -d ]`: a path that exists and is not a
-# work tree has to reach the fallback, not fail open past it.
+# work tree has to reach the fallback, not fail open past it. HEAD is asked for in
+# the same breath, because `--show-toplevel` alone succeeds on a repo with no
+# commits — and the `|| exit 0` further down would then turn the gate off for the
+# checkout the PR actually belongs to, rather than falling back to it. The empty
+# case is checked first: `git -C ""` runs against the hook's own directory, which
+# is nobody's checkout in particular.
 root=$(printf '%s' "$input" | jq -r '.cwd // ""')
-git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1 || root="${CLAUDE_PROJECT_DIR:-.}"
+[ -n "$root" ] && git -C "$root" rev-parse --show-toplevel HEAD >/dev/null 2>&1 \
+  || root="${CLAUDE_PROJECT_DIR:-.}"
 cd "$root" 2>/dev/null || exit 0
 # The record sits at the repo root, not beside wherever the shell happens to sit.
 top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0

--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -15,16 +15,31 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 # cooperative-but-forgetful agent, not an adversary.
 printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:space:]])(then|do)[[:space:]]+)gh[[:space:]]+pr[[:space:]]+create' || exit 0
 
-cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+# Where the session actually is, when that is a work tree; the project dir
+# otherwise. This used to read the project dir unconditionally, so a session
+# working in a git worktree -- the ordinary way to work while another session
+# holds the main checkout -- had its PR judged against whatever that checkout
+# happened to be on. Blocking is the harmless half; the other half is that a
+# record for that unrelated branch, referencing its own HEAD, satisfied the gate.
+#
+# Asked of git rather than tested with `[ -d ]`: a path that exists and is not a
+# work tree has to reach the fallback, not fail open past it.
+root=$(printf '%s' "$input" | jq -r '.cwd // ""')
+git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1 || root="${CLAUDE_PROJECT_DIR:-.}"
+cd "$root" 2>/dev/null || exit 0
+# The record sits at the repo root, not beside wherever the shell happens to sit.
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
 head=$(git rev-parse HEAD 2>/dev/null) || exit 0
-record=".work/reviews/${branch//\//__}.md"
+record="$top/.work/reviews/${branch//\//__}.md"
 
 if [ ! -f "$record" ]; then
   echo "Blocked: no adversarial review record ($record). Before creating a PR, have an independent context (a fresh subagent — no extra accounts needed; Codex is optional) review the diff, then write findings and dispositions (fixed / skipped+reason) to that file, including the full 40-char HEAD hash (git rev-parse HEAD). Docs-only PR: skip the review but still write the record with the skip reason and the same full HEAD hash. If this command is not actually creating a PR (the text merely mentions the command), split that text into a separate command. See: AGENTS.md > Adversarial Review." >&2
   exit 2
 fi
-if ! grep -q "$head" "$record"; then
+# Anchored on hex boundaries: unanchored, the match is satisfied by any longer
+# hex string that merely contains the sha, which is not "reviewed == shipped".
+if ! grep -qE "(^|[^0-9a-fA-F])$head([^0-9a-fA-F]|$)" "$record"; then
   echo "Blocked: $record does not reference the current HEAD ($head). Either commits were added after the review, or the record contains an abbreviated hash — refresh the review against the current diff and record the full 40-char hash (git rev-parse HEAD), then retry." >&2
   exit 2
 fi

--- a/scripts/__tests__/reviewGateReadsTheRightCheckout.test.mjs
+++ b/scripts/__tests__/reviewGateReadsTheRightCheckout.test.mjs
@@ -1,0 +1,135 @@
+// The review gate judges the checkout the session is actually in.
+//
+// **Written because the permissive direction was reachable.** The gate resolved its branch by
+// `cd`-ing to `CLAUDE_PROJECT_DIR` unconditionally, so a session working in a git worktree — the
+// ordinary way to work while another session holds the main checkout — had its PR judged against
+// whatever that checkout happened to be sitting on. Blocking is the harmless half. The other half is
+// that a record for that unrelated branch, referencing its own HEAD, **satisfied the gate**, and the
+// PR went out labelled reviewed with nothing having read its diff.
+//
+// The gate still does not know which branch `gh pr create --head X` names, and does not try: reading
+// a branch out of an arbitrary shell command means handling quoting, heredocs and substitutions, and
+// that limit predates this change rather than being introduced by it.
+//
+// The hook is a shell script fed JSON on stdin, so it is exercised exactly as Claude Code runs it.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const HOOK = join(import.meta.dirname, '..', '..', '.claude', 'hooks', 'adversarial-review-gate.sh')
+const CREATE = 'gh pr create --base main'
+
+let repo, worktree, elsewhere, sha
+
+const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim()
+
+/** Run the hook the way Claude Code does: JSON on stdin, exit code and stderr out. */
+function gate(command, { cwd = repo, projectDir = repo } = {}) {
+  const res = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({ hook_event_name: 'PreToolUse', tool_name: 'Bash', cwd, tool_input: { command } }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    encoding: 'utf8',
+  })
+  return { code: res.status, stderr: res.stderr ?? '' }
+}
+
+const recordPath = (dir, branch) => join(dir, '.work', 'reviews', `${branch.replaceAll('/', '__')}.md`)
+const record = (dir, branch, hash) => {
+  mkdirSync(join(dir, '.work', 'reviews'), { recursive: true })
+  writeFileSync(recordPath(dir, branch), `head: ${hash}\n`)
+}
+const unrecord = (dir, branch) => {
+  if (existsSync(recordPath(dir, branch))) rmSync(recordPath(dir, branch))
+}
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), 'gate-repo-'))
+  elsewhere = mkdtempSync(join(tmpdir(), 'gate-notarepo-'))
+  git('init', '-b', 'main')
+  git('config', 'user.email', 't@example.com')
+  git('config', 'user.name', 'T')
+  writeFileSync(join(repo, 'f.txt'), 'x')
+  git('add', '-A')
+  git('commit', '-m', 'one')
+  sha = git('rev-parse', 'HEAD')
+  mkdirSync(join(repo, 'sub'), { recursive: true })
+  worktree = mkdtempSync(join(tmpdir(), 'gate-wt-'))
+  rmSync(worktree, { recursive: true, force: true }) // `git worktree add` wants the path absent
+  git('worktree', 'add', '-b', 'fix/other', worktree, 'HEAD')
+  record(repo, 'main', sha)
+})
+
+afterAll(() => {
+  for (const d of [repo, worktree, elsewhere]) rmSync(d, { recursive: true, force: true })
+})
+
+describe('the review gate', () => {
+  it('reaches both verdicts, so nothing below passes vacuously', () => {
+    // A hook that blocked everything would satisfy every refusal in this file, and one whose matcher
+    // stopped firing would satisfy every pass. Both ends are pinned before anything else is claimed.
+    expect(gate('echo hello').code, 'a command that creates no PR was gated').toBe(0)
+    unrecord(repo, 'main')
+    expect(gate(CREATE).code, 'a PR with no record was allowed').toBe(2)
+    record(repo, 'main', sha)
+    expect(gate(CREATE).code, 'a PR with a valid record was refused').toBe(0)
+  })
+
+  it('refuses a record that names a different commit', () => {
+    record(repo, 'main', '0'.repeat(40))
+    expect(gate(CREATE).stderr).toContain('does not reference the current HEAD')
+    record(repo, 'main', sha)
+  })
+
+  it('does not take the sha out of a longer hex string', () => {
+    // Unanchored, the match is satisfied by anything that merely contains the sha, which is not the
+    // "reviewed code == PR code" the header promises. Both sides, since a boundary check can be
+    // written to guard only one.
+    for (const written of [`${sha}cafe`, `dead${sha}`]) {
+      record(repo, 'main', written)
+      expect(gate(CREATE).code, `a longer hex string passed: ${written}`).toBe(2)
+    }
+    // The control: the same sha with ordinary punctuation around it still counts.
+    record(repo, 'main', `${sha}, verified`)
+    expect(gate(CREATE).code, 'a real sha was rejected by the boundary').toBe(0)
+    record(repo, 'main', sha)
+  })
+
+  it('judges the worktree the session is in, not the project directory', () => {
+    // **The defect this change exists for.** `main` is recorded and `fix/other` is not, so a pass
+    // here could only come from judging the wrong checkout — which is the case where a PR shipped
+    // labelled reviewed because some other branch happened to have a record.
+    const r = gate(CREATE, { cwd: worktree })
+    expect(r.code, "the project directory's record passed a PR from another worktree").toBe(2)
+    expect(r.stderr).toContain('fix__other.md')
+
+    record(worktree, 'fix/other', git('rev-parse', 'fix/other'))
+    expect(gate(CREATE, { cwd: worktree }).code, "the worktree's own record was not found").toBe(0)
+    unrecord(worktree, 'fix/other')
+  })
+
+  it('looks for the record at the repo root, not beside the shell', () => {
+    // A session sitting in a subdirectory resolved `.work/reviews/…` relative to itself and reported
+    // a missing record the user could see was present, which reads as the gate being broken.
+    expect(gate(CREATE, { cwd: join(repo, 'sub') }).code,
+      'a subdirectory session false-blocked a reviewed branch').toBe(0)
+  })
+
+  it('falls back to the project directory when cwd exists but is not a work tree', () => {
+    // **The trap in resolving the root.** Testing the path with `[ -d ]` passes for any directory
+    // that exists — a parent holding several repos, a scratch directory — and then `--show-toplevel`
+    // fails and the whole gate exits 0. Asserted with the record REMOVED, because with it present a
+    // pass proves nothing about whether the fallback ran or the gate simply gave up.
+    unrecord(repo, 'main')
+    expect(gate(CREATE, { cwd: elsewhere }).code, 'a cwd outside any repo disabled the gate').toBe(2)
+    record(repo, 'main', sha)
+    expect(gate(CREATE, { cwd: elsewhere }).code, 'and it still passes a reviewed branch').toBe(0)
+  })
+
+  it('falls back when cwd does not exist at all', () => {
+    unrecord(repo, 'main')
+    expect(gate(CREATE, { cwd: '/nonexistent/path/for/this/test' }).code).toBe(2)
+    record(repo, 'main', sha)
+  })
+})

--- a/scripts/__tests__/reviewGateReadsTheRightCheckout.test.mjs
+++ b/scripts/__tests__/reviewGateReadsTheRightCheckout.test.mjs
@@ -21,15 +21,18 @@ import { tmpdir } from 'node:os'
 const HOOK = join(import.meta.dirname, '..', '..', '.claude', 'hooks', 'adversarial-review-gate.sh')
 const CREATE = 'gh pr create --base main'
 
-let repo, worktree, elsewhere, sha
+let repo, worktree, elsewhere, unborn, sha
 
 const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim()
 
 /** Run the hook the way Claude Code does: JSON on stdin, exit code and stderr out. */
-function gate(command, { cwd = repo, projectDir = repo } = {}) {
+function gate(command, { cwd = repo, projectDir = repo, spawnIn } = {}) {
   const res = spawnSync('bash', [HOOK], {
     input: JSON.stringify({ hook_event_name: 'PreToolUse', tool_name: 'Bash', cwd, tool_input: { command } }),
     env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    // `spawnIn` is the hook process's own directory, which only matters for the empty-cwd case:
+    // `git -C ""` reads it, so the test has to be able to make it a repo that WOULD satisfy the gate.
+    ...(spawnIn ? { cwd: spawnIn } : {}),
     encoding: 'utf8',
   })
   return { code: res.status, stderr: res.stderr ?? '' }
@@ -47,6 +50,8 @@ const unrecord = (dir, branch) => {
 beforeAll(() => {
   repo = mkdtempSync(join(tmpdir(), 'gate-repo-'))
   elsewhere = mkdtempSync(join(tmpdir(), 'gate-notarepo-'))
+  unborn = mkdtempSync(join(tmpdir(), 'gate-unborn-'))
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: unborn })
   git('init', '-b', 'main')
   git('config', 'user.email', 't@example.com')
   git('config', 'user.name', 'T')
@@ -62,7 +67,7 @@ beforeAll(() => {
 })
 
 afterAll(() => {
-  for (const d of [repo, worktree, elsewhere]) rmSync(d, { recursive: true, force: true })
+  for (const d of [repo, worktree, elsewhere, unborn]) rmSync(d, { recursive: true, force: true })
 })
 
 describe('the review gate', () => {
@@ -125,6 +130,31 @@ describe('the review gate', () => {
     expect(gate(CREATE, { cwd: elsewhere }).code, 'a cwd outside any repo disabled the gate').toBe(2)
     record(repo, 'main', sha)
     expect(gate(CREATE, { cwd: elsewhere }).code, 'and it still passes a reviewed branch').toBe(0)
+  })
+
+  it('falls back from a work tree that has no commits yet', () => {
+    // **The other half of the same guard.** `--show-toplevel` succeeds on a repo with no commits, so
+    // asking only that question lets the resolution through, and the `|| exit 0` on the HEAD lookup
+    // below then turns the gate off for the checkout the PR belongs to rather than falling back to
+    // it. A scratch repo a session initialised and never committed to is enough to reach it.
+    unrecord(repo, 'main')
+    expect(gate(CREATE, { cwd: unborn }).code, 'an unborn work tree disabled the gate').toBe(2)
+    record(repo, 'main', sha)
+    expect(gate(CREATE, { cwd: unborn }).code, 'and it still passes a reviewed branch').toBe(0)
+  })
+
+  it('falls back when cwd is empty, rather than reading the hook\'s own directory', () => {
+    // `git -C ""` runs against whatever directory the hook process happens to be launched in, which
+    // is nobody's checkout in particular — so an empty `cwd` has to be caught before the probe, not
+    // by it. The hook is launched inside `repo`, which IS recorded, while the project directory is
+    // the unrecorded worktree: a pass could then only come from judging `repo`, which nothing asked
+    // about.
+    expect(gate(CREATE, { cwd: '', projectDir: worktree, spawnIn: repo }).code,
+      "an empty cwd judged the hook's own directory").toBe(2)
+    // The control, so this cannot pass on a gate that refuses every empty cwd outright: with the
+    // project directory recorded, the fallback still answers yes.
+    expect(gate(CREATE, { cwd: '', projectDir: repo, spawnIn: repo }).code,
+      'the fallback stopped accepting a reviewed branch').toBe(0)
   })
 
   it('falls back when cwd does not exist at all', () => {


### PR DESCRIPTION
## Summary

The adversarial-review gate resolved its branch by `cd`-ing to `CLAUDE_PROJECT_DIR` unconditionally, so a session working in a git worktree — the ordinary way to work while another session holds the main checkout — had its PR judged against whatever that checkout happened to be sitting on. Blocking is the harmless half. The other half is that a record for that unrelated branch, referencing its own HEAD, **satisfied the gate**, and the PR went out labelled reviewed with nothing having read its diff.

Six lines of code. The root now comes from the reported `cwd` when git resolves it to a work tree with a HEAD, falling back to `CLAUDE_PROJECT_DIR` otherwise — asked of git rather than tested with `[ -d ]`, because a path that exists and is not a work tree has to reach the fallback rather than fail open past it. Two more, both in the lines this already touches: the record is looked for at `--show-toplevel` so a session in a subdirectory stops reporting a record it can see is there, and the sha match is anchored on hex boundaries, since unanchored it was satisfied by any longer hex string containing it.

**What this deliberately does not do** is work out which branch `gh pr create --head X` names. That needs the command parsed — quoting, heredocs, substitutions — and the limit is on `main` too rather than being introduced here. Three earlier attempts at it are in the review record, along with what each one broke; all were reverted.

## Checklist

- [x] Tests written and passing — 9 cases over six `cwd` shapes, eight mutations one per guard, all caught; `pnpm test:scripts` 468/468
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/fix__review-gate-worktree-blind.md` — four independent passes. The one finding on the shipped design was a regression this branch introduced (a work tree with no commits disabled the gate; measured `0` against `main`'s `2`) and is fixed in `bd4de067`. The record also carries what the three earlier passes cost and why the parsing approach was abandoned.

<!-- no-changeset: no published source changed — the diff is a repo hook and its test -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review validation now correctly identifies the active Git checkout, including worktrees.
  * Review records are consistently stored and checked against the correct repository.
  * Commit validation now prevents partial or embedded hash matches.
  * Improved handling for non-repositories, empty repositories, and invalid working directories.

* **Tests**
  * Added coverage for checkout resolution, command matching, record validation, and commit-hash boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->