### PR TITLE
docs(contributing): point the test principles at the mutation rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,8 @@ Run the tests for any changed packages before opening a PR. New behavior must be
 
 **Mock only at system boundaries** — real network, OS calls, external processes. Internal module interactions run against real code.
 
+**Name the mutation.** For every test, know the production change that would make it fail. For a test asserting that something does *not* happen, make that change and watch it fail before you commit — an absence assertion passes when nothing happens at all, so a green run on its own is not evidence it holds anything. [test-and-guard-coverage.md](./contributing/test-and-guard-coverage.md) collects the cases where that went wrong, including a guard bypassed four ways with the whole suite green.
+
 ## Technical internals
 
 Platform-specific implementation notes for contributors:


### PR DESCRIPTION
## Summary

`### Test principles` already says a test must be able to fail. What it does not say is the
operational half — make that production change and watch the test go red before committing — and it
never names `contributing/test-and-guard-coverage.md`, so someone writing their first test here
cannot find the rule they are being held to.

The doc was reachable: `INDEX.md` lists it with a description and `AGENTS.md` links it twice. It was
just not reachable from where a contributor writing a test is standing.

Not added to `## Technical internals`, which was the first candidate and the wrong one. That section
introduces itself as platform-specific implementation notes and all five entries are investigation
logs. It is also not an exhaustive list — 24 of the 29 files in `contributing/` are absent from it,
and `INDEX.md` is the full index.

Prompted by #748: a first-time contributor is about to write the first tests for
`SimulatorInfoCard`, and pointing them at this rule in a comment while the docs stay silent would be
a rule that exists only in issue threads.

## Checklist

- [x] Tests written and passing — docs-only; `pnpm test:scripts` 798 passed
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `pnpm changeset:check` reports *No published source changed*.

## Related `.work/` docs

- `.work/reviews/docs__link-test-guard-coverage.md` — adversarial review skipped as docs-only, per
  AGENTS.md; the record says why, and why the section choice changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contributor guidance for identifying the production mutation that would cause each test to fail.
  - Added specific guidance for writing absence assertions.
  - Linked related documentation covering test-and-guard practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->