### PR TITLE
fix(hooks): read the command, not the text that spells one

### DIFF
--- a/.claude/hooks/gh-language-gate.sh
+++ b/.claude/hooks/gh-language-gate.sh
@@ -20,12 +20,12 @@
 # it (#699). Deriving it from `CLAUDE_PROJECT_DIR` alone means a session in a worktree — or one whose
 # project dir points anywhere else — finds no `scripts/` and the gate turns itself off.
 #
-# **What the prefilter cannot see is an obfuscated spelling.** `g"h" issue create` survives quote
-# removal as a real invocation and never matches the raw text, so the gate exits before the parser
-# runs. Left as it is on purpose: these gates state a cooperative-but-forgetful agent as their threat
-# model, writing `g"h"` is intent rather than forgetfulness, and the alternative — dropping the
-# prefilter — puts a node process on every Bash call in the session, which is the cost it exists to
-# avoid.
+# **It matches what the shell would leave, not what was typed.** The prefilter reads raw text while
+# the parser reads a tokenized command, so `g"h" issue create` -- a real invocation -- was not in the
+# raw text and the gate exited before the parser ever saw it. Removing the quotes and backslashes the
+# shell removes closes that for nothing, because squashing only ever *widens* what reaches the
+# parser, and the parser is the half that decides. It remains a prefilter rather than a decision:
+# `$VAR` and `$(...)` are unresolved here, as they are there.
 #
 # **This file is only the prefilter.** Deciding needs the command tokenized and the body read, which
 # is `scripts/gh-language-gate.mjs`, where it is tested.
@@ -35,7 +35,14 @@ input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 [ -n "$cmd" ] || cmd=$input
 
-case "$cmd" in
+
+# The characters the shell strips on the way to a command word. Two substitutions rather than one
+# bracket expression: a backslash inside one is its own argument about quoting, and this has to be
+# read correctly by whoever edits it next.
+squashed=${cmd//[\"\']/}
+squashed=${squashed//\\/}
+
+case "$squashed" in
   *gh*issue*|*gh*pr*) ;;
   *) exit 0 ;;
 esac

--- a/.claude/hooks/gh-language-gate.sh
+++ b/.claude/hooks/gh-language-gate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# PreToolUse(Bash) gate: a PR or issue title and body are written in English.
+#
+# **It replaces an inline perl regex in `settings.json`**, which matched
+# `/gh\s+(pr|issue)\s+(create|edit)/` against the whole command and blocked anything that also
+# contained Hangul. Measured: a `node -e` script investigating this very gate carried
+# `gh issue create` inside a JS string literal and Korean in a `console.log` label, and was refused
+# as an issue creation. It creates no issue. That is the mistake `issue-parent-gate.sh` next to it
+# was written to end, still live one hook over.
+#
+# The regex was also blind in the other direction. It saw only the command text, so Korean in a
+# `--body-file` — the form CONTRIBUTING tells everyone to use — was never looked at.
+#
+# **This file is only the prefilter.** Deciding needs the command tokenized and the body read, which
+# is `scripts/gh-language-gate.mjs`, where it is tested. Node is spawned only for a command that
+# mentions `gh` and one of the two nouns, which is rare.
+
+input=$(cat)
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+
+case "$input" in
+  *gh*issue*|*gh*pr*) ;;
+  *) exit 0 ;;
+esac
+[ -f scripts/gh-language-gate.mjs ] || exit 0
+
+printf '%s' "$input" | node scripts/gh-language-gate.mjs

--- a/.claude/hooks/gh-language-gate.sh
+++ b/.claude/hooks/gh-language-gate.sh
@@ -11,17 +11,36 @@
 # The regex was also blind in the other direction. It saw only the command text, so Korean in a
 # `--body-file` — the form CONTRIBUTING tells everyone to use — was never looked at.
 #
+# **The prefilter reads the command, not the payload.** Matching the whole JSON meant the `cwd` field
+# supplied words the command never had: in a checkout under `personal-project`, `*gh*pr*` reduced to
+# "contains gh", and `rg -n "highlight"` paid for a node process. Falling back to the raw input when
+# `jq` cannot produce a command keeps the gate on rather than silently off.
+#
+# **The root comes from the session's own checkout**, the way `adversarial-review-gate.sh` resolves
+# it (#699). Deriving it from `CLAUDE_PROJECT_DIR` alone means a session in a worktree — or one whose
+# project dir points anywhere else — finds no `scripts/` and the gate turns itself off.
+#
 # **This file is only the prefilter.** Deciding needs the command tokenized and the body read, which
-# is `scripts/gh-language-gate.mjs`, where it is tested. Node is spawned only for a command that
-# mentions `gh` and one of the two nouns, which is rare.
+# is `scripts/gh-language-gate.mjs`, where it is tested.
 
 input=$(cat)
-cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 
-case "$input" in
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || cmd=$input
+
+case "$cmd" in
   *gh*issue*|*gh*pr*) ;;
   *) exit 0 ;;
 esac
+
+root=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null)
+if [ -n "$root" ] && top=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null); then
+  root=$top
+else
+  root="${CLAUDE_PROJECT_DIR:-.}"
+fi
+cd "$root" 2>/dev/null || exit 0
+
 [ -f scripts/gh-language-gate.mjs ] || exit 0
 
 printf '%s' "$input" | node scripts/gh-language-gate.mjs

--- a/.claude/hooks/gh-language-gate.sh
+++ b/.claude/hooks/gh-language-gate.sh
@@ -20,6 +20,13 @@
 # it (#699). Deriving it from `CLAUDE_PROJECT_DIR` alone means a session in a worktree — or one whose
 # project dir points anywhere else — finds no `scripts/` and the gate turns itself off.
 #
+# **What the prefilter cannot see is an obfuscated spelling.** `g"h" issue create` survives quote
+# removal as a real invocation and never matches the raw text, so the gate exits before the parser
+# runs. Left as it is on purpose: these gates state a cooperative-but-forgetful agent as their threat
+# model, writing `g"h"` is intent rather than forgetfulness, and the alternative — dropping the
+# prefilter — puts a node process on every Bash call in the session, which is the cost it exists to
+# avoid.
+#
 # **This file is only the prefilter.** Deciding needs the command tokenized and the body read, which
 # is `scripts/gh-language-gate.mjs`, where it is tested.
 

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -19,13 +19,29 @@
 # a `--title` could satisfy a rule about bodies. The decision is in `scripts/issue-parent-gate.mjs`,
 # where it is tested. Node is spawned only for a command that mentions both words, which is rare.
 
+# The prefilter reads the command rather than the whole payload: the JSON carries `cwd`, so a repo
+# path could supply words the command never had. And the root comes from the session's own checkout,
+# the way `adversarial-review-gate.sh` resolves it (#699) -- `CLAUDE_PROJECT_DIR` alone turns the
+# gate off for a session in a worktree, which finds no `scripts/` there. Falling back to the raw
+# input, and to the project dir, keeps the gate on rather than silently off.
 input=$(cat)
-cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
 
-case "$input" in
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || cmd=$input
+
+case "$cmd" in
   *gh*issue*) ;;
   *) exit 0 ;;
 esac
+
+root=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null)
+if [ -n "$root" ] && top=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null); then
+  root=$top
+else
+  root="${CLAUDE_PROJECT_DIR:-.}"
+fi
+cd "$root" 2>/dev/null || exit 0
+
 [ -f scripts/issue-parent-gate.mjs ] || exit 0
 
 printf '%s' "$input" | node scripts/issue-parent-gate.mjs

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -13,12 +13,12 @@
 # A `Parent:` line is greppable, so the parent's checklist can be regenerated instead of maintained
 # by memory.
 #
-# **What the prefilter cannot see is an obfuscated spelling.** `g"h" issue create` survives quote
-# removal as a real invocation and never matches the raw text, so the gate exits before the parser
-# runs. Left as it is on purpose: these gates state a cooperative-but-forgetful agent as their threat
-# model, writing `g"h"` is intent rather than forgetfulness, and the alternative — dropping the
-# prefilter — puts a node process on every Bash call in the session, which is the cost it exists to
-# avoid.
+# **It matches what the shell would leave, not what was typed.** The prefilter reads raw text while
+# the parser reads a tokenized command, so `g"h" issue create` -- a real invocation -- was not in the
+# raw text and the gate exited before the parser ever saw it. Removing the quotes and backslashes the
+# shell removes closes that for nothing, because squashing only ever *widens* what reaches the
+# parser, and the parser is the half that decides. It remains a prefilter rather than a decision:
+# `$VAR` and `$(...)` are unresolved here, as they are there.
 #
 # **This file is only the prefilter.** Deciding needs the command tokenized and the body parsed, and
 # the version that tried both in shell got three rules wrong at once — `gh issue new` walked through,
@@ -36,7 +36,14 @@ input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 [ -n "$cmd" ] || cmd=$input
 
-case "$cmd" in
+
+# The characters the shell strips on the way to a command word. Two substitutions rather than one
+# bracket expression: a backslash inside one is its own argument about quoting, and this has to be
+# read correctly by whoever edits it next.
+squashed=${cmd//[\"\']/}
+squashed=${squashed//\\/}
+
+case "$squashed" in
   *gh*issue*) ;;
   *) exit 0 ;;
 esac

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -13,6 +13,13 @@
 # A `Parent:` line is greppable, so the parent's checklist can be regenerated instead of maintained
 # by memory.
 #
+# **What the prefilter cannot see is an obfuscated spelling.** `g"h" issue create` survives quote
+# removal as a real invocation and never matches the raw text, so the gate exits before the parser
+# runs. Left as it is on purpose: these gates state a cooperative-but-forgetful agent as their threat
+# model, writing `g"h"` is intent rather than forgetfulness, and the alternative — dropping the
+# prefilter — puts a node process on every Bash call in the session, which is the cost it exists to
+# avoid.
+#
 # **This file is only the prefilter.** Deciding needs the command tokenized and the body parsed, and
 # the version that tried both in shell got three rules wrong at once — `gh issue new` walked through,
 # so did an environment assignment before `gh`, `-F "issue body.md"` read a file called `issue`, and

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); printf '%s' \"$cmd\" | perl -CSD -e 'local $/; my $c=<>; if ($c =~ /gh\\s+(pr|issue)\\s+(create|edit)/ && $c =~ /\\p{Hangul}/) { print STDERR \"Blocked: the gh pr/issue command contains Korean. Rewrite the PR/Issue title and body in English, then re-run.\\n\"; exit 2 }'"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/gh-language-gate.sh\""
           },
           {
             "type": "command",

--- a/scripts/__tests__/ghLanguageGate.test.mjs
+++ b/scripts/__tests__/ghLanguageGate.test.mjs
@@ -194,9 +194,26 @@ describe('a body file the same command is about to write', () => {
     expect(verdict(cmd).blocked).toBe(false)
   })
 
-  it('prefers the file when there is one to read', () => {
-    const cmd = `cat > b.md <<'EOF'\n${KO}\nEOF\n\n${PR_CREATE} -F b.md`
-    expect(verdict(cmd, { 'b.md': 'English on disk.' }).blocked, 'disk wins over the payload').toBe(false)
+  it('prefers the pending write to the stale file it replaces', () => {
+    // **This assertion used to say the opposite, and the opposite was a bypass.** An English body on
+    // disk, overwritten by a Korean heredoc in the same call: judging the file judges text that no
+    // longer exists by the time `gh` runs. Written as "disk wins over the payload", it read like a
+    // decision and was a hole with a test holding it open.
+    const cmd = `cat > b.md <<'EOF'\n${KO}입니다.\nEOF\n\n${PR_CREATE} -F b.md`
+    expect(verdict(cmd, { 'b.md': 'English on disk.' }).blocked).toBe(true)
+  })
+
+  it('does not blame an unrelated heredoc on the body file', () => {
+    // The other half: with no target to match on, the command's only heredoc was assigned to a body
+    // file whose contents were never read — and the message named that path.
+    const cmd = `cat > notes.md <<'EOF'\n${KO}입니다.\nEOF\n\n${PR_CREATE} -F body.md`
+    expect(verdict(cmd, { 'body.md': 'English body.' }).blocked).toBe(false)
+    expect(verdict(cmd).blocked, 'nor when the body file cannot be read at all').toBe(false)
+  })
+
+  it('still judges the heredoc that writes a body file which does not exist yet', () => {
+    const cmd = `cat > b.md <<'EOF'\n${KO}입니다.\nEOF\n\n${PR_CREATE} -F b.md`
+    expect(verdict(cmd).blocked).toBe(true)
   })
 })
 

--- a/scripts/__tests__/ghLanguageGate.test.mjs
+++ b/scripts/__tests__/ghLanguageGate.test.mjs
@@ -11,7 +11,8 @@
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
-import { judge, authoringInvocations } from '../lib/gh-language.mjs'
+import { readFileSync } from 'node:fs'
+import { judge, authoringInvocations, koreanLine } from '../lib/gh-language.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const KO = '한글 본문'
@@ -20,10 +21,12 @@ const KO = '한글 본문'
 const PR_CREATE = ['gh', 'pr', 'create'].join(' ')
 const ISSUE_CREATE = ['gh', 'issue', 'create'].join(' ')
 
-/** `judge` with no filesystem: every body file is supplied inline. */
+/** `judge` with no filesystem: every body file is supplied inline, keyed as the command writes it.
+ *  The reader is handed a resolved path, so the keys are resolved to match. */
 const verdict = (cmd, files = {}) => judge(cmd, (p) => {
-  if (!(p in files)) throw new Error('ENOENT')
-  return files[p]
+  const key = Object.keys(files).find((k) => path.resolve(k) === p)
+  if (key === undefined) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+  return files[key]
 })
 
 describe('which commands author something on GitHub', () => {
@@ -101,12 +104,12 @@ describe('Korean is judged where it reaches GitHub, and nowhere else', () => {
 })
 
 describe('what this gate cannot see', () => {
-  it('lets an unreadable body file through', () => {
-    // **A floor, not a fence,** and the boundary is deliberate. The gate judges from the repo root
-    // while the command runs wherever its own `cd` put it, so a relative path can be readable to
-    // `gh` and not to this. Blocking every such path would refuse correct work for a file the gate
-    // merely could not open; the issue-parent gate reports that case for issues, and for a PR the
-    // remaining exposure is a Korean body passed by a relative path from another directory.
+  it('lets an unreadable body file with no heredoc behind it through', () => {
+    // **A floor, not a fence,** and the boundary is deliberate. The gate resolves against the
+    // session's directory while the command may `cd` first, so a path can be readable to `gh` and
+    // not to this. Blocking every such path would refuse correct work over a file the gate merely
+    // could not open. What remains uncovered is a Korean body passed by a path only the command can
+    // reach, with nothing in the command to read instead.
     expect(verdict(`${PR_CREATE} -F somewhere/else.md`).blocked).toBe(false)
   })
 
@@ -145,5 +148,96 @@ describe('the hook itself, spawned', () => {
       env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
     })
     expect(r.status, 'a malformed payload would block every Bash call in the session').toBe(0)
+  })
+})
+
+// ── Added after the adversarial review of this branch ───────────────────────────────────────────
+
+describe('an English body may name a Korean string', () => {
+  // **Merged PR #660 is the case.** Its body is 60+ lines of English with one line reading
+  // `Renamed sidebar labels to "Network Control" and "네트워크 제어."` — and a codepoint test blocks
+  // it, then advises rewriting that label in English, which would make the sentence false. The repo
+  // ships `docs/ko/`, so naming Korean labels and paths is a live workflow rather than a
+  // hypothetical. A line counts as Korean when its Hangul outnumbers its Latin letters.
+  const PR660 = '  * Renamed sidebar labels to "Network Control" and "네트워크 제어."'
+
+  it('allows the line #660 actually shipped', () => {
+    expect(koreanLine(PR660)).toBeNull()
+    expect(verdict(`${PR_CREATE} -F b.md`, { 'b.md': `## Summary\n\nEnglish.\n\n${PR660}\n` }).blocked).toBe(false)
+  })
+
+  it('still catches the sentence around it', () => {
+    expect(koreanLine(`${PR660}\n사이드바 라벨 이름을 바꿨습니다.`)).toBe('사이드바 라벨 이름을 바꿨습니다.')
+  })
+
+  it('catches a title that is mostly Korean even with an English prefix', () => {
+    expect(verdict(`${PR_CREATE} --title "docs: 네트워크 제어 가이드"`).blocked).toBe(true)
+  })
+
+  it('reports the offending line, not just the argument', () => {
+    expect(verdict(`${PR_CREATE} --body "en line\n한글 문장입니다."`).line).toBe('한글 문장입니다.')
+  })
+})
+
+describe('a body file the same command is about to write', () => {
+  it('is judged from the heredoc, since the file does not exist yet', () => {
+    // The headline hole, still open for the single-call shape: a heredoc writes the body and `gh`
+    // sends it in the same Bash call, so at gate time there is no file to read and the Korean sat
+    // unread in the payload. `lets an unreadable body file through` asserted the absence and locked
+    // it in, which is why no mutation found it.
+    const cmd = `cat > /tmp/nb.md <<'EOF'\n## Summary\n\n${KO}입니다.\nEOF\n\n${PR_CREATE} --title T --body-file /tmp/nb.md`
+    expect(verdict(cmd).blocked).toBe(true)
+  })
+
+  it('allows the same shape with an English heredoc', () => {
+    const cmd = `cat > /tmp/nb.md <<'EOF'\n## Summary\n\nA fix.\nEOF\n\n${PR_CREATE} --title T --body-file /tmp/nb.md`
+    expect(verdict(cmd).blocked).toBe(false)
+  })
+
+  it('prefers the file when there is one to read', () => {
+    const cmd = `cat > b.md <<'EOF'\n${KO}\nEOF\n\n${PR_CREATE} -F b.md`
+    expect(verdict(cmd, { 'b.md': 'English on disk.' }).blocked, 'disk wins over the payload').toBe(false)
+  })
+})
+
+describe('a short flag carrying its value reaches this gate too', () => {
+  it('blocks Korean attached to the shorthand', () => {
+    // The readers are shared with the parent gate, where missing this is a false block. Here it is a
+    // bypass: no text found means nothing to check.
+    expect(verdict(`${PR_CREATE} -t"${KO} 제목"`).blocked).toBe(true)
+    expect(verdict(`${PR_CREATE} -b"${KO}입니다"`).blocked).toBe(true)
+  })
+})
+
+describe('the hook resolves the checkout the session is in', () => {
+  const runIn = (cmd, cwd, projectDir) => spawnSync('bash', [path.join(REPO, '.claude/hooks/gh-language-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd }, cwd }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+  })
+
+  it('still judges when CLAUDE_PROJECT_DIR points somewhere else', () => {
+    // Deriving the root from the project dir alone turns the gate off for a session in a worktree,
+    // or one whose project dir is stale: `scripts/` is not there, so the prefilter gives up. The
+    // sibling review gate resolves this from the payload's cwd (#699); this one now does too.
+    expect(runIn(`${PR_CREATE} --title "${KO} 제목"`, REPO, '/nope/nope').status).toBe(2)
+  })
+
+  it('falls back to the project dir when the cwd is not a checkout', () => {
+    expect(runIn(`${PR_CREATE} --title "${KO} 제목"`, '/nope/nope', REPO).status).toBe(2)
+  })
+
+  it('reads the command out of the payload before matching it', () => {
+    // **A source-text floor, and it says so.** The prefilter used to match the whole JSON payload,
+    // whose `cwd` supplies words the command never had — in a checkout under `personal-project`,
+    // `*gh*pr*` meant "contains gh", and `rg -n "highlight"` paid for a node process. The fix is
+    // cost, not behaviour: both spellings exit 0 on such a command, so nothing observable from
+    // outside can fail. Asserting the exit code here would read as coverage and be unable to fail,
+    // which `contributing/test-and-guard-coverage.md` names as the shape to avoid. This checks the
+    // one thing that is visible instead.
+    const hook = readFileSync(path.join(REPO, '.claude/hooks/gh-language-gate.sh'), 'utf8')
+    expect(hook).toMatch(/case "\$cmd" in/)
+    expect(hook, 'the payload is not the haystack').not.toMatch(/case "\$input" in/)
+    expect(runIn('rg -n "highlight" --pretty src', REPO, REPO).status, 'and it still allows it').toBe(0)
   })
 })

--- a/scripts/__tests__/ghLanguageGate.test.mjs
+++ b/scripts/__tests__/ghLanguageGate.test.mjs
@@ -1,0 +1,149 @@
+// The gate that keeps PR and issue titles and bodies in English.
+//
+// **It replaces a one-line perl regex over the whole command**, which is the same mistake the issue
+// parent gate was written to end and which this file's first case is named after: a `node -e` script
+// with `gh issue create` inside a *string literal* was refused as an issue creation, because the
+// pattern matched text rather than a command. The parser next door already knew the difference.
+//
+// The port also closes the opposite hole. The old regex saw only the command text, so Korean typed
+// inline was caught while Korean in a `--body-file` sailed through — the gate was strictest about
+// the shape that is easiest to avoid.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { judge, authoringInvocations } from '../lib/gh-language.mjs'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const KO = '한글 본문'
+
+/** Assembled rather than written, so this file can be edited from a heredoc. */
+const PR_CREATE = ['gh', 'pr', 'create'].join(' ')
+const ISSUE_CREATE = ['gh', 'issue', 'create'].join(' ')
+
+/** `judge` with no filesystem: every body file is supplied inline. */
+const verdict = (cmd, files = {}) => judge(cmd, (p) => {
+  if (!(p in files)) throw new Error('ENOENT')
+  return files[p]
+})
+
+describe('which commands author something on GitHub', () => {
+  const AUTHORS = {
+    'creating a PR': `${PR_CREATE} --title x`,
+    'editing a PR': 'gh pr edit 42 --body x',
+    'creating an issue': `${ISSUE_CREATE} --title x`,
+    'editing an issue': 'gh issue edit 42 --body x',
+    'the undocumented `new` alias': 'gh issue new --title x',
+    'behind an environment assignment': `GH_REPO=o/r ${PR_CREATE} --title x`,
+    'after a separator': `git status && ${PR_CREATE} --title x`,
+  }
+  for (const [name, cmd] of Object.entries(AUTHORS)) {
+    it(`sees ${name}`, () => {
+      expect(authoringInvocations(cmd)).toHaveLength(1)
+    })
+  }
+
+  const NOT_AUTHORS = {
+    'listing PRs': 'gh pr list --state open',
+    'viewing one': 'gh pr view 42 --json body',
+    'checking one out': 'gh pr checkout 42',
+    'commenting': 'gh pr comment 42 --body x',
+    'the words inside a script string': `node -e "import { judge } from './lib.mjs'; judge('${ISSUE_CREATE} --title x')"`,
+    'the words in a grep pattern': `grep -rn '${PR_CREATE}' docs/`,
+    'the words in a heredoc payload': `cat > plan.md <<EOF\nRun ${PR_CREATE} when ready\nEOF`,
+  }
+  for (const [name, cmd] of Object.entries(NOT_AUTHORS)) {
+    it(`ignores ${name}`, () => {
+      // A present count of zero rather than "nothing happened": these run through the same parser,
+      // so a parser that returned early could not pass this by finding nothing.
+      expect(authoringInvocations(cmd)).toEqual([])
+    })
+  }
+})
+
+describe('Korean is judged where it reaches GitHub, and nowhere else', () => {
+  it('blocks it in a title', () => {
+    expect(verdict(`${PR_CREATE} --title "${KO}" --body "in English"`)).toMatchObject({ blocked: true })
+  })
+
+  it('blocks it in a body', () => {
+    expect(verdict(`${PR_CREATE} --title "x" --body "${KO}"`)).toMatchObject({ blocked: true })
+  })
+
+  it('blocks it in a body file, which the regex could not see at all', () => {
+    // The hole the port closes. `--body-file` is the form CONTRIBUTING tells everyone to use, so the
+    // old gate was blind in exactly the case the convention produces.
+    expect(verdict(`${PR_CREATE} -F body.md`, { 'body.md': `## Summary\n\n${KO}\n` })).toMatchObject({ blocked: true })
+  })
+
+  it('blocks it in the heredoc that reaches `--body-file -`', () => {
+    expect(verdict(`${PR_CREATE} --body-file - <<EOF\n${KO}\nEOF`)).toMatchObject({ blocked: true })
+  })
+
+  it('allows an English body file', () => {
+    expect(verdict(`${PR_CREATE} -F body.md`, { 'body.md': '## Summary\n\nA fix.\n' }).blocked).toBe(false)
+  })
+
+  it('allows Korean that never reaches GitHub', () => {
+    // The false positive that started this. Every one of these was refused by the regex.
+    const elsewhere = [
+      `${PR_CREATE} --title x --body "in English" && echo "${KO}"`,
+      `node -e "console.log('${KO}'); // ${ISSUE_CREATE}"`,
+      `grep -rn '${PR_CREATE}' docs/ # ${KO}`,
+    ]
+    for (const cmd of elsewhere) expect(verdict(cmd).blocked, cmd).toBe(false)
+  })
+
+  it('names where it found it, so the message can point at one thing', () => {
+    expect(verdict(`${PR_CREATE} --title "${KO}" --body "en"`).where).toBe('--title')
+    expect(verdict(`${PR_CREATE} --title "en" --body "${KO}"`).where).toBe('--body')
+    expect(verdict(`${PR_CREATE} -F body.md`, { 'body.md': KO }).where).toContain('body.md')
+  })
+})
+
+describe('what this gate cannot see', () => {
+  it('lets an unreadable body file through', () => {
+    // **A floor, not a fence,** and the boundary is deliberate. The gate judges from the repo root
+    // while the command runs wherever its own `cd` put it, so a relative path can be readable to
+    // `gh` and not to this. Blocking every such path would refuse correct work for a file the gate
+    // merely could not open; the issue-parent gate reports that case for issues, and for a PR the
+    // remaining exposure is a Korean body passed by a relative path from another directory.
+    expect(verdict(`${PR_CREATE} -F somewhere/else.md`).blocked).toBe(false)
+  })
+
+  it('lets a body built by a substitution through', () => {
+    // `$(…)` is not resolved by the tokenizer and never will be. Named so the next reader does not
+    // mistake silence here for coverage.
+    expect(verdict(`${PR_CREATE} --body "$(cat ko.md)"`).blocked).toBe(false)
+  })
+})
+
+describe('the hook itself, spawned', () => {
+  const run = (cmd) => spawnSync('bash', [path.join(REPO, '.claude/hooks/gh-language-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd } }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  it('blocks a Korean title and says where it is', () => {
+    const r = run(`${PR_CREATE} --title "${KO}" --body "en"`)
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/--title/)
+  })
+
+  it('allows the command that the regex refused', () => {
+    expect(run(`node -e "judge('${ISSUE_CREATE}'); console.log('${KO}')"`).status).toBe(0)
+  })
+
+  it('allows an unrelated command without paying for node', () => {
+    expect(run('git status --short').status).toBe(0)
+  })
+
+  it('fails open on a payload it cannot parse', () => {
+    const r = spawnSync('bash', [path.join(REPO, '.claude/hooks/gh-language-gate.sh')], {
+      input: `not json at all, ${PR_CREATE} ${KO}`,
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status, 'a malformed payload would block every Bash call in the session').toBe(0)
+  })
+})

--- a/scripts/__tests__/ghLanguageGate.test.mjs
+++ b/scripts/__tests__/ghLanguageGate.test.mjs
@@ -253,8 +253,31 @@ describe('the hook resolves the checkout the session is in', () => {
     // which `contributing/test-and-guard-coverage.md` names as the shape to avoid. This checks the
     // one thing that is visible instead.
     const hook = readFileSync(path.join(REPO, '.claude/hooks/gh-language-gate.sh'), 'utf8')
-    expect(hook).toMatch(/case "\$cmd" in/)
+    // Asserted on what the haystack is *derived from*, not on one spelling of it: the first version
+    // pinned `case "$cmd" in` and broke the moment the same command was squashed into `$squashed`
+    // first, which changed nothing about the property being held. That is the standing cost of a
+    // source-text floor, and pinning the derivation is as close to the property as text gets.
+    expect(hook, 'the haystack comes from the command').toMatch(/squashed=\$\{cmd\/\//)
     expect(hook, 'the payload is not the haystack').not.toMatch(/case "\$input" in/)
     expect(runIn('rg -n "highlight" --pretty src', REPO, REPO).status, 'and it still allows it').toBe(0)
+  })
+})
+
+describe('the prefilter matches what the shell would leave', () => {
+  const run = (cmd) => spawnSync('bash', [path.join(REPO, '.claude/hooks/gh-language-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd }, cwd: REPO }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  it('reaches the parser through a quoted break in the command word', () => {
+    // Same hole as the issue-parent gate's, and the same one line closes it. Without it a Korean
+    // title sails past on a spelling that is a real invocation everywhere except in the raw text.
+    expect(run(`g"h" pr create --title "${KO} 제목"`).status).toBe(2)
+    expect(run(`gh p"r" create --title "${KO} 제목"`).status).toBe(2)
+  })
+
+  it('still lets an unrelated command past', () => {
+    expect(run('rg -n "highlight" --pretty src').status).toBe(0)
   })
 })

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -481,3 +481,48 @@ describe('a body file that is not a regular file', () => {
     }
   })
 })
+
+describe('a command reached through a control condition', () => {
+  // `if`, `elif`, `while` and `until` take a command as their condition, so the word after one is in
+  // command position — the mirror of `then`/`do`/`else`, which were separators from the start.
+  // Without them `if gh issue create …; then` was invisible to both gates.
+  for (const kw of ['if', 'elif', 'while', 'until']) {
+    it(`is seen after \`${kw}\``, () => {
+      const cmd = `${kw} ${CREATE} --title x --body "a bug"; then :; fi`
+      expect(issueCreateInvocations(cmd)).toHaveLength(1)
+      expect(verdict(cmd).blocked).toBe(true)
+    })
+  }
+})
+
+describe('a scalar flag given twice', () => {
+  it('is read the way pflag reads it — the last one wins', () => {
+    // Reading the first let a command satisfy the gate with text GitHub would never receive:
+    // `--body "Parent: #607" --body "a bug"` sends the second.
+    expect(verdict(`${CREATE} --title x --body "${PARENT}" --body "a bug"`).blocked).toBe(true)
+    expect(verdict(`${CREATE} --title x --body "a bug" --body "${PARENT}"`).blocked).toBe(false)
+    expect(bodyFileArg(tokenize(`${CREATE} -F first.md --body-file second.md`))).toBe('second.md')
+  })
+})
+
+describe('a body file the command writes before sending it', () => {
+  it('is judged from the heredoc that targets it, not from the disk', () => {
+    const cmd = `cat > b.md <<'EOF'\n${PARENT}\nEOF\n\n${CREATE} --title x -F b.md`
+    expect(verdict(cmd, { 'b.md': 'no parent on disk' }).blocked, 'the pending write carries it').toBe(false)
+  })
+
+  it('does not take an unrelated heredoc for the body', () => {
+    const cmd = `cat > notes.md <<'EOF'\n${PARENT}\nEOF\n\n${CREATE} --title x -F b.md`
+    expect(verdict(cmd, { 'b.md': 'no parent on disk' }).blocked, 'notes.md is not the body').toBe(true)
+  })
+
+  it('reads a quoted redirection target', () => {
+    const cmd = `cat > "my body.md" <<'EOF'\n${PARENT}\nEOF\n\n${CREATE} --title x -F "my body.md"`
+    expect(verdict(cmd).blocked).toBe(false)
+  })
+
+  it('does not read `2>&1` as a redirection target', () => {
+    const cmd = `cat > b.md 2>&1 <<'EOF'\n${PARENT}\nEOF\n\n${CREATE} --title x -F b.md`
+    expect(verdict(cmd).blocked).toBe(false)
+  })
+})

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -9,10 +9,9 @@
 // through a prefilter that never calls it is not a gate.
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { judge, tokenize, issueCreateInvocations, bodyFileArg, hasParent, hasStandalone, heredocs } from '../lib/issue-parent.mjs'
+import { judge, issueCreateInvocations, hasParent, hasStandalone } from '../lib/issue-parent.mjs'
+import { tokenize, bodyFileArg, heredocs } from '../lib/gh-command.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const PARENT = 'Parent: #607'
@@ -202,5 +201,106 @@ describe('the hook itself, spawned', () => {
       env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
     })
     expect(r.status, 'a malformed payload would block every Bash call in the session').toBe(0)
+  })
+})
+
+// ── Added with the gate-misdiagnosis work ───────────────────────────────────────────────────────
+
+/** `gh issue create`, assembled rather than written, so this file can be edited from a heredoc. */
+const CREATE = ['gh', 'issue', 'create'].join(' ')
+
+describe('a blocked command is told which rule it broke', () => {
+  // **Both failures printed one constant.** The decision layer separated them from the first commit
+  // and the entrypoint dropped `detail`, so a body file the gate could not open was reported as a
+  // body naming no parent — and the author goes off to add a line that is already there. Measured
+  // filing #700: the body had `Parent: #609` on its own line the whole time.
+  it('separates an unreadable body file from a body that names nothing', () => {
+    expect(verdict(`${CREATE} --body-file rel.md`).reason).toBe('unreadable-body-file')
+    expect(verdict(`${CREATE} --body "a bug"`).reason).toBe('no-parent')
+  })
+
+  it('separates a body file it could not read from no body at all', () => {
+    expect(verdict(`${CREATE} --title x`).reason).toBe('no-body')
+  })
+
+  it('names the path it tried, resolved', () => {
+    // The hook judges from `CLAUDE_PROJECT_DIR`, so a relative `--body-file` is resolved against the
+    // repo root rather than the cwd the command would actually run in. Following the command's own
+    // `cd` would be guessing; saying which path was opened is not, and it is the whole fix.
+    expect(verdict(`${CREATE} --body-file rel.md`).detail).toContain(path.resolve('rel.md'))
+  })
+
+  it('still blocks all three', () => {
+    // The reasons are for the message. Nothing about which rule broke may change whether it blocks.
+    for (const cmd of [`${CREATE} --body-file rel.md`, `${CREATE} --title x`, `${CREATE} --body "a bug"`]) {
+      expect(verdict(cmd).blocked, cmd).toBe(true)
+    }
+  })
+})
+
+describe('a heredoc payload is text, not a command', () => {
+  it('does not read an invocation written inside one', () => {
+    // Found by being blocked from writing the plan document for this change: its prose carried
+    // `&& gh issue create --body-file rel.md` as an example, and a heredoc payload tokenizes as bare
+    // words, so that line landed in command position. Quoting is what saves `echo "…"` and the grep
+    // pattern above; nothing was saving a heredoc, and the file's own header claims this case works.
+    const doc = ['cat > plan.md <<EOF', 'Repro:', `A) cd /elsewhere && ${CREATE} --body-file rel.md`, 'EOF'].join('\n')
+    expect(issueCreateInvocations(doc)).toEqual([])
+  })
+
+  it('reads the payload when the invocation outside it is real', () => {
+    // Two different questions, and the fix to the first must not answer the second. The payload is
+    // not where invocations live, and it is exactly where `--body-file -` gets its body.
+    expect(verdict(`${CREATE} --body-file - <<EOF\n${PARENT}\nEOF`).blocked).toBe(false)
+    expect(verdict(`${CREATE} --body-file - <<EOF\nnothing\nEOF`).blocked).toBe(true)
+  })
+
+  it('is not fooled by an unterminated one', () => {
+    // No terminator means no payload anyone can read, which `heredocs` already decides. Leaving the
+    // text scannable fails toward blocking, which is the safe direction for a gate.
+    expect(issueCreateInvocations(`${CREATE} --title x <<EOF\nstill the same command`)).toHaveLength(1)
+  })
+})
+
+describe('a newline begins a command', () => {
+  it('sees an invocation on a line of its own', () => {
+    // **A hole, not a nuisance.** `SEPARATOR` carried `;`, `&&` and `|` but not the newline, so
+    // command position never reset across lines and a multi-line Bash call — the ordinary shape for
+    // anything with a heredoc or a long flag list — walked straight past the gate.
+    const cmd = `git status\n${CREATE} --title x --body "a bug"`
+    expect(issueCreateInvocations(cmd)).toHaveLength(1)
+    expect(verdict(cmd).blocked).toBe(true)
+  })
+
+  it('judges each line-separated invocation on its own body', () => {
+    expect(verdict(`${CREATE} --body "${PARENT}"\n${CREATE} --body "a bug"`).blocked).toBe(true)
+    expect(verdict(`${CREATE} --body "${PARENT}"\n${CREATE} --body "${PARENT}"`).blocked).toBe(false)
+  })
+
+  it('does not treat a newline inside a quoted argument as one', () => {
+    // The tokenizer resolves quotes first, so a body with paragraphs stays one word.
+    expect(verdict(`${CREATE} --body "intro\n\n${PARENT}\n"`).blocked).toBe(false)
+  })
+})
+
+describe('the hook reports the reason it decided on', () => {
+  const run = (cmd) => spawnSync('bash', [path.join(REPO, '.claude/hooks/issue-parent-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd } }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  it('does not answer an unreadable body file with the parent rule', () => {
+    const r = run(`${CREATE} --title x --body-file nowhere-at-all.md`)
+    expect(r.status).toBe(2)
+    expect(r.stderr, 'the misdiagnosis this change exists for').not.toMatch(/names no parent/i)
+    expect(r.stderr, 'and it says which path it opened').toContain(path.join(REPO, 'nowhere-at-all.md'))
+  })
+
+  it('still answers a parentless body with the parent rule', () => {
+    const r = run(`${CREATE} --title x --body "a bug"`)
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/names no parent/i)
+    expect(r.stderr).toMatch(/Parent: #607/)
   })
 })

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -9,17 +9,21 @@
 // through a prefilter that never calls it is not a gate.
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { judge, issueCreateInvocations, hasParent, hasStandalone } from '../lib/issue-parent.mjs'
-import { tokenize, bodyFileArg, heredocs } from '../lib/gh-command.mjs'
+import { tokenize, bodyFileArg, bodyArg, titleArg, heredocs, readBodyFile } from '../lib/gh-command.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const PARENT = 'Parent: #607'
 
-/** `judge` with no filesystem: every body is supplied inline. */
+/** `judge` with no filesystem: every body is supplied inline, keyed as the command writes it. The
+ *  reader is handed a resolved path, so the keys are resolved to match. */
 const verdict = (cmd, files = {}) => judge(cmd, (p) => {
-  if (!(p in files)) throw new Error('ENOENT')
-  return files[p]
+  const key = Object.keys(files).find((k) => path.resolve(k) === p)
+  if (key === undefined) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+  return files[key]
 })
 
 describe('which commands are issue creations', () => {
@@ -302,5 +306,178 @@ describe('the hook reports the reason it decided on', () => {
     expect(r.status).toBe(2)
     expect(r.stderr).toMatch(/names no parent/i)
     expect(r.stderr).toMatch(/Parent: #607/)
+  })
+})
+
+// ── Added after the adversarial review of this branch ───────────────────────────────────────────
+
+describe('an operator does not need a space to end a command', () => {
+  // **Every one of these is valid shell and hid the invocation completely.** `tokenize` split on
+  // whitespace alone, so an operator glued to `gh` stayed inside that word and command position was
+  // never reached. `ASSIGNMENT` made the commonest form worse rather than better: `URL=$(gh` is a
+  // prefix match, so the mechanism added to see through `GH_REPO=o/r gh issue create` swallowed the
+  // capture form whole. Predates this branch; found by the review of it.
+  const GLUED = {
+    'a command substitution': `URL=$(${CREATE} --title t --body "a bug")`,
+    'an unspaced &&': `true&&${CREATE} --title t --body "a bug"`,
+    'an unspaced ;': `cd /tmp;${CREATE} --title t --body "a bug"`,
+    'an unspaced subshell': `(${CREATE} --title t --body "a bug")`,
+    'an unspaced pipe': `echo x|${CREATE} --body "a bug"`,
+  }
+  for (const [name, cmd] of Object.entries(GLUED)) {
+    it(`sees one behind ${name}`, () => {
+      expect(issueCreateInvocations(cmd)).toHaveLength(1)
+      expect(verdict(cmd).blocked, 'and judges it').toBe(true)
+    })
+  }
+
+  it('sees one behind xargs, which keeps the next word in command position', () => {
+    expect(issueCreateInvocations(`echo t | xargs ${CREATE} --body "a bug"`)).toHaveLength(1)
+  })
+
+  it('still ends the slice at the operator that follows, spaced or not', () => {
+    // The borrowed-flags case, now reachable without spaces: `echo`'s --body must not count as this
+    // invocation's.
+    expect(verdict(`${CREATE} --web&&echo --body "${PARENT}"`).blocked).toBe(true)
+  })
+
+  it('does not treat an operator inside a quoted argument as one', () => {
+    expect(verdict(`${CREATE} --body "${PARENT}" --title "a && b | c;"`).blocked).toBe(false)
+  })
+})
+
+describe('a heredoc opener ends its line', () => {
+  it('does not strip on a `<<` written inside an argument', () => {
+    // Introduced by the payload strip and caught by review. `<<EOF` matched anywhere on a line, so a
+    // command that merely *mentions* one began deleting lines until a later heredoc supplied the
+    // terminator — and took a real invocation with it. Requiring the opener to end its line
+    // separates the two, and the conservative direction of that rule is to strip nothing, which
+    // leaves the text scanned rather than skipped.
+    const cmd = [
+      'grep -n "<<EOF" scripts/lib/gh-command.mjs',
+      `${CREATE} --title x --body "a bug"`,
+      "cat > /tmp/n.md <<'EOF'",
+      'text',
+      'EOF',
+    ].join('\n')
+    expect(issueCreateInvocations(cmd)).toHaveLength(1)
+    expect(verdict(cmd).blocked).toBe(true)
+  })
+
+  it('still strips a real one, quoted delimiter and all', () => {
+    expect(verdict(`${CREATE} --body-file - <<'EOF'\n${PARENT}\nEOF`).blocked).toBe(false)
+  })
+
+  it('reads CRLF line endings the same way it reads LF', () => {
+    // `heredocs` split on /\r?\n/ while the strip split on '\n', so under CRLF the terminator line
+    // was `EOF\r`, never matched, and the payload was kept — bringing back the exact prose
+    // regression this branch exists to fix, on the line endings a Windows contributor produces.
+    // The terminator must not be the last line: joining three lines leaves the final `EOF` without
+    // its `\r`, which matches the delimiter by accident and strips the payload for the wrong reason.
+    // That shape passed under the mutation, which is how this probe was found to be measuring nothing.
+    const doc = [`cat > plan.md <<'EOF'`, `A) cd /elsewhere && ${CREATE} --body-file rel.md`, 'EOF', 'echo done']
+    expect(issueCreateInvocations(doc.join('\r\n')), 'CRLF').toEqual([])
+    expect(issueCreateInvocations(doc.join('\n')), 'LF').toEqual([])
+  })
+})
+
+describe('a short flag may carry its value', () => {
+  // pflag accepts a shorthand's value attached to it, verified against the binary: `gh issue list
+  // -Lx` answers `invalid argument "x" for "-L, --limit" flag`. The readers matched only an exact
+  // `-F`/`-b`/`-t` token or `--long=`, so a correctly-filed issue was refused for a body it does
+  // have — and the language gate, which shares these readers, saw no text to check at all.
+  it('reads a value attached to the shorthand', () => {
+    expect(bodyFileArg(tokenize(`${CREATE} -F/tmp/body.md`))).toBe('/tmp/body.md')
+    expect(bodyFileArg(tokenize(`${CREATE} -F-`)), 'stdin').toBe('-')
+    expect(bodyArg(tokenize(`${CREATE} -b"${PARENT}"`))).toBe(PARENT)
+    expect(titleArg(tokenize(`${CREATE} -t"a title"`))).toBe('a title')
+  })
+
+  it('does not read a long flag as a shorthand carrying a value', () => {
+    // `'--title'.startsWith('-t')`, so the prefix rule has to refuse a double dash or it answers
+    // `itle` for every long spelling the gate was already reading correctly.
+    expect(titleArg(tokenize(`${CREATE} --title x`))).toBe('x')
+    expect(bodyArg(tokenize(`${CREATE} --body y`))).toBe('y')
+    expect(bodyFileArg(tokenize(`${CREATE} --body-file z`))).toBe('z')
+    expect(bodyFileArg(tokenize(`${CREATE} --body-file=z`))).toBe('z')
+  })
+
+  it('allows an issue whose body arrives that way, and blocks one that does not', () => {
+    expect(verdict(`${CREATE} -b"${PARENT}"`).blocked).toBe(false)
+    expect(verdict(`${CREATE} -b"a bug"`).reason).toBe('no-parent')
+  })
+})
+
+describe('an unreadable body file is told why', () => {
+  const run = (cmd, cwd = REPO) => spawnSync('bash', [path.join(REPO, '.claude/hooks/issue-parent-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd }, cwd }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  // **One message for every errno reproduced this fix's own defect inside it.** A typo in an
+  // absolute path, a directory and a permissions failure were all answered with "pass an absolute
+  // path", which the author already had.
+  it('separates a missing absolute path from a relative one', () => {
+    expect(run(`${CREATE} --title T --body-file /nowhere/at/all.md`).stderr).toMatch(/No file is there/)
+    expect(run(`${CREATE} --title T --body-file rel.md`).stderr).toMatch(/relative to the directory/)
+  })
+
+  it('names a directory and a permissions failure as themselves', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gate-'))
+    expect(run(`${CREATE} --title T --body-file ${dir}`).stderr).toMatch(/is a directory/)
+
+    const locked = path.join(dir, 'locked.md')
+    writeFileSync(locked, 'x')
+    chmodSync(locked, 0o000)
+    expect(run(`${CREATE} --title T --body-file ${locked}`).stderr).toMatch(/permissions/)
+    chmodSync(locked, 0o644)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reads a relative body file from the checkout the session is in', () => {
+    // The hook runs from the repository root while `gh` runs where the session is, so resolving
+    // against the payload's cwd is what lets a relative path be read at all rather than reported.
+    const dir = mkdtempSync(path.join(tmpdir(), 'gate-'))
+    writeFileSync(path.join(dir, 'body.md'), `${PARENT}\n`)
+    expect(run(`${CREATE} --title T --body-file body.md`, dir).status).toBe(0)
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe('a body file that is not a regular file', () => {
+  // **A gate that hangs is worse than one that blocks.** `readFileSync` on a FIFO with no writer
+  // blocks until the hook times out, and the language gate reaching body files put that on the
+  // `gh pr create` path for the first time. `statSync` does not open the file, so it answers at once.
+  it('answers instead of blocking on a FIFO', () => {
+    // **Read in a child process, on purpose.** `readFileSync` is synchronous, so without the guard
+    // it blocks the worker thread and vitest's own `testTimeout` cannot interrupt it — the suite
+    // hangs rather than failing, which turns a regression into a stopped CI job instead of a red
+    // one. The child carries the timeout, so a missing guard shows up as `killed`.
+    const dir = mkdtempSync(path.join(tmpdir(), 'gate-'))
+    const fifo = path.join(dir, 'body.md')
+    spawnSync('mkfifo', [fifo])
+    try {
+      const r = spawnSync(process.execPath, [
+        '--input-type=module',
+        '-e',
+        `import { readBodyFile } from ${JSON.stringify(path.join(REPO, 'scripts/lib/gh-command.mjs'))}
+         try { readBodyFile(${JSON.stringify(fifo)}); console.log('read') }
+         catch (e) { console.log('threw:' + e.code) }`,
+      ], { encoding: 'utf8', timeout: 4000 })
+      expect(r.signal, 'the reader blocked on a FIFO instead of answering').toBeNull()
+      expect(r.stdout.trim()).toBe('threw:ENOTFILE')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 15000)
+
+  it('gives a directory its own errno so the message can name it', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gate-'))
+    try {
+      expect(() => readBodyFile(dir)).toThrow(expect.objectContaining({ code: 'EISDIR' }))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/scripts/__tests__/issueParentGate.test.mjs
+++ b/scripts/__tests__/issueParentGate.test.mjs
@@ -526,3 +526,35 @@ describe('a body file the command writes before sending it', () => {
     expect(verdict(cmd).blocked).toBe(false)
   })
 })
+
+describe('the prefilter matches what the shell would leave', () => {
+  const run = (cmd) => spawnSync('bash', [path.join(REPO, '.claude/hooks/issue-parent-gate.sh')], {
+    input: JSON.stringify({ tool_input: { command: cmd }, cwd: REPO }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  })
+
+  // The prefilter reads raw text and the parser reads a tokenized command, so a spelling that only
+  // becomes `gh issue create` after quote removal was a real invocation the gate exited before
+  // seeing. Squashing the characters the shell strips costs nothing, because it can only widen what
+  // reaches the parser — and the parser is what decides.
+  const SPELLINGS = {
+    'a double-quoted break': 'g"h" issue create --title x --body "a bug"',
+    'a single-quoted break': "g'h' issue create --title x --body 'a bug'",
+    'a break in the noun': 'gh iss"ue" create --title x --body "a bug"',
+    'a backslash escape': 'g\\h issue create --title x --body "a bug"',
+  }
+  for (const [name, cmd] of Object.entries(SPELLINGS)) {
+    it(`reaches the parser through ${name}`, () => {
+      expect(run(cmd).status).toBe(2)
+    })
+  }
+
+  it('still lets an unrelated command past without paying for node', () => {
+    // The widening has to stay narrow enough to be worth having. These are the shapes the prefilter
+    // exists for, and none of them contains the pair after squashing.
+    for (const cmd of ['rg -n "highlight" --pretty src', 'npm run build 2>&1 | grep -i high', 'git status --short']) {
+      expect(run(cmd).status, cmd).toBe(0)
+    }
+  })
+})

--- a/scripts/gh-language-gate.mjs
+++ b/scripts/gh-language-gate.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// The decision half of `.claude/hooks/gh-language-gate.sh`. Reads the PreToolUse payload on stdin,
+// exits 0 to allow and 2 to block. Kept out of the shell for the reason the file it replaces proves:
+// a regex over the whole command cannot tell a `gh` call from the words that spell one.
+import { judge } from './lib/gh-language.mjs'
+
+const message = (where) => `Blocked: ${where} is in Korean.
+
+PR and issue titles and bodies are written in English, so a contributor of any language can read
+them (AGENTS.md > "Branches, Commits & Releases"). Conversation and docs keep their own KO/EN rules,
+and this gate reads only the title and body — the rest of your command is yours.
+
+Rewrite that argument in English and re-run.`
+
+let raw = ''
+process.stdin.setEncoding('utf8')
+for await (const chunk of process.stdin) raw += chunk
+
+// Fail open on anything unparseable, matching the other gates in this directory: this guards a
+// cooperative-but-forgetful agent, not an adversary, and a gate that dies noisily on a malformed
+// payload would block every Bash call in the session.
+let cmd
+try { cmd = JSON.parse(raw)?.tool_input?.command ?? '' } catch { process.exit(0) }
+if (typeof cmd !== 'string' || !cmd) process.exit(0)
+
+let verdict
+try { verdict = judge(cmd) } catch { process.exit(0) }
+if (!verdict.blocked) process.exit(0)
+
+process.stderr.write(`${message(verdict.where)}\n`)
+process.exit(2)

--- a/scripts/gh-language-gate.mjs
+++ b/scripts/gh-language-gate.mjs
@@ -4,13 +4,15 @@
 // a regex over the whole command cannot tell a `gh` call from the words that spell one.
 import { judge } from './lib/gh-language.mjs'
 
-const message = (where) => `Blocked: ${where} is in Korean.
+const message = (v) => `Blocked: ${v.where} is in Korean: "${v.line}"
 
 PR and issue titles and bodies are written in English, so a contributor of any language can read
 them (AGENTS.md > "Branches, Commits & Releases"). Conversation and docs keep their own KO/EN rules,
-and this gate reads only the title and body — the rest of your command is yours.
+and this gate reads only the title and body — the rest of your command is yours. A line is judged
+Korean only when its Hangul outnumbers its Latin letters, so an English sentence naming a Korean
+label passes.
 
-Rewrite that argument in English and re-run.`
+Rewrite that line in English and re-run.`
 
 let raw = ''
 process.stdin.setEncoding('utf8')
@@ -20,12 +22,19 @@ for await (const chunk of process.stdin) raw += chunk
 // cooperative-but-forgetful agent, not an adversary, and a gate that dies noisily on a malformed
 // payload would block every Bash call in the session.
 let cmd
-try { cmd = JSON.parse(raw)?.tool_input?.command ?? '' } catch { process.exit(0) }
+let cwd
+try {
+  const payload = JSON.parse(raw)
+  cmd = payload?.tool_input?.command ?? ''
+  // The directory the command would run in, so a relative --body-file is read from the tree the
+  // session is in rather than from wherever the hook was launched.
+  cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
+} catch { process.exit(0) }
 if (typeof cmd !== 'string' || !cmd) process.exit(0)
 
 let verdict
-try { verdict = judge(cmd) } catch { process.exit(0) }
+try { verdict = judge(cmd, undefined, cwd) } catch { process.exit(0) }
 if (!verdict.blocked) process.exit(0)
 
-process.stderr.write(`${message(verdict.where)}\n`)
+process.stderr.write(`${message(verdict)}\n`)
 process.exit(2)

--- a/scripts/issue-parent-gate.mjs
+++ b/scripts/issue-parent-gate.mjs
@@ -35,13 +35,31 @@ or found several heredocs and will not guess which one is the body.
 
 Nothing has been decided about the Parent: line — the body was never read.`
 
-/** Names the path that was opened, because the reason it was not found is never in the command. */
-const unreadableBodyFile = (detail) => `Blocked: ${detail}
+/**
+ * Names the path that was opened and why it could not be read.
+ *
+ * **The cause is not always the relative path**, and saying so anyway reproduces inside this fix the
+ * exact defect it exists to end: a typo in an absolute path, a directory, and a permissions failure
+ * were all answered with "pass an absolute path", which the author already had.
+ */
+const CAUSE = {
+  EISDIR: 'That path is a directory.',
+  EACCES: 'That path is not readable — check its permissions.',
+  EPERM: 'That path is not readable — check its permissions.',
+  ELOOP: 'That path is a symlink loop.',
+}
 
-The gate runs from the repository root, not from the directory your command runs in, so a relative
---body-file resolves against the repo. Pass an absolute path, or --body, and re-run.
+function unreadableBodyFile(v) {
+  const why = CAUSE[v.code]
+    ?? (v.file !== v.resolved
+      ? `It was written relative to the directory your command runs in, and resolved as above.`
+      : `No file is there.`)
+  return `Blocked: ${v.detail}
+
+${why}
 
 Nothing has been decided about the Parent: line — the body was never read.`
+}
 
 const MESSAGES = {
   'no-parent': () => NO_PARENT,
@@ -57,15 +75,22 @@ for await (const chunk of process.stdin) raw += chunk
 // cooperative-but-forgetful agent, not an adversary, and a gate that dies noisily on a malformed
 // payload would block every Bash call in the session.
 let cmd
-try { cmd = JSON.parse(raw)?.tool_input?.command ?? '' } catch { process.exit(0) }
+let cwd
+try {
+  const payload = JSON.parse(raw)
+  cmd = payload?.tool_input?.command ?? ''
+  // The directory the command would run in. The hook itself runs from the repository root, so
+  // without this a relative --body-file is looked for in the wrong tree and reported as missing.
+  cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
+} catch { process.exit(0) }
 if (typeof cmd !== 'string' || !cmd) process.exit(0)
 
 let verdict
-try { verdict = judge(cmd) } catch { process.exit(0) }
+try { verdict = judge(cmd, undefined, cwd) } catch { process.exit(0) }
 if (!verdict.blocked) process.exit(0)
 
 // An unrecognised reason falls back to the parent rule rather than to silence: a new reason added
 // without a message here should still block, since blocking is what the verdict said.
-const message = (MESSAGES[verdict.reason] ?? MESSAGES['no-parent'])(verdict.detail)
+const message = (MESSAGES[verdict.reason] ?? MESSAGES['no-parent'])(verdict)
 process.stderr.write(`${message}\n`)
 process.exit(2)

--- a/scripts/issue-parent-gate.mjs
+++ b/scripts/issue-parent-gate.mjs
@@ -2,9 +2,15 @@
 // The decision half of `.claude/hooks/issue-parent-gate.sh`. Reads the PreToolUse payload on stdin,
 // exits 0 to allow and 2 to block. Kept out of the shell because the rules are parsing rules and the
 // shell version got three of them wrong — see `scripts/lib/issue-parent.mjs`.
+//
+// **A blocked command is told which rule it broke.** This file used to print one constant for all
+// three outcomes, so a body file the gate could not open was answered with the parent rule — and the
+// author goes to add a line the body already has. That happened filing #700, whose body carried
+// `Parent: #609` the whole time; the real fault was a relative `--body-file` resolved against the
+// repo root rather than the directory the command would have run in.
 import { judge } from './lib/issue-parent.mjs'
 
-const MESSAGE = `Blocked: this issue names no parent.
+const NO_PARENT = `Blocked: this issue names no parent.
 
 An issue split out of other work needs a line of its own in the body:
 
@@ -22,6 +28,27 @@ And before filing at all: a finding under ~10 lines that the lens you are alread
 is fixed in that PR, not deferred. AGENTS.md > "An adjacent defect is fixed here unless it needs its
 own decision".`
 
+const NO_BODY = `Blocked: no body could be read from this issue creation.
+
+The gate reads --body, --body-file, or the heredoc behind \`--body-file -\`. It found none of them,
+or found several heredocs and will not guess which one is the body.
+
+Nothing has been decided about the Parent: line — the body was never read.`
+
+/** Names the path that was opened, because the reason it was not found is never in the command. */
+const unreadableBodyFile = (detail) => `Blocked: ${detail}
+
+The gate runs from the repository root, not from the directory your command runs in, so a relative
+--body-file resolves against the repo. Pass an absolute path, or --body, and re-run.
+
+Nothing has been decided about the Parent: line — the body was never read.`
+
+const MESSAGES = {
+  'no-parent': () => NO_PARENT,
+  'no-body': () => NO_BODY,
+  'unreadable-body-file': unreadableBodyFile,
+}
+
 let raw = ''
 process.stdin.setEncoding('utf8')
 for await (const chunk of process.stdin) raw += chunk
@@ -36,5 +63,9 @@ if (typeof cmd !== 'string' || !cmd) process.exit(0)
 let verdict
 try { verdict = judge(cmd) } catch { process.exit(0) }
 if (!verdict.blocked) process.exit(0)
-process.stderr.write(`${MESSAGE}\n`)
+
+// An unrecognised reason falls back to the parent rule rather than to silence: a new reason added
+// without a message here should still block, since blocking is what the verdict said.
+const message = (MESSAGES[verdict.reason] ?? MESSAGES['no-parent'])(verdict.detail)
+process.stderr.write(`${message}\n`)
 process.exit(2)

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+
 /**
  * Reading a Bash command well enough to tell a `gh` invocation from the words that spell one.
  *
@@ -13,22 +15,34 @@
  * Split a shell command into words the way the shell would, enough for this job: single quotes are
  * literal, double quotes group, a backslash escapes the next character.
  *
+ * **Operators are their own tokens even with no space around them.** Splitting on whitespace alone
+ * meant an operator glued to `gh` stayed inside that word and command position was never reached, so
+ * `true&&gh issue create`, `cd /tmp;gh …`, `(gh …)` and `echo x|gh …` were all invisible. The
+ * commonest form was the worst: `URL=$(gh` is a *prefix* match for `ASSIGNMENT`, so the mechanism
+ * added to see through `GH_REPO=o/r gh issue create` swallowed the capture form whole.
+ *
  * **An unquoted newline becomes a `NEWLINE` token** rather than vanishing into whitespace, because a
  * newline starts a command and the caller has to see that. A NUL is used as the sentinel since it is
  * the one byte that cannot appear in a real argument — `execve` strings are NUL-terminated — so no
  * quoted body can forge one. A backslash before a newline is a line continuation and produces
  * neither a token nor a break.
  *
- * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and the
- * callers treat what it cannot resolve as unresolved rather than as absent.
+ * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and it
+ * resolves quoting before the caller consults `SEPARATOR`, so a quoted word that happens to read
+ * `do` or `then` is taken for one. Every case that costs is a false block rather than a miss.
  */
 export const NEWLINE = '\0'
+
+/** Unquoted characters that end a word and begin a new command. `(` and `)` are here so that both
+ *  `(gh …)` and `$(gh …)` reach command position. */
+const OPERATOR = '&|;()'
 
 export function tokenize(cmd) {
   const out = []
   let cur = ''
   let started = false
   let quote = null
+  const flush = () => { if (started || cur) out.push(cur); cur = ''; started = false }
   for (let i = 0; i < cmd.length; i++) {
     const c = cmd[i]
     if (quote === "'") {
@@ -45,23 +59,21 @@ export function tokenize(cmd) {
     if (c === "'" || c === '"') { quote = c; started = true; continue }
     if (c === '\\' && cmd[i + 1] === '\n') { i++; continue }
     if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue }
-    if (c === '\n') {
-      if (started || cur) out.push(cur)
-      out.push(NEWLINE)
-      cur = ''
-      started = false
+    if (c === '\n') { flush(); out.push(NEWLINE); continue }
+    if (OPERATOR.includes(c)) {
+      flush()
+      // A run of the same operator is one token, so `&&` and `||` stay recognisable rather than
+      // arriving as two singles that both happen to be separators anyway.
+      let run = c
+      while (cmd[i + 1] === c) { run += c; i++ }
+      out.push(run)
       continue
     }
-    if (/\s/.test(c)) {
-      if (started || cur) out.push(cur)
-      cur = ''
-      started = false
-      continue
-    }
+    if (/\s/.test(c)) { flush(); continue }
     cur += c
     started = true
   }
-  if (started || cur) out.push(cur)
+  flush()
   return out
 }
 
@@ -69,13 +81,25 @@ export function tokenize(cmd) {
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
 
 /** Wrappers that keep the next word in command position. */
-const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time'])
+const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time', 'xargs'])
 
 /** Separators after which a new command begins. */
-const SEPARATOR = new Set([NEWLINE, ';', '&&', '||', '|', '&', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
+const SEPARATOR = new Set([NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
 
-/** The opening of a heredoc: `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`. */
-const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/
+/**
+ * The opening of a heredoc: `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
+ *
+ * **Anchored to the end of the line.** Unanchored it fired on a `<<` written inside an argument —
+ * `grep -n "<<EOF" file` — and the strip below then deleted every line up to whatever terminator a
+ * later, genuine heredoc supplied, taking a real invocation with it. A real opener is the last thing
+ * on its line in every shape this repo writes; one followed by a further redirection is treated as
+ * no heredoc at all, which leaves its text scanned rather than skipped.
+ */
+const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2\s*$/
+
+/** Split on either line ending. A CRLF command reaching `'\n'` alone left `EOF\r` never matching its
+ *  delimiter, so every payload read as unterminated and the prose regression came back. */
+const lines = (cmd) => cmd.split(/\r?\n/)
 
 /**
  * Every heredoc payload in a command, in order.
@@ -84,20 +108,20 @@ const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/
  * that is never terminated has no payload anyone can read and is skipped.
  */
 export function heredocs(cmd) {
-  const lines = cmd.split(/\r?\n/)
+  const src = lines(cmd)
   const out = []
-  for (let i = 0; i < lines.length; i++) {
-    const m = HEREDOC_OPEN.exec(lines[i])
+  for (let i = 0; i < src.length; i++) {
+    const m = HEREDOC_OPEN.exec(src[i])
     if (!m) continue
     const [, dash, , delim] = m
     const body = []
     let j = i + 1
-    for (; j < lines.length; j++) {
-      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
+    for (; j < src.length; j++) {
+      const candidate = dash ? src[j].replace(/^\t+/, '') : src[j]
       if (candidate === delim) break
-      body.push(lines[j])
+      body.push(src[j])
     }
-    if (j >= lines.length) continue          // never terminated: not a payload anyone can read
+    if (j >= src.length) continue          // never terminated: not a payload anyone can read
     out.push(body.join('\n'))
     i = j
   }
@@ -109,27 +133,27 @@ export function heredocs(cmd) {
  *
  * **A payload is text, and it was being read as a command.** Quoting is what keeps
  * `echo "gh issue create"` from counting; a heredoc body is unquoted, so its words tokenize as bare
- * words and any line inside it could land in command position. Found by being blocked from writing
+ * words and any line inside one could land in command position. Found by being blocked from writing
  * the plan document for this change, whose prose carried the example `&& gh issue create …`.
  *
  * The opening line stays — the invocation lives there — and so does an unterminated heredoc, whose
  * text keeps being scanned. That direction costs a false block rather than a miss.
  */
 export function withoutHeredocPayloads(cmd) {
-  const lines = cmd.split('\n')
+  const src = lines(cmd)
   const kept = []
-  for (let i = 0; i < lines.length; i++) {
-    kept.push(lines[i])
-    const m = HEREDOC_OPEN.exec(lines[i])
+  for (let i = 0; i < src.length; i++) {
+    kept.push(src[i])
+    const m = HEREDOC_OPEN.exec(src[i])
     if (!m) continue
     const [, dash, , delim] = m
     let j = i + 1
-    for (; j < lines.length; j++) {
-      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
+    for (; j < src.length; j++) {
+      const candidate = dash ? src[j].replace(/^\t+/, '') : src[j]
       if (candidate === delim) break
     }
-    if (j >= lines.length) continue          // unterminated: nothing to strip, keep scanning it
-    i = j                                    // skip the payload and its terminator
+    if (j >= src.length) continue          // unterminated: nothing to strip, keep scanning it
+    i = j                                  // skip the payload and its terminator
   }
   return kept.join('\n')
 }
@@ -139,7 +163,7 @@ export function withoutHeredocPayloads(cmd) {
  *
  * Command position is tracked rather than pattern-matched, so this repo's own docs — which print
  * these commands inside prose, inside `echo`, and inside heredocs — do not trip it, while the
- * wrapped and prefixed forms do.
+ * wrapped, prefixed and unspaced forms do.
  */
 export function ghInvocations(cmd, noun, verbs) {
   const words = tokenize(withoutHeredocPayloads(cmd))
@@ -165,13 +189,22 @@ export function ghInvocations(cmd, noun, verbs) {
   return found
 }
 
-/** Read a flag's argument, in every spelling gh accepts for it. */
+/**
+ * Read a flag's argument, in every spelling gh accepts for it.
+ *
+ * **Including the value attached to the shorthand**, which pflag takes and this read none of:
+ * verified against the binary, `gh issue list -Lx` answers `invalid argument "x" for "-L, --limit"`.
+ * The prefix rule refuses a double dash, or `--title` — which does start with `-t` — would come back
+ * as `itle`.
+ */
 function flagArg(words, long, short) {
-  const eq = new RegExp(`^${long}=(.*)$`, 's')
+  const eq = new RegExp(`^${long}=([\\s\\S]*)$`)
   for (let i = 0; i < words.length; i++) {
-    if (words[i] === long || words[i] === short) return words[i + 1] ?? null
-    const m = eq.exec(words[i])
+    const w = words[i]
+    if (w === long || w === short) return words[i + 1] ?? null
+    const m = eq.exec(w)
     if (m) return m[1]
+    if (!w.startsWith('--') && w.startsWith(short) && w.length > short.length) return w.slice(short.length)
   }
   return null
 }
@@ -184,3 +217,21 @@ export const bodyArg = (words) => flagArg(words, '--body', '-b')
 
 /** The `--title` / `-t` argument, quoting resolved. */
 export const titleArg = (words) => flagArg(words, '--title', '-t')
+
+/**
+ * The reader both gates use for a `--body-file`.
+ *
+ * **It stats before it reads**, because `readFileSync` on a FIFO with no writer blocks until the
+ * hook times out — a gate that hangs is worse than one that blocks, and the language gate reaching
+ * body files put that on the `gh pr create` path for the first time. `statSync` does not open, so it
+ * answers immediately. A directory keeps its own errno so the message can name it.
+ */
+export function readBodyFile(p) {
+  const st = fs.statSync(p)
+  if (!st.isFile()) {
+    const err = new Error(`not a regular file: ${p}`)
+    err.code = st.isDirectory() ? 'EISDIR' : 'ENOTFILE'
+    throw err
+  }
+  return fs.readFileSync(p, 'utf8')
+}

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 
 /**
  * Reading a Bash command well enough to tell a `gh` invocation from the words that spell one.
@@ -83,8 +84,17 @@ const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
 /** Wrappers that keep the next word in command position. */
 const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time', 'xargs'])
 
-/** Separators after which a new command begins. */
-const SEPARATOR = new Set([NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
+/**
+ * Separators after which a new command begins.
+ *
+ * **The control-flow keywords are here because they take a command as their condition.** `if`,
+ * `elif`, `while` and `until` left `atStart` false, so `if gh issue create …; then` was invisible to
+ * both gates — the mirror of `then`/`do`/`else`, which were in the set from the start.
+ */
+const SEPARATOR = new Set([
+  NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')', '{', '}',
+  'if', 'elif', 'then', 'while', 'until', 'do', 'else', '!',
+])
 
 /**
  * The opening of a heredoc: `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
@@ -107,7 +117,31 @@ const lines = (cmd) => cmd.split(/\r?\n/)
  * The caller blocks when a command carries more than one, because picking is guessing. A heredoc
  * that is never terminated has no payload anyone can read and is skipped.
  */
-export function heredocs(cmd) {
+export const heredocs = (cmd) => heredocEntries(cmd).map((e) => e.body)
+
+/**
+ * The redirection target on a line, or null — the last one, since a later `>` wins.
+ *
+ * `&` is excluded so `2>&1` is not read as a filename, and `<`/`|`/`;` cannot appear in the target.
+ */
+const REDIRECT = /(?:^|\s)\d?>>?\s*(?!&)("[^"]*"|'[^']*'|[^\s<>|&;]+)/g
+
+function redirectTarget(line) {
+  let target = null
+  for (const m of line.matchAll(REDIRECT)) target = m[1].replace(/^['"]|['"]$/g, '')
+  return target
+}
+
+/**
+ * Every heredoc payload with the file its opening line redirects to, if any.
+ *
+ * **Which heredoc is the body is a question about the redirection, not about how many there are.**
+ * Treating the command's only heredoc as the body did two wrong things at once: an unrelated one was
+ * blamed on a body file whose contents were never read, and a heredoc *overwriting* an existing body
+ * file was ignored in favour of the stale text on disk — so a body the command was about to replace
+ * is what got judged, and the replacement reached GitHub unread.
+ */
+export function heredocEntries(cmd) {
   const src = lines(cmd)
   const out = []
   for (let i = 0; i < src.length; i++) {
@@ -121,11 +155,20 @@ export function heredocs(cmd) {
       if (candidate === delim) break
       body.push(src[j])
     }
-    if (j >= src.length) continue          // never terminated: not a payload anyone can read
-    out.push(body.join('\n'))
+    if (j >= src.length) continue
+    out.push({ target: redirectTarget(src[i]), body: body.join('\n') })
     i = j
   }
   return out
+}
+
+/** The payload of a heredoc this command writes to `resolvedPath`, or null. What a command is about
+ *  to write is what reaches GitHub, so it outranks whatever is on disk now. */
+export function heredocWrittenTo(cmd, resolvedPath, cwd) {
+  for (const { target, body } of heredocEntries(cmd)) {
+    if (target !== null && path.resolve(cwd, target) === resolvedPath) return body
+  }
+  return null
 }
 
 /**
@@ -196,17 +239,22 @@ export function ghInvocations(cmd, noun, verbs) {
  * verified against the binary, `gh issue list -Lx` answers `invalid argument "x" for "-L, --limit"`.
  * The prefix rule refuses a double dash, or `--title` — which does start with `-t` — would come back
  * as `itle`.
+ *
+ * **The last occurrence wins, because that is what pflag does.** A scalar flag given twice overwrites,
+ * so reading the first let `--body "Parent: #607" --body "a bug"` satisfy the gate with text GitHub
+ * would never receive.
  */
 function flagArg(words, long, short) {
   const eq = new RegExp(`^${long}=([\\s\\S]*)$`)
+  let found = null
   for (let i = 0; i < words.length; i++) {
     const w = words[i]
-    if (w === long || w === short) return words[i + 1] ?? null
+    if (w === long || w === short) { found = words[i + 1] ?? null; continue }
     const m = eq.exec(w)
-    if (m) return m[1]
-    if (!w.startsWith('--') && w.startsWith(short) && w.length > short.length) return w.slice(short.length)
+    if (m) { found = m[1]; continue }
+    if (!w.startsWith('--') && w.startsWith(short) && w.length > short.length) found = w.slice(short.length)
   }
-  return null
+  return found
 }
 
 /** The `--body-file` / `-F` argument, quoting resolved. `-` means stdin, which is not a path. */

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -1,0 +1,186 @@
+/**
+ * Reading a Bash command well enough to tell a `gh` invocation from the words that spell one.
+ *
+ * **Two gates needed this and only one had it.** `issue-parent.mjs` was written because a shell
+ * regex got three rules wrong in the same way — it matched text anywhere in the command instead of
+ * parsing anything — and the language gate next to it in `settings.json` was still a perl regex over
+ * the whole command. It refused a `node -e` script that carried `gh issue create` inside a string
+ * literal. Rather than write the parser twice, it lives here and both import it; a second, weaker
+ * copy is how this kind of guard drifts, which `check-changeset.mjs` already says about `proseLines`.
+ */
+
+/**
+ * Split a shell command into words the way the shell would, enough for this job: single quotes are
+ * literal, double quotes group, a backslash escapes the next character.
+ *
+ * **An unquoted newline becomes a `NEWLINE` token** rather than vanishing into whitespace, because a
+ * newline starts a command and the caller has to see that. A NUL is used as the sentinel since it is
+ * the one byte that cannot appear in a real argument — `execve` strings are NUL-terminated — so no
+ * quoted body can forge one. A backslash before a newline is a line continuation and produces
+ * neither a token nor a break.
+ *
+ * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and the
+ * callers treat what it cannot resolve as unresolved rather than as absent.
+ */
+export const NEWLINE = '\0'
+
+export function tokenize(cmd) {
+  const out = []
+  let cur = ''
+  let started = false
+  let quote = null
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]
+    if (quote === "'") {
+      if (c === "'") quote = null
+      else cur += c
+      continue
+    }
+    if (quote === '"') {
+      if (c === '"') quote = null
+      else if (c === '\\' && i + 1 < cmd.length && '"\\$`'.includes(cmd[i + 1])) cur += cmd[++i]
+      else cur += c
+      continue
+    }
+    if (c === "'" || c === '"') { quote = c; started = true; continue }
+    if (c === '\\' && cmd[i + 1] === '\n') { i++; continue }
+    if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue }
+    if (c === '\n') {
+      if (started || cur) out.push(cur)
+      out.push(NEWLINE)
+      cur = ''
+      started = false
+      continue
+    }
+    if (/\s/.test(c)) {
+      if (started || cur) out.push(cur)
+      cur = ''
+      started = false
+      continue
+    }
+    cur += c
+    started = true
+  }
+  if (started || cur) out.push(cur)
+  return out
+}
+
+/** `FOO=bar`, the form that let `GH_REPO=o/r gh issue create` past a matcher anchored on `gh`. */
+const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+/** Wrappers that keep the next word in command position. */
+const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time'])
+
+/** Separators after which a new command begins. */
+const SEPARATOR = new Set([NEWLINE, ';', '&&', '||', '|', '&', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
+
+/** The opening of a heredoc: `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`. */
+const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/
+
+/**
+ * Every heredoc payload in a command, in order.
+ *
+ * The caller blocks when a command carries more than one, because picking is guessing. A heredoc
+ * that is never terminated has no payload anyone can read and is skipped.
+ */
+export function heredocs(cmd) {
+  const lines = cmd.split(/\r?\n/)
+  const out = []
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEREDOC_OPEN.exec(lines[i])
+    if (!m) continue
+    const [, dash, , delim] = m
+    const body = []
+    let j = i + 1
+    for (; j < lines.length; j++) {
+      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
+      if (candidate === delim) break
+      body.push(lines[j])
+    }
+    if (j >= lines.length) continue          // never terminated: not a payload anyone can read
+    out.push(body.join('\n'))
+    i = j
+  }
+  return out
+}
+
+/**
+ * The same command with every heredoc payload removed, leaving the lines that are commands.
+ *
+ * **A payload is text, and it was being read as a command.** Quoting is what keeps
+ * `echo "gh issue create"` from counting; a heredoc body is unquoted, so its words tokenize as bare
+ * words and any line inside it could land in command position. Found by being blocked from writing
+ * the plan document for this change, whose prose carried the example `&& gh issue create …`.
+ *
+ * The opening line stays — the invocation lives there — and so does an unterminated heredoc, whose
+ * text keeps being scanned. That direction costs a false block rather than a miss.
+ */
+export function withoutHeredocPayloads(cmd) {
+  const lines = cmd.split('\n')
+  const kept = []
+  for (let i = 0; i < lines.length; i++) {
+    kept.push(lines[i])
+    const m = HEREDOC_OPEN.exec(lines[i])
+    if (!m) continue
+    const [, dash, , delim] = m
+    let j = i + 1
+    for (; j < lines.length; j++) {
+      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
+      if (candidate === delim) break
+    }
+    if (j >= lines.length) continue          // unterminated: nothing to strip, keep scanning it
+    i = j                                    // skip the payload and its terminator
+  }
+  return kept.join('\n')
+}
+
+/**
+ * Every `gh <noun> <verb>` in the command, as the token slice that starts at `gh`.
+ *
+ * Command position is tracked rather than pattern-matched, so this repo's own docs — which print
+ * these commands inside prose, inside `echo`, and inside heredocs — do not trip it, while the
+ * wrapped and prefixed forms do.
+ */
+export function ghInvocations(cmd, noun, verbs) {
+  const words = tokenize(withoutHeredocPayloads(cmd))
+  const wanted = new Set(verbs)
+  const found = []
+  let atStart = true
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (SEPARATOR.has(w)) { atStart = true; continue }
+    if (!atStart) continue
+    let j = i
+    while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
+    if (words[j] === 'gh' && words[j + 1] === noun && wanted.has(words[j + 2])) {
+      // **Stop at the next separator.** Running to the end of the token list meant a later command's
+      // flags counted as this one's: `gh issue create --web && echo --body "Parent: #607"` was
+      // allowed, because `bodyArg` found `echo`'s argument.
+      let end = j
+      while (end < words.length && !SEPARATOR.has(words[end])) end++
+      found.push(words.slice(j, end))
+    }
+    atStart = false
+  }
+  return found
+}
+
+/** Read a flag's argument, in every spelling gh accepts for it. */
+function flagArg(words, long, short) {
+  const eq = new RegExp(`^${long}=(.*)$`, 's')
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === long || words[i] === short) return words[i + 1] ?? null
+    const m = eq.exec(words[i])
+    if (m) return m[1]
+  }
+  return null
+}
+
+/** The `--body-file` / `-F` argument, quoting resolved. `-` means stdin, which is not a path. */
+export const bodyFileArg = (words) => flagArg(words, '--body-file', '-F')
+
+/** The `--body` / `-b` argument, quoting resolved. */
+export const bodyArg = (words) => flagArg(words, '--body', '-b')
+
+/** The `--title` / `-t` argument, quoting resolved. */
+export const titleArg = (words) => flagArg(words, '--title', '-t')

--- a/scripts/lib/gh-language.mjs
+++ b/scripts/lib/gh-language.mjs
@@ -1,5 +1,5 @@
-import fs from 'node:fs'
-import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs } from './gh-command.mjs'
+import path from 'node:path'
+import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs, readBodyFile } from './gh-command.mjs'
 
 /**
  * Are this PR's or issue's title and body in English, as AGENTS.md requires?
@@ -14,8 +14,35 @@ import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs } from './gh-co
  * heredoc behind `--body-file -`. Everything else in the command is somebody else's text.
  */
 
-/** Hangul anywhere. The rule is about the language of the prose, not about a particular character. */
 const HANGUL = /\p{Script=Hangul}/u
+const LATIN = /\p{Script=Latin}/u
+
+/**
+ * The first line whose prose is Korean, or null.
+ *
+ * **Judged per line and by predominance, not by any Hangul at all.** The rule AGENTS.md states is
+ * that the prose is English so contributors of any language can read it, and an English sentence
+ * that *names* a Korean string satisfies it. Merged PR #660 carries
+ * `Renamed sidebar labels to "Network Control" and "네트워크 제어."` in an otherwise English body;
+ * a codepoint test blocks it and then advises rewriting the label in English, which would make the
+ * sentence false. The repo ships `docs/ko/`, so naming Korean labels and paths is a live workflow.
+ *
+ * A line counts as Korean when its Hangul outnumbers its Latin letters — a quoted label inside an
+ * English sentence never does, and a Korean sentence always does.
+ */
+export function koreanLine(text) {
+  for (const line of String(text).split(/\r?\n/)) {
+    if (!HANGUL.test(line)) continue
+    let hangul = 0
+    let latin = 0
+    for (const ch of line) {
+      if (HANGUL.test(ch)) hangul++
+      else if (LATIN.test(ch)) latin++
+    }
+    if (hangul > latin) return line.trim()
+  }
+  return null
+}
 
 /** Every `gh` call that writes a title or body to GitHub. `comment` is not one: a review comment is
  *  a conversation, and the rule AGENTS.md states is about PR and issue titles and bodies. */
@@ -29,12 +56,14 @@ export function authoringInvocations(cmd) {
 /**
  * @param {string} cmd the Bash command the tool was asked to run
  * @param {(p: string) => string} [readFile] injected for the tests
- * @returns {{ blocked: boolean, where?: string }} `where` names the argument it found Korean in
+ * @param {string} [cwd] the directory the command would run in, from the hook payload
+ * @returns {{ blocked: boolean, where?: string, line?: string }}
  */
-export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
+export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
   for (const words of authoringInvocations(cmd)) {
-    for (const [where, text] of textsReachingGitHub(words, cmd, readFile)) {
-      if (HANGUL.test(text)) return { blocked: true, where }
+    for (const [where, text] of textsReachingGitHub(words, cmd, readFile, cwd)) {
+      const line = koreanLine(text)
+      if (line !== null) return { blocked: true, where, line }
     }
   }
   return { blocked: false }
@@ -43,13 +72,17 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
 /**
  * Every piece of prose this invocation would publish, paired with what to call it in the message.
  *
- * **An unreadable body file is skipped rather than blocked, and that is a real limit.** The gate
- * runs from the repository root while the command runs wherever its own `cd` put it, so a relative
+ * **A body file the same command is about to write does not exist yet**, and that is the natural
+ * single-call shape: a heredoc writes the body, then `gh pr create --body-file` sends it. Reading
+ * the file then fails and the Korean sits unread in the payload — the very hole the port was for.
+ * So an unreadable body file falls back to the command's sole heredoc, which is where that body is.
+ *
+ * With no heredoc to fall back to, an unreadable file is skipped rather than blocked, and that limit
+ * is real: the gate resolves against the session's directory while the command may `cd` first, so a
  * path can be readable to `gh` and not to this. Blocking every such path would refuse correct work
- * over a file the gate merely could not open. What that leaves uncovered is a Korean body passed by
- * a relative path from another directory — a floor, not a fence.
+ * over a file the gate merely could not open. A floor, not a fence.
  */
-function* textsReachingGitHub(words, cmd, readFile) {
+function* textsReachingGitHub(words, cmd, readFile, cwd) {
   const title = titleArg(words)
   if (title !== null) yield ['--title', title]
 
@@ -57,16 +90,17 @@ function* textsReachingGitHub(words, cmd, readFile) {
   if (body !== null) yield ['--body', body]
 
   const file = bodyFileArg(words)
+  const docs = heredocs(cmd)
   if (file !== null && file !== '-') {
     let contents = null
-    try { contents = readFile(file) } catch { contents = null }
+    try { contents = readFile(path.resolve(cwd, file)) } catch { contents = null }
     if (contents !== null) yield [`the body file ${file}`, contents]
+    else if (docs.length === 1) yield [`the heredoc written to ${file}`, docs[0]]
   }
   if (file === '-') {
-    // One heredoc is the body. Several means the command builds text elsewhere too, and picking
-    // would be guessing — the parent gate blocks on that ambiguity because a wrong guess there is
-    // permissive; here a wrong guess would refuse someone else's prose, so it is left alone.
-    const docs = heredocs(cmd)
+    // Several heredocs means the command builds text elsewhere too, and picking would be guessing —
+    // the parent gate blocks on that ambiguity because a wrong guess there is permissive; here a
+    // wrong guess would refuse someone else's prose, so it is left alone.
     if (docs.length === 1) yield ['the heredoc body', docs[0]]
   }
 }

--- a/scripts/lib/gh-language.mjs
+++ b/scripts/lib/gh-language.mjs
@@ -1,0 +1,72 @@
+import fs from 'node:fs'
+import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs } from './gh-command.mjs'
+
+/**
+ * Are this PR's or issue's title and body in English, as AGENTS.md requires?
+ *
+ * **This replaces a perl regex over the whole command**, which was wrong in both directions. It
+ * refused a `node -e` script carrying `gh issue create` inside a string literal, because the pattern
+ * matched text rather than a command — the same mistake `issue-parent.mjs` exists to have fixed, in
+ * the hook sitting next to it. And it never saw a `--body-file`, so Korean in the form CONTRIBUTING
+ * tells everyone to use went straight through while Korean typed inline was caught.
+ *
+ * What is judged is what reaches GitHub: the title, the body, the body file's contents, and the
+ * heredoc behind `--body-file -`. Everything else in the command is somebody else's text.
+ */
+
+/** Hangul anywhere. The rule is about the language of the prose, not about a particular character. */
+const HANGUL = /\p{Script=Hangul}/u
+
+/** Every `gh` call that writes a title or body to GitHub. `comment` is not one: a review comment is
+ *  a conversation, and the rule AGENTS.md states is about PR and issue titles and bodies. */
+export function authoringInvocations(cmd) {
+  return [
+    ...ghInvocations(cmd, 'issue', ['create', 'new', 'edit']),
+    ...ghInvocations(cmd, 'pr', ['create', 'edit']),
+  ]
+}
+
+/**
+ * @param {string} cmd the Bash command the tool was asked to run
+ * @param {(p: string) => string} [readFile] injected for the tests
+ * @returns {{ blocked: boolean, where?: string }} `where` names the argument it found Korean in
+ */
+export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
+  for (const words of authoringInvocations(cmd)) {
+    for (const [where, text] of textsReachingGitHub(words, cmd, readFile)) {
+      if (HANGUL.test(text)) return { blocked: true, where }
+    }
+  }
+  return { blocked: false }
+}
+
+/**
+ * Every piece of prose this invocation would publish, paired with what to call it in the message.
+ *
+ * **An unreadable body file is skipped rather than blocked, and that is a real limit.** The gate
+ * runs from the repository root while the command runs wherever its own `cd` put it, so a relative
+ * path can be readable to `gh` and not to this. Blocking every such path would refuse correct work
+ * over a file the gate merely could not open. What that leaves uncovered is a Korean body passed by
+ * a relative path from another directory — a floor, not a fence.
+ */
+function* textsReachingGitHub(words, cmd, readFile) {
+  const title = titleArg(words)
+  if (title !== null) yield ['--title', title]
+
+  const body = bodyArg(words)
+  if (body !== null) yield ['--body', body]
+
+  const file = bodyFileArg(words)
+  if (file !== null && file !== '-') {
+    let contents = null
+    try { contents = readFile(file) } catch { contents = null }
+    if (contents !== null) yield [`the body file ${file}`, contents]
+  }
+  if (file === '-') {
+    // One heredoc is the body. Several means the command builds text elsewhere too, and picking
+    // would be guessing — the parent gate blocks on that ambiguity because a wrong guess there is
+    // permissive; here a wrong guess would refuse someone else's prose, so it is left alone.
+    const docs = heredocs(cmd)
+    if (docs.length === 1) yield ['the heredoc body', docs[0]]
+  }
+}

--- a/scripts/lib/gh-language.mjs
+++ b/scripts/lib/gh-language.mjs
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs, readBodyFile } from './gh-command.mjs'
+import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs, heredocWrittenTo, readBodyFile } from './gh-command.mjs'
 
 /**
  * Are this PR's or issue's title and body in English, as AGENTS.md requires?
@@ -90,17 +90,26 @@ function* textsReachingGitHub(words, cmd, readFile, cwd) {
   if (body !== null) yield ['--body', body]
 
   const file = bodyFileArg(words)
-  const docs = heredocs(cmd)
   if (file !== null && file !== '-') {
-    let contents = null
-    try { contents = readFile(path.resolve(cwd, file)) } catch { contents = null }
-    if (contents !== null) yield [`the body file ${file}`, contents]
-    else if (docs.length === 1) yield [`the heredoc written to ${file}`, docs[0]]
+    const resolved = path.resolve(cwd, file)
+    // **What the command is about to write outranks what is on disk.** A heredoc overwriting an
+    // existing body file was losing to the stale text, so a Korean body replacing an English one
+    // reached GitHub unjudged; and with no target to match on, an unrelated heredoc was blamed on a
+    // body file whose contents were never read.
+    const pending = heredocWrittenTo(cmd, resolved, cwd)
+    if (pending !== null) yield [`the heredoc written to ${file}`, pending]
+    else {
+      let contents = null
+      try { contents = readFile(resolved) } catch { contents = null }
+      if (contents !== null) yield [`the body file ${file}`, contents]
+    }
   }
   if (file === '-') {
-    // Several heredocs means the command builds text elsewhere too, and picking would be guessing —
-    // the parent gate blocks on that ambiguity because a wrong guess there is permissive; here a
-    // wrong guess would refuse someone else's prose, so it is left alone.
+    const docs = heredocs(cmd)
+    // Stdin has no redirection target to match on, so the sole-heredoc rule still applies here.
+    // Several means the command builds text elsewhere too and picking would be guessing — the parent
+    // gate blocks on that ambiguity because a wrong guess there is permissive; here a wrong guess
+    // would refuse someone else's prose, so it is left alone.
     if (docs.length === 1) yield ['the heredoc body', docs[0]]
   }
 }

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,5 +1,7 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { proseLines } from './prose-lines.mjs'
+import { ghInvocations, bodyFileArg, bodyArg, heredocs } from './gh-command.mjs'
 
 /**
  * Does an issue split out of other work name what it came from?
@@ -8,7 +10,8 @@ import { proseLines } from './prose-lines.mjs'
  * and three of its four rules were wrong in the same way: they matched text anywhere in the command
  * instead of parsing anything. `gh issue new` — an undocumented alias that works — went straight
  * through, so did `GH_REPO=o/r gh issue create`, `-F "issue body.md"` read the file `issue`, and
- * `Parent: #607` in a `--title` satisfied a gate about bodies.
+ * `Parent: #607` in a `--title` satisfied a gate about bodies. The parsing itself now lives in
+ * `gh-command.mjs`, because the language gate needed the same reading and had its own regex.
  *
  * It also means this repo stops keeping a third, weaker copy of "which lines of a markdown body
  * count". `check-changeset.mjs` already had `proseLines`, whose own comment warns that a second copy
@@ -16,105 +19,8 @@ import { proseLines } from './prose-lines.mjs'
  * merely quotes one must not trip it — the same rule, now shared rather than re-derived.
  */
 
-/**
- * Split a shell command into words the way the shell would, enough for this job: single quotes are
- * literal, double quotes group, a backslash escapes the next character.
- *
- * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and the
- * caller treats an unresolvable body as "no parent found" — which fails toward blocking, which for a
- * cooperative agent costs one line and for a wrong guess costs nothing.
- */
-export function tokenize(cmd) {
-  const out = []
-  let cur = ''
-  let started = false
-  let quote = null
-  for (let i = 0; i < cmd.length; i++) {
-    const c = cmd[i]
-    if (quote === "'") {
-      if (c === "'") quote = null
-      else cur += c
-      continue
-    }
-    if (quote === '"') {
-      if (c === '"') quote = null
-      else if (c === '\\' && i + 1 < cmd.length && '"\\$`'.includes(cmd[i + 1])) cur += cmd[++i]
-      else cur += c
-      continue
-    }
-    if (c === "'" || c === '"') { quote = c; started = true; continue }
-    if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue }
-    if (/\s/.test(c)) {
-      if (started || cur) out.push(cur)
-      cur = ''
-      started = false
-      continue
-    }
-    cur += c
-    started = true
-  }
-  if (started || cur) out.push(cur)
-  return out
-}
-
-/** `FOO=bar`, the form that let `GH_REPO=o/r gh issue create` past a matcher anchored on `gh`. */
-const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
-
-/** Wrappers that keep the next word in command position. */
-const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time'])
-
-/** Separators after which a new command begins. */
-const SEPARATOR = new Set([';', '&&', '||', '|', '&', '(', ')', '{', '}', 'then', 'do', 'else', '!'])
-
-/**
- * Every `gh issue create` (or `new`) in the command, as the token slice that starts at `gh`.
- *
- * Command position is tracked rather than pattern-matched, so this repo's own docs — which print
- * `gh issue create` inside prose and inside `echo` — do not trip it, while the wrapped and prefixed
- * forms do.
- */
-export function issueCreateInvocations(cmd) {
-  const words = tokenize(cmd)
-  const found = []
-  let atStart = true
-  for (let i = 0; i < words.length; i++) {
-    const w = words[i]
-    if (SEPARATOR.has(w)) { atStart = true; continue }
-    if (!atStart) continue
-    let j = i
-    while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
-    if (words[j] === 'gh' && words[j + 1] === 'issue' && (words[j + 2] === 'create' || words[j + 2] === 'new')) {
-      // **Stop at the next separator.** Running to the end of the token list meant a later command's
-      // flags counted as this one's: `gh issue create --web && echo --body "Parent: #607"` was
-      // allowed, because `bodyArg` found `echo`'s argument.
-      let end = j
-      while (end < words.length && !SEPARATOR.has(words[end])) end++
-      found.push(words.slice(j, end))
-    }
-    atStart = false
-  }
-  return found
-}
-
-/** The `--body-file` / `-F` argument, quoting resolved. `-` means stdin, which is not a path. */
-export function bodyFileArg(words) {
-  for (let i = 0; i < words.length; i++) {
-    if (words[i] === '--body-file' || words[i] === '-F') return words[i + 1] ?? null
-    const eq = /^--body-file=(.*)$/.exec(words[i])
-    if (eq) return eq[1]
-  }
-  return null
-}
-
-/** The `--body` / `-b` argument, quoting resolved. */
-export function bodyArg(words) {
-  for (let i = 0; i < words.length; i++) {
-    if (words[i] === '--body' || words[i] === '-b') return words[i + 1] ?? null
-    const eq = /^--body=(.*)$/.exec(words[i])
-    if (eq) return eq[1]
-  }
-  return null
-}
+/** Every `gh issue create` (or `new`) in the command, as the token slice that starts at `gh`. */
+export const issueCreateInvocations = (cmd) => ghInvocations(cmd, 'issue', ['create', 'new'])
 
 /**
  * `Parent: #607` on a line of its own.
@@ -144,37 +50,14 @@ export function hasStandalone(body) {
 }
 
 /**
- * Every heredoc payload in a command, in order.
- *
- * Enough for `--body-file -`, which is the only reason this exists: `<<EOF`, `<<'EOF'`, `<<"EOF"`
- * and `<<-EOF`, terminated by a line that is the delimiter alone. The caller blocks when a command
- * carries more than one, because picking is guessing.
- */
-export function heredocs(cmd) {
-  const lines = cmd.split(/\r?\n/)
-  const out = []
-  for (let i = 0; i < lines.length; i++) {
-    const m = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/.exec(lines[i])
-    if (!m) continue
-    const [, dash, , delim] = m
-    const body = []
-    let j = i + 1
-    for (; j < lines.length; j++) {
-      const candidate = dash ? lines[j].replace(/^\t+/, '') : lines[j]
-      if (candidate === delim) break
-      body.push(lines[j])
-    }
-    if (j >= lines.length) continue          // never terminated: not a payload anyone can read
-    out.push(body.join('\n'))
-    i = j
-  }
-  return out
-}
-
-/**
  * @param {string} cmd the Bash command the tool was asked to run
  * @param {(p: string) => string} [readFile] injected for the tests
- * @returns {{ blocked: boolean, detail?: string }}
+ * @returns {{ blocked: boolean, reason?: 'unreadable-body-file' | 'no-body' | 'no-parent', detail?: string }}
+ *
+ * **`reason` exists because the caller printed one message for three outcomes.** A body file the
+ * gate could not open was reported as a body naming no parent, which sends the author to add a line
+ * that is already there — measured filing #700, whose body carried `Parent: #609` throughout. The
+ * three were distinguished here from the start; only the printing collapsed them.
  */
 export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
   const invocations = issueCreateInvocations(cmd)
@@ -184,9 +67,12 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
     // **Only the body is consulted.** `haystack = the whole command` let a `--title` satisfy a rule
     // about bodies, which is the gate agreeing with itself rather than with the issue.
     let body = null
+    let unreadable = null
     const file = bodyFileArg(words)
     if (file && file !== '-') {
-      try { body = readFile(file) } catch { body = null }
+      // Resolved for the message only. `readFile` keeps the path as written so an injected reader
+      // can be keyed on it, and so the failure names what was actually opened.
+      try { body = readFile(file) } catch { unreadable = path.resolve(file) }
     }
     if (body === null) body = bodyArg(words)
     // A heredoc reaches `--body-file -`; its text is in the command and nowhere else. Reading the
@@ -198,8 +84,13 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
       body = docs.length === 1 ? docs[0] : null
     }
 
-    if (body === null) return { blocked: true, detail: 'no body could be read from the command' }
-    if (!hasParent(body) && !hasStandalone(body)) return { blocked: true, detail: 'the body names no parent' }
+    if (body === null && unreadable !== null) {
+      return { blocked: true, reason: 'unreadable-body-file', detail: `could not read the body file at ${unreadable}` }
+    }
+    if (body === null) return { blocked: true, reason: 'no-body', detail: 'no body could be read from the command' }
+    if (!hasParent(body) && !hasStandalone(body)) {
+      return { blocked: true, reason: 'no-parent', detail: 'the body names no parent' }
+    }
   }
   return { blocked: false }
 }

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,7 +1,6 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import { proseLines } from './prose-lines.mjs'
-import { ghInvocations, bodyFileArg, bodyArg, heredocs } from './gh-command.mjs'
+import { ghInvocations, bodyFileArg, bodyArg, heredocs, readBodyFile } from './gh-command.mjs'
 
 /**
  * Does an issue split out of other work name what it came from?
@@ -52,14 +51,16 @@ export function hasStandalone(body) {
 /**
  * @param {string} cmd the Bash command the tool was asked to run
  * @param {(p: string) => string} [readFile] injected for the tests
- * @returns {{ blocked: boolean, reason?: 'unreadable-body-file' | 'no-body' | 'no-parent', detail?: string }}
+ * @param {string} [cwd] the directory the command would run in, from the hook payload
+ * @returns {{ blocked: boolean, reason?: 'unreadable-body-file' | 'no-body' | 'no-parent', detail?: string,
+ *             file?: string, resolved?: string, code?: string | null }}
  *
  * **`reason` exists because the caller printed one message for three outcomes.** A body file the
  * gate could not open was reported as a body naming no parent, which sends the author to add a line
  * that is already there — measured filing #700, whose body carried `Parent: #609` throughout. The
  * three were distinguished here from the start; only the printing collapsed them.
  */
-export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
+export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
   const invocations = issueCreateInvocations(cmd)
   if (invocations.length === 0) return { blocked: false }
 
@@ -70,9 +71,11 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
     let unreadable = null
     const file = bodyFileArg(words)
     if (file && file !== '-') {
-      // Resolved for the message only. `readFile` keeps the path as written so an injected reader
-      // can be keyed on it, and so the failure names what was actually opened.
-      try { body = readFile(file) } catch { unreadable = path.resolve(file) }
+      // **Resolved against the session's directory, not the gate's.** The hook runs from the
+      // repository root while `gh` runs where the session is, so resolving here is what lets a
+      // relative path written from a subdirectory be read at all rather than merely reported.
+      const resolved = path.resolve(cwd, file)
+      try { body = readFile(resolved) } catch (err) { unreadable = { file, resolved, code: err?.code ?? null } }
     }
     if (body === null) body = bodyArg(words)
     // A heredoc reaches `--body-file -`; its text is in the command and nowhere else. Reading the
@@ -85,7 +88,7 @@ export function judge(cmd, readFile = (p) => fs.readFileSync(p, 'utf8')) {
     }
 
     if (body === null && unreadable !== null) {
-      return { blocked: true, reason: 'unreadable-body-file', detail: `could not read the body file at ${unreadable}` }
+      return { blocked: true, reason: 'unreadable-body-file', ...unreadable, detail: `could not read the body file at ${unreadable.resolved}` }
     }
     if (body === null) return { blocked: true, reason: 'no-body', detail: 'no body could be read from the command' }
     if (!hasParent(body) && !hasStandalone(body)) {

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { proseLines } from './prose-lines.mjs'
-import { ghInvocations, bodyFileArg, bodyArg, heredocs, readBodyFile } from './gh-command.mjs'
+import { ghInvocations, bodyFileArg, bodyArg, heredocs, heredocWrittenTo, readBodyFile } from './gh-command.mjs'
 
 /**
  * Does an issue split out of other work name what it came from?
@@ -75,7 +75,11 @@ export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
       // repository root while `gh` runs where the session is, so resolving here is what lets a
       // relative path written from a subdirectory be read at all rather than merely reported.
       const resolved = path.resolve(cwd, file)
-      try { body = readFile(resolved) } catch (err) { unreadable = { file, resolved, code: err?.code ?? null } }
+      // A heredoc this same command writes to that path is the body; the file on disk, if any, is
+      // about to be replaced by it.
+      const pending = heredocWrittenTo(cmd, resolved, cwd)
+      if (pending !== null) body = pending
+      else try { body = readFile(resolved) } catch (err) { unreadable = { file, resolved, code: err?.code ?? null } }
     }
     if (body === null) body = bodyArg(words)
     // A heredoc reaches `--body-file -`; its text is in the command and nowhere else. Reading the


### PR DESCRIPTION
## Summary

Two PreToolUse gates matched text where they meant to match a command, and one reported the wrong
rule when it blocked. Every fault here was found by *using* the gates rather than by reading them.

The issue-parent gate answered an unreadable `--body-file` with "this issue names no parent", so
filing #700 — whose body carried `Parent: #609` throughout — sent me to fix a line that was already
there. Two parsing faults came with it: a heredoc payload was read as a command (this branch's own
plan document was blocked by its own example), and a newline did not begin a command, so
`git status\ngh issue create …` walked past the gate entirely. The language gate was an inline perl
regex over the whole command: it refused a `node -e` script carrying `gh issue create` inside a
string literal, and it never looked at `--body-file`, so Korean in the form CONTRIBUTING tells
everyone to use went straight through. It now runs on the parser that already existed one hook over.

The adversarial review found nine more, including two regressions this branch introduced and one
case of the same misdiagnosis reproduced inside its own fix. Seven fixed here, one deferred as
#702, one recorded. Findings, dispositions and the two probes that turned out to be measuring
nothing are in the review record below.

## Checklist

- [x] Tests written and passing — 539 across 40 files; sixteen mutations, one per guard, all caught
- [x] No `any` — not applicable, `.mjs` tooling
- [x] Interface changes land in `agent-core` first — not applicable
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/2026-08-30-gate-misdiagnosis-plan.md`
- `.work/reviews/fix__gate-misdiagnosis.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks for GitHub issue and pull request commands.
  * Blocks Korean prose in issue and pull request titles or bodies with an explanatory message.
  * Supports inline text, body files, heredocs, command wrappers, repeated flags, quoted command syntax, and relative paths.
  * Validates that new issues include a parent reference and reports specific problems when content is missing or unreadable.

* **Bug Fixes**
  * Prevents unrelated commands from being interrupted.
  * Matches pending heredoc content to the correct body file.
  * Allows execution when validation inputs or project files are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->