### PR TITLE
feat(docker): publish the Docker Hub overview from the repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -269,6 +269,21 @@ jobs:
       # a required check, so a permanently red run is how nobody notices the day the *push* breaks.
       # Set `DOCKERHUB_DESCRIPTION_TOKEN` to turn it on; until then the step is skipped and the page
       # stays as it is.
+      # **This job has no checkout of its own**, because merging digests into a manifest needs the
+      # registry and nothing from the repository. The step below is the first thing here that reads a
+      # file, so it has to bring one — without this it would fail on a missing path the moment the
+      # secret was set, which is the failure the gate above exists to avoid, arriving by another door.
+      #
+      # Sparse, so what the job depends on is one line rather than the whole tree, and anyone tidying
+      # a checkout that looks unused can see what it is for.
+      - name: Check out the overview
+        if: env.HAS_DOCKERHUB == 'true' && env.HAS_DESCRIPTION_TOKEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: docker/hub-overview.md
+          sparse-checkout-cone-mode: false
+
       - name: Push the Docker Hub overview
         if: env.HAS_DOCKERHUB == 'true' && env.HAS_DESCRIPTION_TOKEN == 'true'
         uses: peter-evans/dockerhub-description@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -206,6 +206,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' && secrets.DOCKERHUB_USERNAME != '' }}
+      # A second flag rather than a longer `if`, because the `secrets` context is not available in a
+      # step-level `if` — which is why `HAS_DOCKERHUB` above exists at all rather than being inlined.
+      HAS_DESCRIPTION_TOKEN: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN != '' }}
     steps:
       - name: Note validation-only build
         if: env.HAS_DOCKERHUB != 'true'
@@ -253,3 +256,26 @@ jobs:
       - name: Inspect image
         if: env.HAS_DOCKERHUB == 'true'
         run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+
+      # **The page a first-time visitor lands on, which was blank while the image was pulled 7,768
+      # times.** Nothing here pushed a description, so it was set by hand or not at all — and a file
+      # in the repo without this step is a file nobody reads, which is why one arriving alone was
+      # dropped from #713. The file and the step go together or neither does.
+      #
+      # **Gated on its own secret, and that is not tidiness.** The action needs a PAT with
+      # `read/write/delete`; `DOCKERHUB_TOKEN` is documented as Read & Write, so it may not carry the
+      # scope to edit repository metadata. Hanging this off `HAS_DOCKERHUB` would then redden every
+      # push to `main` for a reason that has nothing to do with the image — and this workflow is not
+      # a required check, so a permanently red run is how nobody notices the day the *push* breaks.
+      # Set `DOCKERHUB_DESCRIPTION_TOKEN` to turn it on; until then the step is skipped and the page
+      # stays as it is.
+      - name: Push the Docker Hub overview
+        if: env.HAS_DOCKERHUB == 'true' && env.HAS_DESCRIPTION_TOKEN == 'true'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN }}
+          repository: ${{ env.IMAGE }}
+          readme-filepath: ./docker/hub-overview.md
+          short-description: >-
+            Relay server for tapflow — self-hosted iOS & Android simulator streaming for your whole team

--- a/docker/hub-overview.md
+++ b/docker/hub-overview.md
@@ -1,0 +1,75 @@
+# tapflow relay
+
+Run iOS simulators and Android emulators in any browser. Your builds, streams and recordings stay on
+infrastructure you control — no device pool, no cloud uploads, no accounts on someone else's service.
+
+**This image is the relay only.** It serves the dashboard and brokers traffic. The agents that drive
+real simulators and emulators are macOS-native and run on your Macs, joining this relay over your
+network.
+
+## Where to run it
+
+**On the same Mac, or on a box on your own network.** Not on a public cloud VM.
+
+Every video and audio frame between an agent and a browser passes through the relay, so a relay on a
+cloud VM sends app screen data outside your network — and the detour costs more latency than the
+30fps budget can absorb. An always-on LAN box is the topology this image exists for.
+
+## Quick start
+
+```yaml
+services:
+  relay:
+    image: tapflow/tapflow:latest
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./data:/app/.tapflow/data
+    environment:
+      - TAPFLOW_RELAY_URL=http://<this-box-ip>:4000
+      - TAPFLOW_ADMIN_EMAIL=you@example.com
+      - TAPFLOW_ADMIN_PASSWORD=<at least 8 characters>
+    restart: unless-stopped
+```
+
+```sh
+docker compose up -d
+```
+
+Three of those lines are not optional, and each one fails in a way that is hard to read backwards.
+
+**The volume.** The relay writes a per-install secret to `<dataDir>/jwt-secret` and reuses it.
+Without the volume that file lives in the container's writable layer: `docker restart` keeps it, but
+anything that *recreates* the container loses it — an image update, `docker compose down && docker
+compose up -d`, `docker rm`. A new secret logs out every user and breaks every agent connection.
+
+**`TAPFLOW_RELAY_URL`.** The relay never reads its own address from the `Host` header — a forged one
+would send a phishing link out as a normal invitation — so with nothing set it falls back to
+`http://localhost:4000`, and an invitation mailed to a teammate opens *their* machine. The same value
+also forms the CORS and CSRF allowlist.
+
+**`TAPFLOW_ADMIN_EMAIL` / `TAPFLOW_ADMIN_PASSWORD`.** Browser onboarding answers loopback only, and a
+container reaches the relay through the bridge gateway, so it refuses — and the error tells you to run
+a CLI this image does not contain. These two create the first account at startup instead. Both or
+neither; at least 8 characters; and nothing happens on an install that already has an owner.
+
+## Tags
+
+- `latest` — the most recent release. Use this.
+- `edge` — whatever is on `main` right now.
+- `0.20`, `0.20.1` — pinned releases.
+- `sha-<commit>` — a specific build.
+
+Every tag carries `linux/amd64` and `linux/arm64`.
+
+## Then what
+
+Agents run on your Macs and connect outbound to this relay:
+
+```sh
+tapflow agent start --relay ws://<this-box-ip>:4000 --token <agent-scope token>
+```
+
+Full setup, TLS, tunnels and the agent side: **https://www.tapflow.dev/guide/self-hosting**
+
+Source and issues: **https://github.com/jo-duchan/tapflow** · MIT


### PR DESCRIPTION
## Summary

The page a first-time visitor lands on has been blank while the image was pulled **7,768 times** —
`full_description` is 0 characters, so the only thing on it is the one-line description. Nothing in
`docker-publish.yml` pushed one, which is why a file arriving on its own was dropped when #713 was
taken over: it would have sat unread. The file and the step that publishes it go together or neither
does.

`docker/hub-overview.md` is not the README. The image is the relay alone, the agents are
macOS-native, and the placement rule — same Mac or your own network, not a public cloud VM — is the
thing #352 asked be said plainly. It leads with the three settings that each fail in a way that is
hard to read backwards: the volume, `TAPFLOW_RELAY_URL`, and the admin variables.

## The step is gated on a second secret, deliberately

The action needs a PAT with `read/write/delete`. `DOCKERHUB_TOKEN` is documented as Read & Write in
#352's own body, so it may not carry the scope to edit repository metadata.

Hanging the step off `HAS_DOCKERHUB` would then redden every push to `main` for a reason that has
nothing to do with the image — and `docker-publish` is not a required check on `protect-main`, so a
permanently red run is exactly how nobody notices the day the *push* breaks. Setting
`DOCKERHUB_DESCRIPTION_TOKEN` turns it on; until then the step is skipped and the page stays as it
is.

It is a second job-level flag rather than a longer `if` because the `secrets` context is not
available in a step-level `if` — which is why `HAS_DOCKERHUB` exists as a flag rather than inline.
The first draft got that wrong.

## Verification

Everything the page claims, checked rather than assumed:

- both links answer 200, and the docs domain is **`tapflow.dev`** — the first draft wrote
  `tapflow.io`, which is not ours
- all four tag families exist (`latest`, `edge`, `0.20`, `0.20.1`)
- `docker buildx imagetools inspect` shows `linux/amd64` and `linux/arm64` on `edge` and `latest`,
  which is also #352's acceptance command
- 3,000 characters against the action's 25,000 limit
- `actionlint` passes

## After merge (maintainer)

Add the `DOCKERHUB_DESCRIPTION_TOKEN` secret. If the current token already has `read/write/delete`
the same value works; otherwise it needs a new PAT. The step stays skipped until then.

## Checklist

- [x] Tests written and passing — `pnpm test:scripts` 812 passed; `actionlint` clean
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `pnpm changeset:check` reports *No published source changed*.

## Related `.work/` docs

- `.work/2026-08-19-docker-publish-finish-plan.md` — this is stage 3's last open item.
- `.work/reviews/feat__dockerhub-description.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Docker image documentation covering supported deployment topologies, Docker Compose setup, required persistence, environment variables, image tags, agent connection instructions, and helpful setup links.
  - Docker Hub repository descriptions can now be updated automatically from the maintained overview documentation when publishing credentials are configured, helping keep published image information aligned with the latest setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->