### PR TITLE
feat(docker): publish to GHCR alongside Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -209,6 +209,15 @@ jobs:
       # A second flag rather than a longer `if`, because the `secrets` context is not available in a
       # step-level `if` — which is why `HAS_DOCKERHUB` above exists at all rather than being inlined.
       HAS_DESCRIPTION_TOKEN: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN != '' }}
+      # Lowercased because a registry path must be, and `github.repository` carries the owner's
+      # capitalisation. `jo-duchan/tapflow` happens to be lowercase already; a fork whose owner is not
+      # would push to a path the registry rejects, and the failure names the tag rather than the case.
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+    permissions:
+      contents: read
+      # `ghcr.io` takes `GITHUB_TOKEN`, so the second registry needs no secret and nothing that
+      # expires. The repository default is `read`, so without this line the push is a 403.
+      packages: write
     steps:
       - name: Note validation-only build
         if: env.HAS_DOCKERHUB != 'true'
@@ -256,6 +265,53 @@ jobs:
       - name: Inspect image
         if: env.HAS_DOCKERHUB == 'true'
         run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+
+      # ── A second registry, copied rather than built twice ──────────────────────────────────────
+      #
+      # **Why a copy and not a second push from the build job.** `buildx` does take repeated image
+      # outputs, so the build could push by digest to both registries and neither would depend on the
+      # other. That is the better shape and it is not the one to land first: it rewrites the
+      # `outputs:` expression that drives the Docker Hub push, and **nothing here can be rehearsed**
+      # — the push path is skipped on pull requests, so its first run is on `main`. A mistake there
+      # stops releases. Everything below runs after Docker Hub already has the manifest, so the worst
+      # it can do is fail by itself.
+      #
+      # The cost is honest: if Docker Hub is down, GHCR gets nothing that day. That matters less than
+      # it sounds, because a failed Hub push is loud — this is the registry that answers when someone
+      # hits Docker Hub's anonymous pull limit, not a hot standby.
+      - name: Log in to GHCR
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `imagetools create` with a source copies the manifest list and any blobs the destination is
+      # missing, so the architectures and the attestations arrive without a rebuild. The tags are the
+      # ones `metadata-action` already worked out, with the registry swapped.
+      - name: Copy the manifest to GHCR
+        if: env.HAS_DOCKERHUB == 'true'
+        env:
+          TAGS_JSON: ${{ steps.meta.outputs.json }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # An array rather than the word-split the sibling step disables SC2046 for: a tag can carry
+          # no whitespace today, and building the flags as elements means that stays true by shape.
+          #
+          # `sub(".*:"; "")` is greedy on purpose — it keeps what follows the *last* colon. Anchoring
+          # on the first one reads the port of a `registry:5000/foo:1.2.3` as the tag.
+          args=()
+          while IFS= read -r tag; do
+            echo "copying to: $tag"
+            args+=(-t "$tag")
+          done < <(jq -r --arg img "$GHCR_IMAGE" '.tags[] | sub(".*:"; "") | $img + ":" + .' <<< "$TAGS_JSON")
+          docker buildx imagetools create "${args[@]}" "${IMAGE}:${VERSION}"
+
+      - name: Inspect the GHCR image
+        if: env.HAS_DOCKERHUB == 'true'
+        run: docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
 
       # **The page a first-time visitor lands on, which was blank while the image was pulled 7,768
       # times.** Nothing here pushed a description, so it was set by hand or not at all — and a file

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -209,10 +209,6 @@ jobs:
       # A second flag rather than a longer `if`, because the `secrets` context is not available in a
       # step-level `if` — which is why `HAS_DOCKERHUB` above exists at all rather than being inlined.
       HAS_DESCRIPTION_TOKEN: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN != '' }}
-      # Lowercased because a registry path must be, and `github.repository` carries the owner's
-      # capitalisation. `jo-duchan/tapflow` happens to be lowercase already; a fork whose owner is not
-      # would push to a path the registry rejects, and the failure names the tag rather than the case.
-      GHCR_IMAGE: ghcr.io/${{ github.repository }}
     permissions:
       contents: read
       # `ghcr.io` takes `GITHUB_TOKEN`, so the second registry needs no secret and nothing that
@@ -279,6 +275,19 @@ jobs:
       # The cost is honest: if Docker Hub is down, GHCR gets nothing that day. That matters less than
       # it sounds, because a failed Hub push is loud — this is the registry that answers when someone
       # hits Docker Hub's anonymous pull limit, not a hot standby.
+      # **A registry path must be lowercase and `github.repository` carries the owner's
+      # capitalisation**, so this cannot be a plain `env:` line — Actions expressions have no
+      # `lower()`. A first draft wrote the caveat as a comment above the unmodified value, which is
+      # the shape of a fix that is only a description of the bug. A fork owned by `Acme-Corp` would
+      # have got `invalid reference format: repository name must be lowercase`, *after* Docker Hub
+      # had already published.
+      - name: Resolve the GHCR image name
+        if: env.HAS_DOCKERHUB == 'true'
+        # `tr` rather than `${VAR,,}`, which is bash 4 and so cannot be exercised on a machine that
+        # ships 3.2 — and nothing about this job can be rehearsed anyway, so it gets no construct
+        # this side cannot run.
+        run: echo "GHCR_IMAGE=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         if: env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@v3
@@ -290,11 +299,17 @@ jobs:
       # `imagetools create` with a source copies the manifest list and any blobs the destination is
       # missing, so the architectures and the attestations arrive without a rebuild. The tags are the
       # ones `metadata-action` already worked out, with the registry swapped.
+      # **The source is the digests, not `IMAGE:VERSION`.** Copying from the tag re-resolves it on
+      # Docker Hub seconds after the sibling step wrote it, and a second push to `main` inside that
+      # window would hand this run *another commit's* manifest — which it would then publish under
+      # its own `sha-<commit>` tag. A floating `edge` recovers on the next run; a `sha-` tag is what
+      # people pin to, and it would be wrong for good. Same source expression as the Docker Hub step
+      # above, so both registries get the bytes this run built.
       - name: Copy the manifest to GHCR
         if: env.HAS_DOCKERHUB == 'true'
+        working-directory: ${{ runner.temp }}/digests
         env:
           TAGS_JSON: ${{ steps.meta.outputs.json }}
-          VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
           # An array rather than the word-split the sibling step disables SC2046 for: a tag can carry
@@ -307,11 +322,34 @@ jobs:
             echo "copying to: $tag"
             args+=(-t "$tag")
           done < <(jq -r --arg img "$GHCR_IMAGE" '.tags[] | sub(".*:"; "") | $img + ":" + .' <<< "$TAGS_JSON")
-          docker buildx imagetools create "${args[@]}" "${IMAGE}:${VERSION}"
+          for d in *; do args+=("${IMAGE}@sha256:${d}"); done
+          docker buildx imagetools create "${args[@]}"
 
+      # Two inspections, and the second is the one that matters. The first runs with the login above
+      # still in hand and proves only that the copy landed. **A GHCR package is private on its first
+      # push**, and the reason this registry exists is anonymous pulls by people who hit Docker Hub's
+      # limit — so an authenticated check would go green while the feature delivers nothing. Logging
+      # out first is what makes the second one anonymous.
+      #
+      # `DOCKER_CONFIG=$(mktemp -d)` looks like the tidier way to drop the credential and is not:
+      # measured, it also hides the CLI plugin directory, and `docker buildx` stops existing.
+      #
+      # A warning rather than a failure. The visibility is a one-time setting on the package, nobody
+      # can flip it from here, and reddening the release for it would be the wrong signal — but it is
+      # said loudly, once per run, until somebody does.
       - name: Inspect the GHCR image
         if: env.HAS_DOCKERHUB == 'true'
-        run: docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect "${GHCR_IMAGE}:${{ steps.meta.outputs.version }}"
+
+      - name: Check that GHCR answers an anonymous pull
+        if: env.HAS_DOCKERHUB == 'true'
+        run: |
+          docker logout ghcr.io
+          if ! docker buildx imagetools inspect "${GHCR_IMAGE}:${{ steps.meta.outputs.version }}"; then
+            echo "::warning::${GHCR_IMAGE} is not anonymously pullable — the package is private," \
+                 "which is how GHCR creates it. Set its visibility to Public once, at" \
+                 "https://github.com/${GITHUB_REPOSITORY}/pkgs/container/${GITHUB_REPOSITORY#*/}"
+          fi
 
       # **The page a first-time visitor lands on, which was blank while the image was pulled 7,768
       # times.** Nothing here pushed a description, so it was set by hand or not at all — and a file


### PR DESCRIPTION
## Summary

A second place to pull from, for anyone who hits Docker Hub's anonymous limit — **100 pulls per IPv4
address per 6 hours**, and a multi-arch image counts once per architecture, so ours is 50. A LAN box
behind one NAT address is the shape that reaches it, and that is the topology this image exists for.

`ghcr.io` takes `GITHUB_TOKEN`, so it needs no secret and nothing that expires. The repository
default is `read`, so the job declares `packages: write`.

## A copy, not a second push — because nothing here can be rehearsed

There is no Docker daemon on the authoring machine, the available token has no `write:packages`, and
this workflow's push path is skipped on pull requests. **The first execution is a push to `main`,
and this job is the release path.**

`buildx` does take repeated image outputs, so the build could push by digest to both registries and
neither would depend on the other. That is the better shape and not the one to land first: it
rewrites the `outputs:` expression that drives the Docker Hub push. These steps run after Docker Hub
already has the manifest, so the worst they can do is fail alone.

The cost is honest — if Docker Hub is down, GHCR gets nothing that day. This is the registry that
answers a rate limit, not a hot standby.

## What the review changed

Three findings, each a way the first run would have gone green while delivering nothing or the wrong
thing:

- **The only check ran authenticated.** A GHCR package is private on first push, and the point of
  this registry is *anonymous* pulls — so inspecting it with the login still in hand proves the copy
  landed and nothing about whether anyone can fetch it. There is a second inspect after
  `docker logout ghcr.io`, warning rather than failing, since visibility is a one-time setting nobody
  can flip from here. `DOCKER_CONFIG=$(mktemp -d)` was the tidier-looking way and does not work —
  measured, it hides the CLI plugin directory and `docker buildx` stops existing.
- **A comment said the image name was lowercased; nothing lowercased it.** Actions expressions have
  no `lower()`, so a fork owned by `Acme-Corp` would have got `repository name must be lowercase`
  *after* Docker Hub published. It is a step now, using `tr` rather than `${VAR,,}` — bash 4 is not
  something this side can exercise, and a job that cannot be rehearsed gets no construct that cannot
  be run here.
- **The copy read a floating tag.** `IMAGE:VERSION` re-resolves on Docker Hub seconds after the
  sibling step wrote it, so a second push to `main` inside that window would hand this run another
  commit's manifest — published under *this* run's `sha-<commit>` tag. A stale `edge` fixes itself
  next run; a `sha-` tag is what people pin to. Same per-digest source as the Docker Hub step now.

One finding is deferred with its reason in the record: every new step is gated on `HAS_DOCKERHUB`, so
a fork without Docker Hub secrets gets nothing — structural, because the copy's *source* is the Hub
manifest, and the real answer is the dual-push design above.

## Verification

Everything the shell does was run under **bash 3.2** — the lowercasing, the tag transformation across
every tag this config can emit, and the digest assembly, producing the expected
`imagetools create` command. The anonymous-pull mechanism was checked against a public GHCR image
(`ghcr.io/astral-sh/uv` answers; a missing or private one gives `failed to fetch anonymous token`).
`actionlint` passes, `pnpm test:scripts` 812 passed.

## After merge (maintainer)

The first push to `main` proves the copy. If the run warns, set the package's visibility to Public —
once. Documentation comes after that: `docker pull ghcr.io/…` would be wrong while it is private.

## Checklist

- [x] Tests written and passing — `actionlint`; shell logic exercised under bash 3.2
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

No changeset: `pnpm changeset:check` reports *No published source changed*.

## Related `.work/` docs

- `.work/2026-08-19-docker-publish-finish-plan.md` — stage 4's GHCR item.
- `.work/reviews/feat__ghcr-alongside-docker-hub.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Docker images are now mirrored to GitHub Container Registry when publishing credentials are configured.
  - Published images retain their corresponding tags and digests across registries.

- **Bug Fixes**
  - Added validation to detect when mirrored packages are not publicly pullable and provide a warning during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->