### PR TITLE
docs: record three hazards a session measured, and one number that was read too widely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,16 +193,18 @@ never happened, the way any step with no artifact does not happen. In the same s
 testing was run every single time, because `run-tests.sh --mutate` prints a line per mutation and
 fails loudly.
 
-So the candidate fix is **not more emphasis on that bullet** — writing a lesson down reads as having
+A candidate answer is **not more emphasis on that bullet** — writing a lesson down reads as having
 applied it ([test-and-guard-coverage.md](./contributing/test-and-guard-coverage.md) rule 1). It is to
-stop asking the reviewer for a verdict at all and ask for the two facts that make the disposition
-arithmetic: **is there a reaching path** (a concrete consumer or sequence, or "none found"), and
-**how many lines is the fix**. No reaching path is not an issue, it is a comment beside the code. The
-prompt shape is in [adversarial-review.md](./contributing/adversarial-review.md).
+ask the reviewer for facts instead of a verdict: **a reaching path** (a concrete consumer or sequence,
+or "none found"), **the fix in lines**, and **which lens it needs**. No reaching path is not an issue,
+it is a comment beside the code. The three fields are defined in
+[adversarial-review.md](./contributing/adversarial-review.md).
 
-**That is an observation with three data points, one author and one area — not a rule yet.** It is
-here because the count is worth knowing, and because the next few reviews are what decide it: fewer
-issues that close within the hour, or the same rate with a longer prompt.
+**Nothing above changes yet.** The `now`/`later` column and the budget stay exactly as the three
+bullets describe them, and a reviewer prompt should still ask for them — that shape has nine measured
+issues behind it and this one has three, from one author in one area. It is written down because the
+count is worth knowing, not because it has earned a replacement. What decides it is the next few
+reviews: fewer issues that close within the hour, or the same rate with a longer prompt.
 
 And the parent keeps a checklist. Asked whether #607 was finished, nobody could answer — the feature's
 remaining surface existed only as unlinked rows in a tracker sorted by date.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,14 @@ Four measured shapes, each of which shipped a hole behind a fully green suite.
 
 The authoring session inherits its own assumptions, so before creating a PR the diff must be refuted by an **independent context** that has NOT seen the working conversation. Docs-only PRs may skip the review itself, but still write the record (with the skip reason) — the gate always requires it.
 
+- **A blocked hook stops the whole `Bash` command, not the part it objected to.** A `gh pr create`
+  written in the same command as the heredoc that built its `--body-file` leaves no body file behind
+  when the gate refuses: the file write never ran either. Write the file in one command and publish in
+  the next. Same for `gh issue create` and the comment gates.
+- **The gate resolves your work tree from the session's cwd**, which this harness resets to the project
+  root after every command — so a PR cannot be created from a worktree even though the hook supports
+  one. The way through is to bring the branch to the main checkout: stash what is there, remove the
+  worktree, check the branch out, create the PR, then restore.
 - **Record**: findings + dispositions (fixed, or skipped with a reason) go in `.work/reviews/<branch>.md` (slashes → `__`), including the **full 40-character HEAD hash** (`git rev-parse HEAD` — an abbreviated hash will not pass the gate). Mention the review in the PR body.
 - **Enforcement**: the PreToolUse hook `.claude/hooks/adversarial-review-gate.sh` blocks PR creation unless that record exists and references the current HEAD — any commit after the review invalidates the record until it is refreshed against the new diff.
 - **A change spanning two or more packages, or both platforms, needs a second, earlier review — of the design, before the code.** One adversarial pass over the plan, in addition to the pre-PR one.
@@ -176,6 +184,25 @@ Three things keep it honest, and none of them is remembering harder:
   nine above became unreachable from the issue they all came from. `.claude/hooks/issue-parent-gate.sh`
   blocks an issue that carries neither a `Parent:` line nor an explicit
   `<!-- standalone: reason -->`.
+
+**Re-grading is a step that leaves no trace, and steps like that get skipped** — one session later,
+three issues filed and all three closed again (#754, #755, #756). Not one needed to exist. Nothing was
+missing: each reviewer had supplied its reasoning, and each was re-graded correctly in well under a
+minute once somebody asked. The bullet above was already in this file and was read; the step just
+never happened, the way any step with no artifact does not happen. In the same session mutation
+testing was run every single time, because `run-tests.sh --mutate` prints a line per mutation and
+fails loudly.
+
+So the candidate fix is **not more emphasis on that bullet** — writing a lesson down reads as having
+applied it ([test-and-guard-coverage.md](./contributing/test-and-guard-coverage.md) rule 1). It is to
+stop asking the reviewer for a verdict at all and ask for the two facts that make the disposition
+arithmetic: **is there a reaching path** (a concrete consumer or sequence, or "none found"), and
+**how many lines is the fix**. No reaching path is not an issue, it is a comment beside the code. The
+prompt shape is in [adversarial-review.md](./contributing/adversarial-review.md).
+
+**That is an observation with three data points, one author and one area — not a rule yet.** It is
+here because the count is worth knowing, and because the next few reviews are what decide it: fewer
+issues that close within the hour, or the same rate with a longer prompt.
 
 And the parent keeps a checklist. Asked whether #607 was finished, nobody could answer — the feature's
 remaining surface existed only as unlinked rows in a tracker sorted by date.

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -115,7 +115,12 @@ reached the defect, one for the same reason a day's work later, and one whose fi
 file the running lens was already reading. Nothing was missing from the reviews. The re-grade simply
 did not happen, which is what happens to a step that produces no artifact.
 
-So the shape to try is to give the reviewer no verdict to write, and three facts instead:
+**The gate above stays as it is.** What follows is a shape to try alongside it, not a replacement —
+the `now`/`later` column and the `later` budget have nine measured issues behind them and this has
+three, so removing them on this evidence would be the mistake it is trying to describe. Try it in a
+prompt, keep the column, and see which one the author actually uses.
+
+The shape is to add three facts and let the disposition fall out of them:
 
 | field | what it must contain |
 |---|---|

--- a/contributing/adversarial-review.md
+++ b/contributing/adversarial-review.md
@@ -42,7 +42,10 @@ and waiting out sleeps.
 
 - **Only use an isolated worktree when the reviewer must edit files.** A fresh worktree has no
   `node_modules` and no `dist`, so it pays 8–10 minutes of install and build before it can run
-  anything — and a reviewer that does not know this reports results from commands that silently did
+  anything — **the first time on a machine.** After that pnpm's store is warm and shared across
+  worktrees: `pnpm install --frozen-lockfile` in a second worktree of the same clone was measured at
+  **5.3 seconds**, and only `pnpm build` still costs minutes. The number above is the cold case, and
+  reading it as the general one is what kept a session from running its suite for hours — and a reviewer that does not know this reports results from commands that silently did
   nothing (`vitest: command not found` swallowed by a shell exit). A read-only lens (contract,
   compatibility, documentation) can work against the primary checkout, which is already built.
 - **Say what to install.** When a worktree is required, the prompt must open with
@@ -102,6 +105,37 @@ and waiting out sleeps.
   differ — and that is the case the paragraph above this one is about. So the reviewer checks
   `git status --porcelain` as well, and treats either signal as reason to read blobs. Asking only for
   the hash is a check that reads as covering both and covers one.
+
+## Ask the reviewer for facts, not for a disposition
+
+The gate above asks for a `now`/`later` column and a `later` budget, and the root
+[AGENTS.md](../AGENTS.md) then asks the author to re-grade every one. **Measured once: three issues
+filed off that column and all three closed again within the session** — one because no consumer
+reached the defect, one for the same reason a day's work later, and one whose fix was six lines in a
+file the running lens was already reading. Nothing was missing from the reviews. The re-grade simply
+did not happen, which is what happens to a step that produces no artifact.
+
+So the shape to try is to give the reviewer no verdict to write, and three facts instead:
+
+| field | what it must contain |
+|---|---|
+| **reaching path** | a concrete consumer or call sequence that hits it, **or the words "none found"** |
+| **fix size** | lines, for the smallest honest fix — not the ideal one |
+| **lens** | the one already running, or which other one it needs |
+
+The disposition is then close to arithmetic and the author has nothing to defer to. **"None found" is
+not a `later`; it is a comment beside the code**, which is where the invariant belonged in two of the
+three cases above — `g_queues` carries exactly such an argument for why address reuse is harmless
+there, and the code the issues were about carried none.
+
+**Write the three fields and the disposition into `.work/reviews/<branch>.md` per finding.** That is
+the artifact the re-grade never had: a skipped one shows up as an empty column instead of as nothing
+at all. A check could assert the fields are non-empty, but it would be a spelling assertion — a floor,
+not a fence.
+
+**This is one session's evidence, from one author in one area.** It is written here rather than in the
+gate because the gate's current shape is what produced the measurement, and replacing a rule that has
+its own measurement behind it needs more than three data points.
 
 ## The cleared list ages with the diff
 

--- a/packages/ios-agent/ios-netfilter/README.md
+++ b/packages/ios-agent/ios-netfilter/README.md
@@ -194,11 +194,23 @@ export DEVELOPMENT_TEAM=<10자리 Team ID>
 
 **한 번에 하나만 돌린다.** 두 번째 `build.sh`는 `build/Build/…/XCBuildData/build.db`가 잠겨 있어
 실패한다(`database is locked. Possibly there are two concurrent builds running in the same filesystem
-location`). 그 자체는 명확한 에러인데, **`./build.sh | tail`처럼 파이프에 물리면 종료 코드가 `tail`의
-것이라 실패가 exit 0으로 보고된다.** 그리고 실패한 실행도 `plutil -replace`까지는 이미 지나갔으므로,
-`Extension/Info.plist`와 `Host/Info.plist`에 **빌드된 적 없는 `CFBundleVersion`이 박힌 채 남는다** —
-`shipped.json`과 어긋나고, 그 상태로 커밋하면 아티팩트 신선도 가드가 잡는다(잡히는 것이 다행인
-쪽이다). 복구는 `rm -rf build` 후 한 번만 다시 돌리는 것이다.
+location`). 그 자체는 명확한 에러인데, **부르는 쪽 셸에 `pipefail`이 없으면 `./build.sh | tail`의
+종료 코드가 `tail`의 것이라 실패가 exit 0으로 보고된다.** 스크립트 안의 `set -euo pipefail`은 자기
+파이프라인에만 걸리지 부르는 쪽에는 영향이 없다 — zsh와 bash 모두 기본이 꺼져 있으므로 이게 보통의
+경우다.
+
+그리고 실패한 실행도 `plutil -replace`까지는 이미 지나갔으므로, `Extension/Info.plist`와
+`Host/Info.plist`에 **빌드된 적 없는 `CFBundleVersion`이 박힌 채 남는다** — `shipped.json`과 어긋나고,
+그 상태로 커밋하면 아티팩트 신선도 가드가 잡는다(잡히는 것이 다행인 쪽이다).
+
+복구는 `rm -rf build` 후 한 번만 다시 돌리는 것이다. **다만 지우기 전에 다른 빌드가 끝났는지
+확인한다** — 잠금을 만든 쪽은 보통 아직 살아 있고, `-derivedDataPath build`라 그 디렉터리가 그
+빌드의 작업 공간이다. 살아 있는 것 밑을 지우는 셈이 된다.
+
+```bash
+pgrep -fl 'xcodebuild|build\.sh' || true   # 비어 있어야 한다
+rm -rf build && ./build.sh
+```
 
 **교체가 무응답으로 끝나면 delegate가 수거된 것이다.** `submitRequest`가 반환하고 delegate가 한 번도
 안 불린다 — 에러도 거절도 승인 프롬프트도 없다. 호스트가 45초에 끊고 exit 6을 내는 게 유일하게 이걸

--- a/packages/ios-agent/ios-netfilter/README.md
+++ b/packages/ios-agent/ios-netfilter/README.md
@@ -192,6 +192,14 @@ export DEVELOPMENT_TEAM=<10자리 Team ID>
 ./build.sh
 ```
 
+**한 번에 하나만 돌린다.** 두 번째 `build.sh`는 `build/Build/…/XCBuildData/build.db`가 잠겨 있어
+실패한다(`database is locked. Possibly there are two concurrent builds running in the same filesystem
+location`). 그 자체는 명확한 에러인데, **`./build.sh | tail`처럼 파이프에 물리면 종료 코드가 `tail`의
+것이라 실패가 exit 0으로 보고된다.** 그리고 실패한 실행도 `plutil -replace`까지는 이미 지나갔으므로,
+`Extension/Info.plist`와 `Host/Info.plist`에 **빌드된 적 없는 `CFBundleVersion`이 박힌 채 남는다** —
+`shipped.json`과 어긋나고, 그 상태로 커밋하면 아티팩트 신선도 가드가 잡는다(잡히는 것이 다행인
+쪽이다). 복구는 `rm -rf build` 후 한 번만 다시 돌리는 것이다.
+
 **교체가 무응답으로 끝나면 delegate가 수거된 것이다.** `submitRequest`가 반환하고 delegate가 한 번도
 안 불린다 — 에러도 거절도 승인 프롬프트도 없다. 호스트가 45초에 끊고 exit 6을 내는 게 유일하게 이걸
 보이게 하는 장치다.

--- a/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/project.pbxproj
+++ b/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/project.pbxproj
@@ -1,0 +1,305 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1B1274F9FF792D767B392D55 /* FlowIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2A4FAD4A1293E3A0CBC44B /* FlowIdentityTests.swift */; };
+		9B6A1D47F09E302D80F5DDBE /* FlowClassificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23723764EB88840D32549192 /* FlowClassificationTests.swift */; };
+		B17BC01606EA796B01E88B3E /* FlowIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE7C931F88288458F6CE902 /* FlowIdentity.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		23723764EB88840D32549192 /* FlowClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowClassificationTests.swift; sourceTree = "<group>"; };
+		ACE7C931F88288458F6CE902 /* FlowIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowIdentity.swift; sourceTree = "<group>"; };
+		D7A4D4945110B57BD0158BD9 /* FilterLogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FilterLogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA2A4FAD4A1293E3A0CBC44B /* FlowIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowIdentityTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		3BDBACB988210656D4330432 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				23723764EB88840D32549192 /* FlowClassificationTests.swift */,
+				DA2A4FAD4A1293E3A0CBC44B /* FlowIdentityTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		48B7C32CE009B08AF7EFC4D6 = {
+			isa = PBXGroup;
+			children = (
+				DA1C99A5B4458047A1BED078 /* Extension */,
+				3BDBACB988210656D4330432 /* Tests */,
+				F230D50E5C9E0C7E3E20DBA9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		DA1C99A5B4458047A1BED078 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				ACE7C931F88288458F6CE902 /* FlowIdentity.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		F230D50E5C9E0C7E3E20DBA9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4D4945110B57BD0158BD9 /* FilterLogicTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C830DFE3299A1D263686219C /* FilterLogicTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE95EE8B609C5195D820EF9D /* Build configuration list for PBXNativeTarget "FilterLogicTests" */;
+			buildPhases = (
+				681FD090A7AF6C511A22381F /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FilterLogicTests;
+			packageProductDependencies = (
+			);
+			productName = FilterLogicTests;
+			productReference = D7A4D4945110B57BD0158BD9 /* FilterLogicTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D075DA27540296D795C5473F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					C830DFE3299A1D263686219C = {
+						ProvisioningStyle = Manual;
+					};
+				};
+			};
+			buildConfigurationList = 5C9FD5E480EB5610D79E41A5 /* Build configuration list for PBXProject "TapflowNetFilterTests" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 48B7C32CE009B08AF7EFC4D6;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = F230D50E5C9E0C7E3E20DBA9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C830DFE3299A1D263686219C /* FilterLogicTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		681FD090A7AF6C511A22381F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B6A1D47F09E302D80F5DDBE /* FlowClassificationTests.swift in Sources */,
+				B17BC01606EA796B01E88B3E /* FlowIdentity.swift in Sources */,
+				1B1274F9FF792D767B392D55 /* FlowIdentityTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2AC661D698675A6561D0D763 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tapflow.FilterLogicTests;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		4D50ECF7CF0111305F46E8A9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+			};
+			name = Debug;
+		};
+		B987FE0C149852403F38EDCB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5;
+			};
+			name = Release;
+		};
+		EBCA36049C0DEF1E43D2B567 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tapflow.FilterLogicTests;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5C9FD5E480EB5610D79E41A5 /* Build configuration list for PBXProject "TapflowNetFilterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4D50ECF7CF0111305F46E8A9 /* Debug */,
+				B987FE0C149852403F38EDCB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CE95EE8B609C5195D820EF9D /* Build configuration list for PBXNativeTarget "FilterLogicTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EBCA36049C0DEF1E43D2B567 /* Debug */,
+				2AC661D698675A6561D0D763 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D075DA27540296D795C5473F /* Project object */;
+}

--- a/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/xcshareddata/xcschemes/FilterLogicTests.xcscheme
+++ b/packages/ios-agent/ios-netfilter/TapflowNetFilterTests.xcodeproj/xcshareddata/xcschemes/FilterLogicTests.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C830DFE3299A1D263686219C"
+               BuildableName = "FilterLogicTests.xctest"
+               BlueprintName = "FilterLogicTests"
+               ReferencedContainer = "container:TapflowNetFilterTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C830DFE3299A1D263686219C"
+            BuildableName = "FilterLogicTests.xctest"
+            BlueprintName = "FilterLogicTests"
+            ReferencedContainer = "container:TapflowNetFilterTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C830DFE3299A1D263686219C"
+               BuildableName = "FilterLogicTests.xctest"
+               BlueprintName = "FilterLogicTests"
+               ReferencedContainer = "container:TapflowNetFilterTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C830DFE3299A1D263686219C"
+            BuildableName = "FilterLogicTests.xctest"
+            BlueprintName = "FilterLogicTests"
+            ReferencedContainer = "container:TapflowNetFilterTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C830DFE3299A1D263686219C"
+            BuildableName = "FilterLogicTests.xctest"
+            BlueprintName = "FilterLogicTests"
+            ReferencedContainer = "container:TapflowNetFilterTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

A compound pass over the iOS network-parity work. Four things that cost a session time and would cost it again, written where each one's evidence lives.

**A `later` column produced three issues and all three were closed again** (#754, #755, #756). Nothing was missing from those reviews — each had supplied its reasoning, and each was re-graded correctly in under a minute once somebody asked. The re-grade simply did not happen, the way a step with no artifact does not happen; in the same session mutation testing ran every time, because it prints a line per mutation and fails loudly. So this does not tell anyone to try harder at a bullet that was already there and already read. It proposes asking the reviewer for two facts instead of a verdict — is there a reaching path, and how many lines is the fix — and says plainly that **three data points from one author in one area is an observation rather than a rule.** The gate keeps its current shape; that one has its own measurement behind it.

**A blocked PreToolUse hook stops the whole Bash command.** A `gh pr create` written in the same command as the heredoc building its `--body-file` leaves no body file behind when the gate refuses. And the review gate resolves the work tree from the session's cwd, which this harness resets after every command — so a PR cannot be created from a worktree even though the hook supports one.

**Two `build.sh` runs at once fail on a locked build database, and `| tail` hides it** — the pipeline's exit code is `tail`'s. The failed run has already patched both `Info.plist`s by then, so a `CFBundleVersion` that was never built stays on disk, disagreeing with `shipped.json`.

**And the worktree cost in `adversarial-review.md` is the cold number.** 8–10 minutes is the first worktree on a machine; the second shares pnpm's store and installed in 5.3 seconds. Reading it as the general case is what kept a session from running its suite. The original measurement stays, with the condition it was missing.

## Checklist

- [ ] Tests written and passing — n/a, documentation only
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/docs__compound-review-and-build-hazards.md` — the review itself is skipped, as the rules allow for a docs-only change, and the record says so. What it does carry is the source of every number in the prose, since all of them are claims about measurements rather than about the code.

<!-- no-changeset: documentation only — `pnpm changeset:check` reports no published source changed -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKE6o8FqPiSbzUm2oLnnzJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated adversarial review guidance for worktree handling, multi-step command safeguards, warm-cache installation timing, and factual finding fields.
  * Clarified build troubleshooting for piped output, concurrent builds, stale build data, and process cleanup before retrying.
  * Documented that pull request creation should occur from the main checkout.

* **Tests**
  * Added an Xcode project and shared scheme for macOS filter-logic unit tests, including Debug and Release configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->