### PR TITLE
test(ios-agent): hold what the capture block's tests claim

### DIFF
--- a/packages/ios-agent/src/__tests__/MjpegStreamer.perf.test.ts
+++ b/packages/ios-agent/src/__tests__/MjpegStreamer.perf.test.ts
@@ -31,7 +31,6 @@ describe('MjpegStreamer — 성능', () => {
     // 캡처 1회에 500ms가 걸리는 상황
     const CAPTURE_DELAY = 500
     const INTERVAL_MS = 100
-    const DURATION_MS = 2000
 
     let resolveCapture!: () => void
     const slowScreenshot = vi.fn(() =>
@@ -54,8 +53,10 @@ describe('MjpegStreamer — 성능', () => {
     resolveCapture()
     await vi.advanceTimersByTimeAsync(CAPTURE_DELAY + INTERVAL_MS)
 
-    // 총 호출 수는 2 이하 (무제한 병렬 호출이 발생하지 않았음)
-    expect(slowScreenshot.mock.calls.length).toBeLessThanOrEqual(2)
+    // Exactly two: the guard let the second capture start, and let only one start. An upper bound
+    // alone is green when the streamer never resumes at all — measured: dropping `capturing = false`
+    // wedges it after one frame and `toBeLessThanOrEqual(2)` passes on the single call.
+    expect(slowScreenshot).toHaveBeenCalledTimes(2)
   })
 
   it('10초 시뮬레이션에서 cancel 후 추가 호출 없음', async () => {

--- a/packages/ios-agent/src/__tests__/MjpegStreamer.test.ts
+++ b/packages/ios-agent/src/__tests__/MjpegStreamer.test.ts
@@ -71,13 +71,20 @@ describe('MjpegStreamer', () => {
     // left all eight tests across this file and the perf one green. A reader waiting on a stream
     // nobody errors waits forever, and a screenshot rejecting mid-stream is what a simulator being
     // shut down under a live session looks like.
+    //
+    // Asserted on identity, not on the message: `SimctlWrapper.screenshot` does not wrap what it
+    // catches, so what arrives here carries `code`/`errno`/`path` from `fs.readFile` or the exit
+    // status from `exec` — the fields a consumer branches on. Re-erroring with
+    // `new Error(String(err))` keeps the message and drops all of it, and passes a message
+    // assertion.
     vi.useFakeTimers()
-    const screenshot = vi.fn().mockRejectedValue(new Error('simulator went away'))
+    const boom = new Error('simulator went away')
+    const screenshot = vi.fn().mockRejectedValue(boom)
     const streamer = new MjpegStreamer({ screenshot }, 'dev-1', 100)
 
     const reader = streamer.start().getReader()
 
-    await expect(reader.read()).rejects.toThrow('simulator went away')
+    await expect(reader.read()).rejects.toBe(boom)
   })
 
   it('skips a capture if the previous one is still in progress', async () => {

--- a/packages/ios-agent/src/__tests__/MjpegStreamer.test.ts
+++ b/packages/ios-agent/src/__tests__/MjpegStreamer.test.ts
@@ -66,6 +66,20 @@ describe('MjpegStreamer', () => {
     expect(simctl.screenshot).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces a capture failure to the reader instead of stalling it', async () => {
+    // The `catch` arm of the capture had no test: replacing `controller.error(err)` with `void err`
+    // left all eight tests across this file and the perf one green. A reader waiting on a stream
+    // nobody errors waits forever, and a screenshot rejecting mid-stream is what a simulator being
+    // shut down under a live session looks like.
+    vi.useFakeTimers()
+    const screenshot = vi.fn().mockRejectedValue(new Error('simulator went away'))
+    const streamer = new MjpegStreamer({ screenshot }, 'dev-1', 100)
+
+    const reader = streamer.start().getReader()
+
+    await expect(reader.read()).rejects.toThrow('simulator went away')
+  })
+
   it('skips a capture if the previous one is still in progress', async () => {
     vi.useFakeTimers()
     let resolve!: () => void


### PR DESCRIPTION
## Summary

`MjpegStreamer.start` wraps every capture in one try/catch/finally, and two of those three arms were
covered by assertions that could not fail for their own subject.

**The concurrency-guard test ended on an upper bound where its own comment states a lower one.**
`toBeLessThanOrEqual(2)` is green for a streamer that never resumes, because one call is also `≤ 2`.
That does not mean the wedge went unnoticed — dropping `capturing = false` is caught by the 30fps
test and by `MjpegStreamer.test.ts`'s interval test, and both were already there. What was missing is
that the test *about* resuming did not check it, so a change to that behaviour would be reported by a
throughput test instead.

**The catch arm had no test at all.** Replacing `controller.error(err)` with `void err` left all
eight tests across both files green. A reader waiting on a stream nobody errors waits forever, and a
screenshot rejecting mid-stream is what a simulator shut down under a live session looks like — with
`MjpegStreamer` and `IOSAgent` both public exports, that reader can be a consumer's.

Seven mutations, each killed. One first appeared to survive and had simply not been applied: the
substitution matched the word in a comment above the call rather than the argument. A replacement
mutation is indistinguishable from a surviving one unless you check it landed.

This came out of a lint warning — an unused `DURATION_MS` — that the previous PR deferred as "needing
its own decision". Reading the file showed there was no decision to make.

## Checklist

- [x] Tests written and passing — ios-agent 512 passed / 2 skipped, typecheck and lint clean
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a, no interface changed
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `check-changeset.mjs` exempts `__tests__/` and `*.test.ts`, and reports
*No published source changed*.

## Related `.work/` docs

- `.work/reviews/test__mjpeg-resume-assertion.md` — one channel, three findings, none deferred. It
  also records that the review caught the commit message overstating its own measurement: the claim
  that only the 30fps test caught the wedge was made from the perf file alone, without running the
  sibling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage to verify screenshot failures propagate the original error.
  * Expanded concurrency checks to confirm a second capture is allowed while overlapping captures remain prevented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->