### PR TITLE
test(relay): make suite Windows-compatible

### DIFF
--- a/packages/relay/src/__tests__/accountKey.test.ts
+++ b/packages/relay/src/__tests__/accountKey.test.ts
@@ -24,7 +24,10 @@ describe('loadOrCreateAccountKey', () => {
     const k1 = await loadOrCreateAccountKey(fp, create)
     expect(k1).toBe('ACCOUNT-KEY-1')
     expect(creates).toBe(1)
-    expect(fs.statSync(fp).mode & 0o777).toBe(0o600)
+    // Windows ACLs do not map to POSIX permission bits.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(fp).mode & 0o777).toBe(0o600)
+    }
 
     const k2 = await loadOrCreateAccountKey(fp, create)
     expect(k2).toBe('ACCOUNT-KEY-1') // 디스크에서 재사용

--- a/packages/relay/src/__tests__/builds.test.ts
+++ b/packages/relay/src/__tests__/builds.test.ts
@@ -2,21 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { spawnSync } from 'child_process'
 import { initDb, getDb, closeDb } from '../db'
-
-// ── fixture helpers ────────────────────────────────────────────────────────
-
-function makeTestZip(tmpDir: string, appName: string, plistXml: string): string {
-  const appDir = path.join(tmpDir, `${appName}.app`)
-  fs.mkdirSync(appDir, { recursive: true })
-  fs.writeFileSync(path.join(appDir, 'Info.plist'), plistXml)
-  // minimal binary placeholder (Mach-O magic is not needed for zip structure test)
-  fs.writeFileSync(path.join(appDir, appName), Buffer.from([0xcf, 0xfa, 0xed, 0xfe]))
-  const zipPath = path.join(tmpDir, `${appName}.app.zip`)
-  spawnSync('zip', ['-r', zipPath, `${appName}.app`], { cwd: tmpDir })
-  return zipPath
-}
+import { makeAppZip, writeZipFixture } from './helpers/zipFixture'
 
 const XML_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -37,7 +24,7 @@ describe('Migration 004: apps/builds split', () => {
     initDb(path.join(tmpDir, 'test.db'))
   })
 
-  afterAll(() => { fs.rmSync(tmpDir, { recursive: true }) })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true }) })
 
   it('apps table has bundle_id_key, platform, no file_path', () => {
     const cols = (getDb().prepare('PRAGMA table_info(apps)').all() as { name: string }[]).map(c => c.name)
@@ -95,7 +82,7 @@ describe('upsertApp: bundle_id grouping', () => {
     upsertApp = mod.upsertApp
   })
 
-  afterAll(() => { fs.rmSync(tmpDir, { recursive: true }) })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true }) })
 
   it('iOS then Android with same bundle_id → single app, platform=both', () => {
     const db = getDb()
@@ -145,7 +132,7 @@ describe('upload: app_id provided but bundle_id differs → new app', () => {
     upsertApp = mod.upsertApp
   })
 
-  afterAll(() => { fs.rmSync(tmpDir, { recursive: true }) })
+  afterAll(() => { closeDb(); fs.rmSync(tmpDir, { recursive: true }) })
 
   it('bundle_id가 다른 앱을 app_id 지정 업로드 시 새 앱에 라우팅된다', () => {
     const db = getDb()
@@ -318,7 +305,7 @@ describe('extractAppZipInfo', () => {
 
   beforeAll(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tapflow-zip-test-'))
-    zipPath = makeTestZip(tmpDir, 'CoffeeApp', XML_PLIST)
+    zipPath = makeAppZip(tmpDir, 'CoffeeApp', XML_PLIST)
     const mod = await import('../api/builds')
     extractAppZipInfo = mod.extractAppZipInfo
   })
@@ -335,7 +322,7 @@ describe('extractAppZipInfo', () => {
   })
 
   it('extracts metadata when .app name contains spaces', () => {
-    const spacedZip = makeTestZip(tmpDir, 'Food Truck', XML_PLIST)
+    const spacedZip = makeAppZip(tmpDir, 'Food Truck', XML_PLIST)
     const info = extractAppZipInfo(spacedZip)
     expect(info).not.toBeNull()
     expect(info!.bundleId).toBe('com.example.coffee')
@@ -343,8 +330,7 @@ describe('extractAppZipInfo', () => {
 
   it('returns null for a zip with no .app directory', () => {
     const emptyZip = path.join(tmpDir, 'empty.zip')
-    fs.writeFileSync(path.join(tmpDir, 'readme.txt'), 'hello')
-    spawnSync('zip', [emptyZip, 'readme.txt'], { cwd: tmpDir })
+    writeZipFixture(emptyZip, [{ name: 'readme.txt', data: 'hello' }])
     const info = extractAppZipInfo(emptyZip)
     expect(info).toBeNull()
   })

--- a/packages/relay/src/__tests__/diskCertStore.test.ts
+++ b/packages/relay/src/__tests__/diskCertStore.test.ts
@@ -40,6 +40,9 @@ describe('DiskCertStore', () => {
     const store = new DiskCertStore(dir)
     await store.save({ cert, key, expiresAt: new Date() })
     const mode = fs.statSync(path.join(dir, 'key.pem')).mode & 0o777
-    expect(mode).toBe(0o600)
+    // Windows ACLs do not map to POSIX permission bits.
+    if (process.platform !== 'win32') {
+      expect(mode).toBe(0o600)
+    }
   })
 })

--- a/packages/relay/src/__tests__/diskCertStore.test.ts
+++ b/packages/relay/src/__tests__/diskCertStore.test.ts
@@ -36,7 +36,7 @@ describe('DiskCertStore', () => {
     expect(loaded!.expiresAt).toEqual(parseCertNotAfter(cert))
   })
 
-  it('key 파일은 0600 권한으로 저장한다', async () => {
+  it('key 파일은 0600 권한으로 저장한다 (POSIX 한정)', async () => {
     const store = new DiskCertStore(dir)
     await store.save({ cert, key, expiresAt: new Date() })
     const mode = fs.statSync(path.join(dir, 'key.pem')).mode & 0o777

--- a/packages/relay/src/__tests__/helpers/zipFixture.ts
+++ b/packages/relay/src/__tests__/helpers/zipFixture.ts
@@ -22,6 +22,8 @@ function entryData(entry: ZipFixtureEntry): Buffer {
   return Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data)
 }
 
+// Keep this writer in-process: the repo has no ZIP library, and fixtures must not
+// depend on a system zip executable.
 function makeZip(entries: readonly ZipFixtureEntry[]): Buffer {
   const localParts: Buffer[] = []
   const centralParts: Buffer[] = []
@@ -93,6 +95,8 @@ export function writeZipFixture(zipPath: string, entries: readonly ZipFixtureEnt
 export function makeAppZip(tmpDir: string, appName: string, plistXml: string): string {
   const zipPath = path.join(tmpDir, `${appName}.app.zip`)
   return writeZipFixture(zipPath, [
+    // This explicit, apparently empty directory entry is load-bearing: production
+    // findAppDirInZip relies on unzip -l output containing a line ending in .app/.
     { name: `${appName}.app/` },
     { name: `${appName}.app/Info.plist`, data: plistXml },
     { name: `${appName}.app/${appName}`, data: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },

--- a/packages/relay/src/__tests__/helpers/zipFixture.ts
+++ b/packages/relay/src/__tests__/helpers/zipFixture.ts
@@ -1,0 +1,100 @@
+import fs from 'fs'
+import path from 'path'
+
+export type ZipFixtureEntry = {
+  name: string
+  data?: Buffer | string
+}
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff
+  for (const byte of data) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ ((crc & 1) === 1 ? 0xedb88320 : 0)
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function entryData(entry: ZipFixtureEntry): Buffer {
+  if (entry.data === undefined) return Buffer.alloc(0)
+  return Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data)
+}
+
+function makeZip(entries: readonly ZipFixtureEntry[]): Buffer {
+  const localParts: Buffer[] = []
+  const centralParts: Buffer[] = []
+  const utf8Flag = 0x800
+  const dosDate = 33 // 1980-01-01
+  let offset = 0
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, 'utf8')
+    const data = entryData(entry)
+    const checksum = crc32(data)
+
+    const localHeader = Buffer.alloc(30)
+    localHeader.writeUInt32LE(0x04034b50, 0)
+    localHeader.writeUInt16LE(20, 4)
+    localHeader.writeUInt16LE(utf8Flag, 6)
+    localHeader.writeUInt16LE(0, 8) // stored, not compressed
+    localHeader.writeUInt16LE(0, 10) // 00:00
+    localHeader.writeUInt16LE(dosDate, 12)
+    localHeader.writeUInt32LE(checksum, 14)
+    localHeader.writeUInt32LE(data.length, 18)
+    localHeader.writeUInt32LE(data.length, 22)
+    localHeader.writeUInt16LE(name.length, 26)
+    localHeader.writeUInt16LE(0, 28)
+    localParts.push(localHeader, name, data)
+
+    const centralHeader = Buffer.alloc(46)
+    centralHeader.writeUInt32LE(0x02014b50, 0)
+    centralHeader.writeUInt16LE(20, 4)
+    centralHeader.writeUInt16LE(20, 6)
+    centralHeader.writeUInt16LE(utf8Flag, 8)
+    centralHeader.writeUInt16LE(0, 10) // stored, not compressed
+    centralHeader.writeUInt16LE(0, 12) // 00:00
+    centralHeader.writeUInt16LE(dosDate, 14)
+    centralHeader.writeUInt32LE(checksum, 16)
+    centralHeader.writeUInt32LE(data.length, 20)
+    centralHeader.writeUInt32LE(data.length, 24)
+    centralHeader.writeUInt16LE(name.length, 28)
+    centralHeader.writeUInt16LE(0, 30)
+    centralHeader.writeUInt16LE(0, 32)
+    centralHeader.writeUInt16LE(0, 34)
+    centralHeader.writeUInt16LE(0, 36)
+    centralHeader.writeUInt32LE(entry.name.endsWith('/') ? 0x10 : 0, 38)
+    centralHeader.writeUInt32LE(offset, 42)
+    centralParts.push(centralHeader, name)
+
+    offset += localHeader.length + name.length + data.length
+  }
+
+  const centralDirectory = Buffer.concat(centralParts)
+  const endOfCentralDirectory = Buffer.alloc(22)
+  endOfCentralDirectory.writeUInt32LE(0x06054b50, 0)
+  endOfCentralDirectory.writeUInt16LE(0, 4)
+  endOfCentralDirectory.writeUInt16LE(0, 6)
+  endOfCentralDirectory.writeUInt16LE(entries.length, 8)
+  endOfCentralDirectory.writeUInt16LE(entries.length, 10)
+  endOfCentralDirectory.writeUInt32LE(centralDirectory.length, 12)
+  endOfCentralDirectory.writeUInt32LE(offset, 16)
+  endOfCentralDirectory.writeUInt16LE(0, 20)
+
+  return Buffer.concat([...localParts, centralDirectory, endOfCentralDirectory])
+}
+
+export function writeZipFixture(zipPath: string, entries: readonly ZipFixtureEntry[]): string {
+  fs.writeFileSync(zipPath, makeZip(entries))
+  return zipPath
+}
+
+export function makeAppZip(tmpDir: string, appName: string, plistXml: string): string {
+  const zipPath = path.join(tmpDir, `${appName}.app.zip`)
+  return writeZipFixture(zipPath, [
+    { name: `${appName}.app/` },
+    { name: `${appName}.app/Info.plist`, data: plistXml },
+    { name: `${appName}.app/${appName}`, data: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  ])
+}

--- a/packages/relay/src/__tests__/upload-limits.test.ts
+++ b/packages/relay/src/__tests__/upload-limits.test.ts
@@ -3,11 +3,11 @@ import http from 'http'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { spawnSync } from 'child_process'
 import { RelayServer } from '../RelayServer'
 import { initDb, getDb, closeDb } from '../db'
 import { makePasswordHash } from '../api/auth'
 import { signJwt } from '../middleware/auth'
+import { writeZipFixture } from './helpers/zipFixture'
 
 // multipart/form-data 바디를 직접 구성한다 (busboy 파싱용).
 function multipartBody(boundary: string, parts: { name: string; filename?: string; contentType?: string; data: Buffer | string }[]): Buffer {
@@ -106,10 +106,8 @@ describe('upload size-limit handling', () => {
   })
 
   it('빌드: .app 디렉토리 없는 zip은 400 + 영어 안내', async () => {
-    const readme = path.join(uploadsDir, 'readme.txt')
-    fs.writeFileSync(readme, 'hello')
     const noAppZip = path.join(uploadsDir, 'noapp.zip')
-    spawnSync('zip', ['-j', noAppZip, readme])
+    writeZipFixture(noAppZip, [{ name: 'readme.txt', data: 'hello' }])
     const boundary = 'X4'
     const body = multipartBody(boundary, [{ name: 'file', filename: 'app.zip', contentType: 'application/zip', data: fs.readFileSync(noAppZip) }])
     const r = await httpPostMultipart(port, '/api/v1/builds', body, boundary, cookie)


### PR DESCRIPTION
## Summary

Make the relay test suite Windows-compatible without changing production key-storage behavior or ZIP extraction.

- Gate only the POSIX `0600` permission assertions on Windows while keeping account-key creation, persistence, reuse, and certificate save/load coverage everywhere.
- Replace system `zip` fixture creation with a self-contained Node ZIP helper that emits explicit root `.app/` directory entries, plist files, placeholder binaries, and no-app archives.
- Close each `builds.test.ts` SQLite handle before removing its temporary directory.

Closes #661

## Validation

Before, on unmodified upstream `main` at `aec46dbc174b6398686eba3b0de5b528535dc167`:

```text
Test Files  4 failed | 57 passed | 1 skipped (62)
Tests       5 failed | 699 passed | 1 skipped (705)
```

The five failed tests were the two POSIX mode assertions, two app ZIP metadata tests, and one no-app ZIP upload test; three `builds.test.ts` cleanup hooks also reported `EPERM`.

After, on final commit `a5dd2a12ed9777c85b150a8de360df3a84b3a101`:

```text
Test Files  61 passed | 1 skipped (62)
Tests       704 passed | 1 skipped (705)
```

The unchanged production `unzip` executable was already installed under Git for Windows but not on this PowerShell session's `PATH`, so it was appended only for the test process.

- Relay typecheck passed.
- Relay lint passed with 5 pre-existing warnings and 0 errors.
- Repository pre-commit checks passed.
- Independent adversarial review found no actionable issues.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first (not applicable)
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/reviews/test__661-windows-relay-suite.md`

<!-- no-changeset: test-only changes; no published source or user-facing behavior changed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability, including Windows-compatible permission checks.
  * Standardized ZIP fixture creation across application, build, and upload-limit tests.
  * Added support for testing macOS application bundle ZIP fixtures.
  * Ensured temporary test databases are closed during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->