### PR TITLE
fix(hooks): read a reserved word by position, and reach the api surface

### DIFF
--- a/.claude/hooks/adversarial-review-gate.sh
+++ b/.claude/hooks/adversarial-review-gate.sh
@@ -7,6 +7,10 @@
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+# A payload with no `command` key is not an empty command -- `// ""` made the two identical and the
+# gate passed at exit 0. Judge the whole payload instead, the way the sibling gates do; the
+# command-position rule below still applies, so an ordinary payload is unaffected.
+[ -n "$cmd" ] || cmd=$input
 # Match the PR-create invocation only in command position: line start, after
 # ; && |, inside $( ) capture, or after then/do. A plain substring match would
 # false-positive on commit messages / docs that merely mention the command.

--- a/.claude/hooks/comment-card-gate.sh
+++ b/.claude/hooks/comment-card-gate.sh
@@ -29,8 +29,13 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 squashed=${cmd//[\"\']/}
 squashed=${squashed//\\/}
 
+# **`graphql` is its own arm rather than a case-insensitive widening of the others.** A comment
+# posted through the API is spelled `addComment`, which no lowercase `*comment*` pattern matches, and
+# folding the whole filter to case-insensitive would make `*gh*` mean "contains gh" — that is the
+# cost this prefilter exists to avoid, measured once already when matching the payload rather than
+# the command. `graphql` is a subcommand and is always lowercase, so one more literal arm covers it.
 case "$squashed" in
-  *gh*comment*|*gh*review*|*gh*replies*) ;;
+  *gh*comment*|*gh*review*|*gh*replies*|*gh*api*graphql*) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/hooks/comment-card-gate.sh
+++ b/.claude/hooks/comment-card-gate.sh
@@ -48,5 +48,12 @@ fi
 cd "$root" 2>/dev/null || exit 0
 
 [ -f scripts/comment-card-gate.mjs ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
 
+# **Only status 2 is a verdict.** node's own failures are not — a missing binary exits 127, an
+# import error exits 1 — and propagating those made every matching command in the session report a
+# hook error while blocking nothing, which is the opposite of the fail-open promise above.
 printf '%s' "$input" | node scripts/comment-card-gate.mjs
+status=$?
+[ "$status" -eq 2 ] && exit 2
+exit 0

--- a/.claude/hooks/gh-language-gate.sh
+++ b/.claude/hooks/gh-language-gate.sh
@@ -56,5 +56,12 @@ fi
 cd "$root" 2>/dev/null || exit 0
 
 [ -f scripts/gh-language-gate.mjs ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
 
+# **Only status 2 is a verdict.** node's own failures are not — a missing binary exits 127, an
+# import error exits 1 — and propagating those made every matching command in the session report a
+# hook error while blocking nothing, which is the opposite of the fail-open promise above.
 printf '%s' "$input" | node scripts/gh-language-gate.mjs
+status=$?
+[ "$status" -eq 2 ] && exit 2
+exit 0

--- a/.claude/hooks/issue-parent-gate.sh
+++ b/.claude/hooks/issue-parent-gate.sh
@@ -57,5 +57,12 @@ fi
 cd "$root" 2>/dev/null || exit 0
 
 [ -f scripts/issue-parent-gate.mjs ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
 
+# **Only status 2 is a verdict.** node's own failures are not — a missing binary exits 127, an
+# import error exits 1 — and propagating those made every matching command in the session report a
+# hook error while blocking nothing, which is the opposite of the fail-open promise above.
 printf '%s' "$input" | node scripts/issue-parent-gate.mjs
+status=$?
+[ "$status" -eq 2 ] && exit 2
+exit 0

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -91,5 +91,12 @@ fi
 cd "$root" 2>/dev/null || exit 0
 
 [ -f scripts/pr-merge-guard.mjs ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
 
+# **Only status 2 is a verdict.** node's own failures are not — a missing binary exits 127, an
+# import error exits 1 — and propagating those made every matching command in the session report a
+# hook error while blocking nothing, which is the opposite of the fail-open promise above.
 printf '%s' "$input" | node scripts/pr-merge-guard.mjs
+status=$?
+[ "$status" -eq 2 ] && exit 2
+exit 0

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -20,11 +20,18 @@
 # session on a missing jq, and the 2191 failures above are the calibration for
 # how long such a break can go unnoticed.
 #
-# Not covered, deliberately: the `gh api` / git plumbing equivalents. Same
-# threat model — see the issue linked from the review record.
+# The `gh api` equivalents ARE covered, below, by a parsing half in
+# scripts/pr-merge-guard.mjs. Still not covered: git plumbing, and GraphQL
+# mergePullRequest -- see scripts/lib/pr-merge.mjs for why that one waits.
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
+# **A payload with no `command` key is not an empty command.** `// ""` made the two identical, every
+# pattern below then failed, and the gate passed at exit 0 -- verified: `{"tool_input":{}}` allowed.
+# Falling back to the whole payload keeps the gate deciding, which is what the language and
+# issue-parent prefilters already do. The command-position rule still applies to it, so this catches
+# less than a substring scan would and costs no new false blocks on ordinary payloads.
+[ -n "$cmd" ] || cmd=$input
 
 # Join backslash-newline continuations before matching. grep decides line by
 # line, so `gh \` / `pr \` / `merge` on three physical lines reads as three
@@ -45,7 +52,34 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
 # one, and the block message says to split such text into its own command.
 cmd=$(printf '%s' "$cmd" | perl -0777 -pe 's/\\\r?\n//g') || exit 0
 
-printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:space:]])(then|do)[[:space:]]+)gh[[:space:]]+pr[[:space:]]+(merge|review)' || exit 0
+if printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[[:space:]])(then|do)[[:space:]]+)gh[[:space:]]+pr[[:space:]]+(merge|review)'; then
+  echo "Blocked: creating the PR is yours to do; merging and approving are the user's — leave them, even with --admin (AGENTS.md > Core Principles). If this command is not actually merging or approving (the text merely mentions the command), split that text into a separate command." >&2
+  exit 2
+fi
 
-echo "Blocked: creating the PR is yours to do; merging and approving are the user's — leave them, even with --admin (AGENTS.md > Core Principles). If this command is not actually merging or approving (the text merely mentions the command), split that text into a separate command." >&2
-exit 2
+# The `gh api` forms of the same two actions, which the grep above cannot judge: `gh api` names
+# what it acts on in a path and how in a flag, and the same path is a read or a write depending
+# on the method. Deciding that needs parsing, so it is `scripts/pr-merge-guard.mjs`, where it is
+# tested. What follows is only a prefilter over whether to pay for a node process.
+squashed=${cmd//[\"\']/}
+squashed=${squashed//\\/}
+
+case "$squashed" in
+  *gh*api*) ;;
+  *) exit 0 ;;
+esac
+
+# The session's own checkout, the way `adversarial-review-gate.sh` resolves it (#699):
+# `CLAUDE_PROJECT_DIR` alone turns the gate off for a session in a worktree, which finds no
+# `scripts/` there.
+root=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null)
+if [ -n "$root" ] && top=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null); then
+  root=$top
+else
+  root="${CLAUDE_PROJECT_DIR:-.}"
+fi
+cd "$root" 2>/dev/null || exit 0
+
+[ -f scripts/pr-merge-guard.mjs ] || exit 0
+
+printf '%s' "$input" | node scripts/pr-merge-guard.mjs

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -8,11 +8,15 @@
 # string. Measured across 150 sessions: 2191 parse failures against 1 success —
 # every multi-line command passed unguarded. Reading stdin with printf is the fix.
 #
-# Match the invocation only in command position: line start, after ; && |,
-# inside $( ) capture, or after then/do. A plain substring match would
-# false-positive on commit messages / docs that merely mention the command —
-# and this repo's own docs discuss `gh pr merge` by name.
+# The grep below matches the invocation only in command position: line start,
+# after ; && |, inside $( ) capture, or after then/do. A plain substring match
+# would false-positive on commit messages / docs that merely mention the
+# command — and this repo's own docs discuss `gh pr merge` by name.
 # Backticks are deliberately NOT a command position (markdown quoting).
+#
+# **That list of positions is not what bash means by command position**, which
+# is why the decision now lives in scripts/pr-merge-guard.mjs and this grep is
+# a backstop for when node cannot run. See the note above it, below.
 #
 # Fail-open by design (jq missing, unparseable payload), matching
 # adversarial-review-gate.sh: this gate guards a cooperative-but-forgetful
@@ -20,9 +24,8 @@
 # session on a missing jq, and the 2191 failures above are the calibration for
 # how long such a break can go unnoticed.
 #
-# The `gh api` equivalents ARE covered, below, by a parsing half in
-# scripts/pr-merge-guard.mjs. Still not covered: git plumbing, and GraphQL
-# mergePullRequest -- see scripts/lib/pr-merge.mjs for why that one waits.
+# Covered by the parsing half: the `gh api` REST endpoints and the GraphQL
+# mutations that merge or approve. Still not covered: git plumbing.
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""') || exit 0
@@ -57,15 +60,22 @@ if printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|(;|&&|\||\$\()[[:space:]]*|(^|[
   exit 2
 fi
 
-# The `gh api` forms of the same two actions, which the grep above cannot judge: `gh api` names
-# what it acts on in a path and how in a flag, and the same path is a read or a write depending
-# on the method. Deciding that needs parsing, so it is `scripts/pr-merge-guard.mjs`, where it is
-# tested. What follows is only a prefilter over whether to pay for a node process.
+# Everything the grep above cannot judge, which turned out to be most of it. Two classes:
+#
+#   - the `gh api` forms, where the same path is a read or a write depending on the method;
+#   - the ordinary prefixes and wrappers, which the grep's notion of command position misses.
+#     Measured against this file before the parser was wired in: an assignment prefix, `env`,
+#     `sudo`, `command`, `xargs`, `if ...; then` and a background `&` all passed at exit 0 while
+#     the bare form was blocked.
+#
+# So the grep above is a backstop for when node cannot run, and the decision is
+# `scripts/pr-merge-guard.mjs`, where it is tested. What follows is a prefilter over whether to
+# pay for a node process.
 squashed=${cmd//[\"\']/}
 squashed=${squashed//\\/}
 
 case "$squashed" in
-  *gh*api*) ;;
+  *gh*api*|*gh*pr*) ;;
   *) exit 0 ;;
 esac
 

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -146,22 +146,10 @@ describe('which commands post a comment', () => {
       expect(postsAComment('cat > n.md <<EOF\ngh api graphql -f query=mutation{addComment}\nEOF')).toBe(false)
     })
 
-    it('the prefilter lets the mutation reach the parser', () => {
-      // Both halves missed it: the path matcher looks for a `/comments` segment and the shell
-      // prefilter matches `*gh*comment*` in lowercase, while the mutation is spelled `addComment`.
-      // Node was never spawned, so neither half got a chance. Asserted through the hook because the
-      // prefilter is the half a unit test cannot see.
-      const r = spawnSync('bash', [HOOK], {
-        input: JSON.stringify({
-          tool_input: { command: "gh api graphql -f query='mutation{addComment(input:{}){id}}'" },
-          cwd: REPO,
-          transcript_path: path.join(REPO, 'no-such-transcript.jsonl'),
-        }),
-        encoding: 'utf8',
-        env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
-      })
-      expect(r.status).toBe(2)
-    })
+    // The prefilter half is asserted where the hook is spawned against a throwaway checkout — see
+    // `the hook itself, spawned`. It cannot be done from here: this repo's own card lives under
+    // gitignored `.work/`, so a test that spawns the hook against this checkout passes on the
+    // author's machine and allows the command in CI, where the card does not exist.
   })
 
   it('sees a body that arrives without a field flag', () => {
@@ -395,6 +383,23 @@ describe('the hook itself, spawned', () => {
 
   it('allows an unrelated command without paying for node', () => {
     expect(inRepo('git status --short').status).toBe(0)
+  })
+
+  it('the prefilter lets a GraphQL mutation reach the parser', () => {
+    // **Both halves missed it at once.** The path matcher looks for a `/comments` segment and the
+    // path here is `graphql`; the shell prefilter matches `*gh*comment*` in lowercase while the
+    // mutation is spelled `addComment`, so node was never spawned and the parser never got a chance.
+    // Asserted through the hook because the prefilter is the half a unit test cannot see.
+    //
+    // In a throwaway checkout, not this one: the card the gate needs lives under gitignored
+    // `.work/`, so spawning against this repo passes locally and allows the command in CI.
+    expect(inRepo("gh api graphql -f query='mutation{addComment(input:{}){id}}'").status).toBe(2)
+  })
+
+  it('the prefilter still ignores a command that is neither', () => {
+    // `*gh*api*graphql*` was added as one more literal arm rather than making the filter
+    // case-insensitive, because that would widen what pays for a node process on every Bash call.
+    expect(inRepo('gh api graphql -f query="query{viewer{login}}"').status).toBe(0)
   })
 
   it('fails open on a payload it cannot parse', () => {

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -38,6 +38,7 @@ describe('which commands post a comment', () => {
     'an inline reply through the API': 'gh api repos/o/r/pulls/701/comments/1/replies -F body=@r.md',
     'behind a separator': 'git status && gh pr comment 701 --body "x"',
     'with the command word broken by quotes': 'g"h" pr comment 701 --body "x"',
+    'a GraphQL mutation': "gh api graphql -f query='mutation{addComment(input:{subjectId:\"X\",body:\"hi\"}){clientMutationId}}'",
   }
   for (const [name, cmd] of Object.entries(POSTS)) {
     it(`sees ${name}`, () => {
@@ -79,6 +80,75 @@ describe('which commands post a comment', () => {
       'gh api repos/o/r/issues/1/comments --paginate',
       'gh api repos/o/r/issues/1/comments --jq ".[].body"',
     ]) expect(postsAComment(c), c).toBe(false)
+  })
+
+  describe('a GraphQL mutation is identified by its contents, not its path', () => {
+    // Every other form the gate knows names what it acts on in the URL. Here the path is the
+    // constant `graphql` and the operation is a string passed as a field value, so the endpoint
+    // check is the cheap half and the mutation name is the decision.
+    const mutation = (op) => `gh api graphql -f query='mutation{${op}(input:{}){clientMutationId}}'`
+
+    // The list is GitHub's rather than ours, which is why it is enumerated: a `*Comment*` pattern
+    // would catch `deleteIssueComment`, which publishes nothing, and miss `addPullRequestReview`,
+    // which does.
+    for (const op of ['addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
+      'addDiscussionComment', 'updateIssueComment']) {
+      it(`sees ${op}`, () => expect(postsAComment(mutation(op)), op).toBe(true))
+    }
+
+    it('allows a query that only reads', () => {
+      // The same distinction `--method GET` draws on the REST path: it publishes nothing.
+      expect(postsAComment("gh api graphql -f query='query{viewer{login}}'")).toBe(false)
+    })
+
+    it('allows a mutation that publishes no prose', () => {
+      expect(postsAComment(mutation('addLabelsToLabelable'))).toBe(false)
+      expect(postsAComment(mutation('deleteIssueComment'))).toBe(false)
+    })
+
+    it('reads a query written to a file', () => {
+      // The same question `--input` raised on the REST path, answered the same way: a query long
+      // enough to be written to a file is the one someone took care over.
+      const dir = mkdtempSync(path.join(tmpdir(), 'graphql-'))
+      const file = path.join(dir, 'q.graphql')
+      writeFileSync(file, 'mutation { addComment(input: {body: "hi"}) { clientMutationId } }')
+      try {
+        expect(postsAComment(`gh api graphql -F query=@${file}`, { cwd: dir })).toBe(true)
+        expect(postsAComment(`gh api graphql --input ${file}`, { cwd: dir })).toBe(true)
+      } finally { rmSync(dir, { recursive: true, force: true }) }
+    })
+
+    it('reads a query fed through stdin', () => {
+      const cmd = "gh api graphql -F query=@- <<'EOF'\nmutation { addComment(input: {}) { id } }\nEOF"
+      expect(postsAComment(cmd)).toBe(true)
+    })
+
+    it('allows a file it cannot read rather than blocking on it', () => {
+      // This gate allows what it cannot judge — the posture every other rule here takes.
+      expect(postsAComment('gh api graphql -F query=@/nonexistent/q.graphql')).toBe(false)
+    })
+
+    it('does not fire on the words in prose', () => {
+      expect(postsAComment('echo "gh api graphql addComment"')).toBe(false)
+      expect(postsAComment('cat > n.md <<EOF\ngh api graphql -f query=mutation{addComment}\nEOF')).toBe(false)
+    })
+
+    it('the prefilter lets the mutation reach the parser', () => {
+      // Both halves missed it: the path matcher looks for a `/comments` segment and the shell
+      // prefilter matches `*gh*comment*` in lowercase, while the mutation is spelled `addComment`.
+      // Node was never spawned, so neither half got a chance. Asserted through the hook because the
+      // prefilter is the half a unit test cannot see.
+      const r = spawnSync('bash', [HOOK], {
+        input: JSON.stringify({
+          tool_input: { command: "gh api graphql -f query='mutation{addComment(input:{}){id}}'" },
+          cwd: REPO,
+          transcript_path: path.join(REPO, 'no-such-transcript.jsonl'),
+        }),
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+      })
+      expect(r.status).toBe(2)
+    })
   })
 
   it('sees a body that arrives without a field flag', () => {

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -36,6 +36,7 @@ describe('which commands post a comment', () => {
     'an issue comment': 'gh issue comment 700 --body "x"',
     'a review with a body': 'gh pr review 701 --comment --body "x"',
     'an inline reply through the API': 'gh api repos/o/r/pulls/701/comments/1/replies -F body=@r.md',
+    'a body behind an attached shorthand': 'gh api repos/o/r/issues/1/comments -fbody=hi',
     'behind a separator': 'git status && gh pr comment 701 --body "x"',
     'with the command word broken by quotes': 'g"h" pr comment 701 --body "x"',
     'a GraphQL mutation': "gh api graphql -f query='mutation{addComment(input:{subjectId:\"X\",body:\"hi\"}){clientMutationId}}'",
@@ -99,6 +100,18 @@ describe('which commands post a comment', () => {
     it('allows a query that only reads', () => {
       // The same distinction `--method GET` draws on the REST path: it publishes nothing.
       expect(postsAComment("gh api graphql -f query='query{viewer{login}}'")).toBe(false)
+    })
+
+    it('sees the full-URL spelling of the endpoint', () => {
+      // gh routes any endpoint containing `://` verbatim, so this reaches the same place — and it is
+      // the spelling a docs page hands you. The check was exact string equality; every other
+      // endpoint rule in this file was already a substring regex.
+      expect(postsAComment(`gh api https://api.github.com/graphql ${"-f query='mutation{addComment(input:{}){id}}'"}`)).toBe(true)
+    })
+
+    it('sees the query behind an attached shorthand', () => {
+      // pflag takes `-Fquery=…` as well as `-F query=…`.
+      expect(postsAComment("gh api graphql -Fquery='mutation{addComment(input:{}){id}}'")).toBe(true)
     })
 
     it('allows a mutation that publishes no prose', () => {

--- a/scripts/__tests__/ghCommandParser.test.mjs
+++ b/scripts/__tests__/ghCommandParser.test.mjs
@@ -4,8 +4,10 @@
 // which is one of its three callers, so a parser change was judged by one gate's fixtures while the
 // other two rode along. The cases here are about the reader rather than any gate's verdict.
 import { describe, it, expect } from 'vitest'
-import { ghInvocations, tokenize, tokenizeDetailed, hereStrings, stdinBodies, bodyFileArg }
-  from '../lib/gh-command.mjs'
+import {
+  ghInvocations, tokenize, tokenizeDetailed, hereStrings, stdinBodies, heredocs,
+  bodyFileArg, isProcessSubstitution, apiFlag, flagEntries,
+} from '../lib/gh-command.mjs'
 
 const creates = (cmd) => ghInvocations(cmd, 'issue', ['create']).length
 const merges = (cmd) => ghInvocations(cmd, 'pr', ['merge']).length
@@ -74,11 +76,36 @@ describe('a here-string is a body', () => {
     expect(hereStrings('cmd <<<bare')).toEqual(['bare'])
   })
 
-  it('is not confused with a heredoc opener', () => {
-    // `<<EOF` and `<<<text` differ by one character, and the heredoc regex is anchored to the end of
-    // its line, so neither may claim the other's text.
+  it('is not confused with a heredoc opener, in either direction', () => {
+    // `<<EOF` and `<<<text` differ by one character, and **both directions have to be asserted.**
+    // The first version of this test checked only that a heredoc is not read as a here-string, while
+    // the reverse was the broken one: `HEREDOC_OPEN` was unanchored on the left, so it matched from
+    // the second `<` of `cat <<<EOF` and `withoutHeredocPayloads` then deleted every following line
+    // up to a matching terminator — swallowing real commands. Bash runs them:
+    //   $ bash -c 'cat <<<EOF
+    //   echo SHOULD-RUN
+    //   EOF'    →  EOF / SHOULD-RUN / bash: EOF: command not found
     expect(hereStrings('cmd <<EOF\nbody\nEOF')).toEqual([])
     expect(stdinBodies('cmd <<EOF\nbody\nEOF')).toEqual(['body'])
+    expect(heredocs('cmd <<<EOF\necho hi\nEOF')).toEqual([])
+    expect(ghInvocations('cat <<<EOF\ngh issue create -t x\nEOF', 'issue', ['create'])).toHaveLength(1)
+  })
+
+  it('a <<< inside a quoted argument is text, not a second body', () => {
+    // **Scanning the raw command text counted this one**, so a title that merely mentions
+    // here-strings made `stdinBodies` return two — and every caller's "exactly one body" rule then
+    // switched off and judged nothing. That direction is a miss, not a false block: the Korean body
+    // below reached GitHub unjudged. Bash sees one stdin body here.
+    const cmd = 'gh pr create --title "docs: explain <<<here-strings" --body-file - <<EOF\nbody text\nEOF'
+    expect(stdinBodies(cmd)).toEqual(['body text'])
+    expect(hereStrings(cmd)).toEqual([])
+  })
+
+  it('reads a body through the quoting the shell would resolve', () => {
+    // Matching raw text with `"([^"]*)"` stopped at an escaped quote and handed the caller a
+    // fragment of the body that actually reaches GitHub. Tokens resolve it.
+    expect(hereStrings('cmd <<<"a\\"b"')).toEqual(['a"b'])
+    expect(hereStrings('cmd <<<"one two"')).toEqual(['one two'])
   })
 
   it('stdinBodies carries both, so an ambiguous command stays ambiguous', () => {
@@ -97,8 +124,47 @@ describe('a process substitution is a shape, not a path', () => {
     expect(bodyFileArg(tokenize('gh issue create -t x -F<(echo hi)'))).toBe('<')
   })
 
+  it('recognises both directions, which are one keystroke apart', () => {
+    // Comparing against `<` alone left `>(…)` doing exactly what this check exists to stop:
+    // `could not read the body file at /tmp/>`.
+    expect(isProcessSubstitution(bodyFileArg(tokenize('gh issue create -t x --body-file <(cat)')))).toBe(true)
+    expect(isProcessSubstitution(bodyFileArg(tokenize('gh issue create -t x --body-file >(cat)')))).toBe(true)
+  })
+
   it('an ordinary path is unaffected', () => {
     expect(bodyFileArg(tokenize('gh issue create -t x --body-file body.md'))).toBe('body.md')
     expect(bodyFileArg(tokenize('gh issue create -t x --body-file -'))).toBe('-')
+    expect(isProcessSubstitution('body.md')).toBe(false)
+    expect(isProcessSubstitution('-')).toBe(false)
+  })
+})
+
+describe('a flag argument is read in every spelling pflag accepts', () => {
+  // **Two rules that a second, weaker copy of this reader was missing**, each a live bypass of a
+  // gate built on it. `gh api -Xput …/pulls/1/merge` inferred GET and passed; a method given twice
+  // was read as the first, so `--method GET --method PUT` passed while bash sends PUT.
+  it('takes the value attached to a shorthand', () => {
+    expect(apiFlag(tokenize('gh api -Xput x'), '--method', '-X')).toBe('put')
+    expect(apiFlag(tokenize('gh api -XPUT x'), '--method', '-X')).toBe('PUT')
+  })
+
+  it('takes the last occurrence, because that is what pflag does', () => {
+    expect(apiFlag(tokenize('gh api --method GET --method PUT x'), '--method', '-X')).toBe('PUT')
+  })
+
+  it('works for a flag with no shorthand', () => {
+    expect(apiFlag(tokenize('gh api x --input b.json'), '--input')).toBe('b.json')
+  })
+
+  it('reads a field in all four spellings', () => {
+    const F = ['-f', '-F', '--field', '--raw-field']
+    for (const cmd of ['gh api x -f body=hi', 'gh api x -fbody=hi', 'gh api x --field body=hi', 'gh api x --field=body=hi']) {
+      expect(flagEntries(tokenize(cmd), F).map((e) => e.value), cmd).toEqual(['body=hi'])
+    }
+  })
+
+  it('does not read a long flag as an attached shorthand', () => {
+    // `--field=x` starts with `-f`; the `--` guard is what keeps it from being read as one.
+    expect(flagEntries(tokenize('gh api x --field=body=hi'), ['-f', '--field']).map((e) => e.flag)).toEqual(['--field'])
   })
 })

--- a/scripts/__tests__/ghCommandParser.test.mjs
+++ b/scripts/__tests__/ghCommandParser.test.mjs
@@ -41,6 +41,24 @@ describe('a reserved word is only reserved in command position', () => {
     expect(creates('(gh issue create -t x)')).toBe(1)
   })
 
+  it('a backtick opens a command the same way `$(` does', () => {
+    // **The two spellings of command substitution disagreed.** The dollar-paren form reached command
+    // position because `(` is an operator; the backtick form did not, because the backtick stayed
+    // glued to `gh` as one word. bash runs both — verified with a script file: `echo` of a
+    // backticked `printf RAN` prints `RAN`.
+    const SUB = 'gh issue create -t x'
+    expect(creates(`echo \`${SUB}\``), 'backtick').toBe(1)
+    expect(creates(`echo $(${SUB})`), 'dollar-paren').toBe(1)
+    expect(creates(`URL=\`${SUB}\``), 'assigned from a substitution').toBe(1)
+  })
+
+  it('a backtick inside single quotes is literal, as it is to the shell', () => {
+    // The reason this can be added without the false blocks the shell matcher avoids backticks for:
+    // quoting is already resolved here. bash prints the backticked text verbatim from single quotes
+    // and runs nothing.
+    expect(creates(`echo 'see \`gh issue create\` in the docs'`)).toBe(0)
+  })
+
   it('a quoted keyword is not a keyword even in command position', () => {
     // `"do" gh …` makes bash look for a command named `do`; the quotes take the word out of the
     // grammar. Treating it as a separator put `gh` in command position, which is a false block.

--- a/scripts/__tests__/ghCommandParser.test.mjs
+++ b/scripts/__tests__/ghCommandParser.test.mjs
@@ -1,0 +1,104 @@
+// The shell reader three gates share, tested on its own.
+//
+// **It had no test file of its own until now.** What existed lived inside `issueParentGate.test.mjs`,
+// which is one of its three callers, so a parser change was judged by one gate's fixtures while the
+// other two rode along. The cases here are about the reader rather than any gate's verdict.
+import { describe, it, expect } from 'vitest'
+import { ghInvocations, tokenize, tokenizeDetailed, hereStrings, stdinBodies, bodyFileArg }
+  from '../lib/gh-command.mjs'
+
+const creates = (cmd) => ghInvocations(cmd, 'issue', ['create']).length
+const merges = (cmd) => ghInvocations(cmd, 'pr', ['merge']).length
+
+describe('a reserved word is only reserved in command position', () => {
+  // bash reads `do`, `then`, `else`, `if`, `while`, `until` and `!` as keywords only where a command
+  // may begin. `echo do x` passes `do` to echo as an argument. The parser used to consult one flat
+  // separator set at every position, so an argument that happened to spell a keyword ended the
+  // invocation it sat in and the words after it were read as a new command.
+  const ARGUMENT_KEYWORDS = ['do', 'then', 'else', 'if', 'while', 'until', '!', '{', '}']
+
+  for (const kw of ARGUMENT_KEYWORDS) {
+    it(`\`${kw}\` as an argument does not start a new command`, () => {
+      expect(creates(`echo ${kw} gh issue create -t x`), kw).toBe(0)
+    })
+  }
+
+  it('the same word in command position still separates', () => {
+    // The mirror case, and the reason the set exists: these take a command as their condition.
+    expect(creates('if gh issue create -t x; then echo ok; fi')).toBe(1)
+    expect(creates('while gh issue create -t x; do echo ok; done')).toBe(1)
+    expect(creates('cmd; then gh issue create -t x')).toBe(1)
+  })
+
+  it('operators separate wherever they appear', () => {
+    // `;`, `&&`, `|` and the parens are operators rather than keywords: the shell splits on them in
+    // any position, so nothing here depends on where they sit.
+    expect(creates('true && gh issue create -t x')).toBe(1)
+    expect(creates('cd /tmp;gh issue create -t x')).toBe(1)
+    expect(creates('echo x|gh issue create -t x')).toBe(1)
+    expect(creates('(gh issue create -t x)')).toBe(1)
+  })
+
+  it('a quoted keyword is not a keyword even in command position', () => {
+    // `"do" gh …` makes bash look for a command named `do`; the quotes take the word out of the
+    // grammar. Treating it as a separator put `gh` in command position, which is a false block.
+    expect(creates('echo "do" gh issue create -t x')).toBe(0)
+    expect(merges("echo 'then' gh pr merge 1")).toBe(0)
+    expect(creates('echo \\do gh issue create -t x')).toBe(0)
+  })
+})
+
+describe('tokenizeDetailed reports how a word arrived', () => {
+  it('marks quoted and escaped words', () => {
+    expect(tokenizeDetailed('echo "do" bare').quoted).toEqual([false, true, false])
+    expect(tokenizeDetailed("echo 'do'").quoted).toEqual([false, true])
+    expect(tokenizeDetailed('echo \\do').quoted).toEqual([false, true])
+  })
+
+  it('operators and newlines are never quoted', () => {
+    const { words, quoted } = tokenizeDetailed('a && b\nc')
+    expect(quoted).toEqual(words.map(() => false))
+  })
+
+  it('tokenize stays the word list it was', () => {
+    // Every existing caller destructures a flat array; the detail is additive rather than a new
+    // shape imposed on all of them.
+    expect(tokenize('gh issue create -t "a b"')).toEqual(['gh', 'issue', 'create', '-t', 'a b'])
+  })
+})
+
+describe('a here-string is a body', () => {
+  it('is read like the heredoc it stands in for', () => {
+    expect(hereStrings('gh issue create -t x --body-file - <<< "Parent: #1"')).toEqual(['Parent: #1'])
+    expect(hereStrings("cmd <<<'one two'")).toEqual(['one two'])
+    expect(hereStrings('cmd <<<bare')).toEqual(['bare'])
+  })
+
+  it('is not confused with a heredoc opener', () => {
+    // `<<EOF` and `<<<text` differ by one character, and the heredoc regex is anchored to the end of
+    // its line, so neither may claim the other's text.
+    expect(hereStrings('cmd <<EOF\nbody\nEOF')).toEqual([])
+    expect(stdinBodies('cmd <<EOF\nbody\nEOF')).toEqual(['body'])
+  })
+
+  it('stdinBodies carries both, so an ambiguous command stays ambiguous', () => {
+    // The callers block when a command offers more than one body, because picking one is guessing.
+    // That rule only holds if both kinds are counted together.
+    expect(stdinBodies('cmd <<EOF\na\nEOF\nother <<< "b"')).toEqual(['a', 'b'])
+  })
+})
+
+describe('a process substitution is a shape, not a path', () => {
+  it('is recognisable from the argument the parser produces', () => {
+    // `<(…)` cannot be read without running it, so the honest answer names the shape. Reporting it
+    // as a file that could not be opened invents a path — the parser's `<` — and sends the author
+    // looking for it.
+    expect(bodyFileArg(tokenize('gh issue create -t x --body-file <(echo hi)'))).toBe('<')
+    expect(bodyFileArg(tokenize('gh issue create -t x -F<(echo hi)'))).toBe('<')
+  })
+
+  it('an ordinary path is unaffected', () => {
+    expect(bodyFileArg(tokenize('gh issue create -t x --body-file body.md'))).toBe('body.md')
+    expect(bodyFileArg(tokenize('gh issue create -t x --body-file -'))).toBe('-')
+  })
+})

--- a/scripts/__tests__/hookPayloadShape.test.mjs
+++ b/scripts/__tests__/hookPayloadShape.test.mjs
@@ -1,0 +1,79 @@
+// What every PreToolUse gate does with a payload that is not the shape it expects.
+//
+// **`// ""` made a missing key and an empty command the same thing.** Every pattern then failed to
+// match and the gate passed at exit 0 — verified against the shipped hooks: `{"tool_input":{}}` was
+// allowed by all of them. The failure is silent by construction, so the policy is asserted here
+// rather than left to whichever hook is edited next.
+//
+// **The assertions run the payload through to a verdict**, not just to exit 0. A test that only
+// checks the unexpected shape is allowed cannot tell a working fallback from a gate that died on the
+// way — the shape `contributing/test-and-guard-coverage.md` is about. So each case carries text the
+// gate should refuse, in a key it does not read.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const HOOKS = path.join(REPO, '.claude/hooks')
+
+/** Every hook that reads a Bash command out of the payload. */
+const READS_A_COMMAND = [
+  'pr-merge-guard.sh',
+  'gh-language-gate.sh',
+  'adversarial-review-gate.sh',
+  'issue-parent-gate.sh',
+  'comment-card-gate.sh',
+]
+
+const run = (hook, payload) =>
+  spawnSync('bash', [path.join(HOOKS, hook)], { input: JSON.stringify(payload), encoding: 'utf8', cwd: REPO })
+
+describe('every command-reading hook falls back to the whole payload', () => {
+  // Inspection, because the policy has to hold for a hook added later too. The three that lacked it
+  // were found this way rather than by running them: a gate that is off answers exactly like a gate
+  // with nothing to say.
+  for (const hook of READS_A_COMMAND) {
+    it(`${hook} does not treat a missing key as an empty command`, () => {
+      const src = fs.readFileSync(path.join(HOOKS, hook), 'utf8')
+      expect(src, hook).toMatch(/\[ -n "\$cmd" \] \|\| cmd=\$input/)
+    })
+  }
+})
+
+describe('the fallback reaches a verdict, not just exit 0', () => {
+  // **Assembled rather than written out.** The merge guard is a shell matcher with no notion of a
+  // heredoc, so the literal form in this file's own source sits in a command position as far as it
+  // is concerned — writing this test was blocked by the gate it tests. The node-side gates strip
+  // heredoc payloads and need no such care, which is the difference the two halves exist for.
+  const MERGE = ['gh', 'pr', 'merge'].join(' ')
+
+  it('pr-merge-guard judges a merge hidden in an unread key', () => {
+    // The command-position rule still applies to the payload, so the text has to sit where a command
+    // would. That is the honest reach of this fallback, and saying so here keeps the next reader from
+    // expecting a substring scan.
+    const r = run('pr-merge-guard.sh', { tool_input: { other: `x; ${MERGE} 1` }, cwd: REPO })
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/Blocked/)
+  })
+
+  it('a parsing gate reaches its parser, and its parser reads JSON as quoted text', () => {
+    // **The honest limit of this policy, measured rather than assumed.** The shell prefilter widens
+    // — `*gh*issue*` matches the raw payload, so node is spawned and the parser runs on it. The
+    // parser then reads what a shell would: every value in a JSON payload sits inside double quotes,
+    // so `gh` there is a quoted word rather than a command, exactly as `echo "gh issue create"` is.
+    //
+    // So the fallback keeps the gate *running* rather than making it see through JSON, and that is
+    // the whole of what it buys. Asserted so nobody reads the policy as broader than it is: the
+    // alternative — treating every string in an unrecognised payload as a command — is guessing at a
+    // shape whose meaning we do not know.
+    const r = run('issue-parent-gate.sh', { tool_input: { other: 'gh issue create -t x --body "a bug"' }, cwd: REPO })
+    expect(r.status).toBe(0)
+  })
+
+  it('an ordinary payload is unaffected', () => {
+    for (const hook of ['pr-merge-guard.sh', 'issue-parent-gate.sh', 'gh-language-gate.sh']) {
+      expect(run(hook, { tool_input: { command: 'git status' }, cwd: REPO }).status, hook).toBe(0)
+    }
+  })
+})

--- a/scripts/__tests__/hookPayloadShape.test.mjs
+++ b/scripts/__tests__/hookPayloadShape.test.mjs
@@ -19,6 +19,7 @@
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
@@ -82,6 +83,32 @@ describe('the fallback reaches a verdict, not just exit 0', () => {
     for (const hook of ['pr-merge-guard.sh', 'issue-parent-gate.sh', 'gh-language-gate.sh']) {
       expect(run(hook, { tool_input: { command: 'git status' }, cwd: REPO }).status, hook).toBe(0)
     }
+  })
+
+  it('a node that fails is not a verdict', () => {
+    // **Only status 2 is this gate's answer.** Before, node's exit status was the hook's: a missing
+    // binary made the hook exit 127 and an import error made it exit 1, so every matching command in
+    // the session reported a hook error while blocking nothing — the opposite of the fail-open
+    // contract each of these files states at the top.
+    //
+    // Measured by putting a stub `node` ahead on PATH rather than by emptying PATH, which was the
+    // first attempt and proved nothing: with no PATH at all, `jq` fails first and the hook exits 0
+    // long before node is reached.
+    const bin = fs.mkdtempSync(path.join(tmpdir(), 'fakenode-'))
+    try {
+      for (const status of [1, 127]) {
+        fs.writeFileSync(path.join(bin, 'node'), `#!/bin/sh\nexit ${status}\n`, { mode: 0o755 })
+        for (const hook of READS_A_COMMAND) {
+          const r = spawnSync('bash', [path.join(HOOKS, hook)], {
+            input: JSON.stringify({ tool_input: { command: 'gh api --method PUT repos/o/r/pulls/1/merge' }, cwd: REPO }),
+            encoding: 'utf8',
+            cwd: REPO,
+            env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+          })
+          expect(r.status, `${hook} with node exiting ${status}`).toBe(0)
+        }
+      }
+    } finally { fs.rmSync(bin, { recursive: true, force: true }) }
   })
 
   it('the one real payload without a command carries nothing to judge', () => {

--- a/scripts/__tests__/hookPayloadShape.test.mjs
+++ b/scripts/__tests__/hookPayloadShape.test.mjs
@@ -5,6 +5,13 @@
 // allowed by all of them. The failure is silent by construction, so the policy is asserted here
 // rather than left to whichever hook is edited next.
 //
+// **How much this buys, measured rather than assumed.** Review asked what payload actually arrives
+// with no `command`, and the answer is: none that carries anything to judge. For the `Bash` tool
+// `tool_input.command` is always a non-empty string; the only sibling whose name matches the `Bash`
+// matcher is `BashOutput`, whose payload is `{bash_id}` and contains no command text at all. So the
+// fallback is a floor under a shape that does not arrive today, not a hole being closed — and the
+// case below says so, because a reader who takes it for the latter will over-trust it.
+//
 // **The assertions run the payload through to a verdict**, not just to exit 0. A test that only
 // checks the unexpected shape is allowed cannot tell a working fallback from a gate that died on the
 // way — the shape `contributing/test-and-guard-coverage.md` is about. So each case carries text the
@@ -74,6 +81,16 @@ describe('the fallback reaches a verdict, not just exit 0', () => {
   it('an ordinary payload is unaffected', () => {
     for (const hook of ['pr-merge-guard.sh', 'issue-parent-gate.sh', 'gh-language-gate.sh']) {
       expect(run(hook, { tool_input: { command: 'git status' }, cwd: REPO }).status, hook).toBe(0)
+    }
+  })
+
+  it('the one real payload without a command carries nothing to judge', () => {
+    // `BashOutput` is the only sibling tool whose name matches the `Bash` matcher, and its payload
+    // is a handle rather than a command. Recorded so the fallback is not read as closing a live
+    // hole: it is a floor under a shape that does not arrive today. If a future tool does arrive
+    // with command-shaped text under a different key, this is the case that will change.
+    for (const hook of ['pr-merge-guard.sh', 'adversarial-review-gate.sh', 'issue-parent-gate.sh']) {
+      expect(run(hook, { tool_input: { bash_id: 'bash_1' }, cwd: REPO }).status, hook).toBe(0)
     }
   })
 })

--- a/scripts/__tests__/prMergeGuard.test.mjs
+++ b/scripts/__tests__/prMergeGuard.test.mjs
@@ -1,0 +1,92 @@
+// The gate that leaves merging and approving to the user, on both roads that reach them.
+//
+// **Two halves, on purpose.** `gh pr merge` is identifiable from its words, so a shell matcher
+// anchored on command position decides it — and that half had no test file at all until now, having
+// been calibrated against a measured failure (2191 parse failures to 1 success) rather than fixtures.
+// `gh api` names what it acts on in a path and how in a flag, and the same path is a read or a write
+// depending on the method, so that half parses.
+//
+// The `gh pr merge` strings below are assembled rather than written out: the shell half has no
+// notion of a heredoc or of a string literal, so a literal in this file is a command position as far
+// as it is concerned, and it blocks the test that tests it.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { judge } from '../lib/pr-merge.mjs'
+
+const REPO = path.resolve(import.meta.dirname, '../..')
+const HOOK = path.join(REPO, '.claude/hooks/pr-merge-guard.sh')
+
+const run = (command) =>
+  spawnSync('bash', [HOOK], { input: JSON.stringify({ tool_input: { command }, cwd: REPO }), encoding: 'utf8', cwd: REPO })
+
+const PR_MERGE = ['gh', 'pr', 'merge'].join(' ')
+const PR_REVIEW = ['gh', 'pr', 'review'].join(' ')
+
+describe('gh api reaches the same two actions', () => {
+  const BLOCKED = {
+    'a merge by PUT': 'gh api --method PUT repos/o/r/pulls/1/merge -f merge_method=squash',
+    'a merge by -X': 'gh api -X PUT repos/o/r/pulls/1/merge',
+    'an approval': 'gh api -X POST repos/o/r/pulls/1/reviews -f event=APPROVE',
+    // A review left pending is still one submitted under the user's name, and the shell half refuses
+    // `gh pr review` whatever its flags. Anything that writes to the path counts.
+    'a review with no event': 'gh api -X POST repos/o/r/pulls/1/reviews -f body=x',
+    // With no method given, gh sends POST when a field is present — so the method need not be typed
+    // for the call to be a write.
+    'a write with the method implied': 'gh api repos/o/r/pulls/1/reviews -f event=APPROVE',
+    'behind a separator': 'git status && gh api --method PUT repos/o/r/pulls/1/merge',
+    'with the command word broken by quotes': 'g"h" api --method PUT repos/o/r/pulls/1/merge',
+  }
+  for (const [what, cmd] of Object.entries(BLOCKED)) {
+    it(`blocks ${what}`, () => expect(judge(cmd).blocked, cmd).toBe(true))
+  }
+
+  const ALLOWED = {
+    // `GET …/merge` asks whether a PR is merged; `GET …/reviews` lists them. Refusing these would
+    // refuse the two calls most likely to precede a legitimate question about a PR.
+    'asking whether a PR is merged': 'gh api --method GET repos/o/r/pulls/1/merge',
+    'listing reviews': 'gh api repos/o/r/pulls/1/reviews',
+    'a HEAD request': 'gh api --method HEAD repos/o/r/pulls/1/merge',
+    // The comment card owns this path; this gate is about merging and approving.
+    'a comment': 'gh api repos/o/r/pulls/1/comments -f body=hi',
+    'an unrelated endpoint': 'gh api repos/o/r/issues -f title=x',
+    'prose that mentions the endpoint': 'echo "gh api --method PUT repos/o/r/pulls/1/merge"',
+    // `pulls/1/merge` is the path; `merge` alone is a different endpoint family.
+    'a branch merge': 'gh api --method POST repos/o/r/merges -f base=main',
+  }
+  for (const [what, cmd] of Object.entries(ALLOWED)) {
+    it(`allows ${what}`, () => expect(judge(cmd).blocked, cmd).toBe(false))
+  }
+
+  it('names which of the two it refused', () => {
+    expect(judge('gh api -X PUT repos/o/r/pulls/1/merge').reason).toBe('merge')
+    expect(judge('gh api -X POST repos/o/r/pulls/1/reviews').reason).toBe('review')
+  })
+})
+
+describe('the hook runs both halves', () => {
+  it('still blocks the gh pr forms the shell half owns', () => {
+    expect(run(`${PR_MERGE} 1`).status).toBe(2)
+    expect(run(`${PR_REVIEW} 1 --approve`).status).toBe(2)
+  })
+
+  it('blocks the api forms through the whole hook', () => {
+    const r = run('gh api --method PUT repos/o/r/pulls/1/merge')
+    expect(r.status).toBe(2)
+    expect(r.stderr).toMatch(/merging a PR through the API/)
+  })
+
+  it('leaves everything else alone', () => {
+    for (const cmd of ['git status', 'gh pr create -t x', 'gh api repos/o/r/pulls/1']) {
+      expect(run(cmd).status, cmd).toBe(0)
+    }
+  })
+
+  it('costs no node process for a command that is not gh api', () => {
+    // The prefilter is the reason this gate is cheap on every Bash call in a session. A command with
+    // no `gh` and no `api` in it must not reach the parsing half at all.
+    const r = run('ls -la')
+    expect(r.status).toBe(0)
+    expect(r.stderr).toBe('')
+  })
+})

--- a/scripts/__tests__/prMergeGuard.test.mjs
+++ b/scripts/__tests__/prMergeGuard.test.mjs
@@ -1,16 +1,20 @@
-// The gate that leaves merging and approving to the user, on both roads that reach them.
+// The gate that leaves merging and approving to the user, on every road that reaches them.
 //
-// **Two halves, on purpose.** `gh pr merge` is identifiable from its words, so a shell matcher
-// anchored on command position decides it — and that half had no test file at all until now, having
-// been calibrated against a measured failure (2191 parse failures to 1 success) rather than fixtures.
-// `gh api` names what it acts on in a path and how in a flag, and the same path is a read or a write
-// depending on the method, so that half parses.
+// **This file exists because the gate had none, and the gap that hid was the ordinary one.** The
+// shell matcher recognises command position as line-start / `;` / `&&` / `|` / `$(` / `then` / `do`,
+// which is not what bash means by it: an assignment prefix, `env`, `sudo`, `command`, `xargs`, an
+// `if` condition and a background `&` all passed at exit 0 while the bare form was blocked. The
+// parser in this package had every one of those already. The wrapper cases below are the ones a
+// forgetful agent actually types, so they are asserted through the whole hook rather than only
+// against `judge`.
 //
-// The `gh pr merge` strings below are assembled rather than written out: the shell half has no
-// notion of a heredoc or of a string literal, so a literal in this file is a command position as far
-// as it is concerned, and it blocks the test that tests it.
+// The `gh pr merge` strings are assembled rather than written out: the shell half has no notion of a
+// heredoc or a string literal, so a literal in this file is a command position as far as it is
+// concerned, and it blocks the test that tests it.
 import { describe, it, expect } from 'vitest'
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { judge } from '../lib/pr-merge.mjs'
 
@@ -23,57 +27,122 @@ const run = (command) =>
 const PR_MERGE = ['gh', 'pr', 'merge'].join(' ')
 const PR_REVIEW = ['gh', 'pr', 'review'].join(' ')
 
+describe('the gh pr forms, however they are prefixed', () => {
+  // Each of these ran the action and passed the gate before the parser was wired in. They are the
+  // reason the decision moved out of the shell matcher.
+  const WRAPPED = {
+    'bare': `${PR_MERGE} 1`,
+    'an assignment prefix': `GH_REPO=o/r ${PR_MERGE} 1`,
+    'env': `env ${PR_MERGE} 1`,
+    'sudo': `sudo ${PR_MERGE} 1`,
+    'command': `command ${PR_MERGE} 1`,
+    'xargs': `echo 1 | xargs ${PR_MERGE}`,
+    'an if condition': `if ${PR_MERGE} 1; then echo ok; fi`,
+    'a background &': `sleep 0 & ${PR_MERGE} 1`,
+    'review, wrapped': `env ${PR_REVIEW} 1 --approve`,
+  }
+  for (const [what, cmd] of Object.entries(WRAPPED)) {
+    it(`blocks ${what}`, () => expect(run(cmd).status, cmd).toBe(2))
+  }
+
+  it('still ignores the words in prose', () => {
+    // The parser strips heredoc payloads and respects quoting, which the shell matcher does not.
+    // `judge` is asserted directly here: the shell half runs first and refuses these, which is a
+    // known false block rather than a decision this file is testing.
+    expect(judge(`echo "${PR_MERGE} 1"`).blocked).toBe(false)
+    expect(judge(`cat > n.md <<EOF\n${PR_MERGE} 1\nEOF`).blocked).toBe(false)
+  })
+})
+
 describe('gh api reaches the same two actions', () => {
   const BLOCKED = {
     'a merge by PUT': 'gh api --method PUT repos/o/r/pulls/1/merge -f merge_method=squash',
     'a merge by -X': 'gh api -X PUT repos/o/r/pulls/1/merge',
+    // pflag takes the value attached to a shorthand, verified against the binary: `gh api -XGET
+    // rate_limit` succeeds. Reading only the spaced and `=` spellings inferred GET and let a merge
+    // through — the single most ordinary way someone with curl habits types it.
+    'a merge by attached -Xput': 'gh api -Xput repos/o/r/pulls/1/merge',
+    'a merge by -XPUT': 'gh api -XPUT repos/o/r/pulls/1/merge',
+    // gh sends any endpoint containing `://` verbatim, so the URL a docs page hands you reaches the
+    // same endpoint.
+    'a merge by full URL': 'gh api --method PUT https://api.github.com/repos/o/r/pulls/1/merge',
     'an approval': 'gh api -X POST repos/o/r/pulls/1/reviews -f event=APPROVE',
-    // A review left pending is still one submitted under the user's name, and the shell half refuses
-    // `gh pr review` whatever its flags. Anything that writes to the path counts.
     'a review with no event': 'gh api -X POST repos/o/r/pulls/1/reviews -f body=x',
-    // With no method given, gh sends POST when a field is present — so the method need not be typed
-    // for the call to be a write.
+    'submitting a pending review': 'gh api -X POST repos/o/r/pulls/1/reviews/9/events -f event=APPROVE',
+    // With no method given, gh sends POST when a field is present.
     'a write with the method implied': 'gh api repos/o/r/pulls/1/reviews -f event=APPROVE',
+    'the same with an attached field': 'gh api repos/o/r/pulls/1/reviews -fevent=APPROVE',
     'behind a separator': 'git status && gh api --method PUT repos/o/r/pulls/1/merge',
     'with the command word broken by quotes': 'g"h" api --method PUT repos/o/r/pulls/1/merge',
+    // pflag overwrites a scalar flag given twice, so the last one is the method that is sent.
+    'a method overridden later on the line': 'gh api --method GET --method PUT repos/o/r/pulls/1/merge',
   }
   for (const [what, cmd] of Object.entries(BLOCKED)) {
     it(`blocks ${what}`, () => expect(judge(cmd).blocked, cmd).toBe(true))
   }
 
   const ALLOWED = {
-    // `GET …/merge` asks whether a PR is merged; `GET …/reviews` lists them. Refusing these would
-    // refuse the two calls most likely to precede a legitimate question about a PR.
     'asking whether a PR is merged': 'gh api --method GET repos/o/r/pulls/1/merge',
     'listing reviews': 'gh api repos/o/r/pulls/1/reviews',
     'a HEAD request': 'gh api --method HEAD repos/o/r/pulls/1/merge',
-    // The comment card owns this path; this gate is about merging and approving.
     'a comment': 'gh api repos/o/r/pulls/1/comments -f body=hi',
     'an unrelated endpoint': 'gh api repos/o/r/issues -f title=x',
     'prose that mentions the endpoint': 'echo "gh api --method PUT repos/o/r/pulls/1/merge"',
-    // `pulls/1/merge` is the path; `merge` alone is a different endpoint family.
     'a branch merge': 'gh api --method POST repos/o/r/merges -f base=main',
   }
   for (const [what, cmd] of Object.entries(ALLOWED)) {
     it(`allows ${what}`, () => expect(judge(cmd).blocked, cmd).toBe(false))
   }
+})
 
-  it('names which of the two it refused', () => {
-    expect(judge('gh api -X PUT repos/o/r/pulls/1/merge').reason).toBe('merge')
-    expect(judge('gh api -X POST repos/o/r/pulls/1/reviews').reason).toBe('review')
+describe('the GraphQL mutations that merge or approve', () => {
+  // **The team gate had none of these, and the only thing objecting was a personal gate.**
+  // `comment-card-gate.sh` is wired in gitignored `settings.local.json`, so it is absent for anyone
+  // else — and it objects because its card is unread, which stops applying the moment the card is
+  // read. Nothing in `.claude/settings.json` refused `mergePullRequest` at all.
+  const mutation = (op) => `gh api graphql -f query='mutation{${op}(input:{}){clientMutationId}}'`
+
+  for (const op of ['mergePullRequest', 'enablePullRequestAutoMerge']) {
+    it(`blocks ${op} as a merge`, () => expect(judge(mutation(op)).reason, op).toBe('merge'))
+  }
+  for (const op of ['addPullRequestReview', 'submitPullRequestReview']) {
+    it(`blocks ${op} as a review`, () => expect(judge(mutation(op)).reason, op).toBe('review'))
+  }
+
+  it('blocks the full-URL spelling', () => {
+    expect(judge("gh api https://api.github.com/graphql -f query='mutation{mergePullRequest(input:{}){x}}'").blocked).toBe(true)
+  })
+
+  it('blocks a document written to a file', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gql-'))
+    const file = path.join(dir, 'm.graphql')
+    writeFileSync(file, 'mutation { mergePullRequest(input: {pullRequestId: "x"}) { clientMutationId } }')
+    try {
+      expect(judge(`gh api graphql -F query=@${file}`, dir).blocked).toBe(true)
+      expect(judge(`gh api graphql --input ${file}`, dir).blocked).toBe(true)
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('survives an alias and a variable-based document', () => {
+    expect(judge("gh api graphql -f query='mutation{ m: mergePullRequest(input:{}){x} }'").blocked).toBe(true)
+    expect(judge("gh api graphql -f query='mutation($i: MergePullRequestInput!){ mergePullRequest(input: $i){x} }'").blocked).toBe(true)
+  })
+
+  it('allows a query that only reads, and a mutation that does neither', () => {
+    expect(judge("gh api graphql -f query='query{repository(owner:\"o\",name:\"r\"){pullRequest(number:1){mergeable}}}'").blocked).toBe(false)
+    expect(judge("gh api graphql -f query='mutation{addComment(input:{}){id}}'").blocked).toBe(false)
+  })
+
+  it('allows a document it cannot read rather than blocking on it', () => {
+    expect(judge('gh api graphql -F query=@/nonexistent/m.graphql').blocked).toBe(false)
   })
 })
 
-describe('the hook runs both halves', () => {
-  it('still blocks the gh pr forms the shell half owns', () => {
-    expect(run(`${PR_MERGE} 1`).status).toBe(2)
-    expect(run(`${PR_REVIEW} 1 --approve`).status).toBe(2)
-  })
-
-  it('blocks the api forms through the whole hook', () => {
+describe('the hook as a whole', () => {
+  it('names which of the two it refused', () => {
     const r = run('gh api --method PUT repos/o/r/pulls/1/merge')
     expect(r.status).toBe(2)
-    expect(r.stderr).toMatch(/merging a PR through the API/)
+    expect(r.stderr).toMatch(/merging a PR/)
   })
 
   it('leaves everything else alone', () => {
@@ -82,9 +151,8 @@ describe('the hook runs both halves', () => {
     }
   })
 
-  it('costs no node process for a command that is not gh api', () => {
-    // The prefilter is the reason this gate is cheap on every Bash call in a session. A command with
-    // no `gh` and no `api` in it must not reach the parsing half at all.
+  it('costs no node process for a command that is neither gh api nor gh pr', () => {
+    // The prefilter is why this gate is cheap on every Bash call in a session.
     const r = run('ls -la')
     expect(r.status).toBe(0)
     expect(r.stderr).toBe('')

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -28,8 +28,13 @@ for await (const chunk of process.stdin) raw += chunk
 let payload
 try { payload = JSON.parse(raw) } catch { process.exit(0) }
 
-const cmd = payload?.tool_input?.command
-if (typeof cmd !== 'string' || !cmd) process.exit(0)
+// **A payload with no `command` is judged on the whole payload**, which is what the prefilter in the
+// shell half already does. `?? ''` made a missing key indistinguishable from an empty command, and an
+// empty command matches nothing, so an unexpected payload shape switched the gate off in silence.
+// Reading more than was asked for costs a false block; reading nothing costs the gate.
+let cmd = payload?.tool_input?.command
+if (typeof cmd !== 'string' || !cmd) cmd = raw
+if (!cmd) process.exit(0)
 
 // Fail open here too. Every other missing field lets the command through; a missing transcript is
 // the one that used to block, which is the wrong direction for a gate whose whole posture is that
@@ -47,6 +52,10 @@ const root = process.cwd()
 let verdict
 try {
   verdict = judge(cmd, {
+    // **Two different directories, deliberately.** The card is found from the repo root above; a
+    // `@file` inside a GraphQL field is resolved against the directory the command would run in,
+    // which is what `payload.cwd` is and what the issue-parent gate reads it for.
+    cwd: typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : root,
     cardPath: path.join(root, CARD),
     transcriptPath: transcript,
   })

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -63,4 +63,7 @@ try {
 
 if (!verdict.blocked) process.exit(0)
 process.stderr.write(`${message}\n`)
-process.exit(2)
+// `exitCode` rather than `exit(2)`: writes to a pipe are asynchronous on Windows, and `exit`
+// discards whatever is still queued — the status would block but the reason could arrive cut off.
+// Nothing is pending after the stdin loop, so the process still ends here.
+process.exitCode = 2

--- a/scripts/gh-language-gate.mjs
+++ b/scripts/gh-language-gate.mjs
@@ -42,4 +42,7 @@ try { verdict = judge(cmd, undefined, cwd) } catch { process.exit(0) }
 if (!verdict.blocked) process.exit(0)
 
 process.stderr.write(`${message(verdict)}\n`)
-process.exit(2)
+// `exitCode` rather than `exit(2)`: writes to a pipe are asynchronous on Windows, and `exit`
+// discards whatever is still queued — the status would block but the reason could arrive cut off.
+// Nothing is pending after the stdin loop, so the process still ends here.
+process.exitCode = 2

--- a/scripts/gh-language-gate.mjs
+++ b/scripts/gh-language-gate.mjs
@@ -25,12 +25,17 @@ let cmd
 let cwd
 try {
   const payload = JSON.parse(raw)
-  cmd = payload?.tool_input?.command ?? ''
+  cmd = payload?.tool_input?.command
+  // **A payload with no `command` is judged on the whole payload**, which is what the prefilter in
+  // the shell half already does. `?? ''` made a missing key indistinguishable from an empty command,
+  // and an empty command matches nothing, so an unexpected payload shape switched the gate off in
+  // silence. Reading more than was asked for costs a false block; reading nothing costs the gate.
+  if (typeof cmd !== 'string' || !cmd) cmd = raw
   // The directory the command would run in, so a relative --body-file is read from the tree the
   // session is in rather than from wherever the hook was launched.
   cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
 } catch { process.exit(0) }
-if (typeof cmd !== 'string' || !cmd) process.exit(0)
+if (!cmd) process.exit(0)
 
 let verdict
 try { verdict = judge(cmd, undefined, cwd) } catch { process.exit(0) }

--- a/scripts/issue-parent-gate.mjs
+++ b/scripts/issue-parent-gate.mjs
@@ -112,4 +112,7 @@ if (!verdict.blocked) process.exit(0)
 // without a message here should still block, since blocking is what the verdict said.
 const message = (MESSAGES[verdict.reason] ?? MESSAGES['no-parent'])(verdict)
 process.stderr.write(`${message}\n`)
-process.exit(2)
+// `exitCode` rather than `exit(2)`: writes to a pipe are asynchronous on Windows, and `exit`
+// discards whatever is still queued — the status would block but the reason could arrive cut off.
+// Nothing is pending after the stdin loop, so the process still ends here.
+process.exitCode = 2

--- a/scripts/issue-parent-gate.mjs
+++ b/scripts/issue-parent-gate.mjs
@@ -30,8 +30,8 @@ own decision".`
 
 const NO_BODY = `Blocked: no body could be read from this issue creation.
 
-The gate reads --body, --body-file, or the heredoc behind \`--body-file -\`. It found none of them,
-or found several heredocs and will not guess which one is the body.
+The gate reads --body, --body-file, or the heredoc or here-string behind \`--body-file -\`. It found
+none of them, or found several and will not guess which one is the body.
 
 Nothing has been decided about the Parent: line — the body was never read.`
 
@@ -61,10 +61,24 @@ ${why}
 Nothing has been decided about the Parent: line — the body was never read.`
 }
 
+const PROCESS_SUBSTITUTION = `Blocked: the body is a process substitution.
+
+\`--body-file <(…)\` hands gh a file descriptor, and its text exists only while the command runs.
+The gate cannot read it without running the command, so it cannot tell whether the body names a
+parent.
+
+Write the body to a file, or pass it inline:
+
+    --body-file body.md
+    --body-file - <<< "Parent: #607"
+
+Nothing has been decided about the Parent: line — the body was never read.`
+
 const MESSAGES = {
   'no-parent': () => NO_PARENT,
   'no-body': () => NO_BODY,
   'unreadable-body-file': unreadableBodyFile,
+  'process-substitution': () => PROCESS_SUBSTITUTION,
 }
 
 let raw = ''
@@ -78,12 +92,17 @@ let cmd
 let cwd
 try {
   const payload = JSON.parse(raw)
-  cmd = payload?.tool_input?.command ?? ''
+  cmd = payload?.tool_input?.command
+  // **A payload with no `command` is judged on the whole payload**, which is what the prefilter in
+  // the shell half already does. `?? ''` made a missing key indistinguishable from an empty command,
+  // and an empty command matches nothing, so an unexpected payload shape switched the gate off in
+  // silence. Reading more than was asked for costs a false block; reading nothing costs the gate.
+  if (typeof cmd !== 'string' || !cmd) cmd = raw
   // The directory the command would run in. The hook itself runs from the repository root, so
   // without this a relative --body-file is looked for in the wrong tree and reported as missing.
   cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
 } catch { process.exit(0) }
-if (typeof cmd !== 'string' || !cmd) process.exit(0)
+if (!cmd) process.exit(0)
 
 let verdict
 try { verdict = judge(cmd, undefined, cwd) } catch { process.exit(0) }

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { ghInvocations, tokenize, apiEndpoint, apiFlag, stdinBodies, readBodyFile }
-  from './gh-command.mjs'
+import { ghInvocations, tokenize, apiEndpoint, apiFlag, flagEntries, isGraphqlEndpoint,
+  graphqlDocuments, invokesOperation, API_FIELD_FLAGS, readBodyFile } from './gh-command.mjs'
 
 /**
  * Was the comment card read before writing a comment that goes out under the user's account?
@@ -62,11 +62,7 @@ function apiCommentInvocations(cmd) {
     const method = (apiFlag(words, '--method', '-X') ?? '').toUpperCase()
     if (method === 'GET' || method === 'HEAD') continue
     const hasInput = words.some((w) => w === '--input' || w.startsWith('--input='))
-    const hasBody = words.some((w, i) => {
-      const flags = ['-f', '-F', '--field', '--raw-field']
-      if (flags.includes(w)) return /^body=/.test(words[i + 1] ?? '')
-      return flags.some((f) => w.startsWith(`${f}=`)) && /^body=/.test(w.slice(w.indexOf('=') + 1))
-    })
+    const hasBody = fieldValues(words, 'body').length > 0
     if (hasInput || hasBody || ['POST', 'PATCH', 'PUT'].includes(method)) found.push(words)
   }
   return found
@@ -87,45 +83,11 @@ const COMMENT_MUTATIONS = [
   'addDiscussionComment', 'updateIssueComment',
 ]
 
-/** `gh api` field flags, in every spelling. `-F`/`--field` take `@file`; `-f`/`--raw-field` do not. */
-const FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field']
-const READS_FILE = new Set(['-F', '--field'])
-
-/**
- * Every value given for one field name, with the flag that carried it.
- *
- * Read by name rather than by position: `gh api graphql -f query=… -f owner=…` puts the query
- * behind whichever flag happens to spell it, and only that one is a query.
- */
-function fieldValues(words, name) {
-  const out = []
-  const take = (flag, v) => { if (v.startsWith(`${name}=`)) out.push({ flag, value: v.slice(name.length + 1) }) }
-  for (let i = 0; i < words.length; i++) {
-    const w = words[i]
-    if (FIELD_FLAGS.includes(w)) { take(w, words[i + 1] ?? ''); continue }
-    for (const f of FIELD_FLAGS) if (w.startsWith(`${f}=`)) take(f, w.slice(f.length + 1))
-  }
-  return out
-}
-
-/**
- * The text a field actually carries, following `@file` and `@-` where gh does.
- *
- * **The same question `--input` raised on the REST path, answered the same way.** A query written to
- * a file first is the natural form for anything long, and reading only the inline spelling would
- * mean the gate sees the short mutations and not the ones someone took care over.
- *
- * A file it cannot read yields null rather than blocking: this gate allows what it cannot judge.
- */
-function fieldText({ flag, value }, cmd, cwd, readFile) {
-  if (!value.startsWith('@') || !READS_FILE.has(flag)) return value
-  const ref = value.slice(1)
-  if (ref === '-') {
-    const bodies = stdinBodies(cmd)
-    return bodies.length === 1 ? bodies[0] : null
-  }
-  try { return readFile(path.resolve(cwd, ref)) } catch { return null }
-}
+/** Every value given for one field name. Read by name, since only a `body` field is a body. */
+const fieldValues = (words, name) =>
+  flagEntries(words, API_FIELD_FLAGS)
+    .filter((e) => e.value.startsWith(`${name}=`))
+    .map((e) => e.value.slice(name.length + 1))
 
 /**
  * `gh api graphql` calls that publish a comment.
@@ -142,19 +104,8 @@ function fieldText({ flag, value }, cmd, cwd, readFile) {
 function graphqlCommentInvocations(cmd, cwd, readFile) {
   const found = []
   for (const words of ghInvocations(cmd, 'api', null)) {
-    if (apiEndpoint(words) !== 'graphql') continue
-    const texts = fieldValues(words, 'query').map((f) => fieldText(f, cmd, cwd, readFile))
-    // `--input` carries the whole request body, query included, and needs no field flag at all.
-    const input = apiFlag(words, '--input')
-    if (input && input !== '-') {
-      try { texts.push(readFile(path.resolve(cwd, input))) } catch { /* unreadable: not judged */ }
-    } else if (input === '-') {
-      const bodies = stdinBodies(cmd)
-      if (bodies.length === 1) texts.push(bodies[0])
-    }
-    if (texts.some((t) => t && COMMENT_MUTATIONS.some((n) => new RegExp(`\\b${n}\\s*[({]`).test(t)))) {
-      found.push(words)
-    }
+    if (!isGraphqlEndpoint(apiEndpoint(words))) continue
+    if (invokesOperation(graphqlDocuments(words, cmd, cwd, readFile), COMMENT_MUTATIONS)) found.push(words)
   }
   return found
 }

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { ghInvocations, tokenize } from './gh-command.mjs'
+import { ghInvocations, tokenize, apiEndpoint, apiFlag, stdinBodies, readBodyFile }
+  from './gh-command.mjs'
 
 /**
  * Was the comment card read before writing a comment that goes out under the user's account?
@@ -33,41 +34,6 @@ function commentInvocations(cmd) {
   ].filter((words) => words.some((w, i) => (w === '-c' || w === '--comment') ? words[i + 1] !== undefined
     : /^(-c|--comment)=/.test(w)))
   return [...direct, ...withComment]
-}
-
-/** `gh api` flags that consume the next token, so it is not the endpoint. */
-const API_VALUE_FLAGS = new Set([
-  '--method', '-X', '--field', '-f', '--raw-field', '-F', '--input', '--header', '-H',
-  '--jq', '-q', '--template', '-t', '--hostname', '--preview', '-p', '--cache',
-])
-
-/**
- * The positional endpoint of a `gh api` call — the first word that is neither a flag nor a flag's
- * value.
- *
- * **Scanning every token for a comments-shaped path picked field values.** A quoted field stays one
- * token, so `gh api repos/o/r/issues -f 'body=See /comments/123'` looked like a call to a comments
- * endpoint and was blocked; it creates an issue. The endpoint is a position, so it is read as one.
- */
-function apiEndpoint(words) {
-  for (let i = 2; i < words.length; i++) {
-    const w = words[i]
-    if (API_VALUE_FLAGS.has(w)) { i++; continue }
-    if (w.startsWith('-')) continue
-    return w
-  }
-  return null
-}
-
-/** The value of a `gh api` flag, in both spellings: `--method GET` and `--method=GET`. */
-function apiFlag(words, ...names) {
-  for (let i = 0; i < words.length; i++) {
-    if (names.includes(words[i])) return words[i + 1] ?? null
-    for (const n of names) {
-      if (words[i].startsWith(`${n}=`)) return words[i].slice(n.length + 1)
-    }
-  }
-  return null
 }
 
 /**
@@ -106,8 +72,97 @@ function apiCommentInvocations(cmd) {
   return found
 }
 
-export function postsAComment(cmd) {
-  return commentInvocations(cmd).length + apiCommentInvocations(cmd).length > 0
+
+/**
+ * GraphQL mutations that publish prose into a conversation.
+ *
+ * **The list is GitHub's rather than ours**, which is the reason this is an enumeration and not a
+ * pattern: `addComment` is the obvious one, but a review, a review comment and a discussion comment
+ * all publish too, and `updateIssueComment` republishes. A name GitHub adds later is a name this
+ * list has to grow — a `*Comment*` regex would instead catch `deleteIssueComment`, which publishes
+ * nothing, and miss `addPullRequestReview`, which does.
+ */
+const COMMENT_MUTATIONS = [
+  'addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
+  'addDiscussionComment', 'updateIssueComment',
+]
+
+/** `gh api` field flags, in every spelling. `-F`/`--field` take `@file`; `-f`/`--raw-field` do not. */
+const FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field']
+const READS_FILE = new Set(['-F', '--field'])
+
+/**
+ * Every value given for one field name, with the flag that carried it.
+ *
+ * Read by name rather than by position: `gh api graphql -f query=… -f owner=…` puts the query
+ * behind whichever flag happens to spell it, and only that one is a query.
+ */
+function fieldValues(words, name) {
+  const out = []
+  const take = (flag, v) => { if (v.startsWith(`${name}=`)) out.push({ flag, value: v.slice(name.length + 1) }) }
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (FIELD_FLAGS.includes(w)) { take(w, words[i + 1] ?? ''); continue }
+    for (const f of FIELD_FLAGS) if (w.startsWith(`${f}=`)) take(f, w.slice(f.length + 1))
+  }
+  return out
+}
+
+/**
+ * The text a field actually carries, following `@file` and `@-` where gh does.
+ *
+ * **The same question `--input` raised on the REST path, answered the same way.** A query written to
+ * a file first is the natural form for anything long, and reading only the inline spelling would
+ * mean the gate sees the short mutations and not the ones someone took care over.
+ *
+ * A file it cannot read yields null rather than blocking: this gate allows what it cannot judge.
+ */
+function fieldText({ flag, value }, cmd, cwd, readFile) {
+  if (!value.startsWith('@') || !READS_FILE.has(flag)) return value
+  const ref = value.slice(1)
+  if (ref === '-') {
+    const bodies = stdinBodies(cmd)
+    return bodies.length === 1 ? bodies[0] : null
+  }
+  try { return readFile(path.resolve(cwd, ref)) } catch { return null }
+}
+
+/**
+ * `gh api graphql` calls that publish a comment.
+ *
+ * **A GraphQL call is identified by its contents, not its path.** Every other form the gate knows
+ * names what it acts on in the URL; here the path is the constant `graphql` and the operation is a
+ * string passed as a field value. So the endpoint check is the cheap half and the mutation name is
+ * the decision.
+ *
+ * A read-only query passes for the same reason `--method GET` does on the REST path: it publishes
+ * nothing. That is the whole distinction, and it is why the mutation names are enumerated rather
+ * than the word `mutation` being treated as enough — `mutation { addLabel… }` posts no prose.
+ */
+function graphqlCommentInvocations(cmd, cwd, readFile) {
+  const found = []
+  for (const words of ghInvocations(cmd, 'api', null)) {
+    if (apiEndpoint(words) !== 'graphql') continue
+    const texts = fieldValues(words, 'query').map((f) => fieldText(f, cmd, cwd, readFile))
+    // `--input` carries the whole request body, query included, and needs no field flag at all.
+    const input = apiFlag(words, '--input')
+    if (input && input !== '-') {
+      try { texts.push(readFile(path.resolve(cwd, input))) } catch { /* unreadable: not judged */ }
+    } else if (input === '-') {
+      const bodies = stdinBodies(cmd)
+      if (bodies.length === 1) texts.push(bodies[0])
+    }
+    if (texts.some((t) => t && COMMENT_MUTATIONS.some((n) => new RegExp(`\\b${n}\\s*[({]`).test(t)))) {
+      found.push(words)
+    }
+  }
+  return found
+}
+
+export function postsAComment(cmd, { cwd = process.cwd(), readFile = readBodyFile } = {}) {
+  return commentInvocations(cmd).length
+    + apiCommentInvocations(cmd).length
+    + graphqlCommentInvocations(cmd, cwd, readFile).length > 0
 }
 
 /**
@@ -200,8 +255,8 @@ export function cardWasRead(transcriptPath, cardPath) {
  * and this returns `blocked: false` when the card is absent. The first two are "it was not wired for
  * them"; only the third survives someone wiring it by mistake.
  */
-export function judge(cmd, { cardPath, transcriptPath, exists = (p) => fs.existsSync(p) } = {}) {
-  if (!postsAComment(cmd)) return { blocked: false }
+export function judge(cmd, { cardPath, transcriptPath, cwd, exists = (p) => fs.existsSync(p) } = {}) {
+  if (!postsAComment(cmd, cwd ? { cwd } : {})) return { blocked: false }
   if (!cardPath || !exists(cardPath)) return { blocked: false }
   if (cardWasRead(transcriptPath ?? '', path.resolve(cardPath))) return { blocked: false }
   return { blocked: true, reason: 'card-not-read' }

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -28,9 +28,9 @@ import path from 'node:path'
  * quoted body can forge one. A backslash before a newline is a line continuation and produces
  * neither a token nor a break.
  *
- * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias, and it
- * resolves quoting before the caller consults `SEPARATOR`, so a quoted word that happens to read
- * `do` or `then` is taken for one. Every case that costs is a false block rather than a miss.
+ * Not a shell parser and not trying to be. It cannot see through `$VAR`, `$(…)` or an alias. It
+ * does report how each word arrived — see `tokenizeDetailed` — because whether a word was quoted
+ * decides whether it is a keyword at all.
  */
 export const NEWLINE = '\0'
 
@@ -38,12 +38,17 @@ export const NEWLINE = '\0'
  *  `(gh …)` and `$(gh …)` reach command position. */
 const OPERATOR = '&|;()'
 
-export function tokenize(cmd) {
-  const out = []
+export function tokenizeDetailed(cmd) {
+  const words = []
+  const quoted = []
   let cur = ''
   let started = false
+  let curQuoted = false
   let quote = null
-  const flush = () => { if (started || cur) out.push(cur); cur = ''; started = false }
+  const flush = () => {
+    if (started || cur) { words.push(cur); quoted.push(curQuoted) }
+    cur = ''; started = false; curQuoted = false
+  }
   for (let i = 0; i < cmd.length; i++) {
     const c = cmd[i]
     if (quote === "'") {
@@ -57,17 +62,18 @@ export function tokenize(cmd) {
       else cur += c
       continue
     }
-    if (c === "'" || c === '"') { quote = c; started = true; continue }
+    if (c === "'" || c === '"') { quote = c; started = true; curQuoted = true; continue }
     if (c === '\\' && cmd[i + 1] === '\n') { i++; continue }
-    if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue }
-    if (c === '\n') { flush(); out.push(NEWLINE); continue }
+    if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; curQuoted = true; continue }
+    if (c === '\n') { flush(); words.push(NEWLINE); quoted.push(false); continue }
     if (OPERATOR.includes(c)) {
       flush()
       // A run of the same operator is one token, so `&&` and `||` stay recognisable rather than
       // arriving as two singles that both happen to be separators anyway.
       let run = c
       while (cmd[i + 1] === c) { run += c; i++ }
-      out.push(run)
+      words.push(run)
+      quoted.push(false)
       continue
     }
     if (/\s/.test(c)) { flush(); continue }
@@ -75,8 +81,11 @@ export function tokenize(cmd) {
     started = true
   }
   flush()
-  return out
+  return { words, quoted }
 }
+
+/** The words alone, for the callers that read arguments rather than structure. */
+export const tokenize = (cmd) => tokenizeDetailed(cmd).words
 
 /** `FOO=bar`, the form that let `GH_REPO=o/r gh issue create` past a matcher anchored on `gh`. */
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
@@ -85,16 +94,31 @@ const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
 const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time', 'xargs'])
 
 /**
- * Separators after which a new command begins.
+ * Separators after which a new command begins, in the two kinds the shell distinguishes.
+ *
+ * **An operator splits wherever it appears; a reserved word only where a command may begin.** They
+ * were one set, consulted at every position, so an argument that happened to spell a keyword ended
+ * the invocation it sat in: `echo do gh issue create` was reported as an issue creation and blocked,
+ * because `do` was read as a separator and the words after it as a new command. bash reads that `do`
+ * as an argument to `echo`. Every case this cost was a false block rather than a miss, which is why
+ * it survived as long as it did.
  *
  * **The control-flow keywords are here because they take a command as their condition.** `if`,
  * `elif`, `while` and `until` left `atStart` false, so `if gh issue create …; then` was invisible to
  * both gates — the mirror of `then`/`do`/`else`, which were in the set from the start.
  */
-const SEPARATOR = new Set([
-  NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')', '{', '}',
-  'if', 'elif', 'then', 'while', 'until', 'do', 'else', '!',
-])
+const OPERATOR_SEP = new Set([NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')'])
+const RESERVED = new Set(['{', '}', 'if', 'elif', 'then', 'while', 'until', 'do', 'else', '!'])
+
+/**
+ * Does this token end the command before it?
+ *
+ * **Quoting takes a word out of the grammar entirely.** `"do" gh issue create` makes bash look for a
+ * command named `do`, so the quoted word is neither keyword nor operator. Reading it as a separator
+ * put `gh` in command position and refused a command that creates nothing.
+ */
+const separates = (word, isQuoted, atStart) =>
+  !isQuoted && (OPERATOR_SEP.has(word) || (atStart && RESERVED.has(word)))
 
 /**
  * The opening of a heredoc: `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
@@ -107,6 +131,9 @@ const SEPARATOR = new Set([
  */
 const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2\s*$/
 
+/** A here-string, which differs from a heredoc opener by one `<` and carries its text inline. */
+const HERE_STRING = /<<<\s*("([^"]*)"|'([^']*)'|([^\s;|&<>]+))/g
+
 /** Split on either line ending. A CRLF command reaching `'\n'` alone left `EOF\r` never matching its
  *  delimiter, so every payload read as unterminated and the prose regression came back. */
 const lines = (cmd) => cmd.split(/\r?\n/)
@@ -118,6 +145,39 @@ const lines = (cmd) => cmd.split(/\r?\n/)
  * that is never terminated has no payload anyone can read and is skipped.
  */
 export const heredocs = (cmd) => heredocEntries(cmd).map((e) => e.body)
+
+/**
+ * A here-string's text: `<<< word`, `<<<"text"`, `<<<'text'`.
+ *
+ * **It reaches `--body-file -` exactly as a heredoc does**, and was read as neither. A gate that
+ * only knew heredocs answered `no body could be read from the command` for a command that has one,
+ * which sends the author to add a body that is already there.
+ *
+ * Scanned after heredoc payloads are removed, so a `<<<` written inside one is text rather than a
+ * second body — the same reason `ghInvocations` strips them before looking for a command.
+ */
+export function hereStrings(cmd) {
+  const out = []
+  for (const m of withoutHeredocPayloads(cmd).matchAll(HERE_STRING)) out.push(m[2] ?? m[3] ?? m[4])
+  return out
+}
+
+/**
+ * Every body this command feeds to stdin, heredocs and here-strings together.
+ *
+ * The callers block when there is more than one, because choosing is guessing — a rule that only
+ * holds if both kinds are counted in the same list.
+ */
+export const stdinBodies = (cmd) => [...heredocs(cmd), ...hereStrings(cmd)]
+
+/**
+ * The argument `<(…)` leaves behind.
+ *
+ * `(` is an operator token, so a process substitution arrives as the bare `<` that preceded it. It
+ * is not a path and cannot become one without running the command, so a caller that reports it as a
+ * file it could not open is naming something the author never wrote.
+ */
+export const PROCESS_SUBSTITUTION = '<'
 
 /**
  * The redirection target on a line, or null — the last one, since a later `>` wins.
@@ -212,14 +272,14 @@ export function withoutHeredocPayloads(cmd) {
  * other nouns take a verb, so there is nothing to enumerate.
  */
 export function ghInvocations(cmd, noun, verbs) {
-  const words = tokenize(withoutHeredocPayloads(cmd))
+  const { words, quoted } = tokenizeDetailed(withoutHeredocPayloads(cmd))
   const anyVerb = verbs === null
   const wanted = new Set(verbs ?? [])
   const found = []
   let atStart = true
   for (let i = 0; i < words.length; i++) {
     const w = words[i]
-    if (SEPARATOR.has(w)) { atStart = true; continue }
+    if (separates(w, quoted[i], atStart)) { atStart = true; continue }
     if (!atStart) continue
     let j = i
     while (j < words.length && (ASSIGNMENT.test(words[j]) || PASSTHROUGH.has(words[j]))) j++
@@ -227,8 +287,11 @@ export function ghInvocations(cmd, noun, verbs) {
       // **Stop at the next separator.** Running to the end of the token list meant a later command's
       // flags counted as this one's: `gh issue create --web && echo --body "Parent: #607"` was
       // allowed, because `bodyArg` found `echo`'s argument.
+      // **Only an operator ends the argument list.** Everything after `gh` is an argument
+      // position, where a reserved word is an ordinary word — and the shell requires a `;` or a
+      // newline before a keyword anyway, so an operator is what actually arrives.
       let end = j
-      while (end < words.length && !SEPARATOR.has(words[end])) end++
+      while (end < words.length && !(!quoted[end] && OPERATOR_SEP.has(words[end]))) end++
       found.push(words.slice(j, end))
     }
     atStart = false
@@ -269,6 +332,47 @@ export const bodyArg = (words) => flagArg(words, '--body', '-b')
 
 /** The `--title` / `-t` argument, quoting resolved. */
 export const titleArg = (words) => flagArg(words, '--title', '-t')
+
+/**
+ * `gh api` is a different shape from `gh <noun> <verb>`: what it acts on is a path in argument
+ * position, so a caller has to read the endpoint and the method rather than a verb. Two gates need
+ * that now — the comment card and the merge guard — which is why it lives here rather than in
+ * whichever one grew it first.
+ */
+/** `gh api` flags that consume the next token, so it is not the endpoint. */
+const API_VALUE_FLAGS = new Set([
+  '--method', '-X', '--field', '-f', '--raw-field', '-F', '--input', '--header', '-H',
+  '--jq', '-q', '--template', '-t', '--hostname', '--preview', '-p', '--cache',
+])
+
+/**
+ * The positional endpoint of a `gh api` call — the first word that is neither a flag nor a flag's
+ * value.
+ *
+ * **Scanning every token for a comments-shaped path picked field values.** A quoted field stays one
+ * token, so `gh api repos/o/r/issues -f 'body=See /comments/123'` looked like a call to a comments
+ * endpoint and was blocked; it creates an issue. The endpoint is a position, so it is read as one.
+ */
+export function apiEndpoint(words) {
+  for (let i = 2; i < words.length; i++) {
+    const w = words[i]
+    if (API_VALUE_FLAGS.has(w)) { i++; continue }
+    if (w.startsWith('-')) continue
+    return w
+  }
+  return null
+}
+
+/** The value of a `gh api` flag, in both spellings: `--method GET` and `--method=GET`. */
+export function apiFlag(words, ...names) {
+  for (let i = 0; i < words.length; i++) {
+    if (names.includes(words[i])) return words[i + 1] ?? null
+    for (const n of names) {
+      if (words[i].startsWith(`${n}=`)) return words[i].slice(n.length + 1)
+    }
+  }
+  return null
+}
 
 /**
  * The reader both gates use for a `--body-file`.

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -38,8 +38,15 @@ export const NEWLINE = '\0'
 export const HERE_STRING_OP = '<<<'
 
 /** Unquoted characters that end a word and begin a new command. `(` and `)` are here so that both
- *  `(gh …)` and `$(gh …)` reach command position. */
-const OPERATOR = '&|;()'
+ *  `(gh …)` and `$(gh …)` reach command position.
+ *
+ *  **A backtick is here for the same reason `(` is.** It opens a command substitution, and bash runs
+ *  what is inside one — verified. Leaving it out made the two spellings of one thing disagree: the
+ *  dollar-paren form of a merge was refused while the backtick form passed, because the backtick
+ *  stayed glued to `gh` as one word and never matched. Quoting still decides, as everywhere else
+ *  here: inside single quotes a backtick is literal and never reaches this branch, which is what
+ *  keeps prose that names a command from tripping it. */
+const OPERATOR = '&|;()`'
 
 export function tokenizeDetailed(cmd) {
   const words = []
@@ -122,7 +129,7 @@ const PASSTHROUGH = new Set(['env', 'sudo', 'command', 'nohup', 'time', 'xargs']
  * `elif`, `while` and `until` left `atStart` false, so `if gh issue create …; then` was invisible to
  * both gates — the mirror of `then`/`do`/`else`, which were in the set from the start.
  */
-const OPERATOR_SEP = new Set([NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')'])
+const OPERATOR_SEP = new Set([NEWLINE, ';', ';;', '&', '&&', '|', '||', '(', ')', '`'])
 const RESERVED = new Set(['{', '}', 'if', 'elif', 'then', 'while', 'until', 'do', 'else', '!'])
 
 /**

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -34,6 +34,9 @@ import path from 'node:path'
  */
 export const NEWLINE = '\0'
 
+/** The here-string operator, tokenized on its own so a quoted `<<<` cannot be read as one. */
+export const HERE_STRING_OP = '<<<'
+
 /** Unquoted characters that end a word and begin a new command. `(` and `)` are here so that both
  *  `(gh …)` and `$(gh …)` reach command position. */
 const OPERATOR = '&|;()'
@@ -63,6 +66,18 @@ export function tokenizeDetailed(cmd) {
       continue
     }
     if (c === "'" || c === '"') { quote = c; started = true; curQuoted = true; continue }
+    // **A here-string operator is its own token.** Scanning the raw text for `<<<` counted one
+    // written inside a quoted argument — `--title "docs: explain <<<here-strings"` — as a second
+    // body on stdin, and the callers' "exactly one body" rule then switched off and judged nothing.
+    // Emitting it here means quoting decides, because inside a quote these characters never reach
+    // this branch.
+    if (c === '<' && cmd.startsWith('<<<', i)) {
+      flush()
+      words.push(HERE_STRING_OP)
+      quoted.push(false)
+      i += 2
+      continue
+    }
     if (c === '\\' && cmd[i + 1] === '\n') { i++; continue }
     if (c === '\\' && i + 1 < cmd.length) { cur += cmd[++i]; started = true; curQuoted = true; continue }
     if (c === '\n') { flush(); words.push(NEWLINE); quoted.push(false); continue }
@@ -129,10 +144,12 @@ const separates = (word, isQuoted, atStart) =>
  * on its line in every shape this repo writes; one followed by a further redirection is treated as
  * no heredoc at all, which leaves its text scanned rather than skipped.
  */
-const HEREDOC_OPEN = /<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2\s*$/
+// **Not preceded by a third `<`.** Unanchored on the left, this matched from the second `<` of
+// `cat <<<EOF`, so a here-string was read as a heredoc opener and `withoutHeredocPayloads` deleted
+// every following line up to a matching terminator — taking real commands with it. Verified against
+// bash: `cat <<<EOF` newline `echo hi` runs `echo hi` as a command.
+const HEREDOC_OPEN = /(?<!<)<<(-?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2\s*$/
 
-/** A here-string, which differs from a heredoc opener by one `<` and carries its text inline. */
-const HERE_STRING = /<<<\s*("([^"]*)"|'([^']*)'|([^\s;|&<>]+))/g
 
 /** Split on either line ending. A CRLF command reaching `'\n'` alone left `EOF\r` never matching its
  *  delimiter, so every payload read as unterminated and the prose regression came back. */
@@ -153,12 +170,18 @@ export const heredocs = (cmd) => heredocEntries(cmd).map((e) => e.body)
  * only knew heredocs answered `no body could be read from the command` for a command that has one,
  * which sends the author to add a body that is already there.
  *
- * Scanned after heredoc payloads are removed, so a `<<<` written inside one is text rather than a
- * second body — the same reason `ghInvocations` strips them before looking for a command.
+ * **Read from tokens rather than from the raw text.** Matching `<<<` in the text found one inside a
+ * quoted argument and invented a second body, which turned the callers' sole-body rule off; and a
+ * regex arm of `"([^"]*)"` truncated a body at an escaped quote. The tokenizer already resolves both
+ * questions, so it answers them here. Heredoc payloads are stripped first, for the reason
+ * `ghInvocations` strips them: a payload is text, not a command.
  */
 export function hereStrings(cmd) {
+  const { words, quoted } = tokenizeDetailed(withoutHeredocPayloads(cmd))
   const out = []
-  for (const m of withoutHeredocPayloads(cmd).matchAll(HERE_STRING)) out.push(m[2] ?? m[3] ?? m[4])
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === HERE_STRING_OP && !quoted[i] && i + 1 < words.length) out.push(words[i + 1])
+  }
   return out
 }
 
@@ -171,13 +194,16 @@ export function hereStrings(cmd) {
 export const stdinBodies = (cmd) => [...heredocs(cmd), ...hereStrings(cmd)]
 
 /**
- * The argument `<(…)` leaves behind.
+ * The argument a process substitution leaves behind.
  *
- * `(` is an operator token, so a process substitution arrives as the bare `<` that preceded it. It
- * is not a path and cannot become one without running the command, so a caller that reports it as a
- * file it could not open is naming something the author never wrote.
+ * `(` is an operator token, so `<(…)` and `>(…)` arrive as the bare `<` or `>` that preceded them.
+ * Neither is a path and neither can become one without running the command, so a caller that
+ * resolves it reports a file the author never wrote — `could not read the body file at /tmp/>`.
+ *
+ * **Both directions, because they are one keystroke apart.** Comparing against `<` alone left `>(…)`
+ * doing exactly what this export exists to stop.
  */
-export const PROCESS_SUBSTITUTION = '<'
+export const isProcessSubstitution = (arg) => arg === '<' || arg === '>'
 
 /**
  * The redirection target on a line, or null — the last one, since a later `>` wins.
@@ -311,15 +337,17 @@ export function ghInvocations(cmd, noun, verbs) {
  * so reading the first let `--body "Parent: #607" --body "a bug"` satisfy the gate with text GitHub
  * would never receive.
  */
-function flagArg(words, long, short) {
+export function flagArg(words, long, short) {
   const eq = new RegExp(`^${long}=([\\s\\S]*)$`)
   let found = null
   for (let i = 0; i < words.length; i++) {
     const w = words[i]
-    if (w === long || w === short) { found = words[i + 1] ?? null; continue }
+    if (w === long || (short !== undefined && w === short)) { found = words[i + 1] ?? null; continue }
     const m = eq.exec(w)
     if (m) { found = m[1]; continue }
-    if (!w.startsWith('--') && w.startsWith(short) && w.length > short.length) found = w.slice(short.length)
+    if (short !== undefined && !w.startsWith('--') && w.startsWith(short) && w.length > short.length) {
+      found = w.slice(short.length)
+    }
   }
   return found
 }
@@ -363,16 +391,91 @@ export function apiEndpoint(words) {
   return null
 }
 
-/** The value of a `gh api` flag, in both spellings: `--method GET` and `--method=GET`. */
-export function apiFlag(words, ...names) {
+/**
+ * The value of a `gh api` flag.
+ *
+ * **This is `flagArg`, and it used to be a second, weaker copy.** The copy compared tokens for
+ * equality and for a `--flag=` prefix, and so missed the two rules `flagArg` had already been
+ * corrected on, each against the binary: pflag takes the value attached to a shorthand
+ * (`gh api -Xput …` is a PUT), and a flag given twice takes the **last** occurrence. Both were live
+ * bypasses of gates built on it — `-Xput repos/o/r/pulls/1/merge` inferred `GET` and passed.
+ */
+export const apiFlag = (words, long, short) => flagArg(words, long, short)
+
+/**
+ * Every value given for a field flag, with the flag that carried it, in all four spellings gh
+ * accepts: `-f k=v`, `-fk=v`, `--field k=v`, `--field=k=v`.
+ *
+ * Two gates read fields — the comment card looks for a `query` or a `body`, the merge guard only
+ * asks whether any field is present — and both were reading three of the four spellings.
+ */
+export function flagEntries(words, flags) {
+  const out = []
   for (let i = 0; i < words.length; i++) {
-    if (names.includes(words[i])) return words[i + 1] ?? null
-    for (const n of names) {
-      if (words[i].startsWith(`${n}=`)) return words[i].slice(n.length + 1)
+    const w = words[i]
+    if (flags.includes(w)) { out.push({ flag: w, value: words[i + 1] ?? '' }); continue }
+    for (const f of flags) {
+      if (w.startsWith(`${f}=`)) { out.push({ flag: f, value: w.slice(f.length + 1) }); break }
+      if (!f.startsWith('--') && !w.startsWith('--') && w.startsWith(f) && w.length > f.length) {
+        out.push({ flag: f, value: w.slice(f.length) }); break
+      }
     }
   }
-  return null
+  return out
 }
+
+/** `gh api` field flags. `-F`/`--field` expand a leading `@` to a file; `-f`/`--raw-field` do not. */
+export const API_FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field']
+const READS_FILE = new Set(['-F', '--field'])
+
+/**
+ * Is this endpoint GitHub's GraphQL one?
+ *
+ * Matched as a path segment rather than by equality: gh sends any endpoint containing `://`
+ * verbatim, so a full URL reaches the same place and is the spelling a docs page hands you.
+ */
+export const isGraphqlEndpoint = (endpoint) => !!endpoint && /(^|\/)graphql(\?|$)/.test(endpoint)
+
+/**
+ * Every GraphQL document a `gh api graphql` call would send, following the file and stdin forms.
+ *
+ * **Two gates ask the same question of it** — the comment card asks whether it publishes prose, the
+ * merge guard whether it merges or approves — so the reading lives here and each gate brings its own
+ * list of operation names. A document it cannot read is omitted rather than blocking: both gates
+ * allow what they cannot judge.
+ */
+export function graphqlDocuments(words, cmd, cwd, readFile = readBodyFile) {
+  const out = []
+  const fromStdin = () => {
+    const bodies = stdinBodies(cmd)
+    return bodies.length === 1 ? bodies[0] : null
+  }
+  const readAt = (ref) => {
+    try { return readFile(path.resolve(cwd, ref)) } catch { return null }
+  }
+  for (const { flag, value } of flagEntries(words, API_FIELD_FLAGS)) {
+    if (!value.startsWith('query=')) continue
+    const text = value.slice('query='.length)
+    if (!text.startsWith('@') || !READS_FILE.has(flag)) { out.push(text); continue }
+    const ref = text.slice(1)
+    out.push(ref === '-' ? fromStdin() : readAt(ref))
+  }
+  // `--input` carries the whole request body, query included, and needs no field flag at all.
+  const input = flagArg(words, '--input')
+  if (input === '-') out.push(fromStdin())
+  else if (input) out.push(readAt(input))
+  return out.filter((t) => typeof t === 'string')
+}
+
+/**
+ * Does any of these documents invoke one of `names`?
+ *
+ * `\b<name>\s*[({]` rather than a bare substring: a mutation is a field call, so the name is
+ * followed by its arguments or its selection set. That form survives an alias (`x: addComment(…)`),
+ * a variable-based document, and a newline before the paren — all verified.
+ */
+export const invokesOperation = (docs, names) =>
+  docs.some((d) => names.some((n) => new RegExp(`\\b${n}\\s*[({]`).test(d)))
 
 /**
  * The reader both gates use for a `--body-file`.

--- a/scripts/lib/gh-language.mjs
+++ b/scripts/lib/gh-language.mjs
@@ -1,5 +1,6 @@
 import path from 'node:path'
-import { ghInvocations, titleArg, bodyArg, bodyFileArg, heredocs, heredocWrittenTo, readBodyFile } from './gh-command.mjs'
+import { ghInvocations, titleArg, bodyArg, bodyFileArg, stdinBodies, heredocWrittenTo, readBodyFile }
+  from './gh-command.mjs'
 
 /**
  * Are this PR's or issue's title and body in English, as AGENTS.md requires?
@@ -105,11 +106,12 @@ function* textsReachingGitHub(words, cmd, readFile, cwd) {
     }
   }
   if (file === '-') {
-    const docs = heredocs(cmd)
-    // Stdin has no redirection target to match on, so the sole-heredoc rule still applies here.
+    const docs = stdinBodies(cmd)
+    // Stdin has no redirection target to match on, so the sole-body rule still applies here — to
+    // heredocs and here-strings alike, since both put their text in the command and nowhere else.
     // Several means the command builds text elsewhere too and picking would be guessing — the parent
     // gate blocks on that ambiguity because a wrong guess there is permissive; here a wrong guess
     // would refuse someone else's prose, so it is left alone.
-    if (docs.length === 1) yield ['the heredoc body', docs[0]]
+    if (docs.length === 1) yield ['the body on stdin', docs[0]]
   }
 }

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { proseLines } from './prose-lines.mjs'
-import { ghInvocations, bodyFileArg, bodyArg, heredocs, heredocWrittenTo, readBodyFile } from './gh-command.mjs'
+import { ghInvocations, bodyFileArg, bodyArg, stdinBodies, heredocWrittenTo, readBodyFile, PROCESS_SUBSTITUTION }
+  from './gh-command.mjs'
 
 /**
  * Does an issue split out of other work name what it came from?
@@ -52,7 +53,8 @@ export function hasStandalone(body) {
  * @param {string} cmd the Bash command the tool was asked to run
  * @param {(p: string) => string} [readFile] injected for the tests
  * @param {string} [cwd] the directory the command would run in, from the hook payload
- * @returns {{ blocked: boolean, reason?: 'unreadable-body-file' | 'no-body' | 'no-parent', detail?: string,
+ * @returns {{ blocked: boolean, reason?: 'unreadable-body-file' | 'no-body' | 'no-parent'
+ *             | 'process-substitution', detail?: string,
  *             file?: string, resolved?: string, code?: string | null }}
  *
  * **`reason` exists because the caller printed one message for three outcomes.** A body file the
@@ -70,6 +72,16 @@ export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
     let body = null
     let unreadable = null
     const file = bodyFileArg(words)
+    // **A process substitution is a shape, not a path.** `--body-file <(…)` leaves the parser a bare
+    // `<`, and resolving that produced a report naming a file the author never wrote. Its text
+    // cannot be had without running the command, so the honest answer names the shape and stops.
+    if (file === PROCESS_SUBSTITUTION) {
+      return {
+        blocked: true,
+        reason: 'process-substitution',
+        detail: 'the body comes from a process substitution, which cannot be read without running it',
+      }
+    }
     if (file && file !== '-') {
       // **Resolved against the session's directory, not the gate's.** The hook runs from the
       // repository root while `gh` runs where the session is, so resolving here is what lets a
@@ -87,7 +99,9 @@ export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
     // title-side heredoc satisfied a check about the body — so the payload is extracted, and an
     // ambiguous command is blocked rather than guessed at.
     if (body === null && file === '-') {
-      const docs = heredocs(cmd)
+      // A heredoc or a here-string reaches `--body-file -`; both put the text in the command and
+      // nowhere else, and counting only one of them answered "no body" for a command that has one.
+      const docs = stdinBodies(cmd)
       body = docs.length === 1 ? docs[0] : null
     }
 

--- a/scripts/lib/issue-parent.mjs
+++ b/scripts/lib/issue-parent.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { proseLines } from './prose-lines.mjs'
-import { ghInvocations, bodyFileArg, bodyArg, stdinBodies, heredocWrittenTo, readBodyFile, PROCESS_SUBSTITUTION }
+import { ghInvocations, bodyFileArg, bodyArg, stdinBodies, heredocWrittenTo, readBodyFile, isProcessSubstitution }
   from './gh-command.mjs'
 
 /**
@@ -72,10 +72,11 @@ export function judge(cmd, readFile = readBodyFile, cwd = process.cwd()) {
     let body = null
     let unreadable = null
     const file = bodyFileArg(words)
-    // **A process substitution is a shape, not a path.** `--body-file <(…)` leaves the parser a bare
-    // `<`, and resolving that produced a report naming a file the author never wrote. Its text
-    // cannot be had without running the command, so the honest answer names the shape and stops.
-    if (file === PROCESS_SUBSTITUTION) {
+    // **A process substitution is a shape, not a path.** `--body-file <(…)` and `>(…)` leave the
+    // parser a bare `<` or `>`, and resolving either produced a report naming a file the author
+    // never wrote (`could not read the body file at /tmp/>`). The text cannot be had without running
+    // the command, so the honest answer names the shape and stops.
+    if (file !== null && isProcessSubstitution(file)) {
       return {
         blocked: true,
         reason: 'process-substitution',

--- a/scripts/lib/pr-merge.mjs
+++ b/scripts/lib/pr-merge.mjs
@@ -1,51 +1,85 @@
-import { ghInvocations, apiEndpoint, apiFlag } from './gh-command.mjs'
+import {
+  ghInvocations, apiEndpoint, apiFlag, flagEntries, isGraphqlEndpoint,
+  graphqlDocuments, invokesOperation, API_FIELD_FLAGS, readBodyFile,
+} from './gh-command.mjs'
 
 /**
- * Merging and approving through `gh api`, which `gh pr merge` and `gh pr review` reach by another
- * road.
+ * Merging and approving, on every road that reaches them.
  *
- * **Why this is not the same question as the grep in the hook.** `gh pr merge` is identifiable from
- * its words: the noun and the verb are right there, and a text matcher anchored on command position
- * decides it. `gh api` names what it acts on in a path and how in a flag, and the same path is a
- * read or a write depending on the method — `GET /pulls/1/merge` asks whether a PR was merged and
- * merges nothing. So this half parses and the other half greps, and neither is the wrong tool for
- * the surface it covers.
+ * **The `gh pr` forms are judged here rather than by the hook's grep, and that was a correction.**
+ * The first draft left them to the shell matcher on the grounds that a noun and a verb are
+ * identifiable from the words — true, but the matcher recognises command position as line-start,
+ * `;`, `&&`, `|`, `$(`, `then` or `do`, and nothing else. Measured against the shipped hook, all of
+ * these passed at exit 0 while the bare form was blocked: an assignment prefix (`GH_REPO=o/r …`),
+ * `env`, `sudo`, `command`, `xargs`, `if …; then`, and a background `&`. The parser in this same
+ * package already had every one of them — `ASSIGNMENT`, `PASSTHROUGH` and the reserved words — so
+ * the shell half was the weaker copy of a question already answered. It stays as a prefilter and as
+ * a backstop for when node cannot run.
  *
- * **The scope limit that remains.** GraphQL's `mergePullRequest` is not covered. It is identified by
- * the contents of a query string rather than by a path, which is the same shape as the comment
- * card's `addComment` problem and wants the same enumeration; doing it here first would mean
- * maintaining that list in two places before either has aged. The threat model is unchanged — these
- * gates guard a cooperative-but-forgetful agent, and an agent that means to bypass one always can.
+ * **`gh api` needs parsing rather than matching**, which is the other half of why this file exists:
+ * the same path is a read or a write depending on the method, so `GET /pulls/1/merge` asks whether a
+ * PR was merged and merges nothing.
+ *
+ * The threat model is unchanged — these gates guard a cooperative-but-forgetful agent, and an agent
+ * that means to bypass one always can. What they must not do is miss the spelling a forgetful agent
+ * would actually type.
  */
 
-/** `PUT /repos/{owner}/{repo}/pulls/{n}/merge` — the API form of `gh pr merge`. */
+/** `PUT /repos/{owner}/{repo}/pulls/{n}/merge` — the REST form. */
 const MERGE_PATH = /\/pulls\/[^/]+\/merge(\/|$|\?)/
-/** `POST /repos/{owner}/{repo}/pulls/{n}/reviews` — the API form of `gh pr review`. */
+/** `POST /repos/{owner}/{repo}/pulls/{n}/reviews` — the REST form, including `…/reviews/{id}/events`. */
 const REVIEW_PATH = /\/pulls\/[^/]+\/reviews(\/|$|\?)/
 
-/** Field flags. Their presence is what makes gh send POST when no method is given. */
-const FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field', '--input']
+/**
+ * The GraphQL mutations that merge or approve.
+ *
+ * **Covered here rather than deferred, because the team gate was the one without them.** The first
+ * draft left GraphQL out to avoid maintaining a mutation list in two places — but the comment card's
+ * list and this one are different sets for different questions, so there was no shared list to
+ * duplicate. What there was, measured: `mergePullRequest` and `addPullRequestReview(event: APPROVE)`
+ * were refused by nothing in `.claude/settings.json`. The only objection came from the comment-card
+ * gate, which is personal (gitignored `settings.local.json`), is absent for anyone else, and objects
+ * for a reason that stops applying the moment its card is read.
+ *
+ * `addPullRequestReview` is both a merge-guard concern and a comment-card concern, for different
+ * reasons — approving is the user's, and a review body publishes prose. Two gates may care about one
+ * mutation.
+ */
+const MERGE_MUTATIONS = ['mergePullRequest', 'enablePullRequestAutoMerge']
+const REVIEW_MUTATIONS = ['addPullRequestReview', 'submitPullRequestReview']
+
+/** Flags whose presence makes gh send POST when no method is given. */
+const IMPLIES_POST = [...API_FIELD_FLAGS, '--input']
 
 /**
  * @returns {{ blocked: boolean, reason?: 'merge' | 'review' }}
  *
  * **A read of the same path is allowed**, the way `--method GET` is on every other `gh api` rule
  * here. `GET /pulls/1/merge` is how you ask whether a PR is merged, and `GET …/reviews` lists them;
- * blocking those would refuse the two commands most likely to precede a legitimate question about a
- * PR. With no method given, gh sends GET unless a field is present, so that is what decides.
+ * blocking those would refuse the two calls most likely to precede a legitimate question about a PR.
+ * With no method given, gh sends GET unless a field is present, so that is what decides.
  */
-export function judge(cmd) {
+export function judge(cmd, cwd = process.cwd(), readFile = readBodyFile) {
+  if (ghInvocations(cmd, 'pr', ['merge']).length > 0) return { blocked: true, reason: 'merge' }
+  if (ghInvocations(cmd, 'pr', ['review']).length > 0) return { blocked: true, reason: 'review' }
+
   for (const words of ghInvocations(cmd, 'api', null)) {
     const endpoint = apiEndpoint(words)
     if (!endpoint) continue
+
+    if (isGraphqlEndpoint(endpoint)) {
+      const docs = graphqlDocuments(words, cmd, cwd, readFile)
+      if (invokesOperation(docs, MERGE_MUTATIONS)) return { blocked: true, reason: 'merge' }
+      if (invokesOperation(docs, REVIEW_MUTATIONS)) return { blocked: true, reason: 'review' }
+      continue
+    }
+
     const explicit = (apiFlag(words, '--method', '-X') ?? '').toUpperCase()
-    const hasField = words.some((w) => FIELD_FLAGS.includes(w) || FIELD_FLAGS.some((f) => w.startsWith(`${f}=`)))
-    const method = explicit || (hasField ? 'POST' : 'GET')
+    const method = explicit || (flagEntries(words, IMPLIES_POST).length > 0 ? 'POST' : 'GET')
     if (method === 'GET' || method === 'HEAD') continue
     if (MERGE_PATH.test(endpoint)) return { blocked: true, reason: 'merge' }
-    // Every write to `…/reviews` is refused, not only `event=APPROVE`. The sibling grep refuses
-    // `gh pr review` whatever its flags, and a review left pending is still a review submitted under
-    // the user's name.
+    // Every write to `…/reviews` is refused, not only `event=APPROVE`: a review left pending is
+    // still one submitted under the user's name.
     if (REVIEW_PATH.test(endpoint)) return { blocked: true, reason: 'review' }
   }
   return { blocked: false }

--- a/scripts/lib/pr-merge.mjs
+++ b/scripts/lib/pr-merge.mjs
@@ -1,0 +1,52 @@
+import { ghInvocations, apiEndpoint, apiFlag } from './gh-command.mjs'
+
+/**
+ * Merging and approving through `gh api`, which `gh pr merge` and `gh pr review` reach by another
+ * road.
+ *
+ * **Why this is not the same question as the grep in the hook.** `gh pr merge` is identifiable from
+ * its words: the noun and the verb are right there, and a text matcher anchored on command position
+ * decides it. `gh api` names what it acts on in a path and how in a flag, and the same path is a
+ * read or a write depending on the method — `GET /pulls/1/merge` asks whether a PR was merged and
+ * merges nothing. So this half parses and the other half greps, and neither is the wrong tool for
+ * the surface it covers.
+ *
+ * **The scope limit that remains.** GraphQL's `mergePullRequest` is not covered. It is identified by
+ * the contents of a query string rather than by a path, which is the same shape as the comment
+ * card's `addComment` problem and wants the same enumeration; doing it here first would mean
+ * maintaining that list in two places before either has aged. The threat model is unchanged — these
+ * gates guard a cooperative-but-forgetful agent, and an agent that means to bypass one always can.
+ */
+
+/** `PUT /repos/{owner}/{repo}/pulls/{n}/merge` — the API form of `gh pr merge`. */
+const MERGE_PATH = /\/pulls\/[^/]+\/merge(\/|$|\?)/
+/** `POST /repos/{owner}/{repo}/pulls/{n}/reviews` — the API form of `gh pr review`. */
+const REVIEW_PATH = /\/pulls\/[^/]+\/reviews(\/|$|\?)/
+
+/** Field flags. Their presence is what makes gh send POST when no method is given. */
+const FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field', '--input']
+
+/**
+ * @returns {{ blocked: boolean, reason?: 'merge' | 'review' }}
+ *
+ * **A read of the same path is allowed**, the way `--method GET` is on every other `gh api` rule
+ * here. `GET /pulls/1/merge` is how you ask whether a PR is merged, and `GET …/reviews` lists them;
+ * blocking those would refuse the two commands most likely to precede a legitimate question about a
+ * PR. With no method given, gh sends GET unless a field is present, so that is what decides.
+ */
+export function judge(cmd) {
+  for (const words of ghInvocations(cmd, 'api', null)) {
+    const endpoint = apiEndpoint(words)
+    if (!endpoint) continue
+    const explicit = (apiFlag(words, '--method', '-X') ?? '').toUpperCase()
+    const hasField = words.some((w) => FIELD_FLAGS.includes(w) || FIELD_FLAGS.some((f) => w.startsWith(`${f}=`)))
+    const method = explicit || (hasField ? 'POST' : 'GET')
+    if (method === 'GET' || method === 'HEAD') continue
+    if (MERGE_PATH.test(endpoint)) return { blocked: true, reason: 'merge' }
+    // Every write to `…/reviews` is refused, not only `event=APPROVE`. The sibling grep refuses
+    // `gh pr review` whatever its flags, and a review left pending is still a review submitted under
+    // the user's name.
+    if (REVIEW_PATH.test(endpoint)) return { blocked: true, reason: 'review' }
+  }
+  return { blocked: false }
+}

--- a/scripts/pr-merge-guard.mjs
+++ b/scripts/pr-merge-guard.mjs
@@ -40,4 +40,7 @@ Creating the PR is yours to do; merging and approving are the user's — leave t
 A read of the same path is allowed: \`--method GET\` asks whether a PR is merged, or lists its
 reviews, without doing either.
 `)
-process.exit(2)
+// `exitCode` rather than `exit(2)`: writes to a pipe are asynchronous on Windows, and `exit`
+// discards whatever is still queued — the status would block but the reason could arrive cut off.
+// Nothing is pending after the stdin loop, so the process still ends here.
+process.exitCode = 2

--- a/scripts/pr-merge-guard.mjs
+++ b/scripts/pr-merge-guard.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// The `gh api` half of `.claude/hooks/pr-merge-guard.sh`. Reads the PreToolUse payload on stdin,
+// exits 0 to allow and 2 to block. The `gh pr merge` half stays in the shell, where a text matcher
+// is the right tool — see `scripts/lib/pr-merge.mjs` for why these are two questions.
+import { judge } from './lib/pr-merge.mjs'
+
+const WHAT = {
+  merge: 'merging a PR through the API',
+  review: 'submitting a PR review through the API',
+}
+
+let raw = ''
+process.stdin.setEncoding('utf8')
+for await (const chunk of process.stdin) raw += chunk
+
+// Fail open on anything unparseable, matching every other gate in this directory.
+let cmd
+try {
+  const payload = JSON.parse(raw)
+  cmd = payload?.tool_input?.command
+  // A payload with no `command` is judged on the whole payload, the way the shell half does.
+  if (typeof cmd !== 'string' || !cmd) cmd = raw
+} catch { process.exit(0) }
+if (!cmd) process.exit(0)
+
+let verdict
+try { verdict = judge(cmd) } catch { process.exit(0) }
+if (!verdict.blocked) process.exit(0)
+
+process.stderr.write(`Blocked: ${WHAT[verdict.reason]}.
+
+Creating the PR is yours to do; merging and approving are the user's — leave them, even with --admin
+(AGENTS.md > Core Principles). Reaching the same endpoint through \`gh api\` is the same action.
+
+A read of the same path is allowed: \`--method GET\` asks whether a PR is merged, or lists its
+reviews, without doing either.
+`)
+process.exit(2)

--- a/scripts/pr-merge-guard.mjs
+++ b/scripts/pr-merge-guard.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-// The `gh api` half of `.claude/hooks/pr-merge-guard.sh`. Reads the PreToolUse payload on stdin,
-// exits 0 to allow and 2 to block. The `gh pr merge` half stays in the shell, where a text matcher
-// is the right tool — see `scripts/lib/pr-merge.mjs` for why these are two questions.
+// The deciding half of `.claude/hooks/pr-merge-guard.sh`. Reads the PreToolUse payload on stdin,
+// exits 0 to allow and 2 to block. It judges both roads to the same two actions — the `gh pr` verbs
+// and the `gh api` endpoints — because the shell matcher it sits behind misses every prefixed and
+// wrapped spelling of the first. See `scripts/lib/pr-merge.mjs`.
 import { judge } from './lib/pr-merge.mjs'
 
 const WHAT = {
-  merge: 'merging a PR through the API',
-  review: 'submitting a PR review through the API',
+  merge: 'merging a PR',
+  review: 'submitting a PR review',
 }
 
 let raw = ''
@@ -15,16 +16,20 @@ for await (const chunk of process.stdin) raw += chunk
 
 // Fail open on anything unparseable, matching every other gate in this directory.
 let cmd
+let cwd
 try {
   const payload = JSON.parse(raw)
   cmd = payload?.tool_input?.command
   // A payload with no `command` is judged on the whole payload, the way the shell half does.
   if (typeof cmd !== 'string' || !cmd) cmd = raw
+  // The directory the command would run in, so a `@file` in a GraphQL field is read from the tree
+  // the session is in rather than from wherever the hook was launched.
+  cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()
 } catch { process.exit(0) }
 if (!cmd) process.exit(0)
 
 let verdict
-try { verdict = judge(cmd) } catch { process.exit(0) }
+try { verdict = judge(cmd, cwd) } catch { process.exit(0) }
 if (!verdict.blocked) process.exit(0)
 
 process.stderr.write(`Blocked: ${WHAT[verdict.reason]}.


### PR DESCRIPTION
## Summary

Four follow-ups from #701 and #706, taken together because they all pass through
`scripts/lib/gh-command.mjs` or the same entry idiom in the hooks — doing them separately would
mean editing the same parser four times.

Three of the four turned out to be further along than their issues said, and one was diagnosed
differently: #702 reads as a quoting bug, but its own first example has no quotes in it. A reserved
word in bash is a keyword only where a command may begin, so `echo do gh issue create` is one
command with arguments. Quoting matters too, and that is the half that changed `tokenize`'s shape.

The adversarial review then found two blockers the first pass had not: `gh api -Xput …/pulls/1/merge`
merged, because pflag takes a value attached to a shorthand and this file had one reader that knew
that and one that did not; and `gh pr merge` was blocked only in its bare form, while `env`, `sudo`,
`xargs`, an assignment prefix and an `if` condition all passed — every one of which this package's
parser already recognised. The decision for that half moved out of the shell matcher as a result.

Closes #702, #707, #552, #553. Split out: #711.

## Checklist

- [x] Tests written and passing — 723 in the scripts suite, up from 599
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a, repository tooling only
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- Plan: `.work/2026-08-31-gate-parser-followups-plan.md`
- Adversarial review: `.work/reviews/fix__gate-parser-followups.md` — two independent channels
  (parser semantics, gate coverage) run in parallel, nine findings, eight fixed here and one filed
  as #711. Two dispositions were re-graded against the reviewers': one `later` closed for free once
  its parent finding was fixed properly, and one finding was regraded from a regression in this
  branch to a pre-existing bug fixed in place.

<!-- no-changeset: repository tooling (.claude/hooks, scripts), not published source -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safeguards for pull-request merges and review submissions, including API and GraphQL requests.
  * Prevented incomplete, wrapped, or unusually formatted commands from bypassing safety checks.
  * Improved detection of comment submissions from file-based, stdin-based, and GraphQL requests.
  * Added clearer handling for unsupported process substitutions and missing request bodies.
  * Improved diagnostic output and handling when safety checks encounter unavailable tools or unexpected errors.

* **Tests**
  * Expanded coverage for command parsing, API operations, payload handling, and safety-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->