### PR TITLE
docs: lead the README badges with the numbers people actually check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@
   </p>
 
   <p>
-    <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
+    <a href="https://github.com/jo-duchan/tapflow/stargazers"><img src="https://img.shields.io/github/stars/jo-duchan/tapflow" alt="GitHub stars" /></a>
+    <a href="https://hub.docker.com/r/tapflow/tapflow"><img src="https://img.shields.io/docker/pulls/tapflow/tapflow" alt="Docker pulls" /></a>
     <a href="https://github.com/jo-duchan/tapflow/releases"><img src="https://img.shields.io/github/v/release/jo-duchan/tapflow?include_prereleases&sort=semver" alt="Latest release" /></a>
     <a href="https://github.com/jo-duchan/tapflow/commits/main"><img src="https://img.shields.io/github/last-commit/jo-duchan/tapflow" alt="Last commit" /></a>
+    <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
   </p>
 
   <p>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,9 +17,11 @@
   </p>
 
   <p>
-    <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
+    <a href="https://github.com/jo-duchan/tapflow/stargazers"><img src="https://img.shields.io/github/stars/jo-duchan/tapflow" alt="GitHub stars" /></a>
+    <a href="https://hub.docker.com/r/tapflow/tapflow"><img src="https://img.shields.io/docker/pulls/tapflow/tapflow" alt="Docker pulls" /></a>
     <a href="https://github.com/jo-duchan/tapflow/releases"><img src="https://img.shields.io/github/v/release/jo-duchan/tapflow?include_prereleases&sort=semver" alt="Latest release" /></a>
     <a href="https://github.com/jo-duchan/tapflow/commits/main"><img src="https://img.shields.io/github/last-commit/jo-duchan/tapflow" alt="Last commit" /></a>
+    <img src="https://img.shields.io/badge/platform-macOS%20agent-lightgrey" alt="macOS Agent" />
   </p>
 
   <p>


### PR DESCRIPTION
## Summary

The README badge row opened with a static platform label and carried no measure of use at all. The two numbers that exist — 611 stars and ~9k Docker Hub pulls — appeared nowhere in the repo.

Measured while deciding what to put there: 625 unique GitHub visitors and 526 unique cloners in the last 14 days, flat day over day, against roughly 90 npm downloads a week once registry outage days are excluded. npm's count here is release-day scanner traffic decaying off a new-package peak, so it is the weakest signal available and is deliberately not added.

The row now reads stars, pulls, release, last commit, platform — social proof first, static label last. Both READMEs, since they are one document.

**Safe to widen only as of last month.** Badge rows used to stack vertically for logged-out visitors, which is most of them, because `@primer/react-brand` leaked `img,picture{…display:block}` into `.markdown-body` — primer/brand#1426, filed from this repo in July. The bundle github.com serves anonymously today reads `img,picture{max-width:100%}`, so the row renders inline again. Read from the shipped CSS, not from the closed issue.

Docs-only — `pnpm changeset:check` reports no published source changed.

## Checklist

- [x] Tests written and passing — `pnpm test:scripts`, 838 passing, `readmeSync.test.mjs` included
- [x] No `any`
- [x] Interface changes land in `agent-core` first — n/a
- [x] No sensitive info (tokens, paths, credentials)

## Related `.work/` docs

`.work/reviews/docs__readme-social-proof.md` — review skipped as docs-only, with the badge endpoints, the sync test, the CSS evidence, and the measurement table behind the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKE6o8FqPiSbzUm2oLnnzJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README badge displays to include GitHub star and Docker pull metrics.
  - Reordered existing release, commit, and macOS platform badges for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->