### PR TITLE
fix(changeset): name the CLI package `tapflow`, and check that every changeset names a real one

### DIFF
--- a/.changeset/ios-reachability-hook.md
+++ b/.changeset/ios-reachability-hook.md
@@ -1,6 +1,6 @@
 ---
 "@tapflowio/ios-agent": patch
-"@tapflowio/cli": patch
+"tapflow": patch
 ---
 
 An iOS app that reads `SCNetworkReachability` is now told when its simulator is taken off the network. Taking a device offline already stopped its traffic, and an app built on `NWPathMonitor` drew its offline state correctly — but Alamofire's `NetworkReachabilityManager` and the older `Reachability.swift` read a different API, and that one kept answering "reachable" while every request failed. The offline screen a tester came to check never appeared.

--- a/scripts/__tests__/changesetNamesRealPackages.test.mjs
+++ b/scripts/__tests__/changesetNamesRealPackages.test.mjs
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { getPackages } from '@manypkg/get-packages'
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+// A changeset naming a package that does not exist stops `changeset version` dead:
+//
+//     Found changeset ios-reachability-hook for package @tapflowio/cli which is not in the workspace
+//
+// **And nothing before release day says so.** The CI `changeset` job asks whether a changeset
+// *exists*, not whether it names anything real; `pnpm changeset:check` does the same. So the frontmatter
+// is unread from the moment it is written until the release that consumes it — which is how
+// `ios-reachability-hook.md` shipped naming `@tapflowio/cli`, a package whose actual name is `tapflow`.
+// The CLI directory is `packages/cli`, so the wrong name is the natural guess and reads correct.
+//
+// It cost two releases rather than one: the fix was first made inside a release branch, that branch was
+// abandoned, and the correction went with it — so the same error stopped the next cut too.
+//
+// **The enumerator is changesets' own**, for the reason its sibling `changesetIgnoresPrivate.test.mjs`
+// gives: two of this workspace's packages are not under `packages/`, so a glob would declare a list
+// complete while missing them. A check that reimplements a tool's discovery to guard that tool is a
+// floor rather than a fence (`contributing/test-and-guard-coverage.md` §3).
+const REPO = path.resolve(import.meta.dirname, '../..')
+const workspace = await getPackages(REPO)
+const known = new Set(workspace.packages.map((p) => p.packageJson.name))
+
+/** Package names in a changeset's frontmatter — the `'name': bump` lines between the `---` fences. */
+function namesIn(source) {
+  const fence = source.indexOf('---', 3)
+  if (!source.startsWith('---') || fence === -1) return []
+  return source
+    .slice(3, fence)
+    .split('\n')
+    .map((l) => /^\s*['"]?(@?[\w.\-/]+)['"]?\s*:\s*(major|minor|patch)\s*$/.exec(l.trim()))
+    .filter(Boolean)
+    .map((m) => m[1])
+}
+
+const dir = path.join(REPO, '.changeset')
+const files = readdirSync(dir).filter((f) => f.endsWith('.md') && f !== 'README.md')
+
+describe('every changeset names a package this workspace has', () => {
+  // Anti-vacuity: with no changesets pending the loop below asserts nothing, and "all of them are
+  // valid" is true of an empty set. The parser is exercised against a known-good input either way.
+  it('parses names out of frontmatter', () => {
+    expect(namesIn("---\n'@tapflowio/relay': patch\n\"tapflow\": minor\n---\n\nbody\n"))
+      .toEqual(['@tapflowio/relay', 'tapflow'])
+    expect(namesIn('no frontmatter here')).toEqual([])
+  })
+
+  it('knows the workspace has at least the published packages', () => {
+    expect(known.size).toBeGreaterThanOrEqual(9)
+    expect(known.has('tapflow')).toBe(true)
+    // The name that was got wrong. Stated so this test fails loudly if the CLI is ever renamed,
+    // rather than quietly guarding a fact that stopped being true.
+    expect(known.has('@tapflowio/cli')).toBe(false)
+  })
+
+  it.each(files.length ? files : ['(none pending)'])('%s', (file) => {
+    if (file === '(none pending)') return
+    const names = namesIn(readFileSync(path.join(dir, file), 'utf8'))
+    const unknown = names.filter((n) => !known.has(n))
+    expect(unknown, `${file} names ${unknown.join(', ')}, which this workspace does not have`).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

`ios-reachability-hook.md` declared `@tapflowio/cli`. There is no such package — the CLI lives in `packages/cli` but its name is `tapflow`, so the wrong guess reads correct. `changeset version` refuses outright:

```
Found changeset ios-reachability-hook for package @tapflowio/cli which is not in the workspace
```

**Nothing before release day says so.** The CI `changeset` job asks whether a changeset exists, not whether it names anything real, and `changeset:check` does the same — so the frontmatter is unread from the moment it is written until the release that consumes it.

It cost two cuts rather than one. The fix was first made inside a release branch that was then abandoned, and the correction went with it, so the same error stopped the next attempt in the same place. **That is also why this is its own PR** rather than a line inside the release: a one-line fix living in a release branch has already evaporated once here.

The guard enumerates the workspace with changesets' own `getPackages`, for the reason its sibling `changesetIgnoresPrivate.test.mjs` gives — two packages are not under `packages/`, so a glob would call the list complete while missing them. Verified by mutation: restoring the typo fails with the file and the package named.

## Checklist

- [x] Tests written and passing
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/fix__changeset-cli-package-name.md` — review skipped, with the reason

<!-- no-changeset: corrects a pending changeset's frontmatter and adds a script test; the release note it fixes is already written -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKE6o8FqPiSbzUm2oLnnzJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed iOS network reachability updates so connectivity results are refreshed reliably.
  - Reachability callbacks now re-fire correctly for both dispatch-queue and run-loop scheduling, helping applications respond promptly when network availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->