### PR TITLE
ci: say on an issue that a pull request is working on it

### DIFF
--- a/.github/workflows/announce-linked-pr.yml
+++ b/.github/workflows/announce-linked-pr.yml
@@ -23,6 +23,15 @@ on:
   pull_request_target:
     types: [opened, reopened, edited]
 
+  # **The event-driven half cannot reach a pull request that is already open.** A
+  # `pull_request_target` workflow only takes effect once it is on the default branch, and it fires
+  # on events rather than on state — so every issue that already had a PR against it when this landed
+  # stays silent until that PR happens to be edited. Three of them were in exactly that position on
+  # the day this was written. Running it by hand walks the open list through the same code, which
+  # matters more than the convenience: a backfill written separately would be a second implementation
+  # of the marker, and the two would disagree the first time one changed.
+  workflow_dispatch:
+
 permissions:
   contents: read
   issues: write
@@ -30,7 +39,7 @@ permissions:
 
 concurrency:
   # Two `edited` events in quick succession would otherwise both find no marker and both comment.
-  group: announce-linked-pr-${{ github.event.pull_request.number }}
+  group: announce-linked-pr-${{ github.event.pull_request.number || 'manual' }}
   cancel-in-progress: false
 
 jobs:
@@ -48,92 +57,112 @@ jobs:
           owner=${REPO%/*}
           name=${REPO#*/}
 
-          # **`closingIssuesReferences`, not a regex over the body.** GitHub already decides what
-          # closes what — `Closes`, `Fixes`, `Resolves`, each in any case, across repositories. A
-          # second parser here would disagree with the sidebar sooner or later, and the disagreement
-          # would be invisible.
-          #
-          # The response is captured whole rather than filtered with `--jq`, because three separate
-          # questions are asked of it below and one API call is enough for all three. `gh` still
-          # exits non-zero when the call fails, which `set -e` carries out.
-          # shellcheck disable=SC2016  # `$owner`/`$name`/`$pr` below are GraphQL variables,
-          # bound by the -F flags. Single quotes are what keeps the shell out of them.
-          resp=$(gh api graphql \
-            -f query='
-              query($owner:String!, $name:String!, $pr:Int!) {
-                repository(owner:$owner, name:$name) {
-                  pullRequest(number:$pr) {
-                    closingIssuesReferences(first:100) {
-                      pageInfo { hasNextPage }
-                      nodes { number repository { nameWithOwner } }
-                    }
-                  }
-                }
-              }' \
-            -F owner="$owner" -F name="$name" -F pr="$PR")
-
-          refs=.data.repository.pullRequest.closingIssuesReferences
-
-          # A null `pullRequest` means the query succeeded and answered about nothing — a shape that
-          # would otherwise flow on as "closes no issues".
-          [ "$(jq -r '.data.repository.pullRequest == null' <<<"$resp")" = "false" ] || {
-            echo "the query returned no pull request for #$PR — refusing to report on that"
-            exit 1
-          }
-
-          # **A truncated list is a stop, not a shorter list.** `first:100` is far past anything real
-          # here, so reaching the cap means something is wrong rather than busy — and silently
-          # dropping the overflow is the failure this repository keeps finding in its own guards.
-          [ "$(jq -r "$refs.pageInfo.hasNextPage" <<<"$resp")" = "false" ] || {
-            echo "PR #$PR closes more than 100 issues — refusing to report on a truncated list"
-            exit 1
-          }
-
-          # **Only this repository.** A closing reference can point at another repo, and the loop
-          # below posts by number alone — so `other-org/other-repo#42` would land a comment on *our*
-          # #42, which is a different issue. The token cannot write to that repo anyway, so those are
-          # named in the log and skipped.
-          issues=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner == \$repo) | .number" <<<"$resp")
-          foreign=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner != \$repo) | \"\(.repository.nameWithOwner)#\(.number)\"" <<<"$resp")
-          [ -z "$foreign" ] || echo "skipping references outside $REPO: $(tr '\n' ' ' <<<"$foreign")"
-
-          if [ -z "$issues" ]; then
-            echo "PR #$PR closes no issues in $REPO — nothing to announce."
-            exit 0
-          fi
-
-          # The marker is the whole idempotency story: `edited` fires on a title change, and a
-          # reopen fires again on a PR that was already announced.
-          marker="<!-- linked-pr: $PR -->"
           announced=0
           skipped=0
+          scanned=0
 
-          for issue in $issues; do
-            # **The fetch and the match are separate statements on purpose.** Written as one
-            # pipeline ending in `|| true`, that `true` covers the whole thing: a 5xx or a secondary
-            # rate limit trips `pipefail`, the failure is swallowed, `grep -c` prints 0, and the
-            # workflow reads "not announced yet" when it means "could not check" — posting the
-            # duplicate the marker exists to prevent. Assigning first lets `set -e` see a failed
-            # read; `grep -q` inside `if` is then free to answer no.
-            bodies=$(gh api --paginate "repos/$REPO/issues/$issue/comments" --jq '.[].body')
-            if grep -qF "$marker" <<<"$bodies"; then
-              echo "issue #$issue already carries the marker for PR #$PR — skipping"
-              skipped=$((skipped + 1))
-              continue
+          announce() {
+            pr=$1
+
+            # **`closingIssuesReferences`, not a regex over the body.** GitHub already decides what
+            # closes what — `Closes`, `Fixes`, `Resolves`, each in any case, across repositories. A
+            # second parser here would disagree with the sidebar sooner or later, and the
+            # disagreement would be invisible.
+            #
+            # The response is captured whole rather than filtered with `--jq`, because three separate
+            # questions are asked of it below and one API call is enough for all three. `gh` still
+            # exits non-zero when the call fails, which `set -e` carries out.
+            # shellcheck disable=SC2016  # `$owner`/`$name`/`$pr` below are GraphQL variables,
+            # bound by the -F flags. Single quotes are what keeps the shell out of them.
+            resp=$(gh api graphql \
+              -f query='
+                query($owner:String!, $name:String!, $pr:Int!) {
+                  repository(owner:$owner, name:$name) {
+                    pullRequest(number:$pr) {
+                      closingIssuesReferences(first:100) {
+                        pageInfo { hasNextPage }
+                        nodes { number repository { nameWithOwner } }
+                      }
+                    }
+                  }
+                }' \
+              -F owner="$owner" -F name="$name" -F pr="$pr")
+
+            refs=.data.repository.pullRequest.closingIssuesReferences
+
+            # A null `pullRequest` means the query succeeded and answered about nothing — a shape
+            # that would otherwise flow on as "closes no issues".
+            [ "$(jq -r '.data.repository.pullRequest == null' <<<"$resp")" = "false" ] || {
+              echo "the query returned no pull request for #$pr — refusing to report on that"
+              exit 1
+            }
+
+            # **A truncated list is a stop, not a shorter list.** `first:100` is far past anything
+            # real here, so reaching the cap means something is wrong rather than busy — and silently
+            # dropping the overflow is the failure this repository keeps finding in its own guards.
+            [ "$(jq -r "$refs.pageInfo.hasNextPage" <<<"$resp")" = "false" ] || {
+              echo "PR #$pr closes more than 100 issues — refusing to report on a truncated list"
+              exit 1
+            }
+
+            # **Only this repository.** A closing reference can point at another repo, and the loop
+            # below posts by number alone — so `other-org/other-repo#42` would land a comment on
+            # *our* #42, which is a different issue. The token cannot write to that repo anyway, so
+            # those are named in the log and skipped.
+            issues=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner == \$repo) | .number" <<<"$resp")
+            foreign=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner != \$repo) | \"\(.repository.nameWithOwner)#\(.number)\"" <<<"$resp")
+            [ -z "$foreign" ] || echo "PR #$pr: skipping references outside $REPO: $(tr '\n' ' ' <<<"$foreign")"
+
+            if [ -z "$issues" ]; then
+              echo "PR #$pr closes no issues in $REPO"
+              return 0
             fi
 
-            # **"links this issue", not "is open".** A bare `#123` reference is rendered by GitHub
-            # with the pull request's *current* state, so a sentence written in this tense stays true
-            # after the PR merges or closes. Saying "is open" would need a second workflow to come
-            # back and correct it, which is a second thing to get wrong.
-            gh api "repos/$REPO/issues/$issue/comments" -f body="$(printf '%s\n\n%s' \
-              "#$PR links this issue. Under [CONTRIBUTING](https://github.com/$REPO/blob/main/CONTRIBUTING.md#claiming-an-issue), opening a pull request is how an issue is claimed — check that one before starting your own." \
-              "$marker")" >/dev/null
-            echo "commented on issue #$issue for PR #$PR"
-            announced=$((announced + 1))
+            # The marker is the whole idempotency story: `edited` fires on a title change, a reopen
+            # fires again on a PR that was already announced, and the manual run walks every open PR
+            # whether or not it has been seen.
+            marker="<!-- linked-pr: $pr -->"
+
+            for issue in $issues; do
+              # **The fetch and the match are separate statements on purpose.** Written as one
+              # pipeline ending in `|| true`, that `true` covers the whole thing: a 5xx or a
+              # secondary rate limit trips `pipefail`, the failure is swallowed, `grep -c` prints 0,
+              # and the workflow reads "not announced yet" when it means "could not check" — posting
+              # the duplicate the marker exists to prevent. Assigning first lets `set -e` see a
+              # failed read; `grep -q` inside `if` is then free to answer no.
+              bodies=$(gh api --paginate "repos/$REPO/issues/$issue/comments" --jq '.[].body')
+              if grep -qF "$marker" <<<"$bodies"; then
+                echo "issue #$issue already carries the marker for PR #$pr — skipping"
+                skipped=$((skipped + 1))
+                continue
+              fi
+
+              # **"links this issue", not "is open".** A bare `#123` reference is rendered by GitHub
+              # with the pull request's *current* state, so a sentence written in this tense stays
+              # true after the PR merges or closes. Saying "is open" would need a second workflow to
+              # come back and correct it, which is a second thing to get wrong.
+              gh api "repos/$REPO/issues/$issue/comments" -f body="$(printf '%s\n\n%s' \
+                "#$pr links this issue. Under [CONTRIBUTING](https://github.com/$REPO/blob/main/CONTRIBUTING.md#claiming-an-issue), opening a pull request is how an issue is claimed — check that one before starting your own." \
+                "$marker")" >/dev/null
+              echo "commented on issue #$issue for PR #$pr"
+              announced=$((announced + 1))
+            done
+          }
+
+          # One pull request on an event; every open one when a human asks.
+          if [ -n "${PR:-}" ]; then
+            targets=$PR
+          else
+            targets=$(gh pr list --state open --limit 200 --json number --jq '.[].number')
+            if [ -z "$targets" ]; then
+              echo "no open pull requests — nothing to announce."
+              exit 0
+            fi
+          fi
+
+          for pr_number in $targets; do
+            announce "$pr_number"
+            scanned=$((scanned + 1))
           done
 
-          # **Say what was done.** A run that announced nothing and a run that could not read
-          # anything look identical in a log that only prints on success — the failure this
-          # repository keeps finding in its own guards.
-          echo "issues in $REPO: $(grep -c . <<<"$issues"), announced: $announced, already marked: $skipped"
+          echo "pull requests scanned: $scanned, announced: $announced, already marked: $skipped"

--- a/.github/workflows/announce-linked-pr.yml
+++ b/.github/workflows/announce-linked-pr.yml
@@ -1,0 +1,107 @@
+# Say on an issue that a pull request is working on it.
+#
+# **The reader this exists for has not arrived yet.** When #630 opened against #481 the claim was
+# real, but it showed only as a linked-PR row in the sidebar — so the good-first-issue list went on
+# advertising the issue, and thirteen days later #743 arrived having written the same fix. Two
+# contributors lost an evening to that in one day. A sentence on the issue is what neither of them
+# had.
+#
+# So this fires on *every* link, not only on a collision: the value is in the comment already being
+# there when the next person reads the issue.
+name: Announce linked PR
+
+on:
+  # **`pull_request_target`, and the checkout is deliberately absent.**
+  #
+  # Every contributor PR here comes from a fork, and a fork's `pull_request` run gets a read-only
+  # token — it cannot comment, which is the whole job. `pull_request_target` runs with the base
+  # repository's permissions instead. That is only safe while no PR code is fetched or executed, so
+  # nothing below checks anything out: it reads the event payload and calls the API.
+  #
+  # `edited` is here because the closing keyword is often added after opening. It also fires on a
+  # title change, which is why the idempotency marker below is not optional.
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  # Two `edited` events in quick succession would otherwise both find no marker and both comment.
+  group: announce-linked-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on every issue this PR closes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          owner=${REPO%/*}
+          name=${REPO#*/}
+
+          # **`closingIssuesReferences`, not a regex over the body.** GitHub already decides what
+          # closes what — `Closes`, `Fixes`, `Resolves`, each in any case, across repositories. A
+          # second parser here would disagree with the sidebar sooner or later, and the disagreement
+          # would be invisible.
+          #
+          # `--jq` on a failed call prints nothing and exits non-zero; `set -o pipefail` is what
+          # makes that reach us rather than reading as "this PR closes no issues".
+          # shellcheck disable=SC2016  # `$owner`/`$name`/`$pr` below are GraphQL variables,
+          # bound by the -F flags. Single quotes are what keeps the shell out of them.
+          issues=$(gh api graphql \
+            -f query='
+              query($owner:String!, $name:String!, $pr:Int!) {
+                repository(owner:$owner, name:$name) {
+                  pullRequest(number:$pr) {
+                    closingIssuesReferences(first:20) { nodes { number } }
+                  }
+                }
+              }' \
+            -F owner="$owner" -F name="$name" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')
+
+          if [ -z "$issues" ]; then
+            echo "PR #$PR closes no issues — nothing to announce."
+            exit 0
+          fi
+
+          # The marker is the whole idempotency story: `edited` fires on a title change, and a
+          # reopen fires again on a PR that was already announced.
+          marker="<!-- linked-pr: $PR -->"
+          announced=0
+          skipped=0
+
+          for issue in $issues; do
+            # Every comment, not the first page: a busy issue can push ours past thirty.
+            existing=$(gh api --paginate "repos/$REPO/issues/$issue/comments" --jq '.[].body' \
+              | grep -cF "$marker" || true)
+            if [ "$existing" -gt 0 ]; then
+              echo "issue #$issue already carries the marker for PR #$PR — skipping"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            # **"links this issue", not "is open".** A bare `#123` reference is rendered by GitHub
+            # with the pull request's *current* state, so a sentence written in this tense stays true
+            # after the PR merges or closes. Saying "is open" would need a second workflow to come
+            # back and correct it, which is a second thing to get wrong.
+            gh api "repos/$REPO/issues/$issue/comments" -f body="$(printf '%s\n\n%s' \
+              "#$PR links this issue. Under [CONTRIBUTING](https://github.com/$REPO/blob/main/CONTRIBUTING.md#claiming-an-issue), opening a pull request is how an issue is claimed — check that one before starting your own." \
+              "$marker")" >/dev/null
+            echo "commented on issue #$issue for PR #$PR"
+            announced=$((announced + 1))
+          done
+
+          # **Say what was done.** A run that announced nothing and a run that could not read
+          # anything look identical in a log that only prints on success — the failure this
+          # repository keeps finding in its own guards.
+          echo "issues linked: $(printf '%s\n' "$issues" | grep -c .), announced: $announced, already marked: $skipped"

--- a/.github/workflows/announce-linked-pr.yml
+++ b/.github/workflows/announce-linked-pr.yml
@@ -53,24 +53,52 @@ jobs:
           # second parser here would disagree with the sidebar sooner or later, and the disagreement
           # would be invisible.
           #
-          # `--jq` on a failed call prints nothing and exits non-zero; `set -o pipefail` is what
-          # makes that reach us rather than reading as "this PR closes no issues".
+          # The response is captured whole rather than filtered with `--jq`, because three separate
+          # questions are asked of it below and one API call is enough for all three. `gh` still
+          # exits non-zero when the call fails, which `set -e` carries out.
           # shellcheck disable=SC2016  # `$owner`/`$name`/`$pr` below are GraphQL variables,
           # bound by the -F flags. Single quotes are what keeps the shell out of them.
-          issues=$(gh api graphql \
+          resp=$(gh api graphql \
             -f query='
               query($owner:String!, $name:String!, $pr:Int!) {
                 repository(owner:$owner, name:$name) {
                   pullRequest(number:$pr) {
-                    closingIssuesReferences(first:20) { nodes { number } }
+                    closingIssuesReferences(first:100) {
+                      pageInfo { hasNextPage }
+                      nodes { number repository { nameWithOwner } }
+                    }
                   }
                 }
               }' \
-            -F owner="$owner" -F name="$name" -F pr="$PR" \
-            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')
+            -F owner="$owner" -F name="$name" -F pr="$PR")
+
+          refs=.data.repository.pullRequest.closingIssuesReferences
+
+          # A null `pullRequest` means the query succeeded and answered about nothing — a shape that
+          # would otherwise flow on as "closes no issues".
+          [ "$(jq -r '.data.repository.pullRequest == null' <<<"$resp")" = "false" ] || {
+            echo "the query returned no pull request for #$PR — refusing to report on that"
+            exit 1
+          }
+
+          # **A truncated list is a stop, not a shorter list.** `first:100` is far past anything real
+          # here, so reaching the cap means something is wrong rather than busy — and silently
+          # dropping the overflow is the failure this repository keeps finding in its own guards.
+          [ "$(jq -r "$refs.pageInfo.hasNextPage" <<<"$resp")" = "false" ] || {
+            echo "PR #$PR closes more than 100 issues — refusing to report on a truncated list"
+            exit 1
+          }
+
+          # **Only this repository.** A closing reference can point at another repo, and the loop
+          # below posts by number alone — so `other-org/other-repo#42` would land a comment on *our*
+          # #42, which is a different issue. The token cannot write to that repo anyway, so those are
+          # named in the log and skipped.
+          issues=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner == \$repo) | .number" <<<"$resp")
+          foreign=$(jq -r --arg repo "$REPO" "$refs.nodes[] | select(.repository.nameWithOwner != \$repo) | \"\(.repository.nameWithOwner)#\(.number)\"" <<<"$resp")
+          [ -z "$foreign" ] || echo "skipping references outside $REPO: $(tr '\n' ' ' <<<"$foreign")"
 
           if [ -z "$issues" ]; then
-            echo "PR #$PR closes no issues — nothing to announce."
+            echo "PR #$PR closes no issues in $REPO — nothing to announce."
             exit 0
           fi
 
@@ -81,10 +109,14 @@ jobs:
           skipped=0
 
           for issue in $issues; do
-            # Every comment, not the first page: a busy issue can push ours past thirty.
-            existing=$(gh api --paginate "repos/$REPO/issues/$issue/comments" --jq '.[].body' \
-              | grep -cF "$marker" || true)
-            if [ "$existing" -gt 0 ]; then
+            # **The fetch and the match are separate statements on purpose.** Written as one
+            # pipeline ending in `|| true`, that `true` covers the whole thing: a 5xx or a secondary
+            # rate limit trips `pipefail`, the failure is swallowed, `grep -c` prints 0, and the
+            # workflow reads "not announced yet" when it means "could not check" — posting the
+            # duplicate the marker exists to prevent. Assigning first lets `set -e` see a failed
+            # read; `grep -q` inside `if` is then free to answer no.
+            bodies=$(gh api --paginate "repos/$REPO/issues/$issue/comments" --jq '.[].body')
+            if grep -qF "$marker" <<<"$bodies"; then
               echo "issue #$issue already carries the marker for PR #$PR — skipping"
               skipped=$((skipped + 1))
               continue
@@ -104,4 +136,4 @@ jobs:
           # **Say what was done.** A run that announced nothing and a run that could not read
           # anything look identical in a log that only prints on success — the failure this
           # repository keeps finding in its own guards.
-          echo "issues linked: $(printf '%s\n' "$issues" | grep -c .), announced: $announced, already marked: $skipped"
+          echo "issues in $REPO: $(grep -c . <<<"$issues"), announced: $announced, already marked: $skipped"

--- a/.github/workflows/announce-linked-pr.yml
+++ b/.github/workflows/announce-linked-pr.yml
@@ -39,7 +39,11 @@ permissions:
 
 concurrency:
   # Two `edited` events in quick succession would otherwise both find no marker and both comment.
-  group: announce-linked-pr-${{ github.event.pull_request.number || 'manual' }}
+  # **One group for every run, not one per pull request.** A manual backfill and an `edited` event
+  # for the same PR would otherwise sit in different groups, run together, both find no marker and
+  # both comment — the duplicate the marker exists to prevent. Serialising event runs against each
+  # other is the price, and it is small: each run is short, and nothing is cancelled.
+  group: announce-linked-pr
   cancel-in-progress: false
 
 jobs:
@@ -153,7 +157,11 @@ jobs:
           if [ -n "${PR:-}" ]; then
             targets=$PR
           else
-            targets=$(gh pr list --state open --limit 200 --json number --jq '.[].number')
+            # **`--repo` is not optional here.** Nothing is checked out, so `gh` has no git remote to
+            # infer the repository from and the command fails outright. Every other call in this job
+            # names the repository in its path, which is why this one stood out only once it was
+            # written — and a local dry run cannot catch it, because a local run has a checkout.
+            targets=$(gh pr list --repo "$REPO" --state open --limit 200 --json number --jq '.[].number')
             if [ -z "$targets" ]; then
               echo "no open pull requests — nothing to announce."
               exit 0


### PR DESCRIPTION
## Summary

Two contributor collisions today, both from the same gap: an issue with an open PR against it said so only as a linked-PR row in the sidebar, and the good-first-issue lists that surface the work show a title and nothing else.

- #713 / #721 on #352 — 22 hours apart.
- #630 / #743 on #481 — **13 days** apart.

This posts the sentence neither issue had. It fires on **every** link rather than on a collision, because the reader it exists for has not arrived yet — the value is in the comment already being there when the next person opens the issue.

### Why not labels, and why not claim comments

Removing `good first issue` when a PR opens means putting it back when one is abandoned — a second piece of state to get wrong, on a repository that is listed in directories which crawl those labels. A comment only has to be right once.

Claim comments ("I'll take this") are already ruled out by CONTRIBUTING, with a reason: *"a comment reserving one does not hold it, so no issue sits blocked behind an intent that never lands."* This posts a **fact** — a PR exists — not an intent, so it does not reopen that decision.

### Four decisions with their reasons

- **`pull_request_target`, with no checkout.** Every contributor PR here is from a fork, and a fork's `pull_request` token is read-only — it cannot comment, which is the entire job. `pull_request_target` carries this repository's permissions, which is safe only while no PR code is fetched or run. Nothing is checked out.
- **`closingIssuesReferences`, not a regex over the body.** GitHub already resolves the keywords across cases and repositories; a second parser would drift from the sidebar invisibly.
- **"links this issue", not "is open".** GitHub renders a bare `#123` with the PR's current state, so the sentence stays true after a merge or close. "Is open" would need a second workflow to come back and correct it.
- **A marker comment for idempotency.** `edited` fires on a title change and `reopened` fires on a PR already announced.

### Dry-run against live data, before shipping

| input | expected | got |
|---|---|---|
| PR #630 | 481 | `481` |
| PR #743 | 481 | `481` |
| PR #739 (closes nothing) | empty | empty |
| PR #999999 (absent) | **non-zero exit** | exit 1 |

The last row is the one worth having: a query that fails and prints nothing is indistinguishable from "this PR closes no issues", which is the failure shape [contributing/test-and-guard-coverage.md](https://github.com/jo-duchan/tapflow/blob/main/contributing/test-and-guard-coverage.md) documents and the one `/release`'s dist-tag sweep was rewritten to avoid.

### Not verified

**It has never run.** A `pull_request_target` workflow only takes effect once it is on the default branch, so the first real firing is the next PR opened after this merges. The pieces were exercised individually; the assembly was not.

## Checklist

- [x] Tests written and passing — n/a; dry-run results above
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/ci__announce-linked-pr.md`

<!-- no-changeset: CI only, nothing published changes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rcctur5HNxnb59EwhyeiTY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual backfill support for announcing linked issues across all open pull requests.
  * Announcements can now process multiple pull requests while maintaining per-pull-request tracking.
  * Preserves automated announcements when pull requests are opened, reopened, or edited.
  * Prevents duplicate announcements and reports notification totals by repository.
  * Skips linked issues from other repositories and logs those exclusions.
* **Bug Fixes**
  * Improved validation for missing or incomplete pull request and linked-issue data.
  * Prevents duplicate announcements when comment retrieval or marker matching encounters an API failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->