### PR TITLE
chore: move the local-only docs out of .work, and judge comment mutations by what they carry

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -130,6 +130,9 @@ model: claude-opus-5
 
 - lint / typecheck(pre-commit 훅이 잡지만 미리 확인 가능).
 - 내부 의존성이 `workspace:*`라 lockfile 변경은 없어야 정상 — 변경이 생겼으면 의심한다.
+- **수동 E2E 패스**: `.internal/MANUAL-E2E-CHECKLIST.md`. 자동 스위트가 닿지 않는 것 — 실제
+  시뮬레이터·에뮬레이터의 스트림, 입력, 녹화 — 만 담고 있고 릴리스마다 같은 항목을 돈다. 사용자
+  머신이 필요하므로 여기서 멈추고 결과를 받는다. 파일이 없는 클론이면(gitignore) 이 항목은 건너뛴다.
 
 ## 9. 커밋 → STOP
 

--- a/.claude/hooks/comment-card-gate.sh
+++ b/.claude/hooks/comment-card-gate.sh
@@ -8,7 +8,7 @@
 # prose will be more subtly wrong, not less.
 #
 # **Three independent reasons a contributor is unaffected**, and only the third survives a mistake:
-#   1. the card lives under `.work/`, which is gitignored — they do not have the file
+#   1. the card lives under `.internal/`, which is gitignored — they do not have the file
 #   2. the wiring lives in `settings.local.json`, which is gitignored — they do not load this hook
 #   3. `scripts/lib/comment-card.mjs` allows the command outright when the card is absent
 #

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -93,22 +93,24 @@ describe('which commands post a comment', () => {
     // would catch `deleteIssueComment`, which publishes nothing, and miss `addPullRequestReview`,
     // which does.
     //
-    // The last five were missing and the gate said nothing while a session replied into review
-    // threads with `addPullRequestReviewThreadReply` a dozen times. They come from the live schema
-    // rather than from memory — `{ __type(name: "Mutation") { fields { name } } }`, then every
-    // `add*`/`update*` ending in `Comment` or `Review`, plus the two `ReviewThread` forms, judged
-    // against "does it publish prose".
+    // Nine of these were missing and the gate said nothing while a session replied into review
+    // threads with `addPullRequestReviewThreadReply` a dozen times. The last four are the ones a
+    // second attempt still missed, because it reached for another name rule — none of them starts
+    // with `add` or `update`. The test that matters is the negative pair below.
     for (const op of ['addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
       'addDiscussionComment', 'updateIssueComment',
       'addPullRequestReviewThread', 'addPullRequestReviewThreadReply',
-      'updatePullRequestReview', 'updatePullRequestReviewComment', 'updateDiscussionComment']) {
+      'updatePullRequestReview', 'updatePullRequestReviewComment', 'updateDiscussionComment',
+      'submitPullRequestReview', 'dismissPullRequestReview', 'createDiscussion', 'updateDiscussion']) {
       it(`sees ${op}`, () => expect(postsAComment(mutation(op)), op).toBe(true))
     }
 
-    // The other half of the enumeration's claim: a mutation that touches a conversation without
-    // publishing prose stays out. Without these two the list could grow into a `*Comment*` pattern
-    // and nothing would notice.
-    for (const op of ['deleteIssueComment', 'addLabelsToLabelable']) {
+    // **The negatives are chosen to be reachable by the criterion, not obviously outside it.**
+    // `deleteIssueComment` alone earned nothing: no rule anyone would write puts it in.
+    // `minimizeComment` is the one that costs something to refuse — it is a `*Comment*` name, it
+    // acts on a comment, and its input carries only `classifier`, so the schema is what says no.
+    // `dismissPullRequestReview` is its mirror: not a `*Comment*` name, and it carries `message`.
+    for (const op of ['minimizeComment', 'deleteIssueComment', 'addLabelsToLabelable']) {
       it(`does not see ${op}`, () => expect(postsAComment(mutation(op)), op).toBe(false))
     }
 
@@ -163,7 +165,7 @@ describe('which commands post a comment', () => {
 
     // The prefilter half is asserted where the hook is spawned against a throwaway checkout — see
     // `the hook itself, spawned`. It cannot be done from here: this repo's own card lives under
-    // gitignored `.work/`, so a test that spawns the hook against this checkout passes on the
+    // gitignored `.internal/`, so a test that spawns the hook against this checkout passes on the
     // author's machine and allows the command in CI, where the card does not exist.
   })
 
@@ -298,7 +300,7 @@ describe('whether the card was read this session', () => {
 describe('a contributor is unaffected even if this is wired for them', () => {
   it('allows the command outright when the card is absent', () => {
     // **Layer 3, and the only one that survives a mistake.** The card lives under gitignored
-    // `.work/` and the wiring under gitignored `settings.local.json`, so a contributor does not
+    // `.internal/` and the wiring under gitignored `settings.local.json`, so a contributor does not
     // reach this — but neither of those is a property of the code.
     const v = judge('gh pr comment 1 --body "x"', {
       cardPath: '/repo/.internal/COMMENT-CARD.md',
@@ -407,7 +409,7 @@ describe('the hook itself, spawned', () => {
     // Asserted through the hook because the prefilter is the half a unit test cannot see.
     //
     // In a throwaway checkout, not this one: the card the gate needs lives under gitignored
-    // `.work/`, so spawning against this repo passes locally and allows the command in CI.
+    // `.internal/`, so spawning against this repo passes locally and allows the command in CI.
     expect(inRepo("gh api graphql -f query='mutation{addComment(input:{}){id}}'").status).toBe(2)
   })
 

--- a/scripts/__tests__/commentCardGate.test.mjs
+++ b/scripts/__tests__/commentCardGate.test.mjs
@@ -22,7 +22,7 @@ const HOOK = path.join(REPO, '.claude/hooks/comment-card-gate.sh')
 
 /** A transcript line carrying one tool call, in the shape the runtime writes. */
 const record = (name, input) => JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } })
-const CARD = path.resolve('/repo/.work/COMMENT-CARD.md')
+const CARD = path.resolve('/repo/.internal/COMMENT-CARD.md')
 const READ_CARD = record('Read', { file_path: CARD })
 /** `cardWasRead` against the card this repo would resolve, which is the whole point of the second
  *  argument: a filename match accepted `/tmp/COMMENT-CARD.md` and `NOT-COMMENT-CARD.md` alike. */
@@ -92,9 +92,24 @@ describe('which commands post a comment', () => {
     // The list is GitHub's rather than ours, which is why it is enumerated: a `*Comment*` pattern
     // would catch `deleteIssueComment`, which publishes nothing, and miss `addPullRequestReview`,
     // which does.
+    //
+    // The last five were missing and the gate said nothing while a session replied into review
+    // threads with `addPullRequestReviewThreadReply` a dozen times. They come from the live schema
+    // rather than from memory — `{ __type(name: "Mutation") { fields { name } } }`, then every
+    // `add*`/`update*` ending in `Comment` or `Review`, plus the two `ReviewThread` forms, judged
+    // against "does it publish prose".
     for (const op of ['addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
-      'addDiscussionComment', 'updateIssueComment']) {
+      'addDiscussionComment', 'updateIssueComment',
+      'addPullRequestReviewThread', 'addPullRequestReviewThreadReply',
+      'updatePullRequestReview', 'updatePullRequestReviewComment', 'updateDiscussionComment']) {
       it(`sees ${op}`, () => expect(postsAComment(mutation(op)), op).toBe(true))
+    }
+
+    // The other half of the enumeration's claim: a mutation that touches a conversation without
+    // publishing prose stays out. Without these two the list could grow into a `*Comment*` pattern
+    // and nothing would notice.
+    for (const op of ['deleteIssueComment', 'addLabelsToLabelable']) {
+      it(`does not see ${op}`, () => expect(postsAComment(mutation(op)), op).toBe(false))
     }
 
     it('allows a query that only reads', () => {
@@ -211,34 +226,34 @@ describe('whether the card was read this session', () => {
 
   it('is false when the name only appears in prose', () => {
     // A gate satisfied by its own block message would never fire twice.
-    const mention = JSON.stringify({ message: { content: [{ type: 'text', text: 'read .work/COMMENT-CARD.md first' }] } })
+    const mention = JSON.stringify({ message: { content: [{ type: 'text', text: 'read .internal/COMMENT-CARD.md first' }] } })
     expect(withTranscript([mention], sawCard)).toBe(false)
   })
 
   it('is false for a card that is not this repository\'s', () => {
     // A filename match took any of these. The gate resolves a path; the check now compares it.
-    for (const fp of ['/tmp/COMMENT-CARD.md', '/other/repo/.work/COMMENT-CARD.md', '/repo/.work/NOT-COMMENT-CARD.md']) {
+    for (const fp of ['/tmp/COMMENT-CARD.md', '/other/repo/.internal/COMMENT-CARD.md', '/repo/.internal/NOT-COMMENT-CARD.md']) {
       expect(withTranscript([record('Read', { file_path: fp })], sawCard), fp).toBe(false)
     }
   })
 
   it('resolves a relative shell mention against the directory it ran in', () => {
-    // `cat .work/COMMENT-CARD.md` counted the same from anywhere, so a command that failed — or ran
+    // `cat .internal/COMMENT-CARD.md` counted the same from anywhere, so a command that failed — or ran
     // in a different checkout — satisfied the gate. Every transcript record carries the `cwd` the
     // call ran in; this project's carry 22 distinct ones, so the wrong-directory case is the common
     // one rather than a corner.
     const repo = path.dirname(path.dirname(CARD))
-    expect(withTranscript([bashAt(repo, 'cat .work/COMMENT-CARD.md')], sawCard), 'at the root').toBe(true)
-    expect(withTranscript([bashAt(path.join(repo, 'packages/relay'), 'cat .work/COMMENT-CARD.md')], sawCard),
+    expect(withTranscript([bashAt(repo, 'cat .internal/COMMENT-CARD.md')], sawCard), 'at the root').toBe(true)
+    expect(withTranscript([bashAt(path.join(repo, 'packages/relay'), 'cat .internal/COMMENT-CARD.md')], sawCard),
       'in a subdirectory, where it fails').toBe(false)
-    expect(withTranscript([bashAt('/somewhere/else', 'cat .work/COMMENT-CARD.md')], sawCard),
+    expect(withTranscript([bashAt('/somewhere/else', 'cat .internal/COMMENT-CARD.md')], sawCard),
       'in another checkout').toBe(false)
   })
 
   it('takes an absolute mention with no directory to resolve against', () => {
     const noCwd = JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: `cat ${CARD}` } }] } })
     expect(withTranscript([noCwd], sawCard)).toBe(true)
-    const relativeNoCwd = JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'cat .work/COMMENT-CARD.md' } }] } })
+    const relativeNoCwd = JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'cat .internal/COMMENT-CARD.md' } }] } })
     expect(withTranscript([relativeNoCwd], sawCard), 'a relative one has nothing to resolve with').toBe(false)
   })
 
@@ -268,7 +283,7 @@ describe('whether the card was read this session', () => {
     // and reading it through the shell all put it in front of the writer.
     expect(withTranscript([record('Write', { file_path: CARD, content: '#' })], sawCard)).toBe(true)
     expect(withTranscript([record('Edit', { replace_all: false, file_path: CARD })], sawCard)).toBe(true)
-    expect(withTranscript([bashAt(path.dirname(path.dirname(CARD)), 'cat .work/COMMENT-CARD.md')], sawCard)).toBe(true)
+    expect(withTranscript([bashAt(path.dirname(path.dirname(CARD)), 'cat .internal/COMMENT-CARD.md')], sawCard)).toBe(true)
   })
 
   it('survives an unparseable line', () => {
@@ -286,7 +301,7 @@ describe('a contributor is unaffected even if this is wired for them', () => {
     // `.work/` and the wiring under gitignored `settings.local.json`, so a contributor does not
     // reach this — but neither of those is a property of the code.
     const v = judge('gh pr comment 1 --body "x"', {
-      cardPath: '/repo/.work/COMMENT-CARD.md',
+      cardPath: '/repo/.internal/COMMENT-CARD.md',
       transcriptPath: '/nowhere.jsonl',
       exists: () => false,
     })
@@ -297,7 +312,7 @@ describe('a contributor is unaffected even if this is wired for them', () => {
     // The contrast is what makes the assertion above mean something: without it, "allows" could be
     // true for any reason at all.
     const v = judge('gh pr comment 1 --body "x"', {
-      cardPath: '/repo/.work/COMMENT-CARD.md',
+      cardPath: '/repo/.internal/COMMENT-CARD.md',
       transcriptPath: '/nowhere.jsonl',
       exists: () => true,
     })
@@ -315,8 +330,8 @@ describe('the hook itself, spawned', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'card-repo-'))
     spawnSync('git', ['init', '-q', dir])
     if (card) {
-      mkdirSync(path.join(dir, '.work'), { recursive: true })
-      writeFileSync(path.join(dir, '.work/COMMENT-CARD.md'), '# card\n')
+      mkdirSync(path.join(dir, '.internal'), { recursive: true })
+      writeFileSync(path.join(dir, '.internal/COMMENT-CARD.md'), '# card\n')
     }
     mkdirSync(path.join(dir, 'scripts/lib'), { recursive: true })
     for (const f of ['comment-card-gate.mjs', 'lib/comment-card.mjs', 'lib/gh-command.mjs']) {
@@ -338,7 +353,7 @@ describe('the hook itself, spawned', () => {
   }
 
   it('does not accept a read of some other repository\'s card', () => {
-    // The fixture that used to pass this suite: a `Read` of `/repo/.work/COMMENT-CARD.md` while the
+    // The fixture that used to pass this suite: a `Read` of `/repo/.internal/COMMENT-CARD.md` while the
     // card actually lives in the throwaway checkout. Matching by filename accepted it.
     expect(inRepo('gh pr comment 701 --body "x"', { transcript: [READ_CARD] }).status).toBe(2)
   })
@@ -350,7 +365,7 @@ describe('the hook itself, spawned', () => {
   })
 
   it('allows it once the card has been read', () => {
-    const readItThere = (dir) => [record('Read', { file_path: path.join(dir, '.work/COMMENT-CARD.md') })]
+    const readItThere = (dir) => [record('Read', { file_path: path.join(dir, '.internal/COMMENT-CARD.md') })]
     expect(inRepo('gh pr comment 701 --body "x"', { transcript: readItThere }).status).toBe(0)
   })
 

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -8,7 +8,16 @@
 import path from 'node:path'
 import { judge } from './lib/comment-card.mjs'
 
-const CARD = '.work/COMMENT-CARD.md'
+// `.internal/`, not `.work/`. That directory is dated work logs — `YYYY-MM-DD-{topic}-{type}.md`
+// per its own CLAUDE.md — and the card is a standing register, not a log of anything. It sits
+// with the other local-only operating documents. Both directories are gitignored, so a
+// contributor's checkout has neither and the gate stays off for them either way.
+//
+// **Moving it is a two-file change with a silent failure mode**: `judge` returns `blocked: false`
+// when the card is absent, so a path that points at nothing turns the gate off rather than
+// breaking it. `commentCardGate.test.mjs` builds a throwaway checkout, puts the card where this
+// constant says, and runs the hook — pointing this back at `.work/` turns that suite red.
+const CARD = '.internal/COMMENT-CARD.md'
 
 const message = `Blocked: read ${CARD} before writing this comment.
 

--- a/scripts/comment-card-gate.mjs
+++ b/scripts/comment-card-gate.mjs
@@ -54,7 +54,8 @@ if (typeof transcript !== 'string' || !transcript) process.exit(0)
 // **The shell already resolved the root and `cd`-ed there**, so this is it. Re-deriving it from
 // `payload.cwd` looked equivalent and was not: that field is the session's working directory, which
 // is a subdirectory for most of a session's life — 26 distinct values in this project's transcripts,
-// exactly one of them the repo root. The gate then looked for the card under `packages/relay/.work/`,
+// exactly one of them the repo root. The gate then looked for the card under `packages/relay/.work/`
+// — the card lived there at the time —
 // found nothing, and allowed the command for the same reason a contributor's checkout allows it.
 const root = process.cwd()
 

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -81,15 +81,31 @@ function apiCommentInvocations(cmd) {
 const COMMENT_MUTATIONS = [
   'addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
   'addDiscussionComment', 'updateIssueComment',
-  // **The five below were missing, and the gap was found by using it.** A session replied into review
-  // threads with `addPullRequestReviewThreadReply` a dozen times and the gate said nothing — the
-  // enumeration above is right about *why* it is an enumeration and was simply short. Checked against
-  // the live schema (`{ __type(name: "Mutation") { fields { name } } }`) rather than recalled, which
-  // is also how to grow it next time: every `add*`/`update*` whose name ends in `Comment` or `Review`,
-  // plus the two `ReviewThread` forms, and then judge each one against "does it publish prose".
+  // **The nine below were missing, and the gap was found by using it.** A session replied into review
+  // threads with `addPullRequestReviewThreadReply` a dozen times and the gate said nothing.
   'addPullRequestReviewThread', 'addPullRequestReviewThreadReply',
   'updatePullRequestReview', 'updatePullRequestReviewComment', 'updateDiscussionComment',
+  // Four more that a first attempt at this list missed, because that attempt reached for a name
+  // pattern again — "every `add*`/`update*` ending in `Comment` or `Review`". None of these four
+  // starts with `add` or `update`, and every one of them publishes: `submitPullRequestReview` and
+  // `createDiscussion`/`updateDiscussion` carry `body`, `dismissPullRequestReview` carries `message`
+  // onto the PR timeline. Its REST spelling is already caught by the path regex, so that one action
+  // was blocked one way and open the other.
+  'submitPullRequestReview', 'dismissPullRequestReview', 'createDiscussion', 'updateDiscussion',
 ]
+
+/**
+ * **How to grow the list, which is not by matching names.** Twice now a name rule has produced a
+ * short list — `*Comment*` first, then `add*`/`update*` ending in `Comment` or `Review`. The
+ * criterion is what the mutation *does*, and the schema answers it directly: an input type with a
+ * `body` or `message` field publishes prose, and one without does not. `minimizeComment` carries
+ * only `classifier` and belongs out; `dismissPullRequestReview` carries `message` and belongs in.
+ *
+ *   gh api graphql -f query='{ __type(name: "Mutation") { fields { name } } }'
+ *   gh api graphql -f query='{ __type(name: "<Name>Input") { inputFields { name } } }'
+ *
+ * Read the second for any candidate before adding or refusing it.
+ */
 
 /** Every value given for one field name. Read by name, since only a `body` field is a body. */
 const fieldValues = (words, name) =>
@@ -210,7 +226,7 @@ export function cardWasRead(transcriptPath, cardPath) {
  * @returns {{ blocked: boolean, reason?: 'card-not-read' }}
  *
  * **Three independent reasons a contributor is unaffected**, and the third is the one that matters:
- * the card lives under gitignored `.work/`, the wiring lives in gitignored `settings.local.json`,
+ * the card lives under gitignored `.internal/`, the wiring lives in gitignored `settings.local.json`,
  * and this returns `blocked: false` when the card is absent. The first two are "it was not wired for
  * them"; only the third survives someone wiring it by mistake.
  */

--- a/scripts/lib/comment-card.mjs
+++ b/scripts/lib/comment-card.mjs
@@ -81,6 +81,14 @@ function apiCommentInvocations(cmd) {
 const COMMENT_MUTATIONS = [
   'addComment', 'addPullRequestReview', 'addPullRequestReviewComment',
   'addDiscussionComment', 'updateIssueComment',
+  // **The five below were missing, and the gap was found by using it.** A session replied into review
+  // threads with `addPullRequestReviewThreadReply` a dozen times and the gate said nothing — the
+  // enumeration above is right about *why* it is an enumeration and was simply short. Checked against
+  // the live schema (`{ __type(name: "Mutation") { fields { name } } }`) rather than recalled, which
+  // is also how to grow it next time: every `add*`/`update*` whose name ends in `Comment` or `Review`,
+  // plus the two `ReviewThread` forms, and then judge each one against "does it publish prose".
+  'addPullRequestReviewThread', 'addPullRequestReviewThreadReply',
+  'updatePullRequestReview', 'updatePullRequestReviewComment', 'updateDiscussionComment',
 ]
 
 /** Every value given for one field name. Read by name, since only a `body` field is a body. */
@@ -135,7 +143,7 @@ function samePath(a, b) {
  *
  * **A relative mention is resolved against the record's own directory.** Every transcript record
  * carries the `cwd` the call ran in, and this project's carry 22 distinct ones. Without using it,
- * `cat .work/COMMENT-CARD.md` counted the same whether it ran at the repo root, in
+ * `cat .internal/COMMENT-CARD.md` counted the same whether it ran at the repo root, in
  * `packages/relay` where it fails, or in a different checkout entirely — so a command that never
  * read the card satisfied the gate. A record with no `cwd` cannot resolve a relative mention and
  * does not get one; the absolute form still counts, since it needs no directory to be unambiguous.
@@ -160,7 +168,7 @@ function namesCard(input, cardPath, relative, recordCwd) {
  * would otherwise let it fire exactly once ever.
  *
  * A floor, not a fence, and the boundary is narrower than it was: a command naming the card in the
- * directory that holds it counts whether or not it read anything — `ls .work/COMMENT-CARD.md` does.
+ * directory that holds it counts whether or not it read anything — `ls .internal/COMMENT-CARD.md` does.
  * Whether the read *succeeded* is not checked, because that needs the result rather than the call.
  * That direction costs a missed prompt for a cooperative reader, which is the threat model these
  * gates state.


### PR DESCRIPTION
## Summary

`.work/` is dated work logs — `YYYY-MM-DD-{topic}-{type}.md`, per its own CLAUDE.md. Two files there
were not logs of anything: `COMMENT-CARD.md`, a standing register for comments written from this
account, and `MANUAL-E2E-CHECKLIST.md`, a template repeated every release. Both now sit in
`.internal/` with the other local-only operating documents. Both directories are gitignored, so a
contributor's checkout has neither and nothing changes for them.

`MANUAL-E2E-CHECKLIST.md` had **zero references anywhere**, which is why nobody ran it.
`.claude/commands/release.md` §8 and `.internal/RELEASING.md` now point at it.

**The card is read by a live PreToolUse gate, and that gate fails open** — `judge` returns
`blocked: false` when the card is absent, so a path pointing at nothing switches it off rather than
breaking it. `commentCardGate.test.mjs` builds a throwaway checkout, writes the card where the
constant says, copies the real scripts in and spawns the real hook: pointing the constant back at
`.work/` turns five tests red. Verified against the live hook too.

## Using the gate found it short, twice

`addPullRequestReviewThreadReply` was not in `COMMENT_MUTATIONS`, so a session replying into review
threads over GraphQL was never asked to read the card — a dozen times, in silence. Four more were
missing with it.

Then the note added beside that fix said to grow the list by taking "every `add*`/`update*` ending in
`Comment` or `Review`" — **another name rule**, and it cannot reach `submitPullRequestReview`,
`dismissPullRequestReview`, `createDiscussion` or `updateDiscussion`. All four publish;
`dismissPullRequestReview` puts `message` on the PR timeline, and its REST spelling was already
caught by the path regex, so one action was blocked one way and open the other.

**The criterion is the input type.** An input carrying `body` or `message` publishes prose; one
without does not. `minimizeComment` carries only `classifier`. The two introspection queries that
settle it are written beside the list now, in place of the name rule.

The negative tests changed with it: `deleteIssueComment` earned nothing, since no rule anyone would
write puts it in. `minimizeComment` is the one that costs something to refuse.

## Checklist

- [x] Tests written and passing — `pnpm test:scripts` 812 passed; mutations both directions
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `pnpm changeset:check` reports *No published source changed*.

## Related `.work/` docs

- `.work/reviews/chore__move-local-only-docs.md` — one channel, two findings, none deferred, with
  the cleared list (the test genuinely holds the path, the added mutations all carry a body, the
  hook's root resolution, `.work/CLAUDE.md` unaffected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release guidance to include manual verification of simulator and emulator streaming, input, and recording workflows.
  - Clarified locations for work logs and comment-card records.

- **Chores**
  - Moved the comment-card record from the previous work-log location to the internal records location.

- **Tests**
  - Expanded coverage for additional review, discussion, pull-request, and review-thread activity.
  - Updated validation scenarios for the revised comment-card location and path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->