### PR TITLE
test(cli): pin what `migrate net-filter` exits with, per outcome

### DIFF
--- a/packages/cli/src/__tests__/commands/migrate-net-filter.test.ts
+++ b/packages/cli/src/__tests__/commands/migrate-net-filter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+vi.mock('../../lib/net-filter.js', async (actual) => ({
+  ...(await actual<typeof import('../../lib/net-filter.js')>()),
+  installNetFilter: vi.fn(),
+}))
+
+import { cmdMigrateNetFilter } from '../../commands/migrate.js'
+import { installNetFilter } from '../../lib/net-filter.js'
+
+const mockInstall = vi.mocked(installNetFilter)
+
+/**
+ * **What `tapflow migrate net-filter` exits with, per outcome.**
+ *
+ * This is a contract and not an implementation detail: a provisioning script runs this command and
+ * branches on the code. v0.20.0 answered 0 for every outcome it could produce; `installed-unconfirmed`
+ * is the first one that does not, and it covers a state that used to be reported as `installed` —
+ * so a script that passed on 0.20.0 can fail on 0.21.0 for a Mac whose filter is slow to come up.
+ *
+ * That change is deliberate, because the old answer was a claim the command could not support. It is
+ * pinned here because the release notes state it, and because #731 is an open question about whether
+ * this exit code is right — whoever settles it needs to see which of the eleven outcomes were meant
+ * as failures rather than infer it from a switch.
+ */
+const EXIT_CONTRACT: Record<string, 0 | 1> = {
+  // Nothing is wrong, or the remaining step is a human's.
+  installed: 0,
+  'already-current': 0,
+  'needs-approval': 0,
+  'needs-reboot': 0,
+  'not-macos': 0,
+  // Something is wrong, or the command declines to guess.
+  'installed-unconfirmed': 1,
+  'no-artifact': 1,
+  'refused-devices-busy': 1,
+  'refused-host-unknown': 1,
+  'refused-downgrade': 1,
+  failed: 1,
+}
+
+/** The fields each outcome carries, so the banner renders rather than throwing on `undefined`. */
+const OUTCOME: Record<string, Record<string, unknown>> = {
+  installed: {},
+  'installed-unconfirmed': {},
+  'already-current': {},
+  'needs-approval': { filterLeftDisabled: true },
+  'needs-reboot': {},
+  'not-macos': {},
+  'no-artifact': {},
+  'refused-devices-busy': { busy: ['simulator iPhone 17 Pro'] },
+  'refused-host-unknown': { activated: '1787846299' },
+  'refused-downgrade': { installed: '1788999999', shipped: '1788357869' },
+  failed: { code: 3, detail: 'save refused', filterLeftDisabled: true },
+}
+
+describe('tapflow migrate net-filter — exit code contract', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it.each(Object.entries(EXIT_CONTRACT))('%s exits %d', (status, code) => {
+    mockInstall.mockReturnValue({ status, ...OUTCOME[status] } as never)
+
+    if (code === 0) {
+      cmdMigrateNetFilter()
+      expect(exitSpy, `${status} left the process with a failure code`).not.toHaveBeenCalled()
+    } else {
+      // **The throw is the assertion that it stopped.** `process.exit` is mocked, so without it the
+      // switch would fall through and the next statement would run in a process the real command has
+      // already left — which is how a `break` that should have been a `return` reads as passing.
+      expect(() => { cmdMigrateNetFilter() }).toThrow('process.exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    }
+  })
+
+  it('covers every outcome the command handles', () => {
+    // **By inspection, because the union is erased at runtime.** `migrate.ts` has a `never`
+    // exhaustiveness guard, so a new outcome cannot be forgotten there — but it can be given the
+    // wrong exit code, and nothing above would notice a case this table never names.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'commands', 'migrate.ts'), 'utf8',
+    )
+    const body = src.slice(src.indexOf('export function cmdMigrateNetFilter'))
+    const handled = [...body.matchAll(/^ {4}case '([a-z-]+)':/gm)].map((m) => m[1])
+
+    expect(handled.length, 'no cases were found — the regex stopped matching the source').toBeGreaterThan(5)
+    expect(handled.sort()).toEqual(Object.keys(EXIT_CONTRACT).sort())
+  })
+})


### PR DESCRIPTION
## Summary

v0.21.0's release notes state a contract change: `tapflow migrate net-filter` answers non-zero for `installed-unconfirmed`, a state v0.20.0 reported as `installed` with exit 0. A provisioning script that passed on 0.20.0 can fail on 0.21.0 for a Mac whose filter is slow to come up.

The change is right — the old answer was a claim the command could not support. What was missing is anything that observes it. **This command had no test file at all**: `start`, `ssh` and `tunnel-runner` pin their exit codes and this one did not, so the notes were about to assert a contract with no guard under it.

It also serves #731, which is open on whether that exit code is correct. Settling that should start from which of the eleven outcomes were *meant* as failures, rather than from reading a switch.

| exit 0 | exit 1 |
|---|---|
| `installed` | `installed-unconfirmed` |
| `already-current` | `no-artifact` |
| `needs-approval` | `refused-devices-busy` |
| `needs-reboot` | `refused-host-unknown` |
| `not-macos` | `refused-downgrade` |
| | `failed` |

### Two shapes that are deliberate

**The non-zero cases assert the throw, not just that `process.exit` was called.** It is mocked, so a case that calls it and falls through keeps executing in a process the real command has already left — which is how a `break` that should be a `return` reads as passing.

**A second test re-reads `migrate.ts` and asserts the table names every `case` it handles.** The `never` guard in the command already stops an outcome being forgotten there; nothing stopped a new one being given the wrong exit code here. It also asserts the match found more than five cases, so a source reshuffle that breaks the regex fails loudly instead of reporting an empty list as agreement.

**Mutations — 3, all killed:** `installed-unconfirmed` returning instead of exiting · `needs-approval` exiting 1 · an entry dropped from the table.

## Checklist

- [x] Tests written and passing — CLI 354, 25 files
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/test__migrate-exit-contract.md` — the contract table, the mutation results, and why no independent channel was launched.

<!-- no-changeset: tests only, no published behaviour changes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rcctur5HNxnb59EwhyeiTY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the `tapflow migrate net-filter` command’s exit-code behavior.
  * Verified success and failure outcomes, including required result details and handling of all supported statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->