### PR TITLE
docs: name the GHCR mirror where the pull limit bites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ The `.github/workflows/docker-publish.yml` workflow detects these secrets and pu
 
 **The secrets alone are not enough.** That workflow hardcodes `IMAGE: tapflow/tapflow`, so a fork that sets only the two secrets pushes at *this* project's namespace and fails on permissions. Change `IMAGE` to your own namespace in the workflow as well.
 
+**GHCR needs neither.** The same workflow copies each published manifest to `ghcr.io/<owner>/<repo>`, authenticating with the `GITHUB_TOKEN` Actions already provides — so there is no secret to create and none to rotate, and the name is derived from your fork rather than hardcoded. It is gated on the Docker Hub secrets only because it copies what the Docker Hub push produced; a fork that never sets them publishes to neither.
+
 ### Versioning (Semver)
 
 Versions follow `MAJOR.MINOR.PATCH`. Determine the bump from the commits since the last release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ The `.github/workflows/docker-publish.yml` workflow detects these secrets and pu
 
 **GHCR needs neither.** The same workflow copies each published manifest to `ghcr.io/<owner>/<repo>`, authenticating with the `GITHUB_TOKEN` Actions already provides — so there is no secret to create and none to rotate, and the name is derived from your fork rather than hardcoded. It is gated on the Docker Hub secrets only because it copies what the Docker Hub push produced; a fork that never sets them publishes to neither.
 
+**One click, once, and nothing automates it.** GHCR creates a package *private* on its first push, so a fork's mirror answers no anonymous pull until somebody sets its visibility to Public at `https://github.com/<owner>/<repo>/pkgs/container/<repo>`. A workflow run cannot change that setting, so the last GHCR step logs out and retries the pull unauthenticated: it warns on every publish until the package is public, and reddening the release for it would be the wrong signal. tapflow's own package is already public — this is a fork-only step.
+
 ### Versioning (Semver)
 
 Versions follow `MAJOR.MINOR.PATCH`. Determine the bump from the commits since the last release:

--- a/docker/hub-overview.md
+++ b/docker/hub-overview.md
@@ -36,6 +36,16 @@ services:
 docker compose up -d
 ```
 
+**Also on GHCR**, from the same build and with the same digests:
+
+```
+ghcr.io/jo-duchan/tapflow:latest
+```
+
+Anonymous pulls here are limited to 100 per six hours per IP address, and a multi-architecture image
+spends one per architecture — about 50 in practice, shared by everyone behind that address. GHCR has
+no such limit for public images. Either registry serves the same thing.
+
 Three of those lines are not optional, and each one fails in a way that is hard to read backwards.
 
 **The volume.** The relay writes a per-install secret to `<dataDir>/jwt-secret` and reuses it.
@@ -57,7 +67,7 @@ neither; at least 8 characters; and nothing happens on an install that already h
 
 - `latest` — the most recent release. Use this.
 - `edge` — whatever is on `main` right now.
-- `0.20`, `0.20.1` — pinned releases.
+- `0.21`, `0.21.0` — pinned releases; every published version has both.
 - `sha-<commit>` — a specific build.
 
 Every tag carries `linux/amd64` and `linux/arm64`.

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -21,6 +21,18 @@ You can run the relay via Docker on an always-on LAN box. This provides a clean 
 docker pull tapflow/tapflow:latest
 ```
 
+::: tip Hitting Docker Hub's pull limit? The same image is on GHCR
+Docker Hub limits anonymous pulls to 100 per six hours per IP address, and a multi-architecture image spends one of those per architecture — so roughly 50 in practice, shared by everyone behind the same address. A CI runner or an office network can reach that without anyone doing anything unusual.
+
+The identical image is published to the GitHub Container Registry, which has no such limit for public images:
+
+```sh
+docker pull ghcr.io/jo-duchan/tapflow:latest
+```
+
+Both registries receive the same digests from the same build, so `latest` and a version tag mean the same thing on either. Swap the `image:` line in the Compose file below if you prefer it.
+:::
+
 Create a `docker-compose.yml`:
 
 ```yaml

--- a/docs/ko/guide/self-hosting.md
+++ b/docs/ko/guide/self-hosting.md
@@ -21,6 +21,18 @@
 docker pull tapflow/tapflow:latest
 ```
 
+::: tip Docker Hub 받기 제한에 걸렸다면 GHCR을 쓰세요
+Docker Hub는 로그인하지 않은 받기를 IP당 6시간에 100회로 제한합니다. 멀티 아키텍처 이미지는 아키텍처마다 한 번씩 세므로 실제로는 50회쯤이고, 같은 주소를 쓰는 모두가 그 횟수를 나눠 씁니다. CI 러너나 사무실 네트워크라면 특별한 일을 하지 않아도 닿습니다.
+
+같은 이미지를 GitHub Container Registry에도 올립니다. 공개 이미지에는 이런 제한이 없습니다.
+
+```sh
+docker pull ghcr.io/jo-duchan/tapflow:latest
+```
+
+두 저장소는 같은 빌드가 만든 같은 digest를 받습니다. 그래서 `latest`든 버전 태그든 어느 쪽에서 받아도 같은 것입니다. 아래 Compose 파일의 `image:` 줄만 바꾸면 됩니다.
+:::
+
 `docker-compose.yml`을 만듭니다:
 
 ```yaml


### PR DESCRIPTION
## Summary

The Docker Publish workflow has mirrored every release to `ghcr.io/jo-duchan/tapflow` since #780, and nothing outside that workflow file said so. Docker Hub's anonymous limit is 100 pulls per six hours per IP, and a multi-architecture image spends one per architecture — so a CI runner or an office network reaches it without doing anything unusual, and the person who hits it has no reason to go reading a CI file for the second registry.

Four places a reader arrives from: the self-hosting guide (EN and KO), the Docker Hub overview itself, and `CONTRIBUTING.md` — where a fork setting up publishing needs to know the GHCR answer is "no secret at all", since the copy authenticates with the `GITHUB_TOKEN` Actions already provides.

Also refreshes the overview's pinned-tag example, which still named `0.20`, and states the rule beside it so a stale number reads as an example rather than as the current release.

Docs-only — `pnpm changeset:check` reports no published source changed.

## Checklist

- [x] Tests written and passing — n/a, no source change; `pnpm docs:build` passes
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/docs__ghcr-mirror.md` — review skipped as docs-only, with each factual claim about the workflow checked against `.github/workflows/docker-publish.yml` instead, plus the `/ai-tells` grades for both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKE6o8FqPiSbzUm2oLnnzJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for pulling images from GitHub Container Registry when Docker Hub pull limits are reached.
  - Documented equivalent image names, matching image digests, and the Compose configuration change required.
  - Updated Quick Start examples to use the latest pinned image tag.
  - Added contributor guidance for making fork-published packages publicly pullable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->