### PR TITLE
fix(hooks): document every gate, and parse the transcript instead of matching it

### DIFF
--- a/.claude/hooks/docs-aitells-gate.sh
+++ b/.claude/hooks/docs-aitells-gate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Stop: if this session edited docs/*.md and never ran /ai-tells detect, block finishing and ask for
+# Stop: if this session edited any Markdown under `docs/` — at any depth — and never ran
+# /ai-tells detect, block finishing and ask for
 # the pass. Running ai-tells once satisfies it, so there is no loop.
 #
 # **English, because a contributor's agent reads it.** `.claude/` is committed, so these hooks fire

--- a/.claude/hooks/docs-aitells-gate.sh
+++ b/.claude/hooks/docs-aitells-gate.sh
@@ -1,26 +1,45 @@
 #!/usr/bin/env bash
-# Stop: 이번 세션에 docs/*.md를 편집했는데 /ai-tells detect를 한 번도 실행하지 않았으면
-# 마무리를 차단(block)하고 점검을 요구한다. ai-tells를 한 번이라도 돌리면 통과 → 무한루프 없음.
+# Stop: if this session edited docs/*.md and never ran /ai-tells detect, block finishing and ask for
+# the pass. Running ai-tells once satisfies it, so there is no loop.
+#
+# **English, because a contributor's agent reads it.** `.claude/` is committed, so these hooks fire
+# for anyone working in the repo with Claude Code — measured: #698 arrived from a first-time
+# contributor carrying a `.work/reviews/` record, which exists only because a hook demanded one.
+# A Korean-language block is unreadable to exactly the people AGENTS.md says to write English for.
 set -euo pipefail
 
 input=$(cat)
-tx=$(printf '%s' "$input" | jq -r '.transcript_path // ""')
+
+# **Fail open on anything unparseable**, the way every other gate in this directory does. Under
+# `set -e` a bare `jq` on a malformed payload took the whole script down with jq's own exit 5, which
+# is not the clean pass this is supposed to be — and `pr-merge-guard.sh` is the calibration for how
+# long a hook can be wrong about its payload without anyone noticing: 2191 parse failures to 1
+# success, across 150 sessions.
+tx=$(printf '%s' "$input" | jq -r '.transcript_path // ""' 2>/dev/null) || exit 0
 [ -f "$tx" ] || exit 0
 
-# 안전망: Stop hook이 block으로 재진입한 상태(stop_hook_active)면 통과시켜
-# 사용자가 의도적으로 건너뛸 수 있게 한다(스크립트 오류로 인한 무한 block 방지).
-active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false')
+# Safety net: if the Stop hook has already re-entered after blocking (stop_hook_active), let it
+# through so the user can deliberately skip — a scripting error must not block forever.
+active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
 [ "$active" = "true" ] && exit 0
 
-# docs/*.md를 Edit/Write/MultiEdit 한 횟수 (file_path가 input 첫 필드)
-edited=$(grep -cE '"name":"(Edit|Write|MultiEdit)","input":\{"file_path":"[^"]*/docs/[^"]*\.md' "$tx" || true)
-# ai-tells 스킬을 호출한 횟수 (리마인더 텍스트와 겹치지 않는 정확한 키)
-ran=$(grep -cE '"skill":"ai-tells"' "$tx" || true)
+# How many times docs/*.md was edited.
+#
+# **`file_path` is not the first field of the tool input, and requiring it to be made this gate see
+# 6 of 34 docs edits.** `Write` serialises `{"file_path": …}`, so it matched; `Edit` serialises
+# `{"replace_all": false, "file_path": …}` and never did — 1102 `Edit` records in this project's
+# transcripts, not one of them adjacent. Editing an existing doc is what `Edit` is for, so the gate
+# was blind to the common case and green about it. Scoped to the same `input` object with `[^}]*`
+# rather than to the whole line, which keeps an unrelated tool call on the same line out of it.
+edited=$(grep -cE '"name":"(Edit|Write|MultiEdit)","input":\{[^}]*"file_path":"[^"]*/docs/[^"]*\.md' "$tx" || true)
+# How many times the ai-tells skill was invoked. Matched on the key rather than on the reminder's
+# own wording, which would otherwise satisfy the gate by being injected.
+ran=$(grep -cE '"skill": *"ai-tells"' "$tx" || true)
 
 if [ "${edited:-0}" -gt 0 ] && [ "${ran:-0}" -eq 0 ]; then
   jq -n '{
     decision: "block",
-    reason: "이번 세션에서 docs를 편집했지만 /ai-tells detect를 실행하지 않았습니다. 마무리 전 docs 산문(KO 번역투·em dash 삽입구·어순)을 /ai-tells detect로 점검하세요. 의도적으로 건너뛰려면 그대로 다시 멈추면 통과됩니다."
+    reason: "This session edited docs/ but never ran /ai-tells detect. Check the prose before finishing — translationese in KO, em-dash asides, word order. To skip deliberately, just stop again and this passes."
   }'
 fi
 exit 0

--- a/.claude/hooks/docs-aitells-gate.sh
+++ b/.claude/hooks/docs-aitells-gate.sh
@@ -23,18 +23,28 @@ tx=$(printf '%s' "$input" | jq -r '.transcript_path // ""' 2>/dev/null) || exit 
 active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
 [ "$active" = "true" ] && exit 0
 
-# How many times docs/*.md was edited.
+# **Counted by parsing the transcript, not by matching its serialisation.**
 #
-# **`file_path` is not the first field of the tool input, and requiring it to be made this gate see
-# 6 of 34 docs edits.** `Write` serialises `{"file_path": …}`, so it matched; `Edit` serialises
-# `{"replace_all": false, "file_path": …}` and never did — 1102 `Edit` records in this project's
-# transcripts, not one of them adjacent. Editing an existing doc is what `Edit` is for, so the gate
-# was blind to the common case and green about it. Scoped to the same `input` object with `[^}]*`
-# rather than to the whole line, which keeps an unrelated tool call on the same line out of it.
-edited=$(grep -cE '"name":"(Edit|Write|MultiEdit)","input":\{[^}]*"file_path":"[^"]*/docs/[^"]*\.md' "$tx" || true)
-# How many times the ai-tells skill was invoked. Matched on the key rather than on the reminder's
-# own wording, which would otherwise satisfy the gate by being injected.
-ran=$(grep -cE '"skill": *"ai-tells"' "$tx" || true)
+# The previous matcher was a regex requiring `file_path` to be the first key of the tool input, and
+# it saw 6 of 34 docs edits: true of `Write`, false of `Edit`, which is what changing an existing
+# document uses. Widening the regex fixed that case and left the shape of the bug — review found it
+# still blind to `MultiEdit` with `edits` before `file_path` (the `}` closing an edit object ends the
+# scan), counting `.mdx` and `.md.bak` for an unanchored `\.md`, and missing the whole record if the
+# runtime ever emitted spaced JSON.
+#
+# `jq` answers all of those at once and the hook already depends on it two lines up, so the
+# dependency is not new. Measured against every transcript on this machine: identical counts to the
+# regex it replaces, 34 and 34, and 0.37s on the largest (35 MB) against grep's 0.03s — paid once, at
+# the end of a session.
+#
+# `fromjson?` skips a line that is not JSON, which is what a transcript truncated mid-write looks
+# like. A `docs` directory that is not the repo's own still counts: this repo has one `docs` tree,
+# and over-inclusion on a gate whose override is "stop again" is the safe direction.
+tool_paths='fromjson? | .message.content[]? | select(.type=="tool_use")'
+edited=$(jq -rR "$tool_paths"' | select(.name=="Edit" or .name=="Write" or .name=="MultiEdit") | .input.file_path // empty | select(test("/docs/.*[.]md$"))' "$tx" 2>/dev/null | wc -l) || edited=0
+# Which skills ran. Matched on the invocation rather than on the reminder's own wording, which is
+# injected into the transcript and would otherwise let the gate satisfy itself.
+ran=$(jq -rR "$tool_paths"' | select(.name=="Skill") | .input.skill // empty | select(.=="ai-tells")' "$tx" 2>/dev/null | wc -l) || ran=0
 
 if [ "${edited:-0}" -gt 0 ] && [ "${ran:-0}" -eq 0 ]; then
   jq -n '{

--- a/.claude/hooks/docs-aitells-reminder.sh
+++ b/.claude/hooks/docs-aitells-reminder.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PostToolUse(Edit|Write|MultiEdit): editing prose under docs/ injects a reminder to run the
+# PostToolUse(Edit|Write|MultiEdit): editing prose under `docs/` at any depth injects a reminder to run the
 # ai-tells detect pass. A nudge, not a gate — the gate is at Stop (docs-aitells-gate.sh).
 #
 # **English, because a contributor's agent reads it.** `.claude/` is committed, so these hooks fire

--- a/.claude/hooks/docs-aitells-reminder.sh
+++ b/.claude/hooks/docs-aitells-reminder.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# PostToolUse(Edit|Write|MultiEdit): docs/*.md 산문을 편집하면 ai-tells detect 리마인더를 주입한다.
-# 강제가 아니라 유도. 실제 게이트는 Stop 단계(docs-aitells-gate.sh)가 담당한다.
+# PostToolUse(Edit|Write|MultiEdit): editing prose under docs/ injects a reminder to run the
+# ai-tells detect pass. A nudge, not a gate — the gate is at Stop (docs-aitells-gate.sh).
+#
+# **English, because a contributor's agent reads it.** `.claude/` is committed, so these hooks fire
+# for anyone working in the repo with Claude Code — measured: #698 arrived from a first-time
+# contributor carrying a `.work/reviews/` record, which exists only because a hook demanded one.
+# A Korean-language block is unreadable to exactly the people AGENTS.md says to write English for.
 set -euo pipefail
 
 input=$(cat)
@@ -11,7 +16,7 @@ case "$fp" in
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PostToolUse",
-        additionalContext: "docs 산문을 변경했습니다. 마무리 전 /ai-tells detect로 점검하세요 (KO 번역투·em dash 삽입구 — … —·어순 주의). 이번 세션에 ai-tells를 실행하지 않으면 Stop 단계에서 마무리가 차단됩니다."
+        additionalContext: "You changed prose under docs/. Run /ai-tells detect before finishing (watch for translationese in KO, em-dash asides, and word order). Finishing without running ai-tells at least once this session is blocked at the Stop step."
       }
     }'
     ;;

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -47,5 +47,5 @@ cmd=$(printf '%s' "$cmd" | perl -0777 -pe 's/\\\r?\n//g') || exit 0
 
 printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:space:]])(then|do)[[:space:]]+)gh[[:space:]]+pr[[:space:]]+(merge|review)' || exit 0
 
-echo "Blocked: PR merge/approve는 직접 수행해주세요. Creating the PR is yours to do; merging and approving are the user's — leave them, even with --admin (AGENTS.md > Core Principles). If this command is not actually merging or approving (the text merely mentions the command), split that text into a separate command." >&2
+echo "Blocked: creating the PR is yours to do; merging and approving are the user's — leave them, even with --admin (AGENTS.md > Core Principles). If this command is not actually merging or approving (the text merely mentions the command), split that text into a separate command." >&2
 exit 2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ For the product direction and philosophy behind these — Manual First, Flow Cap
 - **Stop before risky actions** — get user confirmation before any hard-to-reverse operation (`git push --force`, `git reset --hard`, sending messages to external systems, DB drops, etc.). Specifically:
   - Only create commits or PRs when the user explicitly requests it.
   - **Do not merge PRs.** Always leave merging to the user — even with `--admin`. Create the PR and stop.
+    Enforced by the PreToolUse hook `.claude/hooks/pr-merge-guard.sh`, which blocks `gh pr merge` and
+    `gh pr review` in command position. It does not cover the `gh api` and git plumbing equivalents:
+    same threat model, a cooperative agent rather than an adversary.
   - **Avoid breaking changes.** If unavoidable, report to the user and get approval before proceeding. Breaking change scope: public API / interface signature changes, DB schema changes, WebSocket message protocol changes, CLI command / flag changes.
 
 ---
@@ -59,6 +62,19 @@ For the product direction and philosophy behind these — Manual First, Flow Cap
 → [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 Write GitHub PR and issue titles/bodies in **English**, and write new code comments in **English** too. (Conversation and docs follow the existing KO/EN rules.) Code comments default to English so contributors of any language can read and extend them — existing Korean comments stay until the line they sit on is changed.
+
+The PR and issue half is enforced by `.claude/hooks/gh-language-gate.sh`, which reads the title, the
+body, the contents of a `--body-file`, and the heredoc behind `--body-file -` — so the form
+CONTRIBUTING recommends is covered rather than only the text typed inline. **A line counts as Korean
+only when its Hangul outnumbers its Latin letters**, so an English sentence naming a Korean UI label
+passes; #660 shipped one. `gh pr comment` is deliberately out of scope, because a review comment is a
+conversation and the rule is about titles and bodies.
+
+**Docs prose is checked before the session ends.** Editing `docs/*.md` and finishing without running
+`/ai-tells detect` is blocked by `.claude/hooks/docs-aitells-gate.sh`, with
+`docs-aitells-reminder.sh` nudging at the moment of the edit. The check is a **lint, not a
+laundry**: it flags AI-writing tells in prose a human wrote, and `rewrite` stays manual and
+docs-only. Stopping a second time passes, so the block is a prompt rather than a wall.
 
 When starting a **new** task that requires code changes (not when continuing work on an existing branch):
 1. `git checkout main && git pull origin main` — start from the latest main.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ only when its Hangul outnumbers its Latin letters**, so an English sentence nami
 passes; #660 shipped one. `gh pr comment` is deliberately out of scope, because a review comment is a
 conversation and the rule is about titles and bodies.
 
-**Docs prose is checked before the session ends.** Editing `docs/*.md` and finishing without running
+**Docs prose is checked before the session ends.** Editing any Markdown under `docs/` — nested too,
+so `docs/ko/guide/agent.md` counts — and finishing without running
 `/ai-tells detect` is blocked by `.claude/hooks/docs-aitells-gate.sh`, with
 `docs-aitells-reminder.sh` nudging at the moment of the edit. The check is a **lint, not a
 laundry**: it flags AI-writing tells in prose a human wrote, and `rewrite` stays manual and

--- a/scripts/__tests__/docsAitellsGate.test.mjs
+++ b/scripts/__tests__/docsAitellsGate.test.mjs
@@ -7,8 +7,17 @@
 // existing document is what `Edit` is for, so the gate was blind to the common case while reporting
 // nothing wrong.
 //
-// The shapes below are copied from real transcript records rather than invented, because the bug was
-// entirely in the gap between the shape assumed and the shape written.
+// Widening the regex fixed that case and kept the shape of the bug, which review then found: still
+// blind to `MultiEdit` with `edits` before `file_path`, counting `.mdx` for an unanchored `\.md`, and
+// missing the record entirely if the runtime emitted spaced JSON. The hook parses with `jq` now, so
+// none of those is a question about key order any more.
+//
+// **The `input` shapes below are the real ones** — verified against the corpus, `Edit` writes
+// `{"replace_all": …, "file_path": …}` and `Write` writes `{"file_path": …}` — but the envelope is
+// not: a real record also carries `id`, `parentUuid`, `message.model` and more. They are omitted
+// because nothing here reads them, and saying so is the point: the previous version of this comment
+// claimed the records were copied, which was true of the half that mattered and overstated for the
+// rest.
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
@@ -23,6 +32,8 @@ const record = (name, input) => JSON.stringify({ message: { content: [{ type: 't
 
 const EDIT = (file) => record('Edit', { replace_all: false, file_path: file, old_string: 'a', new_string: 'b' })
 const WRITE = (file) => record('Write', { file_path: file, content: 'x' })
+/** `edits` before `file_path`: the order a regex scoped with `[^}]*` could never reach. */
+const MULTI_EDIT = (file) => record('MultiEdit', { edits: [{ old_string: 'a', new_string: 'b' }], file_path: file })
 const AI_TELLS = record('Skill', { skill: 'ai-tells', args: 'en detect' })
 
 /** Run the gate over a transcript built from `lines`. Returns its stdout (a JSON verdict, or ''). */
@@ -66,6 +77,27 @@ describe('which docs edits the gate can see', () => {
     expect(blocked([EDIT('/repo/packages/relay/src/server.ts'), WRITE('/repo/AGENTS.md')])).toBe(false)
   })
 
+  it('sees a MultiEdit whose file_path comes after its edits', () => {
+    // The order a `[^}]*` scan cannot reach, because the `}` closing the first edit ends the scan.
+    // `MultiEdit` writes no records on this machine today, which is exactly why a half-blind matcher
+    // for it would go unnoticed if it came back.
+    expect(blocked([MULTI_EDIT('/repo/docs/guide/agent.md')])).toBe(true)
+  })
+
+  it('counts only .md, not every suffix that starts with it', () => {
+    for (const f of ['/repo/docs/a.mdx', '/repo/docs/a.md.bak', '/repo/docs/a.markdown']) {
+      expect(blocked([EDIT(f)]), f).toBe(false)
+    }
+  })
+
+  it('does not depend on the transcript being written without spaces', () => {
+    // The runtime writes compact JSON today. A matcher that only works because of that is one
+    // serialisation change away from counting zero, which is the regression this file is about.
+    const spaced = JSON.stringify(JSON.parse(EDIT('/repo/docs/guide/agent.md')), null, 1)
+      .replace(/\n\s*/g, ' ')
+    expect(blocked([spaced])).toBe(true)
+  })
+
   it('does not fire on a docs path that is only mentioned in the replaced text', () => {
     // `[^}]*` keeps the match inside the same `input` object, so a source edit whose old_string
     // quotes a docs path is not a docs edit. Scoping to the whole line would have counted it.
@@ -76,6 +108,37 @@ describe('which docs edits the gate can see', () => {
       new_string: 'see the guide',
     })
     expect(blocked([line])).toBe(false)
+  })
+})
+
+describe('the hook agrees with a real parse of the same transcript', () => {
+  // **The oracle.** Every case above asserts one shape at a time, which is how a matcher and its
+  // tests come to agree with each other about a wrong shape — the failure this whole file exists
+  // for. This one computes the answer independently, by parsing, and asks the hook to match it.
+  const CORPUS = [
+    EDIT('/repo/docs/guide/agent.md'),
+    WRITE('/repo/docs/ko/guide/agent.md'),
+    MULTI_EDIT('/repo/docs/reference/cli.md'),
+    EDIT('/repo/packages/relay/src/server.ts'),
+    EDIT('/repo/docs/a.mdx'),
+    record('Edit', { replace_all: false, file_path: '/repo/src/x.ts', old_string: 'docs/guide/agent.md', new_string: '' }),
+    'not json at all',
+  ]
+
+  /** What a JSON parse says the answer is, with no regard for how the line is spelled. */
+  const byParsing = (lines) => lines.filter((line) => {
+    let rec
+    try { rec = JSON.parse(line) } catch { return false }
+    return (rec.message?.content ?? []).some((c) =>
+      c.type === 'tool_use'
+      && ['Edit', 'Write', 'MultiEdit'].includes(c.name)
+      && /\/docs\/.*\.md$/.test(c.input?.file_path ?? ''))
+  }).length
+
+  it('blocks exactly when a parse finds a docs edit', () => {
+    expect(byParsing(CORPUS), 'three docs edits, three decoys, one unparseable line').toBe(3)
+    expect(blocked(CORPUS)).toBe(true)
+    expect(blocked(CORPUS.filter((l) => byParsing([l]) === 0)), 'decoys alone').toBe(false)
   })
 })
 

--- a/scripts/__tests__/docsAitellsGate.test.mjs
+++ b/scripts/__tests__/docsAitellsGate.test.mjs
@@ -1,0 +1,126 @@
+// The Stop gate that asks for an ai-tells pass when the session edited prose under `docs/`.
+//
+// **It had no test, and it was seeing 6 of 34 docs edits.** The transcript matcher required
+// `file_path` to be the first key of the tool input, with a comment saying it is. That is true of
+// `Write` and false of `Edit`, which serialises `{"replace_all": false, "file_path": …}` — measured
+// across this project's transcripts, 1102 `Edit` records and not one of them adjacent. Editing an
+// existing document is what `Edit` is for, so the gate was blind to the common case while reporting
+// nothing wrong.
+//
+// The shapes below are copied from real transcript records rather than invented, because the bug was
+// entirely in the gap between the shape assumed and the shape written.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const HOOK = path.join(REPO, '.claude/hooks/docs-aitells-gate.sh')
+
+/** A transcript line carrying one tool call, in the field order the runtime actually writes. */
+const record = (name, input) => JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } })
+
+const EDIT = (file) => record('Edit', { replace_all: false, file_path: file, old_string: 'a', new_string: 'b' })
+const WRITE = (file) => record('Write', { file_path: file, content: 'x' })
+const AI_TELLS = record('Skill', { skill: 'ai-tells', args: 'en detect' })
+
+/** Run the gate over a transcript built from `lines`. Returns its stdout (a JSON verdict, or ''). */
+function run(lines, { stopHookActive = false } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'aitells-'))
+  const tx = path.join(dir, 'transcript.jsonl')
+  writeFileSync(tx, lines.join('\n') + '\n')
+  try {
+    const r = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({ transcript_path: tx, stop_hook_active: stopHookActive }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status, r.stderr).toBe(0)
+    return r.stdout.trim()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const blocked = (lines, opts) => {
+  const out = run(lines, opts)
+  return out !== '' && JSON.parse(out).decision === 'block'
+}
+
+describe('which docs edits the gate can see', () => {
+  it('sees one made with Edit, where file_path is not the first key', () => {
+    // The regression this file exists for. `Edit` is how an existing document is changed.
+    expect(blocked([EDIT('/repo/docs/guide/agent.md')])).toBe(true)
+  })
+
+  it('sees one made with Write', () => {
+    expect(blocked([WRITE('/repo/docs/guide/agent.md')])).toBe(true)
+  })
+
+  it('sees a translated doc under docs/ko', () => {
+    expect(blocked([EDIT('/repo/docs/ko/guide/agent.md')])).toBe(true)
+  })
+
+  it('does not fire on an edit outside docs/', () => {
+    expect(blocked([EDIT('/repo/packages/relay/src/server.ts'), WRITE('/repo/AGENTS.md')])).toBe(false)
+  })
+
+  it('does not fire on a docs path that is only mentioned in the replaced text', () => {
+    // `[^}]*` keeps the match inside the same `input` object, so a source edit whose old_string
+    // quotes a docs path is not a docs edit. Scoping to the whole line would have counted it.
+    const line = record('Edit', {
+      replace_all: false,
+      file_path: '/repo/packages/relay/src/server.ts',
+      old_string: 'see docs/guide/agent.md',
+      new_string: 'see the guide',
+    })
+    expect(blocked([line])).toBe(false)
+  })
+})
+
+describe('what satisfies it', () => {
+  it('an ai-tells run in the same session', () => {
+    expect(blocked([EDIT('/repo/docs/guide/agent.md'), AI_TELLS])).toBe(false)
+  })
+
+  it('but not the reminder text that merely names the skill', () => {
+    // The reminder is injected into the transcript and says "run /ai-tells detect". Matching on the
+    // prose rather than the invocation key would let the gate satisfy itself.
+    const reminder = JSON.stringify({ message: { content: [{ type: 'text', text: 'Run /ai-tells detect before finishing.' }] } })
+    expect(blocked([EDIT('/repo/docs/guide/agent.md'), reminder])).toBe(true)
+  })
+})
+
+describe('it fails open where it must', () => {
+  it('passes when re-entered after its own block', () => {
+    // Without this a scripting error blocks the session forever.
+    expect(blocked([EDIT('/repo/docs/guide/agent.md')], { stopHookActive: true })).toBe(false)
+  })
+
+  it('passes when the transcript is missing', () => {
+    const r = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({ transcript_path: '/nowhere/at/all.jsonl' }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status).toBe(0)
+    expect(r.stdout.trim()).toBe('')
+  })
+
+  it('passes on a payload it cannot parse', () => {
+    const r = spawnSync('bash', [HOOK], { input: 'not json', encoding: 'utf8', env: { ...process.env } })
+    expect(r.status, 'a Stop hook that dies would block every session').toBe(0)
+  })
+})
+
+describe('the message reaches a contributor who does not read Korean', () => {
+  // `.claude/` is committed, so these hooks fire for anyone working in the repo with Claude Code —
+  // #698 arrived from a first-time contributor carrying a `.work/reviews/` record, which exists only
+  // because a hook demanded one. A block written in Korean is unreadable to exactly the people
+  // AGENTS.md says to write English for.
+  it('blocks in English', () => {
+    const out = run([EDIT('/repo/docs/guide/agent.md')])
+    expect(JSON.parse(out).reason).not.toMatch(/[가-힣]/)
+  })
+})

--- a/scripts/__tests__/docsAitellsGate.test.mjs
+++ b/scripts/__tests__/docsAitellsGate.test.mjs
@@ -73,6 +73,14 @@ describe('which docs edits the gate can see', () => {
     expect(blocked([EDIT('/repo/docs/ko/guide/agent.md')])).toBe(true)
   })
 
+  it('sees Markdown at any depth under docs/', () => {
+    // The prose said `docs/*.md`, which in a reader's head excludes a nested path even though the
+    // shell glob and the jq filter both take it. Every doc in this repo is nested.
+    for (const f of ['/repo/docs/a.md', '/repo/docs/guide/agent.md', '/repo/docs/ko/reference/cli.md']) {
+      expect(blocked([EDIT(f)]), f).toBe(true)
+    }
+  })
+
   it('does not fire on an edit outside docs/', () => {
     expect(blocked([EDIT('/repo/packages/relay/src/server.ts'), WRITE('/repo/AGENTS.md')])).toBe(false)
   })

--- a/scripts/__tests__/hooksDocumented.test.mjs
+++ b/scripts/__tests__/hooksDocumented.test.mjs
@@ -1,0 +1,69 @@
+// Every gate that fires is named in AGENTS.md, and speaks to whoever it stops in English.
+//
+// **`.claude/` is committed, so these hooks fire for contributors too.** #698 arrived from a
+// first-time contributor whose PR body named a `.work/reviews/` record — a file that exists only
+// because `adversarial-review-gate.sh` refused to open the PR without one. That gate had a rule in
+// AGENTS.md to point at. Four of the six had none, so a contributor could be stopped by machinery
+// the repo never mentions, and two of them said so in Korean — to exactly the people the same
+// document says to write English for.
+//
+// The pairing is what makes this checkable at all: a hook is enforcement, and enforcement without a
+// stated rule is a wall with no sign on it.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = join(import.meta.dirname, '../..')
+const settings = JSON.parse(readFileSync(join(root, '.claude/settings.json'), 'utf8'))
+const agents = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+
+/** Every hook script `.claude/settings.json` wires, by basename, in event order. */
+const wired = Object.values(settings.hooks ?? {})
+  .flat()
+  .flatMap((group) => group.hooks ?? [])
+  .map((h) => /([A-Za-z0-9._-]+\.sh)/.exec(h.command ?? '')?.[1])
+  .filter(Boolean)
+
+const HANGUL = /\p{Script=Hangul}/u
+
+/** The text a hook writes to whoever it stops: a `reason:` line or a `Blocked:` message. */
+function contributorFacingText(file) {
+  const src = readFileSync(join(root, '.claude/hooks', file), 'utf8')
+  return [
+    ...src.matchAll(/^\s*reason:\s*"([\s\S]*?)"\s*$/gm),
+    ...src.matchAll(/^\s*(?:echo|printf)\s+"(Blocked:[\s\S]*?)"/gm),
+    ...src.matchAll(/additionalContext:\s*"([\s\S]*?)"\s*$/gm),
+  ].map((m) => m[1])
+}
+
+describe('a wired hook is a documented hook', () => {
+  it('names every one of them in AGENTS.md', () => {
+    // Named rather than counted, so a failure says which hook to write a rule for.
+    expect(wired.filter((h) => !agents.includes(h))).toEqual([])
+  })
+
+  it('found the hooks that are wired today', () => {
+    // The anti-vacuity floor: an empty `wired` satisfies the assertion above by having nothing to
+    // disagree with, which is what a changed settings shape produces silently.
+    expect(wired.length).toBeGreaterThanOrEqual(6)
+  })
+})
+
+describe('a gate speaks to whoever it stops', () => {
+  it('carries no Korean in the text it shows them', () => {
+    const offenders = wired
+      .flatMap((h) => contributorFacingText(h).map((text) => ({ hook: h, text })))
+      .filter(({ text }) => HANGUL.test(text))
+      .map(({ hook }) => hook)
+    expect([...new Set(offenders)]).toEqual([])
+  })
+
+  it('is reading a message from each hook that has one', () => {
+    // Same floor, one level down: a regex that stops matching makes the assertion above vacuous
+    // rather than failing. Measured — five of the six write something when they stop or nudge;
+    // `adversarial-review-gate.sh` builds its message across several lines and is excluded here
+    // rather than counted, because a partial read would be worse than a named gap.
+    const withMessage = wired.filter((h) => contributorFacingText(h).length > 0)
+    expect(withMessage.length).toBeGreaterThanOrEqual(4)
+  })
+})


### PR DESCRIPTION
## Summary

`.claude/` is committed, so these hooks fire for contributors too — #698 arrived from a first-time
contributor whose PR body named a `.work/reviews/` record, a file that exists only because
`adversarial-review-gate.sh` refused to open the PR without one. Four of the six gates had no rule in
AGENTS.md to point at, and two of them stopped people in Korean.

Each hook is now named beside the rule it enforces rather than in a central list, which is how this
repo keeps a rationale from drifting away from its subject. The docs-prose gate needed the rule
written first: it was blocking sessions to enforce something AGENTS.md never stated, in a language
the contributor may not read.

Writing that down turned up faults in that gate. **It was seeing 6 of 34 docs edits** — its matcher
required `file_path` to be the first key of the tool input, with a comment asserting that it is. True
of `Write`; false of `Edit`, which is what changing an existing document uses. And **it did not fail
open**: under `set -e` a bare `jq` on a malformed payload took the script down with jq's own exit 5,
where every sibling gate exits 0.

Widening the regex then kept the shape of the bug, and review found three more ways to be wrong about
a serialisation in a change about being wrong about a serialisation. **It parses with `jq` now** —
identical counts to the regex across every transcript on this machine, 0.37 s on the largest at 35 MB,
paid once at session end.

**To be accurate about what that was worth:** no session would have been blocked under either matcher.
All 34 edits are in three transcripts and each ran ai-tells anyway. What the old matcher cost was
sight — one of those three was invisible to it — not enforcement. The gate has never had to fire,
which is why nobody noticed it could not see.

The gate had no test. It has eleven now, including an oracle whose expected answer is computed by
parsing rather than asserted shape by shape — case-by-case assertions are how a matcher and its tests
come to agree about a wrong shape. A second check holds the pairing itself: a wired hook is named in
AGENTS.md, and the text it shows carries no Hangul.

## Checklist

- [x] Tests written and passing — 576 across 42 files; three mutations against the new matcher, all caught
- [x] No `any` — not applicable, shell and `.mjs` tooling
- [x] Interface changes land in `agent-core` first — not applicable
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/reviews/docs__hook-inventory-and-english-gates.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documentation edits now require running `/ai-tells detect` before completion.
  - Checks cover Markdown files throughout the `docs/` directory and common editing actions.
  - Hook guidance and blocked-action messages are now consistently provided in English.
  - Documentation covers command safeguards, language validation, and documentation quality checks.

- **Bug Fixes**
  - Invalid or incomplete check input no longer unnecessarily prevents completion.

- **Tests**
  - Added comprehensive coverage for documentation checks, hook behavior, message language, and configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->