### PR TITLE
feat(hooks): ask for the comment card before a comment goes out

### DIFF
--- a/.claude/hooks/comment-card-gate.sh
+++ b/.claude/hooks/comment-card-gate.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PreToolUse(Bash) gate: read the comment card before posting a comment under the user's account.
+#
+# **Wired in `.claude/settings.local.json`, not in the team settings.** Reviewing here is done by two
+# people, and a gate meant for the reviewer would misfire on a contributor leaving a note on their
+# own PR — #698's author did exactly that. The script is tracked anyway so it gets tests and review:
+# every gate in this directory turned out to have a hole that only a test found, and one that judges
+# prose will be more subtly wrong, not less.
+#
+# **Three independent reasons a contributor is unaffected**, and only the third survives a mistake:
+#   1. the card lives under `.work/`, which is gitignored — they do not have the file
+#   2. the wiring lives in `settings.local.json`, which is gitignored — they do not load this hook
+#   3. `scripts/lib/comment-card.mjs` allows the command outright when the card is absent
+#
+# **PreToolUse, not Stop.** `docs-aitells-gate.sh` runs at Stop, which is right for a file — it can
+# still be edited afterwards. A comment is public the moment the command runs.
+#
+# Deciding needs the command tokenized, so it is `scripts/comment-card-gate.mjs`, where it is tested.
+# The prefilter here only decides whether to pay for node.
+
+input=$(cat)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || cmd=$input
+
+# Match what the shell would leave, not what was typed: `g"h" pr comment` is a real invocation that
+# the raw text does not contain. Squashing only ever widens what reaches the parser, and the parser
+# is the half that decides.
+squashed=${cmd//[\"\']/}
+squashed=${squashed//\\/}
+
+case "$squashed" in
+  *gh*comment*|*gh*review*|*gh*replies*) ;;
+  *) exit 0 ;;
+esac
+
+root=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null)
+if [ -n "$root" ] && top=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null); then
+  root=$top
+else
+  root="${CLAUDE_PROJECT_DIR:-.}"
+fi
+cd "$root" 2>/dev/null || exit 0
+
+[ -f scripts/comment-card-gate.mjs ] || exit 0
+
+printf '%s' "$input" | node scripts/comment-card-gate.mjs

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -22,7 +22,11 @@ const HOOK = path.join(REPO, '.claude/hooks/comment-card-gate.sh')
 
 /** A transcript line carrying one tool call, in the shape the runtime writes. */
 const record = (name, input) => JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } })
-const READ_CARD = record('Read', { file_path: '/repo/.work/COMMENT-CARD.md' })
+const CARD = path.resolve('/repo/.work/COMMENT-CARD.md')
+const READ_CARD = record('Read', { file_path: CARD })
+/** `cardWasRead` against the card this repo would resolve, which is the whole point of the second
+ *  argument: a filename match accepted `/tmp/COMMENT-CARD.md` and `NOT-COMMENT-CARD.md` alike. */
+const sawCard = (tx) => cardWasRead(tx, CARD)
 
 describe('which commands post a comment', () => {
   const POSTS = {
@@ -85,6 +89,26 @@ describe('which commands post a comment', () => {
     ]) expect(postsAComment(c), c).toBe(true)
   })
 
+  it('sees a closing or reopening comment', () => {
+    // All four of `gh {pr,issue} {close,reopen}` take `-c/--comment` and leave one, verified against
+    // the binary. Only with the flag: closing something silently publishes nothing.
+    for (const c of ['gh pr close 1 --comment "done"', 'gh issue close 1 -c "done"', 'gh pr reopen 1 --comment=x']) {
+      expect(postsAComment(c), c).toBe(true)
+    }
+    expect(postsAComment('gh pr close 1 --delete-branch')).toBe(false)
+  })
+
+  it('sees a review created through the API', () => {
+    // `POST /repos/{o}/{r}/pulls/{n}/reviews` with a body is the API form of `gh pr review --body`.
+    expect(postsAComment('gh api --method POST repos/o/r/pulls/1/reviews -f body=x')).toBe(true)
+  })
+
+  it('reads the endpoint by position, not by scanning every token', () => {
+    // A quoted field stays one token, so scanning for a comments-shaped path picked the *value* and
+    // blocked a command that creates an issue.
+    expect(postsAComment("gh api repos/o/r/issues -f 'body=See /comments/123'")).toBe(false)
+  })
+
   it('sees --input with no method, which gh sends as a POST', () => {
     // The form where `--input` is the only signal there is: supplying a body makes `POST` the
     // default, so nothing on the line says so. With an explicit `--method POST` the method carries
@@ -109,17 +133,24 @@ describe('whether the card was read this session', () => {
   }
 
   it('is true after a Read of it', () => {
-    expect(withTranscript([READ_CARD], cardWasRead)).toBe(true)
+    expect(withTranscript([READ_CARD], sawCard)).toBe(true)
   })
 
   it('is false when the name only appears in prose', () => {
     // A gate satisfied by its own block message would never fire twice.
     const mention = JSON.stringify({ message: { content: [{ type: 'text', text: 'read .work/COMMENT-CARD.md first' }] } })
-    expect(withTranscript([mention], cardWasRead)).toBe(false)
+    expect(withTranscript([mention], sawCard)).toBe(false)
+  })
+
+  it('is false for a card that is not this repository\'s', () => {
+    // A filename match took any of these. The gate resolves a path; the check now compares it.
+    for (const fp of ['/tmp/COMMENT-CARD.md', '/other/repo/.work/COMMENT-CARD.md', '/repo/.work/NOT-COMMENT-CARD.md']) {
+      expect(withTranscript([record('Read', { file_path: fp })], sawCard), fp).toBe(false)
+    }
   })
 
   it('is false when another file was read', () => {
-    expect(withTranscript([record('Read', { file_path: '/repo/AGENTS.md' })], cardWasRead)).toBe(false)
+    expect(withTranscript([record('Read', { file_path: '/repo/AGENTS.md' })], sawCard)).toBe(false)
   })
 
   it('counts an @path attachment, which is not a tool call at all', () => {
@@ -128,35 +159,31 @@ describe('whether the card was read this session', () => {
     // supplied the card.
     const attached = JSON.stringify({
       type: 'user',
-      attachment: {
-        type: 'file',
-        filename: '/repo/.work/COMMENT-CARD.md',
-        content: { type: 'text', file: { filePath: '/repo/.work/COMMENT-CARD.md', content: '# card' } },
-      },
+      attachment: { type: 'file', filename: CARD, content: { type: 'text', file: { filePath: CARD, content: '# card' } } },
       message: null,
     })
-    expect(withTranscript([attached], cardWasRead)).toBe(true)
+    expect(withTranscript([attached], sawCard)).toBe(true)
   })
 
   it('does not count an attachment of some other file', () => {
     const other = JSON.stringify({ type: 'user', attachment: { type: 'file', filename: '/repo/AGENTS.md' }, message: null })
-    expect(withTranscript([other], cardWasRead)).toBe(false)
+    expect(withTranscript([other], sawCard)).toBe(false)
   })
 
   it('counts the other ways the content reaches the context', () => {
     // Narrowing to `Read` excluded all three of these for no reason: authoring the card, editing it,
     // and reading it through the shell all put it in front of the writer.
-    expect(withTranscript([record('Write', { file_path: '/repo/.work/COMMENT-CARD.md', content: '#' })], cardWasRead)).toBe(true)
-    expect(withTranscript([record('Edit', { replace_all: false, file_path: '/repo/.work/COMMENT-CARD.md' })], cardWasRead)).toBe(true)
-    expect(withTranscript([record('Bash', { command: 'cat .work/COMMENT-CARD.md' })], cardWasRead)).toBe(true)
+    expect(withTranscript([record('Write', { file_path: CARD, content: '#' })], sawCard)).toBe(true)
+    expect(withTranscript([record('Edit', { replace_all: false, file_path: CARD })], sawCard)).toBe(true)
+    expect(withTranscript([record('Bash', { command: 'cat .work/COMMENT-CARD.md' })], sawCard)).toBe(true)
   })
 
   it('survives an unparseable line', () => {
-    expect(withTranscript(['not json at all', READ_CARD], cardWasRead)).toBe(true)
+    expect(withTranscript(['not json at all', READ_CARD], sawCard)).toBe(true)
   })
 
   it('is false when the transcript cannot be read', () => {
-    expect(cardWasRead('/nowhere/at/all.jsonl')).toBe(false)
+    expect(cardWasRead('/nowhere/at/all.jsonl', CARD)).toBe(false)
   })
 })
 
@@ -189,6 +216,8 @@ describe('the hook itself, spawned', () => {
   const readSource = (f) => readFileSync(path.join(REPO, 'scripts', f), 'utf8')
 
   /** A throwaway checkout carrying a card, so the hook resolves a root the way it will in use. */
+  /** `transcript` may be a function of the throwaway repo's path, since the card's resolved location
+   *  is now what the check compares against. */
   const inRepo = (cmd, { card = true, transcript = [], from = '.' } = {}) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'card-repo-'))
     spawnSync('git', ['init', '-q', dir])
@@ -201,7 +230,8 @@ describe('the hook itself, spawned', () => {
       writeFileSync(path.join(dir, 'scripts', f), readSource(f))
     }
     const tx = path.join(dir, 't.jsonl')
-    writeFileSync(tx, transcript.join('\n') + '\n')
+    const lines = typeof transcript === 'function' ? transcript(dir) : transcript
+    writeFileSync(tx, lines.join('\n') + '\n')
     mkdirSync(path.join(dir, from), { recursive: true })
     try {
       return spawnSync('bash', [HOOK], {
@@ -214,6 +244,12 @@ describe('the hook itself, spawned', () => {
     }
   }
 
+  it('does not accept a read of some other repository\'s card', () => {
+    // The fixture that used to pass this suite: a `Read` of `/repo/.work/COMMENT-CARD.md` while the
+    // card actually lives in the throwaway checkout. Matching by filename accepted it.
+    expect(inRepo('gh pr comment 701 --body "x"', { transcript: [READ_CARD] }).status).toBe(2)
+  })
+
   it('blocks a comment when the card has not been read', () => {
     const r = inRepo('gh pr comment 701 --body "x"')
     expect(r.status).toBe(2)
@@ -221,7 +257,8 @@ describe('the hook itself, spawned', () => {
   })
 
   it('allows it once the card has been read', () => {
-    expect(inRepo('gh pr comment 701 --body "x"', { transcript: [READ_CARD] }).status).toBe(0)
+    const readItThere = (dir) => [record('Read', { file_path: path.join(dir, '.work/COMMENT-CARD.md') })]
+    expect(inRepo('gh pr comment 701 --body "x"', { transcript: readItThere }).status).toBe(0)
   })
 
   it('allows it in a checkout with no card', () => {

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -1,0 +1,197 @@
+// The gate that asks for the comment card before a comment goes out under the user's account.
+//
+// **It is wired locally and tested here on purpose.** The wiring lives in gitignored
+// `settings.local.json` so a contributor never loads it; the script is tracked so it is not the one
+// gate in this repo without tests. Every other gate here turned out to have a hole that only a test
+// found — a matcher blind to `Edit`, a prefilter blind to `g"h"`, a flag reader taking the first
+// occurrence where pflag takes the last — and this one judges prose, which is more subtly wrong.
+//
+// The contributor-safety assertion below is the load-bearing one. Layers 1 and 2 are "it was not
+// wired for them"; only layer 3, allowing the command outright when the card is absent, survives
+// somebody wiring it by mistake.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { postsAComment, cardWasRead, judge } from '../lib/comment-card.mjs'
+import { ghInvocations } from '../lib/gh-command.mjs'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const HOOK = path.join(REPO, '.claude/hooks/comment-card-gate.sh')
+
+/** A transcript line carrying one tool call, in the shape the runtime writes. */
+const record = (name, input) => JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } })
+const READ_CARD = record('Read', { file_path: '/repo/.work/COMMENT-CARD.md' })
+
+describe('which commands post a comment', () => {
+  const POSTS = {
+    'a PR comment': 'gh pr comment 701 --body "x"',
+    'an issue comment': 'gh issue comment 700 --body "x"',
+    'a review with a body': 'gh pr review 701 --comment --body "x"',
+    'an inline reply through the API': 'gh api repos/o/r/pulls/701/comments/1/replies -F body=@r.md',
+    'behind a separator': 'git status && gh pr comment 701 --body "x"',
+    'with the command word broken by quotes': 'g"h" pr comment 701 --body "x"',
+  }
+  for (const [name, cmd] of Object.entries(POSTS)) {
+    it(`sees ${name}`, () => {
+      expect(postsAComment(cmd)).toBe(true)
+    })
+  }
+
+  const DOES_NOT = {
+    'reading comments': 'gh api repos/o/r/pulls/701/comments --jq ".[].body"',
+    'listing them': 'gh pr view 701 --json comments',
+    'creating a PR': 'gh pr create --title x --body-file b.md',
+    'creating an issue': 'gh issue create --title x --body "Parent: #607"',
+    'the words inside a script string': 'node -e "console.log(\'gh pr comment\')"',
+    'the words in a heredoc payload': 'cat > plan.md <<EOF\nrun gh pr comment when ready\nEOF',
+  }
+  for (const [name, cmd] of Object.entries(DOES_NOT)) {
+    it(`ignores ${name}`, () => {
+      expect(postsAComment(cmd)).toBe(false)
+    })
+  }
+
+  it('needs something after `gh api` to be an invocation at all', () => {
+    // `gh api` takes a path where the other nouns take a verb, so this consumer asks the parser for
+    // "any third token". Any has to mean one that is there — otherwise a bare `gh api`, or a `gh api`
+    // ending a command, reads as a call with no arguments.
+    expect(ghInvocations('gh api repos/o/r/pulls/1/comments', 'api', null)).toHaveLength(1)
+    expect(ghInvocations('gh api', 'api', null)).toHaveLength(0)
+    expect(ghInvocations('echo x && gh api', 'api', null)).toHaveLength(0)
+  })
+
+  it('separates reading an API path from writing to it', () => {
+    // `gh api …/comments` is how the thread is read, and reading it is the *first* step the card
+    // asks for. A gate that blocked that would block its own remedy.
+    expect(postsAComment('gh api repos/o/r/pulls/1/comments')).toBe(false)
+    expect(postsAComment('gh api repos/o/r/pulls/1/comments -f body=hi')).toBe(true)
+  })
+})
+
+describe('whether the card was read this session', () => {
+  const withTranscript = (lines, fn) => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'card-'))
+    const tx = path.join(dir, 't.jsonl')
+    writeFileSync(tx, lines.join('\n') + '\n')
+    try { return fn(tx) } finally { rmSync(dir, { recursive: true, force: true }) }
+  }
+
+  it('is true after a Read of it', () => {
+    expect(withTranscript([READ_CARD], cardWasRead)).toBe(true)
+  })
+
+  it('is false when the name only appears in prose', () => {
+    // A gate satisfied by its own block message would never fire twice.
+    const mention = JSON.stringify({ message: { content: [{ type: 'text', text: 'read .work/COMMENT-CARD.md first' }] } })
+    expect(withTranscript([mention], cardWasRead)).toBe(false)
+  })
+
+  it('is false when another file was read', () => {
+    expect(withTranscript([record('Read', { file_path: '/repo/AGENTS.md' })], cardWasRead)).toBe(false)
+  })
+
+  it('counts the other ways the content reaches the context', () => {
+    // Narrowing to `Read` excluded all three of these for no reason: authoring the card, editing it,
+    // and reading it through the shell all put it in front of the writer.
+    expect(withTranscript([record('Write', { file_path: '/repo/.work/COMMENT-CARD.md', content: '#' })], cardWasRead)).toBe(true)
+    expect(withTranscript([record('Edit', { replace_all: false, file_path: '/repo/.work/COMMENT-CARD.md' })], cardWasRead)).toBe(true)
+    expect(withTranscript([record('Bash', { command: 'cat .work/COMMENT-CARD.md' })], cardWasRead)).toBe(true)
+  })
+
+  it('survives an unparseable line', () => {
+    expect(withTranscript(['not json at all', READ_CARD], cardWasRead)).toBe(true)
+  })
+
+  it('is false when the transcript cannot be read', () => {
+    expect(cardWasRead('/nowhere/at/all.jsonl')).toBe(false)
+  })
+})
+
+describe('a contributor is unaffected even if this is wired for them', () => {
+  it('allows the command outright when the card is absent', () => {
+    // **Layer 3, and the only one that survives a mistake.** The card lives under gitignored
+    // `.work/` and the wiring under gitignored `settings.local.json`, so a contributor does not
+    // reach this — but neither of those is a property of the code.
+    const v = judge('gh pr comment 1 --body "x"', {
+      cardPath: '/repo/.work/COMMENT-CARD.md',
+      transcriptPath: '/nowhere.jsonl',
+      exists: () => false,
+    })
+    expect(v.blocked).toBe(false)
+  })
+
+  it('blocks the same command when the card is there and unread', () => {
+    // The contrast is what makes the assertion above mean something: without it, "allows" could be
+    // true for any reason at all.
+    const v = judge('gh pr comment 1 --body "x"', {
+      cardPath: '/repo/.work/COMMENT-CARD.md',
+      transcriptPath: '/nowhere.jsonl',
+      exists: () => true,
+    })
+    expect(v).toMatchObject({ blocked: true, reason: 'card-not-read' })
+  })
+})
+
+describe('the hook itself, spawned', () => {
+  const readSource = (f) => readFileSync(path.join(REPO, 'scripts', f), 'utf8')
+
+  /** A throwaway checkout carrying a card, so the hook resolves a root the way it will in use. */
+  const inRepo = (cmd, { card = true, transcript = [] } = {}) => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'card-repo-'))
+    spawnSync('git', ['init', '-q', dir])
+    if (card) {
+      mkdirSync(path.join(dir, '.work'), { recursive: true })
+      writeFileSync(path.join(dir, '.work/COMMENT-CARD.md'), '# card\n')
+    }
+    mkdirSync(path.join(dir, 'scripts/lib'), { recursive: true })
+    for (const f of ['comment-card-gate.mjs', 'lib/comment-card.mjs', 'lib/gh-command.mjs']) {
+      writeFileSync(path.join(dir, 'scripts', f), readSource(f))
+    }
+    const tx = path.join(dir, 't.jsonl')
+    writeFileSync(tx, transcript.join('\n') + '\n')
+    try {
+      return spawnSync('bash', [HOOK], {
+        input: JSON.stringify({ tool_input: { command: cmd }, cwd: dir, transcript_path: tx }),
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('blocks a comment when the card has not been read', () => {
+    const r = inRepo('gh pr comment 701 --body "x"')
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/COMMENT-CARD\.md/)
+  })
+
+  it('allows it once the card has been read', () => {
+    expect(inRepo('gh pr comment 701 --body "x"', { transcript: [READ_CARD] }).status).toBe(0)
+  })
+
+  it('allows it in a checkout with no card', () => {
+    expect(inRepo('gh pr comment 701 --body "x"', { card: false }).status).toBe(0)
+  })
+
+  it('blocks a spelling the raw text does not contain', () => {
+    // The prefilter matches what the shell would leave, the way the sibling gates do. Without the
+    // squash, `g"h" pr comment` is a real invocation the hook never looks at.
+    expect(inRepo('g"h" pr comment 701 --body "x"').status).toBe(2)
+  })
+
+  it('allows an unrelated command without paying for node', () => {
+    expect(inRepo('git status --short').status).toBe(0)
+  })
+
+  it('fails open on a payload it cannot parse', () => {
+    const r = spawnSync('bash', [HOOK], {
+      input: 'not json, gh pr comment',
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status, 'a broken gate would block every Bash call in the session').toBe(0)
+  })
+})

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -27,6 +27,8 @@ const READ_CARD = record('Read', { file_path: CARD })
 /** `cardWasRead` against the card this repo would resolve, which is the whole point of the second
  *  argument: a filename match accepted `/tmp/COMMENT-CARD.md` and `NOT-COMMENT-CARD.md` alike. */
 const sawCard = (tx) => cardWasRead(tx, CARD)
+/** A Bash record with the directory it ran in, which is what a relative mention is resolved against. */
+const bashAt = (cwd, command) => JSON.stringify({ cwd, message: { content: [{ type: 'tool_use', name: 'Bash', input: { command } }] } })
 
 describe('which commands post a comment', () => {
   const POSTS = {
@@ -149,6 +151,26 @@ describe('whether the card was read this session', () => {
     }
   })
 
+  it('resolves a relative shell mention against the directory it ran in', () => {
+    // `cat .work/COMMENT-CARD.md` counted the same from anywhere, so a command that failed — or ran
+    // in a different checkout — satisfied the gate. Every transcript record carries the `cwd` the
+    // call ran in; this project's carry 22 distinct ones, so the wrong-directory case is the common
+    // one rather than a corner.
+    const repo = path.dirname(path.dirname(CARD))
+    expect(withTranscript([bashAt(repo, 'cat .work/COMMENT-CARD.md')], sawCard), 'at the root').toBe(true)
+    expect(withTranscript([bashAt(path.join(repo, 'packages/relay'), 'cat .work/COMMENT-CARD.md')], sawCard),
+      'in a subdirectory, where it fails').toBe(false)
+    expect(withTranscript([bashAt('/somewhere/else', 'cat .work/COMMENT-CARD.md')], sawCard),
+      'in another checkout').toBe(false)
+  })
+
+  it('takes an absolute mention with no directory to resolve against', () => {
+    const noCwd = JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: `cat ${CARD}` } }] } })
+    expect(withTranscript([noCwd], sawCard)).toBe(true)
+    const relativeNoCwd = JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'cat .work/COMMENT-CARD.md' } }] } })
+    expect(withTranscript([relativeNoCwd], sawCard), 'a relative one has nothing to resolve with').toBe(false)
+  })
+
   it('is false when another file was read', () => {
     expect(withTranscript([record('Read', { file_path: '/repo/AGENTS.md' })], sawCard)).toBe(false)
   })
@@ -175,7 +197,7 @@ describe('whether the card was read this session', () => {
     // and reading it through the shell all put it in front of the writer.
     expect(withTranscript([record('Write', { file_path: CARD, content: '#' })], sawCard)).toBe(true)
     expect(withTranscript([record('Edit', { replace_all: false, file_path: CARD })], sawCard)).toBe(true)
-    expect(withTranscript([record('Bash', { command: 'cat .work/COMMENT-CARD.md' })], sawCard)).toBe(true)
+    expect(withTranscript([bashAt(path.dirname(path.dirname(CARD)), 'cat .work/COMMENT-CARD.md')], sawCard)).toBe(true)
   })
 
   it('survives an unparseable line', () => {

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -64,9 +64,39 @@ describe('which commands post a comment', () => {
 
   it('separates reading an API path from writing to it', () => {
     // `gh api …/comments` is how the thread is read, and reading it is the *first* step the card
-    // asks for. A gate that blocked that would block its own remedy.
-    expect(postsAComment('gh api repos/o/r/pulls/1/comments')).toBe(false)
-    expect(postsAComment('gh api repos/o/r/pulls/1/comments -f body=hi')).toBe(true)
+    // asks for. A gate that blocked that would block its own remedy. Each read below is a form
+    // `gh api --help` documents, and the first two were blocked before review.
+    for (const c of [
+      'gh api repos/o/r/pulls/1/comments',
+      'gh api --method GET repos/o/r/issues/1/comments -f per_page=100',
+      'gh api -X GET repos/o/r/issues/1/comments -f per_page=100',
+      'gh api repos/o/r/issues/1/comments --paginate',
+      'gh api repos/o/r/issues/1/comments --jq ".[].body"',
+    ]) expect(postsAComment(c), c).toBe(false)
+  })
+
+  it('sees a body that arrives without a field flag', () => {
+    // `--input` carries the whole request body, which is the natural form once a reply has been
+    // written to a file — and reading only field flags missed it completely.
+    for (const c of [
+      'gh api --method POST repos/o/r/issues/1/comments --input b.json',
+      'gh api -X POST repos/o/r/pulls/1/comments/1/replies --input b.json',
+      'gh api --method=PATCH repos/o/r/issues/comments/1 -f body=x',
+    ]) expect(postsAComment(c), c).toBe(true)
+  })
+
+  it('sees --input with no method, which gh sends as a POST', () => {
+    // The form where `--input` is the only signal there is: supplying a body makes `POST` the
+    // default, so nothing on the line says so. With an explicit `--method POST` the method carries
+    // it and this guard cannot be seen to matter.
+    expect(postsAComment('gh api repos/o/r/issues/1/comments --input b.json')).toBe(true)
+  })
+
+  it('does not treat a GET as a write even when a body rides along', () => {
+    // The one combination where the method guard decides. Everywhere else the body-field rule
+    // already answers, which is why removing this guard leaves the rest of the suite green.
+    expect(postsAComment('gh api --method GET repos/o/r/issues/1/comments --input q.json')).toBe(false)
+    expect(postsAComment('gh api --method GET repos/o/r/issues/1/comments -f body=x')).toBe(false)
   })
 })
 
@@ -90,6 +120,27 @@ describe('whether the card was read this session', () => {
 
   it('is false when another file was read', () => {
     expect(withTranscript([record('Read', { file_path: '/repo/AGENTS.md' })], cardWasRead)).toBe(false)
+  })
+
+  it('counts an @path attachment, which is not a tool call at all', () => {
+    // The most direct way the content arrives, and it carries no `message`: 64 such records in this
+    // project's transcripts. Reading only `message.content` blocked the person who had just
+    // supplied the card.
+    const attached = JSON.stringify({
+      type: 'user',
+      attachment: {
+        type: 'file',
+        filename: '/repo/.work/COMMENT-CARD.md',
+        content: { type: 'text', file: { filePath: '/repo/.work/COMMENT-CARD.md', content: '# card' } },
+      },
+      message: null,
+    })
+    expect(withTranscript([attached], cardWasRead)).toBe(true)
+  })
+
+  it('does not count an attachment of some other file', () => {
+    const other = JSON.stringify({ type: 'user', attachment: { type: 'file', filename: '/repo/AGENTS.md' }, message: null })
+    expect(withTranscript([other], cardWasRead)).toBe(false)
   })
 
   it('counts the other ways the content reaches the context', () => {
@@ -138,7 +189,7 @@ describe('the hook itself, spawned', () => {
   const readSource = (f) => readFileSync(path.join(REPO, 'scripts', f), 'utf8')
 
   /** A throwaway checkout carrying a card, so the hook resolves a root the way it will in use. */
-  const inRepo = (cmd, { card = true, transcript = [] } = {}) => {
+  const inRepo = (cmd, { card = true, transcript = [], from = '.' } = {}) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'card-repo-'))
     spawnSync('git', ['init', '-q', dir])
     if (card) {
@@ -151,9 +202,10 @@ describe('the hook itself, spawned', () => {
     }
     const tx = path.join(dir, 't.jsonl')
     writeFileSync(tx, transcript.join('\n') + '\n')
+    mkdirSync(path.join(dir, from), { recursive: true })
     try {
       return spawnSync('bash', [HOOK], {
-        input: JSON.stringify({ tool_input: { command: cmd }, cwd: dir, transcript_path: tx }),
+        input: JSON.stringify({ tool_input: { command: cmd }, cwd: path.join(dir, from), transcript_path: tx }),
         encoding: 'utf8',
         env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
       })
@@ -180,6 +232,23 @@ describe('the hook itself, spawned', () => {
     // The prefilter matches what the shell would leave, the way the sibling gates do. Without the
     // squash, `g"h" pr comment` is a real invocation the hook never looks at.
     expect(inRepo('g"h" pr comment 701 --body "x"').status).toBe(2)
+  })
+
+  it('finds the card from a subdirectory, which is where a session usually is', () => {
+    // `payload.cwd` is the session's working directory, not the repo root — 26 distinct values in
+    // this project's transcripts and exactly one of them the root. Resolving the card against it
+    // looked equivalent and silently turned the gate off for the rest of any session that had
+    // `cd`-ed anywhere.
+    expect(inRepo('gh pr comment 701 --body "x"', { from: 'packages/relay' }).status).toBe(2)
+  })
+
+  it('fails open when the payload carries no transcript', () => {
+    const r = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({ tool_input: { command: 'gh pr comment 1 --body x' }, cwd: REPO }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+    })
+    expect(r.status, 'every other missing field lets the command through').toBe(0)
   })
 
   it('allows an unrelated command without paying for node', () => {

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -31,13 +31,24 @@ try { payload = JSON.parse(raw) } catch { process.exit(0) }
 const cmd = payload?.tool_input?.command
 if (typeof cmd !== 'string' || !cmd) process.exit(0)
 
-const root = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
+// Fail open here too. Every other missing field lets the command through; a missing transcript is
+// the one that used to block, which is the wrong direction for a gate whose whole posture is that
+// it guards a cooperative reader.
+const transcript = payload?.transcript_path
+if (typeof transcript !== 'string' || !transcript) process.exit(0)
+
+// **The shell already resolved the root and `cd`-ed there**, so this is it. Re-deriving it from
+// `payload.cwd` looked equivalent and was not: that field is the session's working directory, which
+// is a subdirectory for most of a session's life — 26 distinct values in this project's transcripts,
+// exactly one of them the repo root. The gate then looked for the card under `packages/relay/.work/`,
+// found nothing, and allowed the command for the same reason a contributor's checkout allows it.
+const root = process.cwd()
 
 let verdict
 try {
   verdict = judge(cmd, {
     cardPath: path.join(root, CARD),
-    transcriptPath: payload?.transcript_path,
+    transcriptPath: transcript,
   })
 } catch { process.exit(0) }
 

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// The decision half of `.claude/hooks/comment-card-gate.sh`. Reads the PreToolUse payload on stdin,
+// exits 0 to allow and 2 to block.
+//
+// **PreToolUse, not Stop.** The sibling prose gate runs at Stop, which is right for a file — you can
+// still edit it. A comment is public the moment the command runs, so the only stage where a check
+// can change anything is before it.
+import path from 'node:path'
+import { judge } from './lib/comment-card.mjs'
+
+const CARD = '.work/COMMENT-CARD.md'
+
+const message = `Blocked: read ${CARD} before writing this comment.
+
+It is one page, and it is there because a comment written from scratch each time reads like a
+different person. The rules it carries are the ones your own edits produced — name the comment's
+job, say only what is new since your last comment on this thread, and file a finding with no action
+for this reader as an issue instead.
+
+Read it, then run this command again.`
+
+let raw = ''
+process.stdin.setEncoding('utf8')
+for await (const chunk of process.stdin) raw += chunk
+
+// Fail open on anything unparseable, matching every other gate in this directory: these guard a
+// cooperative-but-forgetful agent, and a gate that dies would block every Bash call in the session.
+let payload
+try { payload = JSON.parse(raw) } catch { process.exit(0) }
+
+const cmd = payload?.tool_input?.command
+if (typeof cmd !== 'string' || !cmd) process.exit(0)
+
+const root = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
+
+let verdict
+try {
+  verdict = judge(cmd, {
+    cardPath: path.join(root, CARD),
+    transcriptPath: payload?.transcript_path,
+  })
+} catch { process.exit(0) }
+
+if (!verdict.blocked) process.exit(0)
+process.stderr.write(`${message}\n`)
+process.exit(2)

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import { ghInvocations, tokenize } from './gh-command.mjs'
+
+/**
+ * Was the comment card read before writing a comment that goes out under the user's account?
+ *
+ * **A personal gate, wired locally.** Reviewing is done by two people here, so this fires for them
+ * and not for a contributor leaving a note on their own PR — see `judge`'s contract below for the
+ * three independent reasons that holds even if someone wires it wrongly.
+ *
+ * The card is a register, not a template: it exists because comments written from scratch each time
+ * read like different people, and the fix is a fixed reference point rather than a rule about
+ * adjectives. What it cannot do is judge whether a paragraph belongs; that stays a decision.
+ */
+
+/** Every `gh` call that posts prose into a conversation. `create` is not one — a PR body is a
+ *  different genre with its own template, and the card is about comments. */
+function commentInvocations(cmd) {
+  return [
+    ...ghInvocations(cmd, 'pr', ['comment', 'review']),
+    ...ghInvocations(cmd, 'issue', ['comment']),
+  ]
+}
+
+/**
+ * `gh api …/comments` and `…/replies` with a body — the form an inline review reply takes.
+ *
+ * Not reachable through `ghInvocations`, whose shape is `gh <noun> <verb>`. Matched on the path
+ * argument instead, and only when something is being written: a `POST` is the default for `gh api`
+ * once a field is supplied, so the presence of a body field is the signal rather than the method.
+ */
+function apiCommentInvocations(cmd) {
+  const found = []
+  for (const words of ghInvocations(cmd, 'api', null)) {
+    const path = words.find((w) => /\/(comments|replies)(\/|$|\?)/.test(w))
+    const writes = words.some((w) => w === '-f' || w === '-F' || w === '--field' || w === '--raw-field'
+      || /^-{1,2}(f|F|field|raw-field)=/.test(w))
+    if (path && writes) found.push(words)
+  }
+  return found
+}
+
+export function postsAComment(cmd) {
+  return commentInvocations(cmd).length + apiCommentInvocations(cmd).length > 0
+}
+
+/**
+ * Did this session put the card in front of itself?
+ *
+ * **Any tool call naming the card counts; a mention in prose does not.** Every way the content
+ * reaches the context goes through a tool call that names the path — `Read`, a `Write` that authored
+ * it, an `Edit`, a `cat` in Bash — and narrowing to `Read` alone excluded three of those for no
+ * reason. What the rule has to exclude is the gate's own block message, which names the card and
+ * would otherwise let it fire exactly once ever.
+ *
+ * A floor, not a fence: `grep -l COMMENT-CARD` is a tool call naming it and would count, without the
+ * content having been seen. That direction costs a missed prompt for a cooperative reader, which is
+ * the threat model these gates state.
+ *
+ * Parses the transcript rather than matching its serialisation — the lesson `docs-aitells-gate.sh`
+ * paid for, where a matcher assuming key order saw 6 of 34. Only lines that mention the card are
+ * parsed, so a 35 MB transcript costs a substring scan and a handful of `JSON.parse` calls.
+ */
+export function cardWasRead(transcriptPath, cardName = 'COMMENT-CARD.md') {
+  let text
+  try { text = fs.readFileSync(transcriptPath, 'utf8') } catch { return false }
+  if (!text.includes(cardName)) return false
+  for (const line of text.split('\n')) {
+    if (!line.includes(cardName)) continue
+    let rec
+    try { rec = JSON.parse(line) } catch { continue }
+    for (const c of rec?.message?.content ?? []) {
+      // The `input` test is what excludes a text block naming the card — today's non-tool blocks
+      // carry no `input` at all, so the type guard cannot currently change an answer. It stays for
+      // block shapes that do not exist yet, and is named here rather than asserted, because a
+      // fixture invented to make it fail would be testing the fixture.
+      if (c?.type === 'tool_use' && JSON.stringify(c.input ?? null).includes(cardName)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * @returns {{ blocked: boolean, reason?: 'card-not-read' }}
+ *
+ * **Three independent reasons a contributor is unaffected**, and the third is the one that matters:
+ * the card lives under gitignored `.work/`, the wiring lives in gitignored `settings.local.json`,
+ * and this returns `blocked: false` when the card is absent. The first two are "it was not wired for
+ * them"; only the third survives someone wiring it by mistake.
+ */
+export function judge(cmd, { cardPath, transcriptPath, exists = (p) => fs.existsSync(p) } = {}) {
+  if (!postsAComment(cmd)) return { blocked: false }
+  if (!cardPath || !exists(cardPath)) return { blocked: false }
+  if (cardWasRead(transcriptPath ?? '')) return { blocked: false }
+  return { blocked: true, reason: 'card-not-read' }
+}
+
+export { tokenize }

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { ghInvocations, tokenize } from './gh-command.mjs'
 
 /**
@@ -13,13 +14,49 @@ import { ghInvocations, tokenize } from './gh-command.mjs'
  * adjectives. What it cannot do is judge whether a paragraph belongs; that stays a decision.
  */
 
-/** Every `gh` call that posts prose into a conversation. `create` is not one — a PR body is a
- *  different genre with its own template, and the card is about comments. */
+/**
+ * Every `gh` call that posts prose into a conversation.
+ *
+ * `create` is not one — a PR body is a different genre with its own template, and the card is about
+ * comments. **`close` and `reopen` are**, which review caught: all four of
+ * `gh {pr,issue} {close,reopen}` take `-c/--comment` and leave one, verified against the binary.
+ * They only count when that flag is present, since closing something silently publishes nothing.
+ */
 function commentInvocations(cmd) {
-  return [
+  const direct = [
     ...ghInvocations(cmd, 'pr', ['comment', 'review']),
     ...ghInvocations(cmd, 'issue', ['comment']),
   ]
+  const withComment = [
+    ...ghInvocations(cmd, 'pr', ['close', 'reopen']),
+    ...ghInvocations(cmd, 'issue', ['close', 'reopen']),
+  ].filter((words) => words.some((w, i) => (w === '-c' || w === '--comment') ? words[i + 1] !== undefined
+    : /^(-c|--comment)=/.test(w)))
+  return [...direct, ...withComment]
+}
+
+/** `gh api` flags that consume the next token, so it is not the endpoint. */
+const API_VALUE_FLAGS = new Set([
+  '--method', '-X', '--field', '-f', '--raw-field', '-F', '--input', '--header', '-H',
+  '--jq', '-q', '--template', '-t', '--hostname', '--preview', '-p', '--cache',
+])
+
+/**
+ * The positional endpoint of a `gh api` call — the first word that is neither a flag nor a flag's
+ * value.
+ *
+ * **Scanning every token for a comments-shaped path picked field values.** A quoted field stays one
+ * token, so `gh api repos/o/r/issues -f 'body=See /comments/123'` looked like a call to a comments
+ * endpoint and was blocked; it creates an issue. The endpoint is a position, so it is read as one.
+ */
+function apiEndpoint(words) {
+  for (let i = 2; i < words.length; i++) {
+    const w = words[i]
+    if (API_VALUE_FLAGS.has(w)) { i++; continue }
+    if (w.startsWith('-')) continue
+    return w
+  }
+  return null
 }
 
 /** The value of a `gh api` flag, in both spellings: `--method GET` and `--method=GET`. */
@@ -52,8 +89,10 @@ function apiFlag(words, ...names) {
 function apiCommentInvocations(cmd) {
   const found = []
   for (const words of ghInvocations(cmd, 'api', null)) {
-    const path = words.find((w) => /\/(comments|replies)(\/|$|\?)/.test(w))
-    if (!path) continue
+    // `reviews` is here because a review created with a body publishes prose, which review caught:
+    // `POST /repos/{o}/{r}/pulls/{n}/reviews` is the API form of `gh pr review --body`.
+    const endpoint = apiEndpoint(words)
+    if (!endpoint || !/\/(comments|replies|reviews)(\/|$|\?)/.test(endpoint)) continue
     const method = (apiFlag(words, '--method', '-X') ?? '').toUpperCase()
     if (method === 'GET' || method === 'HEAD') continue
     const hasInput = words.some((w) => w === '--input' || w.startsWith('--input='))
@@ -69,6 +108,29 @@ function apiCommentInvocations(cmd) {
 
 export function postsAComment(cmd) {
   return commentInvocations(cmd).length + apiCommentInvocations(cmd).length > 0
+}
+
+/**
+ * The same file, allowing for symlinks.
+ *
+ * `path.resolve` normalises `..` and makes a path absolute; it does not follow links, and on macOS
+ * `/var` is one — so a checkout reached through a symlinked parent produced two spellings of the
+ * same card and the comparison said no. Falls back to the resolved strings when a path no longer
+ * exists, which a transcript's record often does.
+ */
+function samePath(a, b) {
+  if (path.resolve(a) === path.resolve(b)) return true
+  try { return fs.realpathSync(a) === fs.realpathSync(b) } catch { return false }
+}
+
+/** Does this tool input name the card — by the path the gate resolved, or by the repo-relative form
+ *  a shell command would use? */
+function namesCard(input, cardPath, relative) {
+  if (input == null) return false
+  const fp = input.file_path
+  if (typeof fp === 'string') return samePath(fp, cardPath)
+  const text = JSON.stringify(input)
+  return text.includes(cardPath) || text.includes(relative)
 }
 
 /**
@@ -88,7 +150,9 @@ export function postsAComment(cmd) {
  * paid for, where a matcher assuming key order saw 6 of 34. Only lines that mention the card are
  * parsed, so a 35 MB transcript costs a substring scan and a handful of `JSON.parse` calls.
  */
-export function cardWasRead(transcriptPath, cardName = 'COMMENT-CARD.md') {
+export function cardWasRead(transcriptPath, cardPath) {
+  const cardName = path.basename(cardPath)
+  const relative = path.join(path.basename(path.dirname(cardPath)), cardName)
   let text
   try { text = fs.readFileSync(transcriptPath, 'utf8') } catch { return false }
   if (!text.includes(cardName)) return false
@@ -101,14 +165,15 @@ export function cardWasRead(transcriptPath, cardName = 'COMMENT-CARD.md') {
     // direct way the card's content reaches the context, and reading only `message.content` blocked
     // the person who had just supplied it.
     const att = rec?.attachment
-    if (att && (String(att.filename ?? '').endsWith(cardName)
-      || String(att.content?.file?.filePath ?? '').endsWith(cardName))) return true
+    for (const p of [att?.filename, att?.content?.file?.filePath]) {
+      if (typeof p === 'string' && samePath(p, cardPath)) return true
+    }
     for (const c of rec?.message?.content ?? []) {
       // The `input` test is what excludes a text block naming the card — today's non-tool blocks
       // carry no `input` at all, so the type guard cannot currently change an answer. It stays for
       // block shapes that do not exist yet, and is named here rather than asserted, because a
       // fixture invented to make it fail would be testing the fixture.
-      if (c?.type === 'tool_use' && JSON.stringify(c.input ?? null).includes(cardName)) return true
+      if (c?.type === 'tool_use' && namesCard(c.input, cardPath, relative)) return true
     }
   }
   return false
@@ -125,7 +190,7 @@ export function cardWasRead(transcriptPath, cardName = 'COMMENT-CARD.md') {
 export function judge(cmd, { cardPath, transcriptPath, exists = (p) => fs.existsSync(p) } = {}) {
   if (!postsAComment(cmd)) return { blocked: false }
   if (!cardPath || !exists(cardPath)) return { blocked: false }
-  if (cardWasRead(transcriptPath ?? '')) return { blocked: false }
+  if (cardWasRead(transcriptPath ?? '', path.resolve(cardPath))) return { blocked: false }
   return { blocked: true, reason: 'card-not-read' }
 }
 

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -123,14 +123,25 @@ function samePath(a, b) {
   try { return fs.realpathSync(a) === fs.realpathSync(b) } catch { return false }
 }
 
-/** Does this tool input name the card — by the path the gate resolved, or by the repo-relative form
- *  a shell command would use? */
-function namesCard(input, cardPath, relative) {
+/**
+ * Does this tool input name the card — by the path the gate resolved, or by the repo-relative form a
+ * shell command would use?
+ *
+ * **A relative mention is resolved against the record's own directory.** Every transcript record
+ * carries the `cwd` the call ran in, and this project's carry 22 distinct ones. Without using it,
+ * `cat .work/COMMENT-CARD.md` counted the same whether it ran at the repo root, in
+ * `packages/relay` where it fails, or in a different checkout entirely — so a command that never
+ * read the card satisfied the gate. A record with no `cwd` cannot resolve a relative mention and
+ * does not get one; the absolute form still counts, since it needs no directory to be unambiguous.
+ */
+function namesCard(input, cardPath, relative, recordCwd) {
   if (input == null) return false
   const fp = input.file_path
   if (typeof fp === 'string') return samePath(fp, cardPath)
   const text = JSON.stringify(input)
-  return text.includes(cardPath) || text.includes(relative)
+  if (text.includes(cardPath)) return true
+  if (!recordCwd || !text.includes(relative)) return false
+  return samePath(path.resolve(recordCwd, relative), cardPath)
 }
 
 /**
@@ -142,9 +153,11 @@ function namesCard(input, cardPath, relative) {
  * reason. What the rule has to exclude is the gate's own block message, which names the card and
  * would otherwise let it fire exactly once ever.
  *
- * A floor, not a fence: `grep -l COMMENT-CARD` is a tool call naming it and would count, without the
- * content having been seen. That direction costs a missed prompt for a cooperative reader, which is
- * the threat model these gates state.
+ * A floor, not a fence, and the boundary is narrower than it was: a command naming the card in the
+ * directory that holds it counts whether or not it read anything — `ls .work/COMMENT-CARD.md` does.
+ * Whether the read *succeeded* is not checked, because that needs the result rather than the call.
+ * That direction costs a missed prompt for a cooperative reader, which is the threat model these
+ * gates state.
  *
  * Parses the transcript rather than matching its serialisation — the lesson `docs-aitells-gate.sh`
  * paid for, where a matcher assuming key order saw 6 of 34. Only lines that mention the card are
@@ -173,7 +186,7 @@ export function cardWasRead(transcriptPath, cardPath) {
       // carry no `input` at all, so the type guard cannot currently change an answer. It stays for
       // block shapes that do not exist yet, and is named here rather than asserted, because a
       // fixture invented to make it fail would be testing the fixture.
-      if (c?.type === 'tool_use' && namesCard(c.input, cardPath, relative)) return true
+      if (c?.type === 'tool_use' && namesCard(c.input, cardPath, relative, rec?.cwd)) return true
     }
   }
   return false

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -22,20 +22,47 @@ function commentInvocations(cmd) {
   ]
 }
 
+/** The value of a `gh api` flag, in both spellings: `--method GET` and `--method=GET`. */
+function apiFlag(words, ...names) {
+  for (let i = 0; i < words.length; i++) {
+    if (names.includes(words[i])) return words[i + 1] ?? null
+    for (const n of names) {
+      if (words[i].startsWith(`${n}=`)) return words[i].slice(n.length + 1)
+    }
+  }
+  return null
+}
+
 /**
- * `gh api …/comments` and `…/replies` with a body — the form an inline review reply takes.
+ * `gh api …/comments` and `…/replies` that would publish something.
  *
- * Not reachable through `ghInvocations`, whose shape is `gh <noun> <verb>`. Matched on the path
- * argument instead, and only when something is being written: a `POST` is the default for `gh api`
- * once a field is supplied, so the presence of a body field is the signal rather than the method.
+ * Not reachable through `ghInvocations`, whose shape is `gh <noun> <verb>`, so the path argument is
+ * what identifies it. What counts as writing took three corrections from review, each against
+ * `gh api --help` as the authority:
+ *
+ * - **`--input` carries a whole body with no field flag at all** — "a request body may be read from
+ *   file specified by `--input`" — and it is the natural form for a reply written to a file first.
+ *   Reading only field flags missed it entirely.
+ * - **A field does not mean a write.** "To send the parameters as a `GET` query string instead, use
+ *   `--method GET`" — so `--method GET … -f per_page=100` is a *read*, and blocking it blocks the
+ *   first thing the card asks for. Only a field named `body` is a body.
+ * - An explicit write method counts on its own, since a `POST` to a comments path is one whatever
+ *   else is on the line.
  */
 function apiCommentInvocations(cmd) {
   const found = []
   for (const words of ghInvocations(cmd, 'api', null)) {
     const path = words.find((w) => /\/(comments|replies)(\/|$|\?)/.test(w))
-    const writes = words.some((w) => w === '-f' || w === '-F' || w === '--field' || w === '--raw-field'
-      || /^-{1,2}(f|F|field|raw-field)=/.test(w))
-    if (path && writes) found.push(words)
+    if (!path) continue
+    const method = (apiFlag(words, '--method', '-X') ?? '').toUpperCase()
+    if (method === 'GET' || method === 'HEAD') continue
+    const hasInput = words.some((w) => w === '--input' || w.startsWith('--input='))
+    const hasBody = words.some((w, i) => {
+      const flags = ['-f', '-F', '--field', '--raw-field']
+      if (flags.includes(w)) return /^body=/.test(words[i + 1] ?? '')
+      return flags.some((f) => w.startsWith(`${f}=`)) && /^body=/.test(w.slice(w.indexOf('=') + 1))
+    })
+    if (hasInput || hasBody || ['POST', 'PATCH', 'PUT'].includes(method)) found.push(words)
   }
   return found
 }
@@ -69,6 +96,13 @@ export function cardWasRead(transcriptPath, cardName = 'COMMENT-CARD.md') {
     if (!line.includes(cardName)) continue
     let rec
     try { rec = JSON.parse(line) } catch { continue }
+    // **An `@path` mention is not a tool call and carries no `message` at all** — it arrives as its
+    // own record with an `attachment`, 64 of them in this project's transcripts. It is the most
+    // direct way the card's content reaches the context, and reading only `message.content` blocked
+    // the person who had just supplied it.
+    const att = rec?.attachment
+    if (att && (String(att.filename ?? '').endsWith(cardName)
+      || String(att.content?.file?.filePath ?? '').endsWith(cardName))) return true
     for (const c of rec?.message?.content ?? []) {
       // The `input` test is what excludes a text block naming the card — today's non-tool blocks
       // carry no `input` at all, so the type guard cannot currently change an answer. It stays for

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -207,10 +207,14 @@ export function withoutHeredocPayloads(cmd) {
  * Command position is tracked rather than pattern-matched, so this repo's own docs — which print
  * these commands inside prose, inside `echo`, and inside heredocs — do not trip it, while the
  * wrapped, prefixed and unspaced forms do.
+ *
+ * **`verbs: null` matches any third token**, which is what `gh api` needs: it takes a path where the
+ * other nouns take a verb, so there is nothing to enumerate.
  */
 export function ghInvocations(cmd, noun, verbs) {
   const words = tokenize(withoutHeredocPayloads(cmd))
-  const wanted = new Set(verbs)
+  const anyVerb = verbs === null
+  const wanted = new Set(verbs ?? [])
   const found = []
   let atStart = true
   for (let i = 0; i < words.length; i++) {
@@ -219,7 +223,7 @@ export function ghInvocations(cmd, noun, verbs) {
     if (!atStart) continue
     let j = i
     while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
-    if (words[j] === 'gh' && words[j + 1] === noun && wanted.has(words[j + 2])) {
+    if (words[j] === 'gh' && words[j + 1] === noun && (anyVerb ? words[j + 2] !== undefined : wanted.has(words[j + 2]))) {
       // **Stop at the next separator.** Running to the end of the token list meant a later command's
       // flags counted as this one's: `gh issue create --web && echo --body "Parent: #607"` was
       // allowed, because `bodyArg` found `echo`'s argument.


### PR DESCRIPTION
## Summary

Comments written from scratch each time read like different people. `.work/COMMENT-CARD.md` is a
fixed reference point — how long, what belongs, what to leave out — derived from the two comments on
#694 and #695 that were edited down by hand, 150→55 and 247→120 words. This gate makes reading it a
precondition rather than a habit.

**PreToolUse, not Stop.** `docs-aitells-gate.sh` runs at Stop, which is right for a file: it can
still be edited afterwards. A comment is public the moment the command runs.

**Wired in `settings.local.json`, which is gitignored.** Reviewing here is done by two people and
this fires for them; a contributor leaving a note on their own PR would be misfired on, and #698's
author did exactly that. The script is tracked anyway — every other gate in this directory turned
out to have a hole that only a test found, and one standing between a person and a published comment
should not be the one without tests. Three independent reasons a contributor is unaffected, and only
the third survives someone wiring it by mistake: the card is under gitignored `.work/`, the wiring is
gitignored, and the decision allows the command outright when the card is absent. That last one has
its own test, paired with the same command blocking when the card *is* present, so "allows" cannot
pass for the wrong reason.

Detection reuses the parser from #701 rather than a fresh regex, so a comment command behind an
operator, an environment assignment, or a broken-up command word is seen while the words inside a
string literal or a heredoc are not. Reading a thread is deliberately allowed: it is the first thing
the card asks for, and a gate that blocked it would block its own remedy.

Review found four things, two of them serious enough that the gate barely worked. It resolved the
card against the session's *working* directory rather than the repo root — 26 distinct values in
this project's transcripts, one of them the root — so a single `cd packages/relay` turned it off for
the rest of that session. And an `@path` mention is its own record with no `message` at all, 64 of
them here, so the most direct way of supplying the card was the one way that did not count. Two
corrections to what `gh api` writing means came from reading `gh api --help` rather than reasoning
about it: `--input` carries a body with no field flag, and a field is not a body when the method is
`GET`.

The gate enforces one thing — that the card was read. Whether a paragraph serves the comment's job,
repeats the last one, or copies the examples' phrasing is not machine-decidable, and the card says so.

## Checklist

- [x] Tests written and passing — 592 across 41 files; eleven mutations, one per guard, all caught
- [x] No `any` — not applicable, shell and `.mjs` tooling
- [x] Interface changes land in `agent-core` first — not applicable
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/reviews/feature__comment-card-gate.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards to ensure comment and review submissions follow the repository’s comment-card guidance.
  * Recognizes GitHub CLI and API comment, reply, review, close, and reopen commands while allowing read-only operations.
  * Provides clear instructions when required guidance has not been reviewed.
  * Supports guidance detection across repository subdirectories and equivalent paths.

* **Bug Fixes**
  * Improved recognition of varied GitHub API command formats, including quoted commands, positional endpoints, and request bodies.
  * Prevents unrelated commands or incomplete checks from being unnecessarily blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->