### PR TITLE
fix(docker): give the builder the toolchain its fallback already assumed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,13 @@ WORKDIR /app
 # source compile of a few minutes — so an unusually slow build here is worth reading as "the
 # download failed" rather than as a mystery. The runtime stage is a fresh image that copies only
 # `/app/out`, so the shipped image does not carry any of this.
+#
+# **Measured once rather than assumed**, because a normal build never exercises this: it was forced
+# with `npm_config_build_from_source=true` on one CI cycle of the PR that added it, and node-gyp
+# compiled `better_sqlite3.node` to `gyp info ok` on both architectures — 82s on amd64, 90s on
+# arm64, against a ~35s build when the prebuild is fetched. That commit was reverted; a permanent
+# source compile would spend those ninety seconds on every release.
 RUN apk add --no-cache git python3 make g++
-
-# TEMPORARY — forces the node-gyp path so this PR's CI proves the toolchain above can actually
-# compile better-sqlite3 on both architectures. Removed in the next commit; a permanent source
-# compile would cost minutes on every release build.
-ENV npm_config_build_from_source=true
 
 # Install pnpm
 RUN npm install -g pnpm@9.15.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ WORKDIR /app
 # `/app/out`, so the shipped image does not carry any of this.
 RUN apk add --no-cache git python3 make g++
 
+# TEMPORARY — forces the node-gyp path so this PR's CI proves the toolchain above can actually
+# compile better-sqlite3 on both architectures. Removed in the next commit; a permanent source
+# compile would cost minutes on every release build.
+ENV npm_config_build_from_source=true
+
 # Install pnpm
 RUN npm install -g pnpm@9.15.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,26 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-# git is required by lefthook/prepare postinstall scripts that run during pnpm install.
-RUN apk add --no-cache git
+# `git` is required by lefthook/prepare postinstall scripts that run during pnpm install.
+#
+# **`python3 make g++` are for a fallback that could not run** (#773). `better-sqlite3` is a
+# production dependency of the relay and its own install script is
+# `prebuild-install || node-gyp rebuild --release`. Alpine ships none of node-gyp's toolchain, so
+# the right-hand side could never execute: any time `prebuild-install` did not produce a binary the
+# install failed, and the log named a missing Python rather than what actually went wrong.
+#
+# That is not hypothetical and it is not only about missing prebuilds. `prebuild-install` reports a
+# failed *download* as "No prebuilt binaries found", so a network blip reads as an absent artifact —
+# measured on one PR's arm64 leg while `main`'s leg fetched the same `linuxmusl-arm64` binary in
+# 0.15s from the same base image digest. Re-running was enough there; a release is not the place to
+# find that out.
+#
+# Removing the fallback instead was the other option and it is not available: that script belongs to
+# the dependency. The cost of this one is builder-stage size and, when the fallback does fire, a
+# source compile of a few minutes — so an unusually slow build here is worth reading as "the
+# download failed" rather than as a mystery. The runtime stage is a fresh image that copies only
+# `/app/out`, so the shipped image does not carry any of this.
+RUN apk add --no-cache git python3 make g++
 
 # Install pnpm
 RUN npm install -g pnpm@9.15.1


### PR DESCRIPTION
## Summary

`better-sqlite3` is a production dependency of the relay and its own install script is
`prebuild-install || node-gyp rebuild --release`. The builder is `node:24-alpine` with `git` and
nothing else, so **the right-hand side could never run**: any time `prebuild-install` did not produce
a binary the install failed, and the log named a missing Python rather than what actually went wrong.

It is not only about missing prebuilds. `prebuild-install` reports a failed *download* as "No
prebuilt binaries found", so a network blip reads as an absent artifact — measured on #772's arm64
leg while `main`'s leg fetched the same `linuxmusl-arm64` binary in 0.15s from the same base image
digest. Re-running was enough there. A release is not the place to find that out.

**The other option in #773 turned out not to exist.** That issue offered "delete the fallback so the
failure names the download" as the smaller change. It is not available: the script belongs to the
dependency, not to us. The issue's paragraph is wrong and this PR is the correction.

The runtime stage is a fresh image that copies only `/app/out`, so the shipped image carries none of
this. What it costs when the fallback fires is a source compile of a few minutes — worth reading as
"the download failed" rather than as a mystery, which is why that is in the comment.

## Verification

A green build proves the packages install. It does **not** prove they compile, because
`prebuild-install` succeeds and node-gyp is skipped — a fallback nobody has watched run is the defect
this PR exists to fix. So one CI cycle on this branch was forced with
`npm_config_build_from_source=true`, and then reverted:

| | amd64 | arm64 |
|---|---|---|
| node-gyp found Python | 3.14.7 at `/usr/bin/python3` | same |
| `better_sqlite3.node` linked | yes | yes |
| `gyp info ok` | yes | yes |
| compile | 82s | 90s |

Against a ~35s build when the prebuild is fetched, so the fallback costs about ninety seconds when
it actually fires — which is why the forcing is reverted rather than kept. Those numbers are in the
comment beside the change. There is no Docker on the machine this was written on, so CI is the only
place it could be measured.

Checked without it: the runtime stage starts from a fresh image; `python3`, `make` and `g++` all
exist for aarch64 on Alpine v3.22; and `g++` depends on `musl-dev` and `libstdc++-dev`, which is the
gap native modules on Alpine usually fall into.

## Checklist

- [x] Tests written and passing — `pnpm test:scripts` 800 passed; the Docker build is the test here
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `pnpm changeset:check` reports *No published source changed*.

## Related `.work/` docs

- `.work/reviews/fix__docker-prebuild-fallback.md`

Closes #773.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation to allow the use of prebuilt binaries.
  * Retained the native build toolchain for dependencies that require compilation.
* **Documentation**
  * Added recorded measurements from previous source-build installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->