### PR TITLE
perf(ios-agent): build the netfilter tests with swiftc instead of xcodebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,20 +227,28 @@ jobs:
     # while `xcodebuild` was ~13.5s a launch here — sixteen took 2m35s–3m08s, forty-two 9m27s,
     # eighty-three 17m29s, and 18m03s for the whole job. Building the identical XCTest files with
     # `swiftc` and running them under `xcrun xctest` is **1.9s a cycle**, and the full mutation set
-    # went from 1049s to 222s locally. Dropping mutations was the alternative and it was the wrong
-    # one: nothing about the coverage had to change.
+    # went from 1049s to 222–246s across three local runs. Dropping mutations was the alternative and
+    # it was the wrong one: nothing about the coverage had to change.
     #
     # **The remaining floor is one mutation, and it does not move.** `walk: no bound` removes a bound,
     # so it does not fail an assertion — it spins until `run`'s watchdog kills it at 20s. Everything
     # else got seven times faster and that one did not, which is the shape to expect from any future
-    # bound.
+    # bound; the spread in the range above is `cache: no lock` sometimes landing there too.
     #
-    # Twenty against a run now measured in minutes. **When that stops being enough, the answer is not
-    # to raise it**: the honest options are dropping mutations that no longer aim at a decision, or
-    # running `--mutate` on a narrower trigger than every PR update and leaving the plain suite here.
-    # Bounded at all because the default is 360 minutes and this is the repository's only macOS job —
-    # a hung run would otherwise hold the required check for six hours.
-    timeout-minutes: 20
+    # **Thirty-five stays until a run here measures the new engine.** Every number above is local, on
+    # a 12-core machine, and this job runs on a 3-core one. The old ceiling was set from CI's own
+    # measurements and the paragraph that said so — *extrapolate from the slowest, not the luckiest* —
+    # was deleted in the same commit that lowered this to 20 on local numbers, which is the mistake it
+    # existed to prevent. The old 1.25x CI-to-local ratio does not carry either: it measured a
+    # workload dominated by `xcodebuild`'s fixed launch overhead, and this one is compile-bound, where
+    # core count is the variable. Lower it once a green run says what the number is.
+    #
+    # **When that stops being enough, the answer is not to raise it**: the honest options are dropping
+    # mutations that no longer aim at a decision, or running `--mutate` on a narrower trigger than
+    # every PR update and leaving the plain suite here. Bounded at all because the default is 360
+    # minutes and this is the repository's only macOS job — a hung run would otherwise hold the
+    # required check for six hours.
+    timeout-minutes: 35
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,20 +235,21 @@ jobs:
     # else got seven times faster and that one did not, which is the shape to expect from any future
     # bound; the spread in the range above is `cache: no lock` sometimes landing there too.
     #
-    # **Thirty-five stays until a run here measures the new engine.** Every number above is local, on
-    # a 12-core machine, and this job runs on a 3-core one. The old ceiling was set from CI's own
-    # measurements and the paragraph that said so — *extrapolate from the slowest, not the luckiest* —
-    # was deleted in the same commit that lowered this to 20 on local numbers, which is the mistake it
-    # existed to prevent. The old 1.25x CI-to-local ratio does not carry either: it measured a
-    # workload dominated by `xcodebuild`'s fixed launch overhead, and this one is compile-bound, where
-    # core count is the variable. Lower it once a green run says what the number is.
+    # **Fifteen, and the number came from a run here rather than from a laptop.** The first green run
+    # of the new engine took **5m29s** for the whole job against 18m03s before it, so this is 2.7x —
+    # more headroom than the 1.94x the old ceiling settled for, which is deliberate while there is
+    # only one measurement. A draft of this change set it to 20 from local numbers on a 12-core
+    # machine for a job that runs on a 3-core one, in the same commit that deleted the paragraph
+    # saying *extrapolate from the slowest, not the luckiest*. The old 1.25x CI-to-local ratio would
+    # not have helped either: it measured a workload dominated by `xcodebuild`'s fixed launch
+    # overhead, and this one is compile-bound, where core count is the variable.
     #
     # **When that stops being enough, the answer is not to raise it**: the honest options are dropping
     # mutations that no longer aim at a decision, or running `--mutate` on a narrower trigger than
     # every PR update and leaving the plain suite here. Bounded at all because the default is 360
     # minutes and this is the repository's only macOS job — a hung run would otherwise hold the
     # required check for six hours.
-    timeout-minutes: 35
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
   # **`--mutate`, not a plain run.** Many of the tests assert that something is *not* allowed, and a
   # test asserting absence passes when nothing happens — that is its definition. The flag breaks the
   # sources eighty-two ways and requires each one to fail a test, which is the only thing that makes
-  # a green run evidence (`contributing/test-and-guard-coverage.md` rule 2). It runs the suite once
-  # per mutation plus a baseline.
+  # a green run evidence (`contributing/test-and-guard-coverage.md` rule 2). It builds and runs the
+  # suite once per mutation plus a baseline.
   #
   # **What is pinned, and what a pinned label does not cover.** `macos-15` fixes the OS; it does not
   # fix Xcode, which GitHub rolls forward inside a label. So the toolchain here will move without this
@@ -215,35 +215,32 @@ jobs:
     if: needs.changes.outputs.netfilter == 'true'
     runs-on: macos-15
     # The suite is two Swift files and their tests, but the job is `brew`-free installs plus
-    # eighty-three `xcodebuild test` launches — one baseline and one per mutation — and then one
-    # `xcodebuild build` that compiles the shipping targets. **That number is the thing to watch when
-    # adding a mutation**: it was sixteen when the job was written, and every entry in `run-tests.sh`
-    # is a cost paid on every run of this job. Count them with `grep -cE '^mutate "'`, not
-    # `grep -c '^mutate '`, which counts the function definition and is how one version of this
+    # eighty-three `swiftc` build-and-run cycles — one baseline and one per mutation — and then one
+    # `xcodebuild build` that compiles the shipping targets. **That number is still the thing to watch
+    # when adding a mutation**: it was sixteen when the job was written, and every entry in
+    # `run-tests.sh` is a cost paid on every run of this job. Count them with `grep -cE '^mutate "'`,
+    # not `grep -c '^mutate '`, which counts the function definition and is how one version of this
     # comment said thirty-six when it was thirty-four.
     #
-    # **The ceiling comes from measurement, and it has already been outgrown once.** Real runs here:
-    # sixteen launches took 2m35s–3m08s, forty-two took 9m27s, and eighty-three took 17m29s with the
-    # Release build 23s behind it — 18m03s for the job. So a launch costs between 10 and 13.5s
-    # depending on the runner, against 10.8s locally, and **extrapolating from the slowest of those is
-    # what the ceiling should be set on** rather than from the run that happened to be fast. At
-    # `timeout-minutes: 20` the forty-two-launch measurement already left 1.3x, which is not headroom —
-    # it is a coin flip on a slow runner, and the failure it produces is a required check going red for
-    # no reason.
+    # **The engine was swapped, and that is where the headroom came from.** Every launch used to be an
+    # `xcodebuild test`, which was the entire cost: measured on the same sources, `xcodegen` is 0.02s,
+    # while `xcodebuild` was ~13.5s a launch here — sixteen took 2m35s–3m08s, forty-two 9m27s,
+    # eighty-three 17m29s, and 18m03s for the whole job. Building the identical XCTest files with
+    # `swiftc` and running them under `xcrun xctest` is **1.9s a cycle**, and the full mutation set
+    # went from 1049s to 222s locally. Dropping mutations was the alternative and it was the wrong
+    # one: nothing about the coverage had to change.
     #
-    # **At thirty-five the measured job is 1.94x, and the paragraph below is being reached.** The cost is
-    # `xcodebuild` and nothing else: measured on the same sources, `xcodegen` is 0.02s, and building
-    # the identical XCTest files with `swiftc` and running them under `xcrun xctest` is 4.3s against
-    # this job's 13.5s. Layer 2's equivalent runs twenty-six mutations in fifteen seconds for exactly
-    # that reason — it never invokes `xcodebuild`. Replacing the engine is the option that costs no
-    # mutations, and it is the one to take before dropping any.
+    # **The remaining floor is one mutation, and it does not move.** `walk: no bound` removes a bound,
+    # so it does not fail an assertion — it spins until `run`'s watchdog kills it at 20s. Everything
+    # else got seven times faster and that one did not, which is the shape to expect from any future
+    # bound.
     #
-    # Thirty-five keeps under 2x now. **When that is not enough either, raising it again is the wrong
-    # move**: around a hundred launches the honest options are dropping mutations that no longer aim
-    # at a decision, or running `--mutate` on a narrower trigger than every PR update and leaving the
-    # plain suite here. Bounded at all because the default is 360 minutes and this is the repository's
-    # only macOS job — a hung run would otherwise hold the required check for six hours.
-    timeout-minutes: 35
+    # Twenty against a run now measured in minutes. **When that stops being enough, the answer is not
+    # to raise it**: the honest options are dropping mutations that no longer aim at a decision, or
+    # running `--mutate` on a narrower trigger than every PR update and leaving the plain suite here.
+    # Bounded at all because the default is 360 minutes and this is the repository's only macOS job —
+    # a hung run would otherwise hold the required check for six hours.
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -819,27 +819,50 @@ The flag breaks the sources eighty-two ways and requires each one to fail a test
 not have done that: `run()` piped `xcodebuild` into `grep` and returned *grep's* status, so a mutation
 that did not even compile would have been reported as killed.
 
-**Every mutation is a cost paid on every push**, now that CI runs the flag — one `xcodebuild` each.
-Count them with `grep -cE '^mutate "'`, not `grep -c '^mutate '`, which counts the function
-definition; a comment in `ci.yml` said thirty-six for exactly that reason.
+**Every mutation is a cost paid on every push**, now that CI runs the flag, which is why the engine
+is `swiftc` and `xcrun xctest` rather than `xcodebuild`. Measured on these same files: 1.9s a
+build-and-run cycle against ~13.5s for one `xcodebuild test` launch on CI's runner, and the whole set
+from 1049s to 222s. The alternative was dropping mutations, and nothing about the coverage had to
+change. Count them with `grep -cE '^mutate "'`, not `grep -c '^mutate '`, which counts the function
+definition; a comment in `ci.yml` said thirty-six for exactly that reason, and
+`scripts/__tests__/mutationCountsStated.test.mjs` now holds the stated counts against the real one.
+
+**One mutation does not get faster, and it is a shape rather than an exception.**
+`walk: no bound` removes a bound, so it fails nothing — it spins until `run`'s watchdog kills it at
+20s, and reports as `killed (hung)` rather than as a plain kill. Any future mutation aimed at a bound
+costs the deadline too.
+
+**Two exit codes replaced a string search, which is the other half of the gain.** `xcodebuild test`
+builds and tests as one action and reports one status, so telling a compile error from a failing
+assertion meant counting `Test Case` lines in the log — a textual check this file had already got
+wrong twice. Compiling and running are separate commands now, so `2` means it did not build and `1`
+means a test caught it.
 
 **And it has found something.** A mutation deleting `.filter { !$0.isEmpty }` from `parseUDIDs`
 survived — not because the test was decoration but because the filter was: `split(separator:)`
 defaults to `omittingEmptySubsequences: true`, so the line could never remove anything. A green suite
 would not have said so.
 
-**The spec is `tests.yml`, deliberately separate from `project.yml`.** `project.yml` is one of the
-four enumerated inputs to the extension's version stamp, so a test target declared there would make
-every test-only edit bump `CFBundleVersion` — and that replaces the system extension on every
-self-hoster's Mac, stopping all new connections while it happens. A new file at `ios-netfilter/`'s top
-level is not an input unless `EXT_SOURCE_FILES` names it, so this spec is free. The generated
+**`tests.yml` is how you open these tests in Xcode, and nothing else reads it.** `run-tests.sh` hands
+its own `SOURCES` array to `swiftc`, so the spec is no longer on the path CI takes — it is kept
+because stepping through a failing Swift test in a debugger is worth more than the file costs, and
+`scripts/__tests__/netfilterTestSources.test.mjs` compares what the two would compile, resolved
+against the disk rather than as text. Without that, a third pure file wired into one and not the
+other is silent in both directions: every mutation aimed at it reports `BUILD BROKE`, which reads as
+the mutation having drifted, or the mutations pass and only the project nobody runs in CI is stale.
+
+**It is deliberately separate from `project.yml`.** `project.yml` is one of the four enumerated
+inputs to the extension's version stamp, so a test target declared there would make every test-only
+edit bump `CFBundleVersion` — and that replaces the system extension on every self-hoster's Mac,
+stopping all new connections while it happens. A new file at `ios-netfilter/`'s top level is not an
+input unless `EXT_SOURCE_FILES` names it, so this spec is free. The generated
 `TapflowNetFilterTests.xcodeproj` is gitignored, unlike the shipping one.
 
 **Do not run bare `xcodegen generate` to check a build.** It rewrites both `Info.plist`s with the
 literal `CURRENT_PROJECT_VERSION` from `project.yml` — `1` — discarding the committed
 `CFBundleVersion` that `shipped.json` records. `build.sh` patches them back immediately, so the
 release path is safe and only a hand-run generate leaves it wrong. Check `git status` afterwards.
-`run-tests.sh` generates from `tests.yml` alone and does not touch them.
+`run-tests.sh` runs no `xcodegen` at all and does not touch them.
 
 #### Building the system extension
 

--- a/packages/ios-agent/AGENTS.md
+++ b/packages/ios-agent/AGENTS.md
@@ -822,7 +822,7 @@ that did not even compile would have been reported as killed.
 **Every mutation is a cost paid on every push**, now that CI runs the flag, which is why the engine
 is `swiftc` and `xcrun xctest` rather than `xcodebuild`. Measured on these same files: 1.9s a
 build-and-run cycle against ~13.5s for one `xcodebuild test` launch on CI's runner, and the whole set
-from 1049s to 222s. The alternative was dropping mutations, and nothing about the coverage had to
+from 1049s to 222–246s across three local runs. The alternative was dropping mutations, and nothing about the coverage had to
 change. Count them with `grep -cE '^mutate "'`, not `grep -c '^mutate '`, which counts the function
 definition; a comment in `ci.yml` said thirty-six for exactly that reason, and
 `scripts/__tests__/mutationCountsStated.test.mjs` now holds the stated counts against the real one.
@@ -846,10 +846,25 @@ would not have said so.
 **`tests.yml` is how you open these tests in Xcode, and nothing else reads it.** `run-tests.sh` hands
 its own `SOURCES` array to `swiftc`, so the spec is no longer on the path CI takes — it is kept
 because stepping through a failing Swift test in a debugger is worth more than the file costs, and
-`scripts/__tests__/netfilterTestSources.test.mjs` compares what the two would compile, resolved
-against the disk rather than as text. Without that, a third pure file wired into one and not the
-other is silent in both directions: every mutation aimed at it reports `BUILD BROKE`, which reads as
-the mutation having drifted, or the mutations pass and only the project nobody runs in CI is stale.
+`scripts/__tests__/netfilterTestSources.test.mjs` compares what the two would compile. Without that,
+a third pure file wired into one and not the other is silent in both directions: every mutation aimed
+at it reports `BUILD BROKE`, which reads as the mutation having drifted, or the mutations pass and
+only the project nobody runs in CI is stale.
+
+**That check asks the script rather than modelling it**, via `run-tests.sh --print-sources`, and the
+first version is why. It reimplemented the script's rules in JavaScript and expanded `Tests/*.swift`
+through the same recursive walk it used for `tests.yml`'s `Tests` directory — but a shell glob does
+not descend. Measured with a planted `Tests/Support/ExtraTests.swift` that cannot pass: xcodegen
+compiled it, `swiftc` did not, the suite stayed at 80 tests and exited 0, and the check called the two
+lists equal. The script now gathers the tests with `find`, so a subdirectory reaches both — the
+divergence is gone rather than detected — and `Tests/**/*.swift` was not the fix, because macOS ships
+bash 3.2 with no `globstar` and `**` degrades to one level.
+
+**And an exit code is only a verdict if a test ran.** `xcrun xctest` exits **0** on a bundle holding
+no `XCTestCase` and **1** on one it cannot load, so `run` requires a `Test Case` line before it reads
+any status, and treats a bare 137 — a SIGKILL that was not the watchdog's — as `NO VERDICT` rather
+than as a kill. `--mutate` starts eighty-three processes; one stray `pkill` would otherwise have
+scored a surviving mutation as caught.
 
 **It is deliberately separate from `project.yml`.** `project.yml` is one of the four enumerated
 inputs to the extension's version stamp, so a test target declared there would make every test-only

--- a/packages/ios-agent/ios-netfilter/Tests/ProcessIdentityTests.swift
+++ b/packages/ios-agent/ios-netfilter/Tests/ProcessIdentityTests.swift
@@ -95,10 +95,14 @@ final class ProcessIdentityTests: XCTestCase {
     /// `lock.lock(); defer { lock.unlock() }` from both methods leaves every other assertion in this
     /// file passing, because nothing else here starts a second thread.
     ///
-    /// **The failure is a crash, not a wrong answer**, so this asserts the entries survive rather
-    /// than trying to catch a torn read: a bare Swift `Dictionary` mutated from two threads corrupts
-    /// its own storage. Measured on a copy with the lock removed — `exit=139` (SIGSEGV) on 5 runs of
-    /// 5, against `exit=0` on 5 of 5 with it. `run-tests.sh` plants that mutation.
+    /// **The failure is not a wrong answer**, so this asserts the entries survive rather than trying
+    /// to catch a torn read: a bare Swift `Dictionary` mutated from two threads corrupts its own
+    /// storage. What that corruption *does* varies, because it is undefined behaviour and not a
+    /// defined error — measured on a copy with the lock removed, 28 runs of 28 failed, some with
+    /// `SIGSEGV`, some by surfacing an ObjC exception through this assertion, and one by hanging
+    /// until the runner's watchdog killed it. All of them are the mutation being caught, and an
+    /// earlier version of this comment reported only the first because that is what five runs
+    /// happened to show. `run-tests.sh` plants the mutation.
     func testConcurrentStoresAndLookupsKeepEveryEntry() {
         let cache = UDIDCache()
         let count = 2_000

--- a/packages/ios-agent/ios-netfilter/run-tests.sh
+++ b/packages/ios-agent/ios-netfilter/run-tests.sh
@@ -42,12 +42,20 @@ BIN="$BUNDLE/Contents/MacOS/FilterLogicTests"
 # no `globstar`, so `**` degrades to a single level and drops `Tests/*.swift` entirely — measured, and
 # it would also make the source list depend on which bash a contributor had installed.
 SOURCES=(Extension/FlowIdentity.swift Host/RuleArguments.swift)
-while IFS= read -r f; do SOURCES+=("$f"); done < <(find Tests -name '*.swift' | sort)
-# A failure inside a process substitution does not reach `set -e` — measured: with `find` missing from
-# `PATH` this loop added nothing and the script carried on at rc 0, leaving `SOURCES` as the two pure
-# files. Both consumers would catch it eventually (the guard sees two entries against nine, and a
-# bundle with no tests is now `NO VERDICT` rather than a pass) but three layers away from the cause.
-[[ ${#SOURCES[@]} -gt 2 ]] || { echo "no .swift found under Tests/ — did \`find\` run?" >&2; exit 1; }
+# **Read for its exit status, not only its output**, which a process substitution cannot give: with
+# `find` missing from `PATH` the loop added nothing and the script carried on at rc 0 — measured —
+# leaving `SOURCES` as the two pure files. A count check alone does not cover it either. Discovery
+# that emits some paths and *then* fails leaves more than two entries, so the count passes and the
+# bundle is built from part of the suite, and a mutation aimed at a file that was not compiled is
+# reported killed by tests that never saw it. That is a wrong verdict rather than a missing file,
+# which is the one failure this script may not have.
+if ! found=$(find Tests -name '*.swift' | sort); then
+  echo "could not enumerate Tests/ — refusing to compile a partial suite" >&2
+  exit 1
+fi
+while IFS= read -r f; do [[ -n "$f" ]] && SOURCES+=("$f"); done <<< "$found"
+# And the floor for discovery that succeeds and matches nothing.
+[[ ${#SOURCES[@]} -gt 2 ]] || { echo "no .swift found under Tests/" >&2; exit 1; }
 
 # **Ask the script, do not model it.** The first drift guard reimplemented these rules in JavaScript
 # and got them wrong in the one way that mattered — it expanded the glob recursively, so it reported

--- a/packages/ios-agent/ios-netfilter/run-tests.sh
+++ b/packages/ios-agent/ios-netfilter/run-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# The netfilter's Swift tests (#690). Needs Xcode and xcodegen.
+# The netfilter's Swift tests (#690). Needs a full Xcode — not Command Line Tools, which has no
+# `PlatformPath` and so no XCTest to link against. It runs no `xcodegen`; `tests.yml` is for
+# opening these in Xcode, and `--print-sources` below is what keeps the two honest.
 #
 # **CI runs `--mutate`, not the plain mode.** `.github/workflows/ci.yml` has a `test-swift` job on
 # `macos-15` that calls this script with the flag, and it is part of the `ci` rollup — so a Mac
@@ -37,11 +39,27 @@ HUNG_MARKER=$(mktemp -t netfilter-hung)
 # The same three entries as `tests.yml`'s `sources:`. Both halves of the binary pair, because both
 # have a pure part and neither can be linked: a system extension is not loadable by a test bundle,
 # and `Host/main.swift` is top-level code whose statements would become a second `main`.
-SOURCES=(Extension/FlowIdentity.swift Host/RuleArguments.swift Tests/*.swift)
+# `find` rather than a glob. `Tests/*.swift` does not descend, and `tests.yml` names the `Tests`
+# *directory*, which xcodegen walks — so one file in a subdirectory would be compiled into the Xcode
+# project and not into this bundle. `Tests/**/*.swift` is not the fix: macOS ships bash 3.2, which has
+# no `globstar`, so `**` degrades to a single level and drops `Tests/*.swift` entirely — measured, and
+# it would also make the source list depend on which bash a contributor had installed.
+SOURCES=(Extension/FlowIdentity.swift Host/RuleArguments.swift)
+while IFS= read -r f; do SOURCES+=("$f"); done < <(find Tests -name '*.swift' | sort)
 
-# No `-target`. The bundle is never shipped and only has to run on the machine testing, so pinning a
-# deployment target here would be pinning CI's runner architecture in a file nobody would think to
-# change when that moves. Nothing under test carries an `@available` branch.
+# **Ask the script, do not model it.** The first drift guard reimplemented these rules in JavaScript
+# and got them wrong in the one way that mattered — it expanded the glob recursively, so it reported
+# the two lists equal while a planted `Tests/Support/ExtraTests.swift` was compiled by xcodegen and
+# not by this script. Measured: guard green, suite still 80 tests.
+if [[ "${1:-}" == "--print-sources" ]]; then printf '%s\n' "${SOURCES[@]}"; exit 0; fi
+
+# **`-target` pins the OS and not the architecture, and a draft of this file claimed otherwise.**
+# They are separable halves of a triple: `$(uname -m)` keeps the arch wherever this runs, while
+# `macosx15.0` is the floor `tests.yml` and `project.yml` both declare. Without it the bundle builds
+# at the host's own version — measured `minos 26.0` — and an unguarded call to an API newer than 15.0
+# compiles clean locally while the shipping build rejects it. `-swift-version 5` for the same reason:
+# it is what both specs pin, today's default happens to match, and `macos-15` fixes the OS but not the
+# Xcode inside it.
 PLATFORM_DIR=$(xcrun --show-sdk-platform-path --sdk macosx)
 XCTEST_FW="$PLATFORM_DIR/Developer/Library/Frameworks"
 XCTEST_LIB="$PLATFORM_DIR/Developer/usr/lib"
@@ -61,6 +79,7 @@ DEADLINE=20
 #   1  a test failed — the mutation was killed
 #   2  it did not compile, so nothing judged it
 #   3  it had to be killed at the deadline
+#   4  no test ran, so the exit code is not a verdict either way
 run () {
   # **Emptied first, and that is not tidiness.** An early `return` leaves `$LOG` untouched, so a
   # failed build would otherwise hand `mutate` the *previous* mutation's log.
@@ -78,7 +97,8 @@ run () {
   <key>CFBundleExecutable</key><string>FilterLogicTests</string>
 </dict></plist>
 PLIST
-  swiftc -o "$BIN" -module-name FilterLogicTests \
+  swiftc -o "$BIN" -module-name FilterLogicTests -swift-version 5 \
+    -target "$(uname -m)-apple-macosx15.0" \
     -F "$XCTEST_FW" -I "$XCTEST_LIB" -L "$XCTEST_LIB" \
     -Xlinker -bundle \
     -Xlinker -rpath -Xlinker "$XCTEST_FW" -Xlinker -rpath -Xlinker "$XCTEST_LIB" \
@@ -102,6 +122,15 @@ PLIST
   kill "$watchdog" 2>/dev/null || true
   wait "$watchdog" 2>/dev/null || true
   [[ -f "$HUNG_MARKER" ]] && return 3
+
+  # **An exit code is only a verdict if a test ran, and three ways it can lie were measured.** A
+  # bundle with no `XCTestCase` in it exits **0** — `Executed 0 tests` — which reads as SURVIVED; one
+  # that cannot be loaded exits **1**, which reads as a kill; and a SIGKILL from outside this script
+  # (jetsam, a contributor's `pkill`, and `--mutate` starts eighty-three processes) is non-zero with
+  # nothing having run. The watchdog's own SIGKILL is excluded above by the marker, so a bare 137 here
+  # came from somewhere else and is not this script's to interpret.
+  [[ $rc -eq 137 ]] && return 4
+  grep -q "Test Case '" "$LOG" || return 4
   return $rc
 }
 
@@ -111,6 +140,7 @@ if [[ "${1:-}" != "--mutate" ]]; then
     0) grep -E "Executed .* tests" "$LOG" | tail -1; exit 0 ;;
     2) echo "the tests did not compile:"; grep -E "error:" "$BUILD_LOG" | head -20; exit 1 ;;
     3) echo "the run was killed after ${DEADLINE}s — something is looping"; tail -3 "$LOG"; exit 1 ;;
+    4) echo "the bundle ran and no test did — this is not a pass"; tail -3 "$LOG"; exit 1 ;;
     *) grep -E "error:|failed" "$LOG" | head -20; exit 1 ;;
   esac
 fi
@@ -140,7 +170,19 @@ echo "=== mutating a copy at $WORK — this checkout is not written to ==="
 cd "$WORK"
 
 echo "=== baseline (must PASS) ==="
-run && echo "  PASS" || { echo "  FAIL — fix the tests before mutating"; grep -E "error:" "$LOG" | head; exit 1; }
+# **Diagnosed from the right log.** A baseline that fails because the tests do not compile leaves
+# `$LOG` empty — `run` truncates it and returns before `xctest` writes a byte — so grepping it printed
+# the failure and no reason for it.
+baseline_rc=0; run || baseline_rc=$?
+if [[ $baseline_rc -ne 0 ]]; then
+  echo "  FAIL — fix the tests before mutating"
+  case $baseline_rc in
+    2) grep -E "error:" "$BUILD_LOG" | head ;;
+    *) tail -5 "$LOG" ;;
+  esac
+  exit 1
+fi
+echo "  PASS"
 
 # **Two files carry pure code now**, so a mutation names the one it aims at. The extension's half and
 # the host binary's half are tested by one bundle (`tests.yml`) but they are different targets in the
@@ -171,6 +213,8 @@ orig_for () { [[ "$1" == "$EXT_SRC" ]] && echo "$EXT_ORIG" || echo "$HOST_ORIG";
 #   BUILD BROKE   — it did not compile, so no test ever judged it. Reporting this as `killed` is how a
 #                   suite that tests nothing reads as green, which is the whole failure this file
 #                   guards against.
+#   NO VERDICT    — it built, the process ended, and no test case ever started. The same failure
+#                   reached from the other side, and the one an exit code alone cannot see: see `run`.
 #
 # And one that is a kill rather than a failure to prove anything:
 #
@@ -196,6 +240,8 @@ mutate () {   # $1 = label, $2 = sed program, $3 = file (default: the extension'
     2) echo "  BUILD BROKE: $1   <-- it did not compile, so nothing judged it"
        return 1 ;;
     3) echo "  killed (hung): $1   <-- killed at ${DEADLINE}s" ;;
+    4) echo "  NO VERDICT: $1   <-- no test ran; killed from outside, or the bundle held nothing"
+       return 1 ;;
     *) echo "  killed:   $1" ;;
   esac
 }
@@ -234,9 +280,10 @@ mutate "prune: empty rule keeps" 's/counts.filter { rule.contains($0.key) }/rule
 mutate "pulse: rates swapped"    's/enforcing ? 1 : 5/enforcing ? 5 : 1/'                      || fails=1
 mutate "pulse: always fast"      's/enforcing ? 1 : 5/1/'                                      || fails=1
 # **The one mutation here that kills by crashing rather than by asserting.** A bare Swift `Dictionary`
-# mutated from two threads corrupts its storage, so the test process takes SIGSEGV — which `run` reads
-# as a non-zero exit with `Test Case` present, exactly as a failed assertion does. That is the honest
-# outcome: the lock's absence is not observable any other way.
+# mutated from two threads corrupts its storage, so the test process takes SIGSEGV. `run` requires a
+# test to have started before it reads any exit code as a verdict, and this one does start — measured
+# 57 `Test Case` lines across three runs before the crash — so this is a real kill rather than the
+# process dying on the way in.
 # **This one is killed reliably and not always the same way**, because removing a lock is undefined
 # behaviour rather than a wrong answer. Measured 28 runs of 28 killed, in three shapes: the assertion
 # failing, `SIGSEGV`, and — once, under the load of a full mutation run — the watchdog. All three are

--- a/packages/ios-agent/ios-netfilter/run-tests.sh
+++ b/packages/ios-agent/ios-netfilter/run-tests.sh
@@ -7,9 +7,10 @@
 # expensive mode there is deliberate: a green suite is not evidence on its own, and the whole reason
 # this file exists is that the cheap mode cannot tell the difference.
 #
-# **That makes every mutation added below a cost paid on every push.** One `xcodebuild` launch each,
-# and `timeout-minutes` on that job is the ceiling — a mutation is worth adding when it aims at a
-# decision, not at a line.
+# **That makes every mutation added below a cost paid on every push**, so the engine matters more
+# than the count. It is `swiftc` plus `xcrun xctest`, not `xcodebuild`: measured on these same files,
+# a build-and-run cycle is 1.9s against ~13.5s for one `xcodebuild test` launch on CI's runner. At
+# eighty-three cycles that is the difference between eighteen minutes and three.
 #
 # **An earlier version of this header said CI could not run these at all**, which was true when it
 # was written and stopped being true without anything here noticing.
@@ -23,46 +24,95 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-PROJ=TapflowNetFilterTests.xcodeproj
+# The bundle is assembled by hand rather than by `xcodegen` + `xcodebuild`. `tests.yml` stays —
+# generating a real project is how you open these tests in Xcode and step through one — but nothing
+# in this script reads it, and `scripts/__tests__/netfilterTestSources.test.mjs` holds the two source
+# lists together so the affordance cannot drift away from what is actually tested.
+BUNDLE=build/FilterLogicTests.xctest
+BIN="$BUNDLE/Contents/MacOS/FilterLogicTests"
 LOG=$(mktemp -t netfilter-tests)
+BUILD_LOG=$(mktemp -t netfilter-build)
+HUNG_MARKER=$(mktemp -t netfilter-hung)
 
-# **Returns xcodebuild's own status.** An earlier version piped into `grep` and reported *its* exit
-# code, so a compile error read as a passing run.
+# The same three entries as `tests.yml`'s `sources:`. Both halves of the binary pair, because both
+# have a pure part and neither can be linked: a system extension is not loadable by a test bundle,
+# and `Host/main.swift` is top-level code whose statements would become a second `main`.
+SOURCES=(Extension/FlowIdentity.swift Host/RuleArguments.swift Tests/*.swift)
+
+# No `-target`. The bundle is never shipped and only has to run on the machine testing, so pinning a
+# deployment target here would be pinning CI's runner architecture in a file nobody would think to
+# change when that moves. Nothing under test carries an `@available` branch.
+PLATFORM_DIR=$(xcrun --show-sdk-platform-path --sdk macosx)
+XCTEST_FW="$PLATFORM_DIR/Developer/Library/Frameworks"
+XCTEST_LIB="$PLATFORM_DIR/Developer/usr/lib"
+
+# How long a single run may take before it is treated as hung. The whole suite executes in 0.02s and
+# the process is up for about 0.7s, so this is three orders of magnitude of headroom — it is not a
+# performance budget, it is the only thing that can end a mutation whose failure mode is a loop.
+DEADLINE=20
+
+# **Four outcomes, and the exit code is the discriminator rather than a string in a log.** That is
+# the substantive gain from dropping `xcodebuild`: `xcodebuild test` performs the build and the tests
+# as one action and reports one status, so telling a compile error from a failing assertion meant
+# counting `Test Case` occurrences — a textual check that this file had already got wrong twice.
+# Compiling and running are two commands here, so each has its own status.
 #
-# **That fixed half of it, and the comment here used to claim the whole.** A non-zero status still says
-# only "something went wrong", and `--mutate` below read any non-zero as "a test caught it" — so a
-# mutation that does not compile was indistinguishable from one a test killed.
-#
-# **The discriminator is `Test Case`, and two more obvious ones are wrong.** `** TEST FAILED **` is
-# printed for a compile error too — measured: `xcodebuild test` reports the *action* failing, not the
-# build, so that line appears either way (a review proposed it and it does not work). `error:` is no
-# good either; an XCTest assertion prints those. What a compile failure never produces is a test case
-# running at all: measured, `Test Case` appears 0 times when the mutation does not build and 30 times
-# when a test kills it.
+#   0  every test passed
+#   1  a test failed — the mutation was killed
+#   2  it did not compile, so nothing judged it
+#   3  it had to be killed at the deadline
 run () {
-  # **Emptied first, and that is not tidiness.** The `return` below leaves `$LOG` untouched, so a
-  # failing `xcodegen` would hand `mutate` the *previous* mutation's log — which contains `Test Case`,
-  # and would therefore be read as this mutation having been killed by a test that never ran. The
-  # same hole this file already closed once, reached through a different door.
+  # **Emptied first, and that is not tidiness.** An early `return` leaves `$LOG` untouched, so a
+  # failed build would otherwise hand `mutate` the *previous* mutation's log.
   : > "$LOG"
-  xcodegen generate --spec tests.yml >/dev/null || return 1
-  # `-derivedDataPath` only under `--mutate`, where it keeps the copy's build products inside the
-  # copy. A plain run stays on Xcode's default path so it is incremental across invocations.
-  # **`-test-timeouts-enabled` is what makes a mutation that loops killable at all.** Some decisions
-  # are bounds, and removing a bound does not fail a test — it makes one spin, and a `run` that never
-  # returns stops the whole mode rather than reporting anything. With an allowance, XCTest kills the
-  # case, the run continues, and the assertion that was going to catch it does. Measured: the
-  # `walk: no bound` mutation takes 87s against ~13s for a normal one, and the flags cost nothing on
-  # a green run (3.07s with, 3.71s without — noise).
-  xcodebuild test -project "$PROJ" -scheme FilterLogicTests -destination 'platform=macOS,arch=arm64' \
-    ${MUTATE_DERIVED:+-derivedDataPath "$MUTATE_DERIVED"} \
-    -test-timeouts-enabled YES -default-test-execution-time-allowance 20 \
-    CODE_SIGNING_ALLOWED=NO > "$LOG" 2>&1
+  : > "$BUILD_LOG"
+  rm -rf "$BUNDLE"
+  mkdir -p "$BUNDLE/Contents/MacOS"
+  cat > "$BUNDLE/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleIdentifier</key><string>dev.tapflow.FilterLogicTests</string>
+  <key>CFBundleName</key><string>FilterLogicTests</string>
+  <key>CFBundlePackageType</key><string>BNDL</string>
+  <key>CFBundleExecutable</key><string>FilterLogicTests</string>
+</dict></plist>
+PLIST
+  swiftc -o "$BIN" -module-name FilterLogicTests \
+    -F "$XCTEST_FW" -I "$XCTEST_LIB" -L "$XCTEST_LIB" \
+    -Xlinker -bundle \
+    -Xlinker -rpath -Xlinker "$XCTEST_FW" -Xlinker -rpath -Xlinker "$XCTEST_LIB" \
+    "${SOURCES[@]}" > "$BUILD_LOG" 2>&1 || return 2
+
+  # **A watchdog rather than a poll**, because polling costs its interval on every one of the
+  # eighty-two runs that finish in under a second, and the deadline only ever fires for one or two of
+  # them. `timeout` is not on macOS.
+  #
+  # **The marker is what says the deadline fired, not the exit code.** SIGKILL surfaces as 137 and it
+  # was tempting to read that as the answer, but that is inferring a cause from a number the same way
+  # this file used to infer a build failure from a log line. A run really can die by signal on its
+  # own — `cache: no lock` segfaults, measured — so the watchdog records that *it* acted, before it
+  # acts, which makes the marker present by the time `wait` returns.
+  rm -f "$HUNG_MARKER"
+  xcrun xctest "$BUNDLE" > "$LOG" 2>&1 &
+  local pid=$! rc=0
+  ( sleep "$DEADLINE"; : > "$HUNG_MARKER"; kill -9 "$pid" 2>/dev/null ) &
+  local watchdog=$!
+  wait "$pid" || rc=$?
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" 2>/dev/null || true
+  [[ -f "$HUNG_MARKER" ]] && return 3
+  return $rc
 }
 
 if [[ "${1:-}" != "--mutate" ]]; then
-  if run; then grep -E "Executed .* tests|TEST SUCCEEDED" "$LOG" | tail -2; exit 0
-  else grep -E "error:|Test Case.*failed|TEST FAILED" "$LOG" | head -20; exit 1; fi
+  rc=0; run || rc=$?
+  case $rc in
+    0) grep -E "Executed .* tests" "$LOG" | tail -1; exit 0 ;;
+    2) echo "the tests did not compile:"; grep -E "error:" "$BUILD_LOG" | head -20; exit 1 ;;
+    3) echo "the run was killed after ${DEADLINE}s — something is looping"; tail -3 "$LOG"; exit 1 ;;
+    *) grep -E "error:|failed" "$LOG" | head -20; exit 1 ;;
+  esac
 fi
 
 # **`--mutate` works on a COPY, and the checkout is never written to.**
@@ -78,18 +128,16 @@ fi
 # is no longer a thing that can go wrong, and `git status` stays clean throughout.
 #
 # `mktemp -d` rather than a fixed name, because `rsync --delete` into a path something else can
-# pre-create is a path it can point somewhere worth deleting. The cost is that `xcodebuild` starts
-# cold once per run — DerivedData is pinned inside the copy so nothing accumulates under
-# `~/Library` — which buys back the whole failure mode above.
+# pre-create is a path it can point somewhere worth deleting. Build products land in `build/` inside
+# the copy and go with it, so nothing accumulates anywhere.
 WORK=$(mktemp -d -t tapflow-netfilter-mutate) || exit 1
 # **The second `trap … EXIT` below REPLACES this one**, which is why `cleanup` removes `$WORK` as well.
 # Getting that wrong left a 3.7 GB copy behind on the first run of this mode — bash keeps one EXIT
 # handler, not a list, and nothing says so at the point of the second `trap`.
 trap 'rm -rf "$WORK"' EXIT
-/usr/bin/rsync -a --exclude build --exclude 'DerivedData' --exclude '*.xcodeproj' ./ "$WORK/"
+/usr/bin/rsync -a --exclude build --exclude '*.xcodeproj' ./ "$WORK/"
 echo "=== mutating a copy at $WORK — this checkout is not written to ==="
 cd "$WORK"
-export MUTATE_DERIVED="$WORK/DerivedData"
 
 echo "=== baseline (must PASS) ==="
 run && echo "  PASS" || { echo "  FAIL — fix the tests before mutating"; grep -E "error:" "$LOG" | head; exit 1; }
@@ -109,7 +157,7 @@ HOST_ORIG=$(mktemp -t RuleArguments.orig) || exit 1
 cp "$EXT_SRC" "$EXT_ORIG"
 cp "$HOST_SRC" "$HOST_ORIG"
 restore () { cp "$EXT_ORIG" "$EXT_SRC"; cp "$HOST_ORIG" "$HOST_SRC"; }
-cleanup () { restore; rm -f "$EXT_ORIG" "$HOST_ORIG"; rm -rf "${WORK:-}"; }
+cleanup () { restore; rm -f "$EXT_ORIG" "$HOST_ORIG" "$HUNG_MARKER"; rm -rf "${WORK:-}"; }
 trap cleanup EXIT
 
 # The backup a given source is compared against, so `DID NOT APPLY` stays honest per file.
@@ -123,6 +171,14 @@ orig_for () { [[ "$1" == "$EXT_SRC" ]] && echo "$EXT_ORIG" || echo "$HOST_ORIG";
 #   BUILD BROKE   — it did not compile, so no test ever judged it. Reporting this as `killed` is how a
 #                   suite that tests nothing reads as green, which is the whole failure this file
 #                   guards against.
+#
+# And one that is a kill rather than a failure to prove anything:
+#
+#   killed (hung) — the run reached the deadline. A mutation that removes a *bound* does not make an
+#                   assertion fail, it makes a case spin, so this is what catching one looks like. It
+#                   is printed apart from a plain kill because a hang that is not about a bound is a
+#                   different problem wearing the same clothes, and folding the two together would
+#                   hide it.
 mutate () {   # $1 = label, $2 = sed program, $3 = file (default: the extension's)
   restore
   local src="${3:-$EXT_SRC}" orig
@@ -132,15 +188,16 @@ mutate () {   # $1 = label, $2 = sed program, $3 = file (default: the extension'
     echo "  DID NOT APPLY: $1   <-- the sed matched nothing; the source moved under it"
     return 1
   fi
-  if run >/dev/null 2>&1; then
-    echo "  SURVIVED: $1   <-- it compiled and every test still passed; one of them is decoration"
-    return 1
-  fi
-  if ! grep -q "Test Case" "$LOG"; then
-    echo "  BUILD BROKE: $1   <-- no test case ran, so nothing judged it"
-    return 1
-  fi
-  echo "  killed:   $1"
+  local rc=0
+  run >/dev/null 2>&1 || rc=$?
+  case $rc in
+    0) echo "  SURVIVED: $1   <-- it compiled and every test still passed; one of them is decoration"
+       return 1 ;;
+    2) echo "  BUILD BROKE: $1   <-- it did not compile, so nothing judged it"
+       return 1 ;;
+    3) echo "  killed (hung): $1   <-- killed at ${DEADLINE}s" ;;
+    *) echo "  killed:   $1" ;;
+  esac
 }
 
 echo "=== mutations (each must make a test FAIL) ==="
@@ -180,6 +237,10 @@ mutate "pulse: always fast"      's/enforcing ? 1 : 5/1/'                       
 # mutated from two threads corrupts its storage, so the test process takes SIGSEGV — which `run` reads
 # as a non-zero exit with `Test Case` present, exactly as a failed assertion does. That is the honest
 # outcome: the lock's absence is not observable any other way.
+# **This one is killed reliably and not always the same way**, because removing a lock is undefined
+# behaviour rather than a wrong answer. Measured 28 runs of 28 killed, in three shapes: the assertion
+# failing, `SIGSEGV`, and — once, under the load of a full mutation run — the watchdog. All three are
+# kills; only the third costs the deadline. Do not "stabilise" it by weakening the concurrent test.
 mutate "cache: no lock"          's/lock.lock(); defer { lock.unlock() }//'                     || fails=1
 
 # --- the host binary's arguments and rule arithmetic ---
@@ -269,9 +330,10 @@ mutate "walk: an unreadable path is host" 's/if let path = read.executablePath(c
 mutate "walk: the cache is not consulted" 's/if let cached = cache.lookup(info.identity) { return .simulator(cached) }//' || fails=1
 mutate "walk: nothing is cached"         's/cache.store(info.identity, udid)//'                || fails=1
 # **The bound gets a mutation after all, and the claim that it could not was untested.** This one
-# does not fail fast — it makes the cycle case spin until the execution-time allowance set in
-# `run` kills it, which is why it costs 87s. That is the price of holding a decision whose
-# failure mode is a hang rather than a wrong answer.
+# does not fail fast — it makes the cycle case spin until `run`'s watchdog kills it, so it reports as
+# `killed (hung)` and costs the deadline. That is the price of holding a decision whose failure mode
+# is a hang rather than a wrong answer, and it is the one run in this file that does not get faster
+# by making the engine faster.
 mutate "walk: no bound"                  's/for _ in 0..<attributionWalkLimit {/while true {/' || fails=1
 mutate "walk: one step short"            's/let attributionWalkLimit = 32/let attributionWalkLimit = 31/' || fails=1
 mutate "walk: judges the flow's own process" 's/current = info.ppid//'                         || fails=1

--- a/packages/ios-agent/ios-netfilter/run-tests.sh
+++ b/packages/ios-agent/ios-netfilter/run-tests.sh
@@ -32,9 +32,6 @@ cd "$(dirname "$0")"
 # lists together so the affordance cannot drift away from what is actually tested.
 BUNDLE=build/FilterLogicTests.xctest
 BIN="$BUNDLE/Contents/MacOS/FilterLogicTests"
-LOG=$(mktemp -t netfilter-tests)
-BUILD_LOG=$(mktemp -t netfilter-build)
-HUNG_MARKER=$(mktemp -t netfilter-hung)
 
 # The same three entries as `tests.yml`'s `sources:`. Both halves of the binary pair, because both
 # have a pure part and neither can be linked: a system extension is not loadable by a test bundle,
@@ -46,12 +43,26 @@ HUNG_MARKER=$(mktemp -t netfilter-hung)
 # it would also make the source list depend on which bash a contributor had installed.
 SOURCES=(Extension/FlowIdentity.swift Host/RuleArguments.swift)
 while IFS= read -r f; do SOURCES+=("$f"); done < <(find Tests -name '*.swift' | sort)
+# A failure inside a process substitution does not reach `set -e` — measured: with `find` missing from
+# `PATH` this loop added nothing and the script carried on at rc 0, leaving `SOURCES` as the two pure
+# files. Both consumers would catch it eventually (the guard sees two entries against nine, and a
+# bundle with no tests is now `NO VERDICT` rather than a pass) but three layers away from the cause.
+[[ ${#SOURCES[@]} -gt 2 ]] || { echo "no .swift found under Tests/ — did \`find\` run?" >&2; exit 1; }
 
 # **Ask the script, do not model it.** The first drift guard reimplemented these rules in JavaScript
 # and got them wrong in the one way that mattered — it expanded the glob recursively, so it reported
 # the two lists equal while a planted `Tests/Support/ExtraTests.swift` was compiled by xcodegen and
 # not by this script. Measured: guard green, suite still 80 tests.
 if [[ "${1:-}" == "--print-sources" ]]; then printf '%s\n' "${SOURCES[@]}"; exit 0; fi
+
+# **Below that exit on purpose: this is the only path that runs off a Mac.** The guard test calls
+# `--print-sources` from the ubuntu `test` job, and `mktemp -t foo` is a BSD spelling — GNU's wants a
+# template ending in `XXX` and answers `too few X's in template`. Nothing above the exit may need a
+# Mac or a temp file. That is not a rule anyone has to remember: moving one of these back up turns
+# the ubuntu job red, which is how this was found.
+LOG=$(mktemp -t netfilter-tests)
+BUILD_LOG=$(mktemp -t netfilter-build)
+HUNG_MARKER=$(mktemp -t netfilter-hung)
 
 # **`-target` pins the OS and not the architecture, and a draft of this file claimed otherwise.**
 # They are separable halves of a triple: `$(uname -m)` keeps the arch wherever this runs, while

--- a/scripts/__tests__/mutationCountsStated.test.mjs
+++ b/scripts/__tests__/mutationCountsStated.test.mjs
@@ -1,8 +1,14 @@
 // Three places state how many mutations `--mutate` runs, and the number is what says whether the
-// job fits its timeout: `ci.yml` names it twice (the count, and the count plus a baseline as
-// `xcodebuild` launches) and `ios-agent/AGENTS.md` once. All three have gone stale, and the last
-// time was inside the PR that added the mutations — the count was corrected in the first commit and
-// the review-fix commit added four more without touching it.
+// job fits its timeout: `ci.yml` names it twice (the count, and the count plus a baseline as build
+// cycles) and `ios-agent/AGENTS.md` once. All three have gone stale, and the last time was inside the
+// PR that added the mutations — the count was corrected in the first commit and the review-fix commit
+// added four more without touching it.
+//
+// **The injected library's count used to be checked here and no longer is.** `ci.yml` stated it only
+// as the argument for replacing layer 1's engine — layer 2 never invoked `xcodebuild`, which is why
+// its twenty-six mutations took fifteen seconds. That argument was acted on, the sentence went with
+// it, and nothing else states the number: no timeout is sized from it. Putting the sentence back so
+// this file has something to assert would be inventing the thing being checked.
 //
 // **The prose already carries a warning about this, and the warning is what failed.** `ci.yml` says
 // a version of that comment "said thirty-six when it was thirty-four", and `AGENTS.md` repeats the
@@ -31,7 +37,6 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const read = (...p) => readFileSync(join(ROOT, ...p), 'utf8')
 
 const LAYER1 = 'packages/ios-agent/ios-netfilter/run-tests.sh'
-const LAYER2 = 'packages/ios-agent/mutate-nethook.sh'
 
 const ONES = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
   'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen',
@@ -73,13 +78,8 @@ describe('the stated mutation counts are the ones the scripts run', () => {
     const n = mutationCount(LAYER1)
     const file = '.github/workflows/ci.yml'
     expect(stated(file, /breaks[\s#]+the[\s#]+sources[\s#]+([a-z-]+)[\s#]+ways/)).toBe(words(n))
-    // One baseline runs before the mutations, so the launches are always one more.
-    expect(stated(file, /#\s+([a-z-]+)\s+`xcodebuild test`\s+launches/)).toBe(words(n + 1))
-  })
-
-  it('ci.yml states the injected library\'s count', () => {
-    expect(stated('.github/workflows/ci.yml', /Layer 2's[\s#]+equivalent[\s#]+runs[\s#]+([a-z-]+)[\s#]+mutations/))
-      .toBe(words(mutationCount(LAYER2)))
+    // One baseline runs before the mutations, so the cycles are always one more.
+    expect(stated(file, /#\s+([a-z-]+)\s+`swiftc`\s+build-and-run\s+cycles/)).toBe(words(n + 1))
   })
 
   it('ios-agent/AGENTS.md states the netfilter count', () => {

--- a/scripts/__tests__/netfilterTestSources.test.mjs
+++ b/scripts/__tests__/netfilterTestSources.test.mjs
@@ -4,17 +4,24 @@
 // these tests in Xcode and step through one, and losing that to save a file would be a bad trade.
 //
 // The cost of keeping both is that the source list now exists twice, and the failure it invites is
-// quiet in the direction that matters. Add a third pure file, wire it into `tests.yml`, forget the
-// script — and every mutation aimed at it reports BUILD BROKE, which reads as the mutation having
-// drifted rather than as the runner being wrong. The other direction is worse: the script compiles
-// it, the mutations pass, and the Xcode project nobody runs in CI is the only thing that is stale.
+// quiet in the direction that matters. Add a pure file, wire it into `tests.yml`, forget the script —
+// and every mutation aimed at it reports BUILD BROKE, which reads as the mutation having drifted
+// rather than as the runner being wrong. The other direction is worse: the script compiles it, the
+// mutations pass, and only the project nobody runs in CI is stale.
 //
-// **Compared as file sets, not as text.** The two say it differently on purpose — `tests.yml` names
-// the `Tests` directory because xcodegen walks it, the script globs `Tests/*.swift` because a shell
-// does not recurse — so a spelling comparison would have to encode that difference and would then be
-// asserting its own translation. Both sides are resolved against the disk instead, which is the
-// question actually being asked: does the bundle Xcode builds contain what the mutations judge.
+// **The script is asked, not modelled, and the first version of this file is why that sentence is
+// here.** It reimplemented the script's rules in JavaScript — and got the one that mattered wrong,
+// expanding `Tests/*.swift` through the same recursive walk it used for `tests.yml`'s `Tests`
+// directory. A shell glob does not descend. Measured with a planted `Tests/Support/ExtraTests.swift`
+// containing a test that cannot pass: xcodegen compiled it, `swiftc` did not, the suite stayed at 80
+// tests and exited 0, and this check reported the two lists equal. A guard that re-derives what it is
+// checking is asserting its own translation (`contributing/test-and-guard-coverage.md` rule 1), so
+// `run-tests.sh --print-sources` exists and prints what it will actually hand the compiler.
+//
+// `tests.yml`'s side is still resolved here, because xcodegen is not going to be run to find out —
+// but that side is a directory walk, which is what xcodegen does and what a `Tests` entry means.
 import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'child_process'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, dirname, relative } from 'path'
 import { fileURLToPath } from 'url'
@@ -22,7 +29,7 @@ import { fileURLToPath } from 'url'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const NETFILTER = join(ROOT, 'packages', 'ios-agent', 'ios-netfilter')
 
-/** Every `.swift` under a directory, recursively. */
+/** Every `.swift` under a directory, recursively — what xcodegen does with a directory entry. */
 function swiftUnder(dir, out = []) {
   for (const e of readdirSync(dir, { withFileTypes: true })) {
     const p = join(dir, e.name)
@@ -32,46 +39,56 @@ function swiftUnder(dir, out = []) {
   return out
 }
 
-/** One source entry — a file, a directory, or a `*.swift` glob — as the files it stands for. */
-function resolve(entry) {
-  const abs = join(NETFILTER, entry.replace(/\/\*\.swift$/, ''))
-  return statSync(abs).isDirectory() ? swiftUnder(abs) : [abs]
-}
-
-const asSet = (entries) =>
-  [...new Set(entries.flatMap(resolve).map((p) => relative(NETFILTER, p)))].sort()
-
-/** The `sources:` block of `tests.yml`'s single target. */
+/** `tests.yml`'s `sources:` entries as the files xcodegen would compile. */
 function specSources() {
   const yaml = readFileSync(join(NETFILTER, 'tests.yml'), 'utf8')
   const block = yaml.match(/^ {4}sources:\n((?: {6}(?:#.*|- .+)\n)+)/m)
   expect(block, 'tests.yml: no `sources:` block at the expected indentation').not.toBeNull()
-  return [...block[1].matchAll(/^ {6}- (.+)$/gm)].map((m) => m[1].trim())
+  const entries = [...block[1].matchAll(/^ {6}- (.+)$/gm)].map((m) => m[1].trim())
+  expect(entries.length, 'tests.yml: the `sources:` block parsed as empty').toBeGreaterThan(0)
+  return entries.flatMap((e) => {
+    const abs = join(NETFILTER, e)
+    return statSync(abs).isDirectory() ? swiftUnder(abs) : [abs]
+  })
 }
 
-/** The `SOURCES=(…)` array `run-tests.sh` hands to `swiftc`. */
+/** What `run-tests.sh` will hand `swiftc`, from the script itself. */
 function scriptSources() {
-  const sh = readFileSync(join(NETFILTER, 'run-tests.sh'), 'utf8')
-  const decl = sh.match(/^SOURCES=\(([^)]*)\)/m)
-  expect(decl, 'run-tests.sh: no `SOURCES=(…)` declaration').not.toBeNull()
-  return decl[1].split(/\s+/).filter(Boolean)
+  const out = execFileSync(join(NETFILTER, 'run-tests.sh'), ['--print-sources'], {
+    cwd: NETFILTER,
+    encoding: 'utf8',
+  })
+  return out.split('\n').filter(Boolean).map((p) => join(NETFILTER, p))
 }
+
+const rel = (paths) => [...new Set(paths.map((p) => relative(NETFILTER, p)))].sort()
 
 describe('the netfilter test bundle compiles the same files however it is built', () => {
   it('tests.yml and run-tests.sh resolve to one set of sources', () => {
-    const spec = asSet(specSources())
-    const script = asSet(scriptSources())
-    // Set from the measured count, not a round number: two pure files plus the test tree. If a
-    // derivation breaks and yields nothing, both sides match vacuously.
+    const spec = rel(specSources())
+    // Set from the measured count, not a round number: two pure files plus seven test files. A
+    // derivation that breaks and yields nothing would otherwise match vacuously on both sides.
     expect(spec.length).toBeGreaterThanOrEqual(9)
-    expect(script).toEqual(spec)
+    expect(rel(scriptSources())).toEqual(spec)
+  })
+
+  it('a test file in a subdirectory reaches both, or neither', () => {
+    // The case the first version of this check could not see. `tests.yml` names a directory and
+    // xcodegen descends; the script used a glob that does not, so this asserts on the mechanism
+    // rather than on today's flat tree — `find` is what makes it true, and reverting to a glob
+    // fails here without needing anyone to plant a file first.
+    const sh = readFileSync(join(NETFILTER, 'run-tests.sh'), 'utf8')
+    expect(sh, 'run-tests.sh must gather Tests/ recursively, the way xcodegen walks it')
+      .toMatch(/find\s+Tests\s+-name\s+'\*\.swift'/)
+    expect(sh, 'a non-descending glob is what shipped the hole this check exists for')
+      .not.toMatch(/SOURCES=\([^)]*Tests\/\*\.swift/)
   })
 
   it('both halves of the binary pair are in it', () => {
     // Neither target can be linked — a system extension is not loadable by a test bundle, and
     // `Host/main.swift` is top-level code whose statements would become a second `main` — so the
     // pure files are compiled into the bundle. Losing one silently drops a whole target's coverage.
-    expect(asSet(scriptSources())).toEqual(
+    expect(rel(scriptSources())).toEqual(
       expect.arrayContaining(['Extension/FlowIdentity.swift', 'Host/RuleArguments.swift']),
     )
   })

--- a/scripts/__tests__/netfilterTestSources.test.mjs
+++ b/scripts/__tests__/netfilterTestSources.test.mjs
@@ -1,0 +1,78 @@
+// `run-tests.sh` builds the netfilter's test bundle with `swiftc` directly — measured 1.9s a cycle
+// against ~13.5s for one `xcodebuild test` launch, which is what makes running eighty-two mutations
+// on every push affordable. `tests.yml` did not go with it: generating a real project is how you open
+// these tests in Xcode and step through one, and losing that to save a file would be a bad trade.
+//
+// The cost of keeping both is that the source list now exists twice, and the failure it invites is
+// quiet in the direction that matters. Add a third pure file, wire it into `tests.yml`, forget the
+// script — and every mutation aimed at it reports BUILD BROKE, which reads as the mutation having
+// drifted rather than as the runner being wrong. The other direction is worse: the script compiles
+// it, the mutations pass, and the Xcode project nobody runs in CI is the only thing that is stale.
+//
+// **Compared as file sets, not as text.** The two say it differently on purpose — `tests.yml` names
+// the `Tests` directory because xcodegen walks it, the script globs `Tests/*.swift` because a shell
+// does not recurse — so a spelling comparison would have to encode that difference and would then be
+// asserting its own translation. Both sides are resolved against the disk instead, which is the
+// question actually being asked: does the bundle Xcode builds contain what the mutations judge.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, dirname, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const NETFILTER = join(ROOT, 'packages', 'ios-agent', 'ios-netfilter')
+
+/** Every `.swift` under a directory, recursively. */
+function swiftUnder(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name)
+    if (e.isDirectory()) swiftUnder(p, out)
+    else if (e.name.endsWith('.swift')) out.push(p)
+  }
+  return out
+}
+
+/** One source entry — a file, a directory, or a `*.swift` glob — as the files it stands for. */
+function resolve(entry) {
+  const abs = join(NETFILTER, entry.replace(/\/\*\.swift$/, ''))
+  return statSync(abs).isDirectory() ? swiftUnder(abs) : [abs]
+}
+
+const asSet = (entries) =>
+  [...new Set(entries.flatMap(resolve).map((p) => relative(NETFILTER, p)))].sort()
+
+/** The `sources:` block of `tests.yml`'s single target. */
+function specSources() {
+  const yaml = readFileSync(join(NETFILTER, 'tests.yml'), 'utf8')
+  const block = yaml.match(/^ {4}sources:\n((?: {6}(?:#.*|- .+)\n)+)/m)
+  expect(block, 'tests.yml: no `sources:` block at the expected indentation').not.toBeNull()
+  return [...block[1].matchAll(/^ {6}- (.+)$/gm)].map((m) => m[1].trim())
+}
+
+/** The `SOURCES=(…)` array `run-tests.sh` hands to `swiftc`. */
+function scriptSources() {
+  const sh = readFileSync(join(NETFILTER, 'run-tests.sh'), 'utf8')
+  const decl = sh.match(/^SOURCES=\(([^)]*)\)/m)
+  expect(decl, 'run-tests.sh: no `SOURCES=(…)` declaration').not.toBeNull()
+  return decl[1].split(/\s+/).filter(Boolean)
+}
+
+describe('the netfilter test bundle compiles the same files however it is built', () => {
+  it('tests.yml and run-tests.sh resolve to one set of sources', () => {
+    const spec = asSet(specSources())
+    const script = asSet(scriptSources())
+    // Set from the measured count, not a round number: two pure files plus the test tree. If a
+    // derivation breaks and yields nothing, both sides match vacuously.
+    expect(spec.length).toBeGreaterThanOrEqual(9)
+    expect(script).toEqual(spec)
+  })
+
+  it('both halves of the binary pair are in it', () => {
+    // Neither target can be linked — a system extension is not loadable by a test bundle, and
+    // `Host/main.swift` is top-level code whose statements would become a second `main` — so the
+    // pure files are compiled into the bundle. Losing one silently drops a whole target's coverage.
+    expect(asSet(scriptSources())).toEqual(
+      expect.arrayContaining(['Extension/FlowIdentity.swift', 'Host/RuleArguments.swift']),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`--mutate` runs the suite eighty-three times and every one of those was an `xcodebuild test` launch,
which was the entire cost. Measured on the same sources: `xcodegen` is 0.02s, an `xcodebuild` launch
is ~13.5s on CI's runner, and building the identical XCTest files with `swiftc` and running them
under `xcrun xctest` is **1.9s a cycle**. The full set went from **1049s to 222–246s** across three
local runs.

Dropping mutations was the alternative the `ci.yml` comment had already named as the worse one.
Nothing about the coverage changed: 82 mutations, all killed.

**Two exit codes replaced a string search.** `xcodebuild test` builds and tests as one action and
reports one status, so telling a compile error from a failing assertion meant counting `Test Case`
lines in the log — a check this file had already got wrong twice. Compiling and running are separate
commands now.

**Two outcomes were added rather than one.** `walk: no bound` removes a bound, so it does not fail an
assertion — it spins, and `xcodebuild`'s `-test-timeouts-enabled` has no equivalent here, so `run`
carries a watchdog and reports `killed (hung)`. And `xcrun xctest` exits **0** on a bundle holding no
`XCTestCase` and **1** on one it cannot load, so an exit code is only a verdict once a test has
started; a SIGKILL that was not the watchdog's is `NO VERDICT`, not a kill. With eighty-three
processes started per run, one stray `pkill` would otherwise have scored a surviving mutation as
caught.

`tests.yml` stays — generating a real project is how you open these tests in Xcode and step through
one. Nothing in the script reads it, so a guard holds the two source lists together by asking
`run-tests.sh --print-sources` rather than reimplementing its rules.

**`timeout-minutes` is 15, from a run here.** The first green run of the new engine took **5m29s**
for the whole job against 18m03s before it — 2.7x, deliberately more headroom than the 1.94x the old
ceiling settled for while there is only one measurement. A draft set it to 20 from local numbers on a
12-core machine for a job that runs on a 3-core one.

## What the review changed

Two channels, seven findings, none deferred — three were defects in this branch's own reasoning, and
the record has the measurements:

- **The drift guard could not see the drift it was written for.** It expanded `Tests/*.swift` through
  the same recursive walk it used for a directory entry, so a planted `Tests/Support/ExtraTests.swift`
  that cannot pass was compiled by xcodegen, not by `swiftc`, and the guard called the lists equal.
- **`-target` pins the OS, not the architecture**, and this branch asserted the opposite as its reason
  for omitting it. The bundle was building at `minos 26.0` against the 15.0 both specs declare.
- **`timeout-minutes` was lowered on local numbers** in the same commit that deleted the paragraph
  saying to extrapolate from the slowest run.

## Checklist

- [x] Tests written and passing — 82 mutations killed (224s), `pnpm test:scripts` 800 passed
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

<!-- no-changeset: test-runner and CI tooling only, nothing a self-hoster can observe -->

The gate flags `ios-netfilter/Tests/` and `run-tests.sh` as published source. Neither ships: the
EXEMPT list in `check-changeset.mjs` has `/Test\.swift$/`, which does not match `*Tests.swift`, and
nothing covers the netfilter's dev script. Whether to widen it is a release-packaging decision rather
than one for this PR — noting it here so it is not rediscovered.

## Related `.work/` docs

- `.work/reviews/perf__netfilter-mutation-engine.md` — both channels, all seven findings with the
  commands behind them, and the cleared list (code signing, the watchdog races, `set -e`
  interactions, the `changes` path filter).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved mutation-test execution and reporting, including clearer handling of build failures, timeouts, incomplete results, and missing tests.
  * Added validation to ensure all relevant test sources are discovered and executed consistently.
  * Expanded concurrency-test documentation to reflect a broader range of observed failure outcomes.

* **Documentation**
  * Updated development and CI guidance with current test execution, timing, watchdog, and troubleshooting details.

* **User Impact**
  * No end-user functionality or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->