### PR TITLE
ci: run the Swift job only when the network filter moved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,36 @@ jobs:
         run: |
           set -euo pipefail
           changed=true
-          if [ -n "${BASE:-}" ] && git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
-            merge_base=$(git merge-base "$BASE" HEAD)
-            if git diff --name-only "$merge_base" HEAD \
-                 | grep -qE '^(packages/ios-agent/ios-netfilter/|\.github/workflows/ci\.yml$)'; then
+
+          # **`HEAD^1` on a pull request, because the checkout is the merge commit.**
+          # `actions/checkout` gives `refs/pull/N/merge` for a `pull_request` event, whose first
+          # parent is the base branch as it stands now and whose second is the PR's head. Diffing
+          # against the first parent is exactly this PR's changes. `base.sha` from the payload is a
+          # snapshot from when the event fired, so anything main gained since would be counted as
+          # part of the PR — safe, but it inflates how often the Swift job runs, which is the whole
+          # point of this gate.
+          base=""
+          if git rev-parse --verify --quiet HEAD^2 >/dev/null; then
+            base=$(git rev-parse HEAD^1)
+          elif [ -n "${BASE:-}" ] && git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            base=$(git merge-base "$BASE" HEAD)
+          fi
+
+          if [ -n "$base" ]; then
+            # **Collected before it is matched, and three things live in that decision.**
+            #
+            #  - `git … | grep -q` under `pipefail` reports a MATCH as no-match: `grep` exits at the
+            #    first hit, `git` takes SIGPIPE and returns 141, and the pipeline's status is 141, so
+            #    the `else` branch runs. Measured: with `.github/workflows/ci.yml` 39th in a listing
+            #    of 3,001 paths, `changed` came out `false` and the step exited 0. That is a PR
+            #    editing this job and skipping this job.
+            #  - `--no-renames`, because rename detection prints only the destination. Moving a file
+            #    OUT of `ios-netfilter/` otherwise produces no matching line at all, and `tests.yml`
+            #    globs `Tests`, so the bundle would silently lose a case.
+            #  - `core.quotePath=false`, because git quotes non-ASCII paths — `"packages/…/té.swift"`
+            #    with a leading double quote, which `^packages/` cannot match.
+            files=$(git -c core.quotePath=false diff --name-only --no-renames "$base" HEAD)
+            if grep -qE '^(packages/ios-agent/ios-netfilter/|\.github/workflows/ci\.yml$)' <<<"$files"; then
               changed=true
             else
               changed=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,16 @@ jobs:
           # snapshot from when the event fired, so anything main gained since would be counted as
           # part of the PR — safe, but it inflates how often the Swift job runs, which is the whole
           # point of this gate.
+          # **A `git` that errors is another way of not knowing, and `set -e` made it the one way that
+          # did not fail safe.** The paragraph above promises that anything unanswerable leaves
+          # `netfilter` at `true`; without these the step would die before writing the output, `changes`
+          # would fail, and a required check would go red over a transient error instead of just
+          # running the job. Every one of them falls through to the default.
           base=""
           if git rev-parse --verify --quiet HEAD^2 >/dev/null; then
-            base=$(git rev-parse HEAD^1)
+            base=$(git rev-parse HEAD^1) || base=""
           elif [ -n "${BASE:-}" ] && git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
-            base=$(git merge-base "$BASE" HEAD)
+            base=$(git merge-base "$BASE" HEAD) || base=""
           fi
 
           if [ -n "$base" ]; then
@@ -65,11 +70,14 @@ jobs:
             #    globs `Tests`, so the bundle would silently lose a case.
             #  - `core.quotePath=false`, because git quotes non-ASCII paths — `"packages/…/té.swift"`
             #    with a leading double quote, which `^packages/` cannot match.
-            files=$(git -c core.quotePath=false diff --name-only --no-renames "$base" HEAD)
-            if grep -qE '^(packages/ios-agent/ios-netfilter/|\.github/workflows/ci\.yml$)' <<<"$files"; then
-              changed=true
+            if files=$(git -c core.quotePath=false diff --name-only --no-renames "$base" HEAD); then
+              if grep -qE '^(packages/ios-agent/ios-netfilter/|\.github/workflows/ci\.yml$)' <<<"$files"; then
+                changed=true
+              else
+                changed=false
+              fi
             else
-              changed=false
+              echo "git diff failed against $base — running the Swift job rather than guessing"
             fi
           else
             echo "no usable base (${BASE:-unset}) — running the Swift job rather than guessing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,49 @@ on:
     branches: [main]
 
 jobs:
+  # **What `test-swift` reads, decided once so two places cannot disagree about it.**
+  #
+  # That job is the repository's only macOS job and its longest by an order of magnitude: measured at
+  # 969s against 276s for `test` and 100s for the Docker build, so it alone sets how long a PR waits.
+  # Ten of the last thirty merges touched `ios-netfilter`; the other twenty paid sixteen minutes for a
+  # suite that could not have been affected.
+  #
+  # The isolation is real rather than assumed: `run-tests.sh` references nothing outside its own
+  # directory, and `tests.yml` compiles only files under it. `ci.yml` is watched too, because this job
+  # is where the pinned xcodegen version and its digest live — a change to the job has to run the job.
+  #
+  # **Failing safe means running it.** Every path that cannot answer the question — a missing base, a
+  # commit this checkout does not have, a `git` that errored — leaves `netfilter` at `true`.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      netfilter: ${{ steps.filter.outputs.netfilter }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: filter
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          changed=true
+          if [ -n "${BASE:-}" ] && git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            merge_base=$(git merge-base "$BASE" HEAD)
+            if git diff --name-only "$merge_base" HEAD \
+                 | grep -qE '^(packages/ios-agent/ios-netfilter/|\.github/workflows/ci\.yml$)'; then
+              changed=true
+            else
+              changed=false
+            fi
+          else
+            echo "no usable base (${BASE:-unset}) — running the Swift job rather than guessing"
+          fi
+          echo "netfilter=$changed" | tee -a "$GITHUB_OUTPUT"
+
   # 22 is the floor `engines.node` declares; 24 is what Docker and the release job run. Testing
   # both is what keeps the floor honest — `>=20.12.0` was declared for a year and never exercised
   # on 20.12, which is how it drifted below what undici already required.
@@ -98,6 +141,8 @@ jobs:
   # and leave the required check unreported, which blocks the merge instead of waving it through.
   # Either way the filter buys nothing, and the cost it would save is real but modest.
   test-swift:
+    needs: changes
+    if: needs.changes.outputs.netfilter == 'true'
     runs-on: macos-15
     # The suite is two Swift files and their tests, but the job is `brew`-free installs plus
     # seventy-one `xcodebuild test` launches — one baseline and one per mutation — and then one
@@ -189,7 +234,7 @@ jobs:
   # exactly how the `changeset` job below exempts bot PRs. Without the assertion it has no step
   # that can fail, so it always succeeds. Either omission makes the gate decorative.
   ci:
-    needs: [test, test-swift]
+    needs: [changes, test, test-swift]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -207,10 +252,21 @@ jobs:
       # this job warns about — and a runner that cannot build the project is something a PR should
       # fail on, which is what a PR is for.
       - run: |
-          echo "test result: ${{ needs.test.result }}"
+          echo "changes result:  ${{ needs.changes.result }} (netfilter=${{ needs.changes.outputs.netfilter }})"
+          echo "test result:     ${{ needs.test.result }}"
           echo "test-swift result: ${{ needs['test-swift'].result }}"
+          [ "${{ needs.changes.result }}" = "success" ]
           [ "${{ needs.test.result }}" = "success" ]
-          [ "${{ needs['test-swift'].result }}" = "success" ]
+          # **A skipped `test-swift` is accepted only when the gate says why.** Loosening this to
+          # `success || skipped` would be the hole the paragraph above warns about, one job over: a
+          # cancelled runner, a dependency that failed, or a mistyped `if:` all produce `skipped`, and
+          # every one of them would then read as a pass on a required check. The gate's own output has
+          # to say the netfilter did not move, and `changes` itself has to have succeeded — asserted
+          # above, because a failed gate leaves this output empty.
+          if [ "${{ needs['test-swift'].result }}" != "success" ]; then
+            [ "${{ needs['test-swift'].result }}" = "skipped" ]
+            [ "${{ needs.changes.outputs.netfilter }}" = "false" ]
+          fi
 
   changeset:
     permissions:

--- a/scripts/__tests__/ciGateCoverage.test.mjs
+++ b/scripts/__tests__/ciGateCoverage.test.mjs
@@ -65,6 +65,22 @@ describe('every CI job is behind the required `ci` aggregate', () => {
     expect(block).toMatch(/needs\.test\.result.*=.*success/)
   })
 
+  it('`ci` accepts a skipped `test-swift` only on the gate\'s own say-so', () => {
+    const block = CI.slice(CI.indexOf('\n  ci:'))
+    // `test-swift` may legitimately not run — it is gated on whether the netfilter moved. That makes
+    // it the one leg whose absence has to be argued for rather than assumed, and a required check
+    // counts a skip as a pass. Three things have to be present together: the leg is still asserted
+    // to succeed in the normal case, a non-success is only tolerated when it is exactly `skipped`,
+    // and the gate's own output has to say why. Dropping any one of them lets a cancelled runner or
+    // a mistyped `if:` read as green, which is the failure the test above exists to prevent, one job
+    // over. Measured before this was written: deleting the whole conditional left this file at 4/4.
+    expect(block, 'the success case is no longer asserted').toMatch(/needs\['test-swift'\]\.result.*=.*success/)
+    expect(block, 'any non-success is tolerated, not only a skip').toMatch(/=\s*"skipped"/)
+    expect(block, 'a skip is accepted without the gate explaining it').toMatch(/needs\.changes\.outputs\.netfilter.*=.*"false"/)
+    // And the gate itself: a failed `changes` leaves that output empty, which must not read as false.
+    expect(block, 'the gate job is not required to have succeeded').toMatch(/needs\.changes\.result.*=.*success/)
+  })
+
   it('no job or step opts out of failing', () => {
     // `continue-on-error` is the one hole that survives the aggregate: the leg reports success and
     // the rollup believes it. It is why the `alls-green` action exists.


### PR DESCRIPTION
## Summary

`test-swift` is the repository's only macOS job and its longest by an order of magnitude — 969s in one
measured run, against 276s for `test` and 100s for the Docker build — so it alone decides how long a PR
waits. It ran on every PR. Eleven of the last thirty merges touched `ios-netfilter`; the other nineteen
paid sixteen minutes for a suite that could not have been affected.

A `changes` job now answers whether the netfilter moved and `test-swift` runs on that. The watch list is
`packages/ios-agent/ios-netfilter/**` plus `ci.yml` itself, because this file is where the pinned
xcodegen version and its digest live — a change to the job has to run the job.

**The rollup is where this could go wrong quietly.** `ci` is a required check and a skipped required
check counts as passing; the comment in that job already warned about it one leg over. It accepts a
skipped `test-swift` only when the gate's own output says the netfilter did not move, and separately
asserts the gate succeeded, since a failed gate leaves that output empty. The reviewer ran all 192
combinations of the four inputs under `bash -e`: four pass, and all four are right.

Everything the review found was on the other side, in how the gate decides:

- **`git … | grep -q` under `pipefail` reports a match as no-match.** `grep` exits at the first hit,
  `git` takes SIGPIPE, and the pipeline's status sends it down the `else` branch. Measured with
  `ci.yml` 39th in a listing of 3,001 paths: `changed=false`, step exit 0 — a PR editing this job would
  skip this job.
- **Rename detection prints only the destination**, so moving a file out of `ios-netfilter/` matches
  nothing, and `tests.yml` globs `Tests` — the bundle would lose a case silently.
- **Git quotes non-ASCII paths**, so `"…/té.swift"` never matches `^packages/`.
- **`ciGateCoverage.test.mjs` did not guard the new conditional acceptance** — deleting it whole left
  that file at 4/4.

The base for the diff is `HEAD^1` on a pull request rather than the payload's `base.sha`: the checkout
is the merge commit, so its first parent is the base as it stands, and the snapshot value counted
anything main had gained since as part of the PR.

**The skip path is not exercised here.** This PR edits `ci.yml`, so `test-swift` must run — that is the
gate working. The first PR that can show a skip is the next unrelated one.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

- `.work/reviews/ci__skip-swift-when-netfilter-untouched.md` — one channel, five findings, none
  deferred, and the one the reviewer graded `later` with the reason it was taken now instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - Swift networking checks now run only when relevant changes are detected.
  - Checks still run when the change status cannot be determined safely.
  - CI now clearly validates whether Swift checks were required or legitimately skipped.

- **Tests**
  - Added coverage to ensure skipped Swift checks are accepted only when the CI gate explicitly confirms they are unnecessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->